### PR TITLE
Support for DataTypes/CanSee

### DIFF
--- a/database_migrations/env.py
+++ b/database_migrations/env.py
@@ -1,6 +1,7 @@
 import os
 from logging.config import fileConfig
 
+import enumtables  # noqa: F401
 from alembic import context
 from sqlalchemy import create_engine
 

--- a/database_migrations/script.py.mako
+++ b/database_migrations/script.py.mako
@@ -5,6 +5,7 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+import enumtables  # noqa: F401
 import sqlalchemy as sa
 from alembic import op
 ${imports if imports else ""}

--- a/database_migrations/versions/20210204_110958_add_datatypes_and_can_see_tables.py
+++ b/database_migrations/versions/20210204_110958_add_datatypes_and_can_see_tables.py
@@ -1,0 +1,56 @@
+"""add datatypes and can see tables
+
+Revision ID: 20210204_110958
+Revises: 20210204_104338
+Create Date: 2021-02-04 11:09:58.589711
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210204_110958"
+down_revision = "20210204_104338"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "datatypes",
+        sa.Column("item_id", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("item_id", name=op.f("pk_datatypes")),
+        schema="aspen",
+    )
+    op.create_table(
+        "can_see",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("viewer_group_id", sa.Integer(), nullable=False),
+        sa.Column("owner_group_id", sa.Integer(), nullable=False),
+        sa.Column("data_type", enumtables.enum_column.EnumType(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["data_type"],
+            ["aspen.datatypes.item_id"],
+            name=op.f("fk_can_see_data_type_datatypes"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["owner_group_id"],
+            ["aspen.groups.id"],
+            name=op.f("fk_can_see_owner_group_id_groups"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["viewer_group_id"],
+            ["aspen.groups.id"],
+            name=op.f("fk_can_see_viewer_group_id_groups"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_can_see")),
+        schema="aspen",
+    )
+    op.enum_insert("datatypes", ["TREES", "SEQUENCES"], schema="aspen")
+
+
+def downgrade():
+    op.enum_delete("datatypes", ["TREES", "SEQUENCES"], schema="aspen")
+    op.drop_table("can_see", schema="aspen")
+    op.drop_table("datatypes", schema="aspen")

--- a/src/py/aspen/database/models/tests/test_datatypes.py
+++ b/src/py/aspen/database/models/tests/test_datatypes.py
@@ -1,0 +1,31 @@
+from sqlalchemy.orm import Session
+
+from aspen.database.models import CanSee, DataType, Group
+
+
+def test_can_see_constructor_with_datatype(session: Session):
+    """Test that we can construct a CanSee object with a `data_type` argument."""
+    group1 = Group(name="group1", email="email1@example.com", address="address1")
+    group2 = Group(name="group2", email="email2@example.com", address="address2")
+    can_see = CanSee(viewer_group=group1, owner_group=group2, data_type=DataType.TREES)
+
+    session.add_all((group1, group2, can_see))
+    session.flush()
+
+    assert can_see.data_type == DataType.TREES
+
+
+def test_can_see_datatype_filter(session: Session):
+    """Test that we can filter by the datatype."""
+    group1 = Group(name="group1", email="email1@example.com", address="address1")
+    group2 = Group(name="group2", email="email2@example.com", address="address2")
+    can_see = CanSee(
+        viewer_group=group1,
+        owner_group=group2,
+        data_type=DataType.TREES,
+    )
+
+    session.add_all((group1, group2, can_see))
+    session.flush()
+
+    session.query(CanSee).filter(CanSee.data_type == DataType.TREES).one()


### PR DESCRIPTION
### Description
This adds the part of the schema for DataTypes and CanSee.

Depends on #30, #40, #46, #47, #48, #50, #51, #52, #55

#### Issue
[ch64743](https://app.clubhouse.io/genepi/stories/space/64743)

### Test plan
1. Ran tests!
2. Created a db from scratch and observed that the "enum"s were created.
3. Created a db from the prior revision, applied the autogenerated script, and observed that the "enum"s were created.
