### PR TITLE
Support the Column model for specifying the FK for an enum

### DIFF
--- a/third-party/sqlalchemy-enum-tables/enumtables/alembic_autogen.py
+++ b/third-party/sqlalchemy-enum-tables/enumtables/alembic_autogen.py
@@ -9,7 +9,11 @@ from . import alembic_ops
 def _get_fk_table_name(column):
 	for fk in column.foreign_keys:
 		colspec = fk._get_colspec()
-		tablename, _ = colspec.split(".")
+		# the colspec is either in the form tablename.columnname or
+		# schemaname.tablename.columnname.
+		splitted = colspec.split(".")
+		assert len(splitted) >= 2
+		tablename = splitted[-2]
 		return tablename
 
 


### PR DESCRIPTION
### Description
It is code-wise saner to specify the FK column with the python object rather than a string name.  When that is done, colspec is a `schemaname.tablename.columnname`.  In that case, we want the second-to-last split.

### Test plan
Used in subsequent PR.
