### PR TITLE
Put DB config in a separate object so we can have unimplemented properties

### DIFF
--- a/src/py/covidr/config/config.py
+++ b/src/py/covidr/config/config.py
@@ -26,9 +26,15 @@ class Config:
         return False
 
     @property
-    def DATABASE_URI(self):
+    def DATABASE_CONFIG(self):
+        raise NotImplementedError()
+
+
+class DatabaseConfig:
+    @property
+    def URI(self):
         raise NotImplementedError()
 
     @property
-    def DATABASE_READONLY_URI(self):
+    def READONLY_URI(self):
         raise NotImplementedError()

--- a/src/py/covidr/config/development.py
+++ b/src/py/covidr/config/development.py
@@ -1,4 +1,4 @@
-from .config import Config
+from .config import Config, DatabaseConfig
 
 
 class DevelopmentConfig(Config, descriptive_name="dev"):
@@ -7,6 +7,11 @@ class DevelopmentConfig(Config, descriptive_name="dev"):
         return True
 
     @property
-    def DATABASE_URI(self):
-        # TODO: fetch this from AWS secrets?
+    def DATABASE_CONFIG(self):
+        return DevelopmentDatabaseConfig()
+
+
+class DevelopmentDatabaseConfig(DatabaseConfig):
+    @property
+    def URI(self):
         return "postgresql://user_rw:password_rw@localhost:5432/covidr_db"

--- a/src/py/covidr/config/production.py
+++ b/src/py/covidr/config/production.py
@@ -1,5 +1,9 @@
-from .config import Config
+from .config import Config, DatabaseConfig
 
 
 class ProductionConfig(Config, descriptive_name="prod"):
-    pass
+    ...
+
+
+class ProductionDatabaseConfig(DatabaseConfig):
+    ...

--- a/src/py/covidr/config/testing.py
+++ b/src/py/covidr/config/testing.py
@@ -1,7 +1,15 @@
-from .config import Config
+from .config import Config, DatabaseConfig
 
 
 class TestingConfig(Config, descriptive_name="test"):
     @property
     def TESTING(self):
         return True
+
+    @property
+    def DATABASE_CONFIG(self):
+        return TestingDatabaseConfig()
+
+
+class TestingDatabaseConfig(DatabaseConfig):
+    ...

--- a/src/py/covidr/database/connection.py
+++ b/src/py/covidr/database/connection.py
@@ -53,7 +53,7 @@ def get_db_uri(runtime_config: Config, readonly: bool = False) -> str:
     """
     if readonly:
         try:
-            return runtime_config.DATABASE_READONLY_URI
+            return runtime_config.DATABASE_CONFIG.READONLY_URI
         except NotImplementedError:
             raise ValueError(f"Config {runtime_config} does not have a read-only mode.")
-    return runtime_config.DATABASE_URI
+    return runtime_config.DATABASE_CONFIG.URI


### PR DESCRIPTION
### Description
Development DB will not have a R/O mode, but all properties are read when `application.config.from_object` is called.  This adds one more layer to the config, just for DB config, where some properties do not need to be implemented.

### Test plan
Loading the app in dev mode works now!
