### PR TITLE
Add documentation for pathogen genome statistics

### DIFF
--- a/database_migrations/versions/20214716_114729_update_statistics_for_pathogen_genome.py
+++ b/database_migrations/versions/20214716_114729_update_statistics_for_pathogen_genome.py
@@ -1,0 +1,75 @@
+"""update statistics for pathogen genome
+
+Revision ID: 20214716_114729
+Revises: 20210212_100928
+Create Date: 2021-02-16 11:47:30.766109
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20214716_114729"
+down_revision = "20210212_100928"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "pathogen_genomes",
+        "num_n",
+        new_column_name="num_missing_alleles",
+        existing_type=sa.INTEGER(),
+        comment="Number of sites with N, the missing allele, typically indicating low depth",
+        existing_nullable=False,
+        schema="aspen",
+    )
+    op.alter_column(
+        "pathogen_genomes",
+        "num_mixed",
+        existing_type=sa.INTEGER(),
+        comment="Number of sites with an ambiguous allele, e.g. M, K, Y, etc., indicating support for 2 or more alleles in the reads.",
+        existing_nullable=False,
+        schema="aspen",
+    )
+    op.alter_column(
+        "pathogen_genomes",
+        "num_unambiguous_sites",
+        existing_type=sa.INTEGER(),
+        comment="Number of sites with allele A, C, T, or G",
+        existing_nullable=False,
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "pathogen_genomes",
+        "num_missing_alleles",
+        new_column_name="num_n",
+        existing_type=sa.INTEGER(),
+        comment=None,
+        existing_comment="Number of sites with N, the missing allele, typically indicating low depth",
+        existing_nullable=False,
+        schema="aspen",
+    )
+    op.alter_column(
+        "pathogen_genomes",
+        "num_unambiguous_sites",
+        existing_type=sa.INTEGER(),
+        comment=None,
+        existing_comment="Number of sites with allele A, C, T, or G",
+        existing_nullable=False,
+        schema="aspen",
+    )
+    op.alter_column(
+        "pathogen_genomes",
+        "num_mixed",
+        existing_type=sa.INTEGER(),
+        comment=None,
+        existing_comment="Number of sites with an ambiguous allele, e.g. M, K, Y, etc., indicating support for 2 or more alleles in the reads.",
+        existing_nullable=False,
+        schema="aspen",
+    )

--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -120,7 +120,8 @@ class PathogenGenome(Entity):
     # Number of sites with allele A, C, T, or G
     num_unambiguous_sites = Column(Integer, nullable=False)
 
-    # Number of sites with N, the missing allele
+    # Number of sites with N, the missing allele, typically indicating
+    # low depth
     num_n = Column(Integer, nullable=False)
 
     # Number of sites with an ambiguous allele, e.g. M, K, Y,etc.,

--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -116,8 +116,15 @@ class PathogenGenome(Entity):
     sequence = Column(String, nullable=False)
 
     # statistics for the pathogen genome
+
+    # Number of sites with allele A, C, T, or G
     num_unambiguous_sites = Column(Integer, nullable=False)
+
+    # Number of sites with N, the missing allele
     num_n = Column(Integer, nullable=False)
+
+    # Number of sites with an ambiguous allele, e.g. M, K, Y,etc.,
+    # indicating support for 2 or more alleles in the reads.
     num_mixed = Column(Integer, nullable=False)
 
 

--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -117,16 +117,27 @@ class PathogenGenome(Entity):
 
     # statistics for the pathogen genome
 
-    # Number of sites with allele A, C, T, or G
-    num_unambiguous_sites = Column(Integer, nullable=False)
+    num_unambiguous_sites = Column(
+        Integer, nullable=False, comment="Number of sites with allele A, C, T, or G"
+    )
 
-    # Number of sites with N, the missing allele, typically indicating
-    # low depth
-    num_n = Column(Integer, nullable=False)
+    num_missing_alleles = Column(
+        Integer,
+        nullable=False,
+        comment=(
+            "Number of sites with N, the missing allele,"
+            " typically indicating low depth"
+        ),
+    )
 
-    # Number of sites with an ambiguous allele, e.g. M, K, Y,etc.,
-    # indicating support for 2 or more alleles in the reads.
-    num_mixed = Column(Integer, nullable=False)
+    num_mixed = Column(
+        Integer,
+        nullable=False,
+        comment=(
+            "Number of sites with an ambiguous allele, e.g. M, K, Y, etc.,"
+            " indicating support for 2 or more alleles in the reads."
+        ),
+    )
 
 
 class UploadedPathogenGenome(PathogenGenome):

--- a/src/py/aspen/database/models/tests/test_sequences.py
+++ b/src/py/aspen/database/models/tests/test_sequences.py
@@ -57,7 +57,7 @@ def test_uploaded_pathogen_genome(session):
         physical_sample=physical_sample,
         sequence="GAGAGACTCTCT",
         num_unambiguous_sites=8,
-        num_n=2,
+        num_missing_alleles=2,
         num_mixed=2,
     )
 


### PR DESCRIPTION
At request of https://github.com/chanzuckerberg/aspen/pull/76#discussion_r574857286, here is documentation for fields in PathogenGenome, in the form of comments.

As an aside, I think `num_n` might be clearer as `num_missing_alleles`, but don't have the time to run a proper migration now.
