### PR TITLE
Use date instead of datetime

### DIFF
--- a/database_migrations/versions/20210218_164249_change_some_dates_to_a_date_instead_of_.py
+++ b/database_migrations/versions/20210218_164249_change_some_dates_to_a_date_instead_of_.py
@@ -1,0 +1,46 @@
+"""change some dates to a date instead of a datetime
+
+Revision ID: 20210218_164249
+Revises: 20210212_105950
+Create Date: 2021-02-18 16:42:50.891582
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210218_164249"
+down_revision = "20210212_105950"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "samples",
+        "collection_date",
+        type_=sa.DATE(),
+        schema="aspen",
+    )
+    op.alter_column(
+        "sequencing_reads",
+        "sequencing_date",
+        type_=sa.DATE(),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "samples",
+        "collection_date",
+        type_=sa.DATETIME(),
+        schema="aspen",
+    )
+    op.alter_column(
+        "sequencing_reads",
+        "sequencing_date",
+        type_=sa.DATETIME(),
+        schema="aspen",
+    )

--- a/docs/backend/schema.ddl
+++ b/docs/backend/schema.ddl
@@ -63,7 +63,7 @@ Table Sample {
   sample_collector_contact_address VARCHAR                 // maps to sample_collector_contact_address
   authors JSONB
 
-  collection_date DATETIME [not null]                      // maps to sample_collection_date
+  collection_date DATE [not null]                          // maps to sample_collection_date
   location VARCHAR [not null]
   division VARCHAR [not null]                              // maps to geo_loc_name_state_province_region
   country VARCHAR [not null]                               // maps to geo_loc_name_country
@@ -160,7 +160,7 @@ Table SequencingReads {
   sequencing_protocol_id INT [not null, ref: > SequencingProtocol.id]
 
   // sequencing date is optional, but sample collection date should not be.
-  sequencing_date FLOAT
+  sequencing_date DATE
 
   Indexes {
     (s3_bucket, s3_key) [unique]

--- a/src/py/aspen/database/models/sample.py
+++ b/src/py/aspen/database/models/sample.py
@@ -1,6 +1,6 @@
 from sqlalchemy import (
     Column,
-    DateTime,
+    Date,
     ForeignKey,
     Integer,
     JSON,
@@ -86,7 +86,7 @@ class Sample(idbase):
     )
 
     collection_date = Column(
-        DateTime,
+        Date,
         nullable=False,
         info={
             "schema_mappings": {

--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -3,7 +3,7 @@ import enum
 import enumtables
 from sqlalchemy import (
     Column,
-    DateTime,
+    Date,
     Float,
     ForeignKey,
     Integer,
@@ -107,7 +107,7 @@ class SequencingReads(Entity):
     s3_bucket = Column(String, nullable=False)
     s3_key = Column(String, nullable=False)
 
-    sequencing_date = Column(DateTime)
+    sequencing_date = Column(Date)
 
 
 class PathogenGenome(Entity):


### PR DESCRIPTION
### Description
datetime is probably too much precision, and introduces wonky timezone issues.  Simplify by changing them to `DATE`.

Depends on #62 

### Test plan
Run migration, check the db.
