### PR TITLE
Remove stats from Bam that aren't appropriate

### DIFF
--- a/docs/backend/schema.ddl
+++ b/docs/backend/schema.ddl
@@ -256,10 +256,6 @@ Table Bam {
 
   // statistics from the consensus genome pipeline.
   sequencing_depth FLOAT [not null]
-  library_insert_size INT [not null]
-  num_base_pairs INT [not null]
-  mean_contig_length FLOAT [not null]
-  N50 INT [not null]
 
   s3_bucket VARCHAR [not null]
   s3_key VARCHAR [not null, unique]


### PR DESCRIPTION
Sorry I let this slip by in an earlier PR I was slow to review (https://github.com/chanzuckerberg/aspen/pull/53/files) and may have provided bad advice on.

I think these stats don't really make sense:

- `library_insert_size` should typically be known at time of lib prep/sequencing so would be more appropriate on the `SequencingReads` object. But I'm not sure it's worth the hurdle of asking people to submit it. Also depending on the type of library prep it might be a single int, or it might have a broader expected distribution.
  - The mean observed insert size (a float) can be computed from the Bam, and is indeed a useful statistic, but it's not actually something we're outputting routinely in our current pipeline, though maybe we should. But since we're not outputting it currently, I suggest we just drop it from the schema.
- `num_base_pairs` again this should be on the Fastq, not the Bam, and would require doing some computation on the fastq file -- just counting, but not sure this extra computation at processing time is really worth it.
- `mean_contig_length`, `N50` -- these statistics are appropriate for de novo assembly -- but we're doing alignment to a reference so not so appropriate here (we're not really generating contigs).