### PR TITLE
Update .gitignore to ignore the .venv-ebcli virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,8 +113,9 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
-.venv
+.env/
+.venv/
+.venv-ebcli/
 env/
 venv/
 ENV/
@@ -304,3 +305,4 @@ static
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+/.ebiginore


### PR DESCRIPTION
### Description
The changes in #12 suggested a separate virtual environment to install the ebcli because of a conflict between ebcli's requirements and the app's requirements.  This avoids installing the second virtualenv when deploying.

Also, to ensure that we are all using the same [ignore set while deploying](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-configuration.html#eb-cli3-ebignore), we explicitly do not allow the .ebignore file to be committed.  This means we will all use .gitignore.

### Test plan
deployed successfully with a .venv-ebcli virtualenv in my setup.
