### PR TITLE
Add sqlalchemy-enum-tables to the installed packages.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ psycopg2-binary = "*"
 python-dotenv = "*"
 requests = "*"
 SQLAlchemy = "*"
+sqlalchemy-enum-tables = {editable = true, path = "./third-party/sqlalchemy-enum-tables"}
 
 [dev-packages]
 alembic = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f79b4fd1dec16846335a87bec25f4ed7a2e8f01816fb8d62a186611f09c4e803"
+            "sha256": "00973f2ed904a6772ccc4f91f68e3afe41d6a71b3e81376ee636a5a4649cb79b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -315,6 +315,10 @@
             ],
             "index": "pypi",
             "version": "==1.3.23"
+        },
+        "sqlalchemy-enum-tables": {
+            "editable": true,
+            "path": "./third-party/sqlalchemy-enum-tables"
         },
         "urllib3": {
             "hashes": [

--- a/src/py/requirements-dev.txt
+++ b/src/py/requirements-dev.txt
@@ -9,6 +9,7 @@
 # requirements. To emit only development requirements, pass "--dev-only".
 
 -i https://pypi.org/simple
+./third-party/sqlalchemy-enum-tables
 alembic==1.5.4
 apipkg==1.5; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 appdirs==1.4.4
@@ -27,7 +28,6 @@ execnet==1.8.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2
 flake8==3.8.4
 flask==1.1.2
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-importlib-metadata==3.4.0; python_version < '3.8'
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 ipython==7.20.0
@@ -69,8 +69,7 @@ sqlalchemy==1.3.23
 toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 traitlets==5.0.5; python_version >= '3.7'
 typed-ast==1.4.2
-typing-extensions==3.7.4.3; python_version < '3.8'
+typing-extensions==3.7.4.3
 urllib3==1.26.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
 wcwidth==0.2.5
 werkzeug==1.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-zipp==3.4.0; python_version >= '3.6'

--- a/src/py/requirements.txt
+++ b/src/py/requirements.txt
@@ -6,6 +6,7 @@
 #
 
 -i https://pypi.org/simple
+./third-party/sqlalchemy-enum-tables
 authlib==0.15.3
 certifi==2020.12.5
 cffi==1.14.4


### PR DESCRIPTION
### Description
This installs our private copy of sqlalchemy-enum-tables.

Depends on #46, #50

### Test plan
Deployed to elastic beanstalk.
