### PR TITLE
Fix EnumColumn for use in polymorphic types

### DIFF
--- a/third-party/sqlalchemy-enum-tables/enumtables/__init__.py
+++ b/third-party/sqlalchemy-enum-tables/enumtables/__init__.py
@@ -1,6 +1,6 @@
 
 from .enum_table import EnumTable
-from .enum_column import EnumColumn
+from .enum_column import EnumType
 
 try:
 	import alembic

--- a/third-party/sqlalchemy-enum-tables/enumtables/alembic_autogen.py
+++ b/third-party/sqlalchemy-enum-tables/enumtables/alembic_autogen.py
@@ -10,7 +10,7 @@ def get_declared_enums(metadatas, schema, default):
 		column.type
 		for metadata in metadatas
 		for table in metadata.tables.values()
-		for column in table.columns if (isinstance(column, enum_column.EnumColumn) and table.schema == schema))
+		for column in table.columns if (isinstance(column.type, enum_column.EnumType) and table.schema == schema))
 	return {typ.__enum__.__tablename__ : frozenset(typ.__enum__.__enum__.__members__) for typ in types}
 
 def is_table_present(tablename, connection):

--- a/third-party/sqlalchemy-enum-tables/enumtables/enum_column.py
+++ b/third-party/sqlalchemy-enum-tables/enumtables/enum_column.py
@@ -2,7 +2,7 @@
 import sqlalchemy.types as types
 import sqlalchemy as sa
 
-__all__ = ["EnumColumn"]
+__all__ = ["EnumType"]
 
 def convert_case(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
@@ -21,42 +21,3 @@ class EnumType(types.TypeDecorator):
 		if value is None:
 			return None
 		return self.__enum__.__enum__[value]
-
-class EnumColumn(sa.Column):
-	"""
-	Column class for enumerations.
-
-	This class replaces ``sqlalchemy.Column`` for an enumeration.
-
-	Typical usage::
-
-		class Spam(Base):
-			__tablename__ = "spam"
-			id = sqlalchemy.Column(sqlalchemy.Integer, primary_key = True)
-			egg = enumtables.EnumColumn(EggEnum)
-	
-	This will create a ``spam`` table with an integer PK column ``id``,
-	a string type column ``egg``, and a foreign key from ``spam.egg``
-	to ``egg_enum.item_id``.
-
-	On a valued instance, its value is an instance of the enum type.
-	"""
-	def __init__(self, enumTable, tablename = None, *args, **kwargs):
-		"""
-		Constructor for an enum column
-
-		Parameters
-		----------
-		enum : subclass of enum.Enum
-			The enumeration class for which the column will be created.
-			This class **must** have had an ``EnumTable`` created previously.
-		tablename : str
-			If the table name has been overriden in the ``EnumTable``,
-			the same name **must** be provided here.
-		
-		All remaining arguments are passed to the constructor of ``sqlalchemy.Column``.
-		"""
-		tn = tablename if tablename else enumTable.__tablename__
-		fk = sa.ForeignKey(enumTable.item_id)
-		tp = EnumType(enumTable)
-		super().__init__(tp, fk, *args, **kwargs)


### PR DESCRIPTION
### Description
For polymorphic types, instances are instantiated using the same parameters as `sa.Column`.  Because the pre-existing `EnumColumn` redefines the constructor with different arguments, it does not work.

This PR removes `EnumColumn`.  Users of the enumtables should just call `sa.Column` with the type set to `EnumType(my_python_enum_type)`.  A bonus side effect is that we can remove some of the type checking hacks we introduced earlier in other PRs.

#### Issue
[ch64743](https://app.clubhouse.io/genepi/stories/space/64743)

### Test plan
Used in subsequent PRs.
