### PR TITLE
Use the enum value instead of the enum name

### DIFF
--- a/third-party/sqlalchemy-enum-tables/enumtables/alembic_autogen.py
+++ b/third-party/sqlalchemy-enum-tables/enumtables/alembic_autogen.py
@@ -21,7 +21,13 @@ def get_declared_enums(metadatas, schema, default):
 		for column in table.columns if (isinstance(column.type, enum_column.EnumType) and table.schema == schema)
 	]
 
-	return {tablename : frozenset(column.type.__enum__.__members__) for column, tablename in enum_columns}
+	return {
+		tablename : frozenset(
+			member._value_
+			for member in column.type.__enum__
+		)
+		for column, tablename in enum_columns
+	}
 
 @alembic.autogenerate.comparators.dispatch_for("schema")
 def compare_enums(autogen_context, upgrade_ops, schema_names):

--- a/third-party/sqlalchemy-enum-tables/enumtables/enum_column.py
+++ b/third-party/sqlalchemy-enum-tables/enumtables/enum_column.py
@@ -16,8 +16,8 @@ class EnumType(types.TypeDecorator):
 	def process_bind_param(self, value, dialect):
 		if value is None:
 			return None
-		return value.name
+		return value._value_
 	def process_result_value(self, value, dialect):
 		if value is None:
 			return None
-		return self.__enum__[value]
+		return self.__enum__(value)


### PR DESCRIPTION
### Description
Using the enum value makes it easier to read the db contents.

### Test plan
Used in subsequent PR.
