### PR TITLE
Allow for multiple staging environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ aspen% . .venv/bin/activate
 
 ```bash
 (.venv) aspen% npm --prefix src/ts start
+(.venv) aspen% export AWS_REGION=us-west-2
 (.venv) aspen% export FLASK_APP=aspen.app
 (.venv) aspen% export FLASK_ENV=development
 (.venv) aspen% cd src/py

--- a/src/py/aspen/app.py
+++ b/src/py/aspen/app.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from authlib.integrations.flask_client import OAuth
 from flask import Flask, redirect, send_from_directory, session, url_for
 
-from aspen.config import DevelopmentConfig
+from aspen.config import DevelopmentConfig, StagingConfig
 
 static_folder = Path("static")
 
@@ -15,6 +15,8 @@ application = Flask(__name__, static_folder=str(static_folder))
 
 if os.environ.get("FLASK_ENV") == "development":
     application.config.from_object(DevelopmentConfig())
+if os.environ.get("FLASK_ENV") == "staging":
+    application.config.from_object(StagingConfig())
 
 auth0_config = application.config["AUTH0_CONFIG"]
 oauth = OAuth(application)

--- a/src/py/aspen/aws/__init__.py
+++ b/src/py/aspen/aws/__init__.py
@@ -1,0 +1,3 @@
+from . import elasticbeanstalk  # noqa: F401
+from ._region import region  # noqa: F401
+from ._session import session  # noqa: F401

--- a/src/py/aspen/aws/_region.py
+++ b/src/py/aspen/aws/_region.py
@@ -1,0 +1,5 @@
+import os
+
+
+def region():
+    return os.environ.get("AWS_REGION")

--- a/src/py/aspen/aws/_session.py
+++ b/src/py/aspen/aws/_session.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+from boto3 import Session
+
+from ._region import region
+
+_session: Optional[Session] = None
+
+
+def session() -> Session:
+    global _session
+
+    if _session is None:
+        _session = Session(region_name=region())
+
+    return _session

--- a/src/py/aspen/aws/elasticbeanstalk.py
+++ b/src/py/aspen/aws/elasticbeanstalk.py
@@ -1,0 +1,43 @@
+from typing import Dict, MutableSequence, Sequence
+
+from ._session import session
+
+
+def _get_tags() -> Sequence[Dict]:
+    """Get all the EC2 tags attached to this instance."""
+    results: MutableSequence[Dict] = list()
+    nexttoken = None
+    client = session().client(service_name="ec2")
+
+    while True:
+        kwargs: Dict = {}
+        if nexttoken is not None:
+            kwargs["NextToken"] = nexttoken
+        response = client.describe_tags(**kwargs)
+        results.extend(response["Tags"])
+        nexttoken = response.get("NextToken", None)
+        if nexttoken is None:
+            break
+
+    return results
+
+
+def _get_environment_name() -> str:
+    """Get all Elastic Beanstalk environment name."""
+    tags = _get_tags()
+
+    for tag in tags:
+        if (
+            tag["Key"] == "elasticbeanstalk:environment-name"
+            and tag["ResourceType"] == "instance"
+        ):
+            return tag["Value"]
+    else:
+        raise ValueError("Unable to find environment name")
+
+
+def get_environment_suffix(prefix: str = "aspen-") -> str:
+    """Get all Elastic Beanstalk environment name, excluding the aspen- prefix."""
+    name = _get_environment_name()
+    assert name.startswith(prefix)
+    return name[len(prefix) :]

--- a/src/py/aspen/config/__init__.py
+++ b/src/py/aspen/config/__init__.py
@@ -1,3 +1,4 @@
 from .development import DevelopmentConfig  # noqa: F401
 from .production import ProductionConfig  # noqa: F401
+from .staging import StagingConfig  # noqa: F401
 from .testing import TestingConfig  # noqa: F401

--- a/src/py/aspen/config/staging.py
+++ b/src/py/aspen/config/staging.py
@@ -1,9 +1,14 @@
+import logging
 import uuid
+
+from aspen import aws
 
 from .config import Auth0Config, Config, DatabaseConfig
 
+logger = logging.getLogger(__name__)
 
-class DevelopmentConfig(Config, descriptive_name="dev"):
+
+class StagingConfig(Config, descriptive_name="staging"):
     @property
     def DEBUG(self):
         return True
@@ -14,14 +19,14 @@ class DevelopmentConfig(Config, descriptive_name="dev"):
 
     @property
     def DATABASE_CONFIG(self):
-        return DevelopmentDatabaseConfig()
+        return StagingDatabaseConfig()
 
     @property
     def AUTH0_CONFIG(self):
-        return DevAuth0Config
+        return StagingAuth0Config()
 
 
-class DevelopmentDatabaseConfig(DatabaseConfig):
+class StagingDatabaseConfig(DatabaseConfig):
     @property
     def URI(self):
         return "postgresql://user_rw:password_rw@localhost:5432/aspen_db"
@@ -32,7 +37,11 @@ class DevelopmentDatabaseConfig(DatabaseConfig):
         return 0
 
 
-class DevAuth0Config(Auth0Config):
+class StagingAuth0Config(Auth0Config):
     @property
     def AUTH0_CALLBACK_URL(self):
-        return "http://localhost:3000/callback"
+        eb_env_name = aws.elasticbeanstalk.get_environment_suffix()
+        logger.info(f"DETECTED EB_ENV as {eb_env_name}")
+        return (
+            f"http://aspen-{eb_env_name}.{aws.region()}.elasticbeanstalk.com/callback"
+        )


### PR DESCRIPTION
### Description
Creates an easy-to-setup staging environment.  This allows developers to create arbitrary staging environments without setting up a new secret.  The callback URL is determined by extracting the Elastic Beanstalk environment name.  Note that this is actually dependent on the cname, but if all the instructions are followed, the cname should match the environment name.

Also updated docs to reflect the new setup.

### Test plan
1. Created and deployed to an AWS Elastic Beanstalk environment.
2. Run locally.
