### PR TITLE
[easy] Impose the style checks on the database migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-PYTHON_CODE_DIRECTORIES = src/py
+PYTHON_CODE_DIRECTORIES = database_migrations src/py
 
 
 ### DATABASE #################################################

--- a/database_migrations/env.py
+++ b/database_migrations/env.py
@@ -2,7 +2,7 @@ import os
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import create_engine, engine_from_config, pool
+from sqlalchemy import create_engine
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -32,9 +32,7 @@ target_metadata = None
 fileConfig(config.config_file_name)
 
 
-target_metadata = [
-    models.meta
-]
+target_metadata = [models.meta]
 
 
 # other values from the config, defined by the needs of env.py,
@@ -87,9 +85,7 @@ def run_migrations_online():
     connectable = create_engine(get_uri())
 
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
+        context.configure(connection=connection, target_metadata=target_metadata)
 
         with context.begin_transaction():
             context.run_migrations()

--- a/database_migrations/versions/20212013_182045_create_empty_schema.py
+++ b/database_migrations/versions/20212013_182045_create_empty_schema.py
@@ -1,7 +1,7 @@
 """create empty schema
 
 Revision ID: 20212013_182045
-Revises: 
+Revises:
 Create Date: 2021-01-13 18:20:45.683596
 
 """

--- a/database_migrations/versions/20212415_112447_add_group_and_user_models.py
+++ b/database_migrations/versions/20212415_112447_add_group_and_user_models.py
@@ -39,9 +39,7 @@ def upgrade():
             name=op.f("fk_users_group_id_groups"),
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_users")),
-        sa.UniqueConstraint(
-            "auth0_user_id", name=op.f("uq_users_auth0_user_id")
-        ),
+        sa.UniqueConstraint("auth0_user_id", name=op.f("uq_users_auth0_user_id")),
         schema="aspen",
     )
     # ### end Alembic commands ###


### PR DESCRIPTION
### Description
Add the database migrations folder to the set of folders checked for style.

### Test plan
`make -j style`
