### PR TITLE
Fix the python code style checks in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 SHELL := /bin/bash
-CODE_DIRECTORIES = src
+PYTHON_CODE_DIRECTORIES = src/py
 
-style: lint black isort
+style: lint black isort mypy
 
 lint:
-	flake8 --ignore "E203, E231, E501, W503" $(CODE_DIRECTORIES)
+	flake8 --ignore "E203, E231, E501, W503" $(PYTHON_CODE_DIRECTORIES)
 
 black:
-	black --check $(CODE_DIRECTORIES)
+	black --check $(PYTHON_CODE_DIRECTORIES)
 
 isort:
-	isort --check $(CODE_DIRECTORIES)
+	isort --check $(PYTHON_CODE_DIRECTORIES)
 
 mypy:
-	mypy --ignore-missing-imports $(CODE_DIRECTORIES)
+	mypy --ignore-missing-imports $(PYTHON_CODE_DIRECTORIES)
 
 .PHONY: style lint black isort


### PR DESCRIPTION
### Description
1. Should be "PYTHON_CODE_DIRECTORIES".  The typescript code will probably have its own style checkers (@lvreynoso?).
2. the style rule should also invoke the mypy rule.

### Test plan
`make -j style`