### PR TITLE
Normalize the singular/plural

### DIFF
--- a/database_migrations/versions/20210222_220412_rename_sequencing_reads_tables.py
+++ b/database_migrations/versions/20210222_220412_rename_sequencing_reads_tables.py
@@ -1,0 +1,89 @@
+"""rename *sequencing_reads tables
+
+Revision ID: 20210222_220412
+Revises: 20210218_164249
+Create Date: 2021-02-22 22:04:14.173048
+
+"""
+import enumtables  # noqa: F401
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210222_220412"
+down_revision = "20210218_164249"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table(
+        "sequencing_reads",
+        "sequencing_read_collections",
+        schema="aspen",
+    )
+    op.rename_table(
+        "host_filtered_sequencing_reads",
+        "host_filtered_sequencing_read_collections",
+        schema="aspen",
+    )
+    op.drop_constraint(
+        "uq_host_filtered_sequencing_reads_s3_bucket",
+        "host_filtered_sequencing_read_collections",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_host_filtered_sequencing_read_collections_s3_bucket"),
+        "host_filtered_sequencing_read_collections",
+        ["s3_bucket", "s3_key"],
+        schema="aspen",
+    )
+    op.drop_constraint(
+        "uq_sequencing_reads_s3_bucket",
+        "sequencing_read_collections",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_sequencing_read_collections_s3_bucket"),
+        "sequencing_read_collections",
+        ["s3_bucket", "s3_key"],
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("uq_sequencing_read_collections_s3_bucket"),
+        "sequencing_read_collections",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_sequencing_reads_s3_bucket",
+        "sequencing_read_collections",
+        ["s3_bucket", "s3_key"],
+        schema="aspen",
+    )
+    op.drop_constraint(
+        op.f("uq_host_filtered_sequencing_read_collections_s3_bucket"),
+        "host_filtered_sequencing_read_collections",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_host_filtered_sequencing_reads_s3_bucket",
+        "host_filtered_sequencing_read_collections",
+        ["s3_bucket", "s3_key"],
+        schema="aspen",
+    )
+    op.rename_table(
+        "sequencing_read_collections",
+        "sequencing_reads",
+        schema="aspen",
+    )
+    op.rename_table(
+        "host_filtered_sequencing_read_collections",
+        "host_filtered_sequencing_reads",
+        schema="aspen",
+    )

--- a/docs/backend/schema.ddl
+++ b/docs/backend/schema.ddl
@@ -148,7 +148,7 @@ Table SequencingProtocol {
 
 // describes a single set of sequence data from the sequencer. (FASTQ)
 // these should be replaced by the `HostFilteredSequenceRead` as soon as it is available so we are not storing any host reads
-Table SequencingReads {
+Table SequencingReadCollection {
   id INT [pk, increment]
   entity_id INT [not null, unique, ref: - Entity.id]
 
@@ -200,7 +200,7 @@ Table CalledPathogenGenome {
 
 // TODO: @jackkamm do the BAM/SRA records need to store any metrics?
 
-Table HostFilteredSequenceRead {
+Table HostFilteredSequenceReadCollection {
   id INT [pk, increment]
   entity_id INT [not null, unique, ref: - Entity.id]
 

--- a/src/py/aspen/database/models/__init__.py
+++ b/src/py/aspen/database/models/__init__.py
@@ -8,14 +8,17 @@ from .gisaid_dump import (  # noqa: F401
     ProcessedGisaidDump,
     RawGisaidDump,
 )
-from .host_filtering import FilterRead, HostFilteredSequencingRead  # noqa: F401
+from .host_filtering import (  # noqa: F401
+    FilterRead,
+    HostFilteredSequencingReadCollection,
+)
 from .sample import Sample  # noqa: F401
 from .sequences import (  # noqa: F401
     CallConsensus,
     CalledPathogenGenome,
     SequencingInstrumentType,
     SequencingProtocolType,
-    SequencingReads,
+    SequencingReadCollection,
     UploadedPathogenGenome,
 )
 from .usergroup import Group, User  # noqa: F401

--- a/src/py/aspen/database/models/gisaid_dump.py
+++ b/src/py/aspen/database/models/gisaid_dump.py
@@ -21,7 +21,7 @@ class RawGisaidDump(Entity):
     __mapper_args__ = {"polymorphic_identity": EntityType.RAW_GISAID_DUMP}
 
     @property
-    def processed_gisaid_dump(self) -> Sequence[ProcessedGisaidDump]:
+    def processed_gisaid_dumps(self) -> Sequence[ProcessedGisaidDump]:
         """A sequence of processed gisaid dumps generated from this raw gisaid dump."""
         results: MutableSequence[ProcessedGisaidDump] = list()
         for workflow, entities in self.get_children(ProcessedGisaidDump):

--- a/src/py/aspen/database/models/host_filtering.py
+++ b/src/py/aspen/database/models/host_filtering.py
@@ -4,8 +4,8 @@ from .entity import Entity, EntityType
 from .workflow import Workflow, WorkflowType
 
 
-class HostFilteredSequencingRead(Entity):
-    __tablename__ = "host_filtered_sequencing_reads"
+class HostFilteredSequencingReadCollection(Entity):
+    __tablename__ = "host_filtered_sequencing_read_collections"
     __table_args__ = (UniqueConstraint("s3_bucket", "s3_key"),)
     __mapper_args__ = {"polymorphic_identity": EntityType.HOST_FILTERED_SEQUENCE_READS}
 

--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -84,8 +84,8 @@ _SequencingProtocolTypeTable = enumtables.EnumTable(
 )
 
 
-class SequencingReads(Entity):
-    __tablename__ = "sequencing_reads"
+class SequencingReadCollection(Entity):
+    __tablename__ = "sequencing_read_collections"
     __table_args__ = (UniqueConstraint("s3_bucket", "s3_key"),)
     __mapper_args__ = {"polymorphic_identity": EntityType.SEQUENCING_READS}
 

--- a/src/py/aspen/database/models/tests/test_gisaid_models.py
+++ b/src/py/aspen/database/models/tests/test_gisaid_models.py
@@ -59,4 +59,4 @@ def test_workflow(session):
     assert returned_workflow.outputs[0].id == processed_gisaid_dump.id
 
     assert processed_gisaid_dump.raw_gisaid_dump == raw_gisaid_dump
-    assert processed_gisaid_dump in raw_gisaid_dump.processed_gisaid_dump
+    assert processed_gisaid_dump in raw_gisaid_dump.processed_gisaid_dumps

--- a/src/py/aspen/database/models/tests/test_sequences.py
+++ b/src/py/aspen/database/models/tests/test_sequences.py
@@ -4,7 +4,7 @@ from ..sample import Sample
 from ..sequences import (
     SequencingInstrumentType,
     SequencingProtocolType,
-    SequencingReads,
+    SequencingReadCollection,
     UploadedPathogenGenome,
 )
 from ..usergroup import Group
@@ -25,7 +25,7 @@ def test_sequencing_reads(session):
         country="USA",
         organism="SARS-CoV-2",
     )
-    sequencing_reads = SequencingReads(
+    sequencing_reads = SequencingReadCollection(
         sample=sample,
         sequencing_instrument=SequencingInstrumentType.ILLUMINA_GENOME_ANALYZER_IIX,
         sequencing_protocol=SequencingProtocolType.ARTIC_V3,


### PR DESCRIPTION
### Description
1. `processed_gisaid_dump` should be `processed_gisaid_dumps` because it returns a sequence.
2. Make all the python entities singular (i.e., `SequencingRead`).

#### Issue
[ch64743](https://app.clubhouse.io/genepi/stories/space/64743)

### Test plan
GA
