### PR TITLE
Add "metadata" as a possible data type for cross-group viewing

### DIFF
--- a/database_migrations/versions/20210204_112248_add_metadata_as_a_possible_datatype.py
+++ b/database_migrations/versions/20210204_112248_add_metadata_as_a_possible_datatype.py
@@ -1,0 +1,23 @@
+"""add METADATA as a possible datatype
+
+Revision ID: 20210204_112248
+Revises: 20210204_110958
+Create Date: 2021-02-04 11:22:49.102647
+
+"""
+import enumtables  # noqa: F401
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210204_112248"
+down_revision = "20210204_110958"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.enum_insert("datatypes", ["METADATA"], schema="aspen")
+
+
+def downgrade():
+    op.enum_delete("datatypes", ["METADATA"], schema="aspen")

--- a/src/py/aspen/database/models.py
+++ b/src/py/aspen/database/models.py
@@ -98,6 +98,7 @@ class User(idbase):
 class DataType(enum.Enum):
     TREES = "TREES"
     SEQUENCES = "SEQUENCES"
+    METADATA = "METADATA"
 
 
 # Create the enumeration table


### PR DESCRIPTION
### Description
1. This is in the schema
2. Proof that sqlalchemy-enum-tables works!

Depends on #49 

#### Issue
[ch64743](https://app.clubhouse.io/genepi/stories/space/64743)

### Test plan
Upgraded and downgraded the schema
