### PR TITLE
Helper methods to simplify going from raw gisaid dump <-> processed gisaid dump

### DIFF
--- a/src/py/aspen/database/models/tests/test_gisaid_models.py
+++ b/src/py/aspen/database/models/tests/test_gisaid_models.py
@@ -57,3 +57,6 @@ def test_workflow(session):
     assert returned_workflow.inputs[0].id == raw_gisaid_dump.id
     assert len(returned_workflow.outputs) == 1
     assert returned_workflow.outputs[0].id == processed_gisaid_dump.id
+
+    assert processed_gisaid_dump.raw_gisaid_dump == raw_gisaid_dump
+    assert processed_gisaid_dump in raw_gisaid_dump.processed_gisaid_dump


### PR DESCRIPTION
### Description
Using the `get_parents()` and `get_children()` methods, build an easy way for a raw gisaid dump to find processed gisaid dumps and vice versa.

Depends on #81 

### Test plan
wrote a test that explores the relationship
