### PR TITLE
Bump Node version to latest LTS (14.15.4)

### DIFF
--- a/.platform/hooks/prebuild/01_software_dependencies.sh
+++ b/.platform/hooks/prebuild/01_software_dependencies.sh
@@ -2,17 +2,25 @@
 set -x
 
 export NVM_DIR="${HOME}/.nvm"
-export NODE_VERSION="12.16.1"
+# We want to be on the latest Active LTS; but should
+# set this value manually, so we can test it beforehand
+export NODE_VERSION="14.15.4"
 
-# Install Node 12.16.1
+# Install nvm
 if [[ ! -f "${NVM_DIR}/nvm.sh" ]]; then
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
 fi
 
+# Activate nvm
 source "${NVM_DIR}/nvm.sh"
 
+# Install our preferred Node version
+# Make sure we are using that version, and also
+# make our version the default
 if [[ $(nvm current) != "v${NODE_VERSION}" ]]; then
     nvm install ${NODE_VERSION}
+    nvm alias default ${NODE_VERSION}
+    nvm use ${NODE_VERSION}
 fi
 
 # Install Frontend dependencies

--- a/src/ts/package-lock.json
+++ b/src/ts/package-lock.json
@@ -3498,6 +3498,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6053,6 +6062,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -14711,6 +14726,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
### Description

Bumps the Node version to the latest Active LTS version. I thought it best to get this out of the way before any significant development has started.

#### Issue
[ch65516](https://app.clubhouse.io/genepi/stories/space/65516)

### Test plan

Tested locally by building the frontend and viewing the app.
