### PR TITLE
Refactor enumtables hooks

### DIFF
--- a/src/py/aspen/database/models/accessions.py
+++ b/src/py/aspen/database/models/accessions.py
@@ -1,15 +1,7 @@
 import enum
 
 import enumtables
-from sqlalchemy import (
-    Column,
-    event,
-    ForeignKey,
-    Integer,
-    String,
-    text,
-    UniqueConstraint,
-)
+from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
 from .base import base, idbase
@@ -28,22 +20,6 @@ _PublicRepositoryTypeTable = enumtables.EnumTable(
     PublicRepositoryType,
     base,
     tablename="publicrepositorytypes",
-)
-
-
-def _after_publicrepositorytypes_create(target, connection, **kw):
-    for entitytype in PublicRepositoryType:
-        connection.execute(
-            text(
-                f"INSERT INTO {target.schema}.{target.name} (item_id) VALUES (:name)"
-            ).params(name=entitytype.value)
-        )
-
-
-event.listen(
-    _PublicRepositoryTypeTable.__table__,
-    "after_create",
-    _after_publicrepositorytypes_create,
 )
 
 

--- a/src/py/aspen/database/models/cansee.py
+++ b/src/py/aspen/database/models/cansee.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import enum
 
 import enumtables
-from sqlalchemy import Column, event, ForeignKey, Integer, text
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlalchemy.orm import backref, relationship
 
 from .base import base, idbase
@@ -25,18 +25,6 @@ _DataTypeTable = enumtables.EnumTable(
     base,
     tablename="datatypes",
 )
-
-
-def _after_datatypes_create(target, connection, **kw):
-    for datatype in DataType:
-        connection.execute(
-            text(
-                f"INSERT INTO {target.schema}.{target.name} (item_id) VALUES (:name)"
-            ).params(name=datatype.value)
-        )
-
-
-event.listen(_DataTypeTable.__table__, "after_create", _after_datatypes_create)
 
 
 class CanSee(idbase):

--- a/src/py/aspen/database/models/entity.py
+++ b/src/py/aspen/database/models/entity.py
@@ -2,7 +2,7 @@ import enum
 from typing import Mapping, Union
 
 import enumtables
-from sqlalchemy import Column, event, ForeignKey, text
+from sqlalchemy import Column, ForeignKey
 
 from .base import base, idbase
 from .enum import Enum
@@ -24,18 +24,6 @@ _EntityTypeTable = enumtables.EnumTable(
     base,
     tablename="entitytypes",
 )
-
-
-def _after_entitytypes_create(target, connection, **kw):
-    for entitytype in EntityType:
-        connection.execute(
-            text(
-                f"INSERT INTO {target.schema}.{target.name} (item_id) VALUES (:name)"
-            ).params(name=entitytype.value)
-        )
-
-
-event.listen(_EntityTypeTable.__table__, "after_create", _after_entitytypes_create)
 
 
 class Entity(idbase):

--- a/src/py/aspen/database/models/workflow.py
+++ b/src/py/aspen/database/models/workflow.py
@@ -2,7 +2,7 @@ import enum
 from typing import Mapping, Union
 
 import enumtables
-from sqlalchemy import Column, DateTime, event, ForeignKey, JSON, Table, text
+from sqlalchemy import Column, DateTime, ForeignKey, JSON, Table
 from sqlalchemy.orm import relationship
 
 from .base import base, idbase
@@ -27,18 +27,6 @@ _WorkflowTypeTable = enumtables.EnumTable(
     base,
     tablename="workflowtypes",
 )
-
-
-def _after_workflowtypes_create(target, connection, **kw):
-    for workflowtype in WorkflowType:
-        connection.execute(
-            text(
-                f"INSERT INTO {target.schema}.{target.name} (item_id) VALUES (:name)"
-            ).params(name=workflowtype.value)
-        )
-
-
-event.listen(_WorkflowTypeTable.__table__, "after_create", _after_workflowtypes_create)
 
 
 _workflow_inputs_table = Table(


### PR DESCRIPTION
### Description
Enumtables require entries to be put there after the table is created, but there is not a convenient sqlalchemy way to do so.  This dedups the logic that I've been sprinkling all over the codebase to do this work after table creation.  This is now done automatically by `enumtables.EnumTable`.

Depends on #60 

#### Issue
[ch64743](https://app.clubhouse.io/genepi/stories/space/64743)

### Test plan
Dropped the database and created it from scratch.  Verified that one of the enumtables had the correct values.
