### PR TITLE
Fix accessions, sequencing_reads, and uploaded_pathogen_genomes

### DIFF
--- a/database_migrations/versions/20210218_211316_fix_accessions_sequencing_reads_and_.py
+++ b/database_migrations/versions/20210218_211316_fix_accessions_sequencing_reads_and_.py
@@ -1,0 +1,76 @@
+"""fix accessions, sequencing_reads, and uploaded_pathogen_genome
+
+Revision ID: 20210218_211316
+Revises: 20210224_105823
+Create Date: 2021-02-18 21:13:17.850532
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210218_211316"
+down_revision = "20210224_105823"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        op.f("pk_accessions"),
+        "accessions",
+        schema="aspen",
+        type_="primary",
+    )
+    op.add_column(
+        "accessions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        schema="aspen",
+    )
+    op.create_primary_key(
+        op.f("pk_accessions"),
+        "accessions",
+        ["id"],
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        op.f("uq_sequencing_reads_collections_sample_id"),
+        "sequencing_reads_collections",
+        ["sample_id"],
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        op.f("uq_uploaded_pathogen_genomes_sample_id"),
+        "uploaded_pathogen_genomes",
+        ["sample_id"],
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("uq_uploaded_pathogen_genomes_sample_id"),
+        "uploaded_pathogen_genomes",
+        schema="aspen",
+        type_="unique",
+    )
+    op.drop_constraint(
+        op.f("uq_sequencing_reads_collections_sample_id"),
+        "sequencing_reads_collections",
+        schema="aspen",
+        type_="unique",
+    )
+    op.drop_constraint(
+        op.f("pk_accessions"),
+        "accessions",
+        schema="aspen",
+        type_="primary",
+    )
+    op.drop_column("accessions", "id", schema="aspen")
+    op.create_primary_key(
+        op.f("pk_accessions"),
+        "accessions",
+        ["entity_id", "public_repository_id"],
+        schema="aspen",
+    )

--- a/src/py/aspen/database/models/accessions.py
+++ b/src/py/aspen/database/models/accessions.py
@@ -37,7 +37,7 @@ class PublicRepository(idbase):
     website = Column(String, nullable=False, unique=True)
 
 
-class Accession(base):
+class Accession(idbase):
     """A single accession of an entity."""
 
     __tablename__ = "accessions"
@@ -46,7 +46,7 @@ class Accession(base):
     entity_id = Column(
         Integer,
         ForeignKey(Entity.id),
-        primary_key=True,
+        nullable=False,
     )
     entity = relationship(Entity, backref=backref("accessions", uselist=True))
 

--- a/src/py/aspen/database/models/sample.py
+++ b/src/py/aspen/database/models/sample.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
 from sqlalchemy import (
     Column,
     Date,
@@ -14,6 +18,9 @@ from sqlalchemy.orm import backref, relationship
 from .base import idbase
 from .mixins import DictMixin
 from .usergroup import Group
+
+if TYPE_CHECKING:
+    from .sequences import SequencingReadsCollection, UploadedPathogenGenome
 
 
 class Sample(idbase, DictMixin):
@@ -157,3 +164,6 @@ class Sample(idbase, DictMixin):
             }
         },
     )
+
+    sequencing_reads: Optional[SequencingReadsCollection]
+    uploaded_pathogen_genome: Optional[UploadedPathogenGenome]

--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -97,8 +97,11 @@ class SequencingReadsCollection(Entity, DictMixin):
     __mapper_args__ = {"polymorphic_identity": EntityType.SEQUENCING_READS}
 
     entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)
-    sample_id = Column(Integer, ForeignKey(Sample.id), nullable=False)
-    sample = relationship(Sample, backref=backref("sequencing_reads_collection"))
+    sample_id = Column(Integer, ForeignKey(Sample.id), unique=True, nullable=False)
+    sample = relationship(
+        Sample,
+        backref=backref("sequencing_reads_collection", uselist=False),
+    )
 
     sequencing_instrument = Column(
         Enum(SequencingInstrumentType),
@@ -170,8 +173,11 @@ class UploadedPathogenGenome(PathogenGenome):
     pathogen_genome_id = Column(
         Integer, ForeignKey(PathogenGenome.entity_id), primary_key=True
     )
-    sample_id = Column(Integer, ForeignKey(Sample.id), nullable=False)
-    sample = relationship(Sample, backref=backref("uploaded_pathogen_genome"))
+    sample_id = Column(Integer, ForeignKey(Sample.id), unique=True, nullable=False)
+    sample = relationship(
+        Sample,
+        backref=backref("uploaded_pathogen_genome", uselist=False),
+    )
 
     sequencing_depth = Column(Float)
 


### PR DESCRIPTION
### Description
Added a migration to handle the change.

1. There should only be one UploadedPathogenGenome _OR_ SequencingReads per Sample.
2. There can be more than one accession per sample id.

Depends on #110 

### Test plan
ran migration forwards and backwards.
