### PR TITLE
Rework the relationship between workflows and entities.

### DIFF
--- a/database_migrations/versions/20210210_232422_update_the_relationship_between_.py
+++ b/database_migrations/versions/20210210_232422_update_the_relationship_between_.py
@@ -1,0 +1,61 @@
+"""update the relationship between entities and workflows
+
+Revision ID: 20210210_232422
+Revises: 20210210_134341
+Create Date: 2021-02-10 23:24:23.837672
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210210_232422"
+down_revision = "20210210_134341"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("workflow_outputs", schema="aspen")
+    op.add_column(
+        "entities",
+        sa.Column("producing_workflow_id", sa.Integer(), nullable=True),
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        op.f("fk_entities_producing_workflow_id_workflows"),
+        "entities",
+        "workflows",
+        ["producing_workflow_id"],
+        ["id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_entities_producing_workflow_id_workflows"),
+        "entities",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.drop_column("entities", "producing_workflow_id", schema="aspen")
+    op.create_table(
+        "workflow_outputs",
+        sa.Column("entity_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("workflow_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["entity_id"],
+            ["aspen.entities.id"],
+            name="fk_workflow_outputs_entity_id_entities",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["aspen.workflows.id"],
+            name="fk_workflow_outputs_workflow_id_workflows",
+        ),
+        sa.PrimaryKeyConstraint("entity_id", "workflow_id", name="pk_workflow_outputs"),
+        schema="aspen",
+    )

--- a/docs/backend/schema.ddl
+++ b/docs/backend/schema.ddl
@@ -109,6 +109,7 @@ Table PhysicalSample {
 
 Table Entity {
   id INT [pk, increment]
+  producing_workflow_id INT [ref: > Workflow.id]
 }
 
 Table WorkflowType {
@@ -125,15 +126,6 @@ Table Workflow {
 }
 
 Table WorkflowInputs {
-  entity_id INT [not null, ref: > Entity.id]
-  workflow_id INT [not null, ref: > Workflow.id]
-
-  Indexes {
-    (entity_id, workflow_id) [unique]
-  }
-}
-
-Table WorkflowOutputs {
   entity_id INT [not null, ref: > Entity.id]
   workflow_id INT [not null, ref: > Workflow.id]
 

--- a/src/py/aspen/database/models/workflow.py
+++ b/src/py/aspen/database/models/workflow.py
@@ -1,15 +1,13 @@
 import enum
-from typing import Mapping, Union
+from typing import Mapping, MutableSequence, Union
 
 import enumtables
 from sqlalchemy import Column, DateTime, ForeignKey, JSON, Table
 from sqlalchemy.orm import relationship
 
 from .base import base, idbase
-from .entity import Entity
+from .entity import _WORKFLOW_TABLENAME, Entity
 from .enum import Enum
-
-_WORKFLOW_TABLENAME = "workflows"  # need this for a forward reference.
 
 
 class WorkflowType(enum.Enum):
@@ -31,12 +29,6 @@ _WorkflowTypeTable = enumtables.EnumTable(
 
 _workflow_inputs_table = Table(
     "workflow_inputs",
-    base.metadata,
-    Column("entity_id", ForeignKey(Entity.id), primary_key=True),
-    Column("workflow_id", ForeignKey(f"{_WORKFLOW_TABLENAME}.id"), primary_key=True),
-)
-_workflow_outputs_table = Table(
-    "workflow_outputs",
     base.metadata,
     Column("entity_id", ForeignKey(Entity.id), primary_key=True),
     Column("workflow_id", ForeignKey(f"{_WORKFLOW_TABLENAME}.id"), primary_key=True),
@@ -75,10 +67,7 @@ class Workflow(idbase):
     inputs = relationship(
         Entity,
         secondary=_workflow_inputs_table,
-        backref="workflow_consumers",
+        backref="consuming_workflows",
+        uselist=True,
     )
-    outputs = relationship(
-        Entity,
-        secondary=_workflow_outputs_table,
-        backref="workflow_producers",
-    )
+    outputs: MutableSequence[Entity]


### PR DESCRIPTION
### Description
The key changes is that only one workflow is considered to ever be responsible for creating an entity.  If more than one workflow contributes to an entity, we should have separate entities to represent them.

Added a method to easily traverse between entities and its parents (entities that feed into the workflow that creates the entity in question) and children (entities that result from workflows that consume the entity in question).

### Test plan
used in next PR
