### PR TITLE
Fix max-warnings rule for Typescript linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v7.11.0
     hooks:
     - id: eslint
-      args: [--fix, --config src/ts/.eslintrc.js. --ignore-path src/ts/.eslintignore]
+      args: [--fix, --config src/ts/.eslintrc.js. --ignore-path src/ts/.eslintignore, --max-warnings 45]
       additional_dependencies:
       - eslint@7.11.0
       - eslint-plugin-react@7.22.0

--- a/src/ts/.eslintrc.js
+++ b/src/ts/.eslintrc.js
@@ -3,12 +3,12 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     plugins: ["@typescript-eslint"],
     extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-    "prettier",
-    "prettier/@typescript-eslint",
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:react/recommended",
+        "plugin:react-hooks/recommended",
+        "prettier",
+        "prettier/@typescript-eslint",
     ],
     settings: {
         react: {
@@ -19,15 +19,14 @@ module.exports = {
         "max-len": ["error", {
             code: 120,
         }],
-        "max-warnings": 0,
         "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
     },
     overrides: [
-    {
-        files: ["*.d.ts"], // type declaration files
-        rules: {
-            "@typescript-eslint/triple-slash-reference": "off",
+        {
+            files: ["*.d.ts"], // type declaration files
+            rules: {
+                "@typescript-eslint/triple-slash-reference": "off",
+            }
         }
-    }
     ]
 };

--- a/src/ts/package.json
+++ b/src/ts/package.json
@@ -7,8 +7,8 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
-    "style": "npx prettier --write src && npx eslint --fix src",
-    "lint-ci": "npx eslint src"
+    "style": "npx prettier --write src && npx eslint --max-warnings 45 --fix src",
+    "lint-ci": "npx eslint --max-warnings 45 src"
   },
   "dependencies": {
     "@babel/core": "7.12.3",


### PR DESCRIPTION
### Description

Properly enforces a max of 45 warnings.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/stories/space/<fill_in_issue_number>)

### Test plan

Tested locally, should also work in CI.
