### PR TITLE
Specify the ForeignKeys not as a string

### DIFF
--- a/src/py/aspen/database/models/accessions.py
+++ b/src/py/aspen/database/models/accessions.py
@@ -29,7 +29,7 @@ class PublicRepository(idbase):
     __tablename__ = "public_repository"
     entity_type = Column(
         Enum(PublicRepositoryType),
-        ForeignKey(f"{_PublicRepositoryTypeTable.__tablename__}.item_id"),
+        ForeignKey(_PublicRepositoryTypeTable.item_id),
         nullable=False,
     )
 
@@ -45,14 +45,14 @@ class Accession(base):
 
     entity_id = Column(
         Integer,
-        ForeignKey(f"{Entity.__tablename__}.id"),
+        ForeignKey(Entity.id),
         primary_key=True,
     )
     entity = relationship(Entity, backref=backref("accessions", uselist=True))
 
     public_repository_id = Column(
         Integer,
-        ForeignKey(f"{PublicRepository.__tablename__}.id"),
+        ForeignKey(PublicRepository.id),
         primary_key=True,
     )
     public_repository = relationship(

--- a/src/py/aspen/database/models/cansee.py
+++ b/src/py/aspen/database/models/cansee.py
@@ -35,15 +35,11 @@ class CanSee(idbase):
 
     __tablename__ = "can_see"
 
-    viewer_group_id = Column(
-        Integer, ForeignKey(f"{Group.__tablename__}.id"), nullable=False
-    )
+    viewer_group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     viewer_group = relationship(
         Group, backref=backref("can_see", uselist=True), foreign_keys=[viewer_group_id]
     )
-    owner_group_id = Column(
-        Integer, ForeignKey(f"{Group.__tablename__}.id"), nullable=False
-    )
+    owner_group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     owner_group = relationship(
         Group,
         backref=backref("can_be_seen_by", uselist=True),
@@ -51,6 +47,6 @@ class CanSee(idbase):
     )
     data_type = Column(
         Enum(DataType),
-        ForeignKey(f"{_DataTypeTable.__tablename__}.item_id"),
+        ForeignKey(_DataTypeTable.item_id),
         nullable=False,
     )

--- a/src/py/aspen/database/models/entity.py
+++ b/src/py/aspen/database/models/entity.py
@@ -34,7 +34,7 @@ class Entity(idbase):
     __tablename__ = "entities"
     entity_type = Column(
         Enum(EntityType),
-        ForeignKey(f"{_EntityTypeTable.__tablename__}.item_id"),
+        ForeignKey(_EntityTypeTable.item_id),
         nullable=False,
     )
 

--- a/src/py/aspen/database/models/physical_sample.py
+++ b/src/py/aspen/database/models/physical_sample.py
@@ -21,7 +21,7 @@ class PhysicalSample(idbase):
 
     submitting_group_id = Column(
         Integer,
-        ForeignKey(f"{Group.__tablename__}.id"),
+        ForeignKey(Group.id),
         nullable=False,
     )
     submitting_group = relationship(

--- a/src/py/aspen/database/models/usergroup.py
+++ b/src/py/aspen/database/models/usergroup.py
@@ -28,7 +28,7 @@ class User(idbase):
     group_admin = Column(Boolean, nullable=False)
     system_admin = Column(Boolean, nullable=False)
 
-    group_id = Column(Integer, ForeignKey(f"{Group.__tablename__}.id"), nullable=False)
+    group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     group = relationship(Group, backref=backref("users", uselist=True))
 
     def __repr__(self):

--- a/src/py/aspen/database/models/workflow.py
+++ b/src/py/aspen/database/models/workflow.py
@@ -32,13 +32,13 @@ _WorkflowTypeTable = enumtables.EnumTable(
 _workflow_inputs_table = Table(
     "workflow_inputs",
     base.metadata,
-    Column("entity_id", ForeignKey(f"{Entity.__tablename__}.id"), primary_key=True),
+    Column("entity_id", ForeignKey(Entity.id), primary_key=True),
     Column("workflow_id", ForeignKey(f"{_WORKFLOW_TABLENAME}.id"), primary_key=True),
 )
 _workflow_outputs_table = Table(
     "workflow_outputs",
     base.metadata,
-    Column("entity_id", ForeignKey(f"{Entity.__tablename__}.id"), primary_key=True),
+    Column("entity_id", ForeignKey(Entity.id), primary_key=True),
     Column("workflow_id", ForeignKey(f"{_WORKFLOW_TABLENAME}.id"), primary_key=True),
 )
 
@@ -52,7 +52,7 @@ class Workflow(idbase):
 
     workflow_type = Column(
         Enum(WorkflowType),
-        ForeignKey(f"{_WorkflowTypeTable.__tablename__}.item_id"),
+        ForeignKey(_WorkflowTypeTable.item_id),
         nullable=False,
     )
     __mapper_args__: Mapping[str, Union[WorkflowType, Column]] = {


### PR DESCRIPTION
### Description
Strings are fickle and can easily be broken.  TableObject.ColumnObject is more durable.

Depends on #77 

### Test plan
Autogenerated a migration and verified that the migration was empty (this is essentially a no-op).
