### PR TITLE
Rearrange config objects

### DIFF
--- a/src/py/aspen/app.py
+++ b/src/py/aspen/app.py
@@ -26,16 +26,15 @@ if flask_env == "staging":
     application.config.from_object(StagingConfig())
 
 if flask_env in ("production", "development", "staging"):
-    auth0_config = application.config["AUTH0_CONFIG"]
     oauth = OAuth(application)
     auth0 = oauth.register(
         "auth0",
-        client_id=auth0_config.AUTH0_CLIENT_ID,
-        client_secret=auth0_config.AUTH0_CLIENT_SECRET,
-        api_base_url=auth0_config.AUTH0_BASE_URL,
-        access_token_url=auth0_config.ACCESS_TOKEN_URL,
-        authorize_url=auth0_config.AUTHORIZE_URL,
-        client_kwargs=auth0_config.CLIENT_KWARGS,
+        client_id=application.config["AUTH0_CLIENT_ID"],
+        client_secret=application.config["AUTH0_CLIENT_SECRET"],
+        api_base_url=application.config["AUTH0_BASE_URL"],
+        access_token_url=application.config["AUTH0_ACCESS_TOKEN_URL"],
+        authorize_url=application.config["AUTH0_AUTHORIZE_URL"],
+        client_kwargs=application.config["AUTH0_CLIENT_KWARGS"],
     )
 
 
@@ -81,7 +80,9 @@ def callback_handling():
 
 @application.route("/login")
 def login():
-    return auth0.authorize_redirect(redirect_uri=auth0_config.AUTH0_CALLBACK_URL)
+    return auth0.authorize_redirect(
+        redirect_uri=application.config["AUTH0_CALLBACK_URL"]
+    )
 
 
 @application.route("/logout")
@@ -91,7 +92,7 @@ def logout():
     # Redirect user to logout endpoint
     params = {
         "returnTo": url_for("serve", _external=True),
-        "client_id": auth0_config.AUTH0_CLIENT_ID,
+        "client_id": application.config["AUTH0_CLIENT_ID"],
     }
     return redirect(auth0.api_base_url + "/v2/logout?" + urlencode(params))
 

--- a/src/py/aspen/config/development.py
+++ b/src/py/aspen/config/development.py
@@ -1,48 +1,45 @@
 import uuid
 from functools import lru_cache
+from typing import Any, Mapping
 
 from ..database.connection import init_db, SqlAlchemyInterface
-from .config import Auth0Config, Config, DatabaseConfig
+from .config import Config, DatabaseConfig, SecretsConfig
 
 
 class DevelopmentConfig(Config, descriptive_name="dev"):
-    @property
-    def DEBUG(self):
-        return True
+    def __init__(self):
+        self.secretsconfig = SecretsConfig()
 
     @property
-    def SECRET_KEY(self):
-        return uuid.uuid4().hex
-
-    @property
-    def DATABASE_CONFIG(self):
+    def DATABASE_CONFIG(self) -> DatabaseConfig:
         return DevelopmentDatabaseConfig()
 
     @property
-    def AUTH0_CONFIG(self):
-        return DevAuth0Config()
+    def _AWS_SECRET(self) -> Mapping[str, Any]:
+        return self.secretsconfig.AWS_SECRET
+
+    @property
+    def DEBUG(self) -> bool:
+        return True
+
+    @property
+    def SECRET_KEY(self) -> str:
+        return uuid.uuid4().hex
+
+    @property
+    def AUTH0_CALLBACK_URL(self) -> str:
+        return "http://localhost:3000/callback"
 
 
 class DevelopmentDatabaseConfig(DatabaseConfig):
     @property
-    def URI(self):
+    def URI(self) -> str:
         return "postgresql://user_rw:password_rw@localhost:5432/aspen_db"
-
-    @property
-    def SEND_FILE_MAX_AGE_DEFAULT(self):
-        """Ensures that latest static assets are read during frontend dev work."""
-        return 0
 
     @lru_cache()
     def _INTERFACE(self) -> SqlAlchemyInterface:
         return init_db(self.URI)
 
     @property
-    def INTERFACE(self):
+    def INTERFACE(self) -> SqlAlchemyInterface:
         return self._INTERFACE()
-
-
-class DevAuth0Config(Auth0Config):
-    @property
-    def AUTH0_CALLBACK_URL(self):
-        return "http://localhost:3000/callback"

--- a/src/py/aspen/config/production.py
+++ b/src/py/aspen/config/production.py
@@ -1,8 +1,29 @@
-from .config import Config, DatabaseConfig
+import uuid
+from typing import Any, Mapping
+
+from .config import Config, DatabaseConfig, SecretsConfig
 
 
 class ProductionConfig(Config, descriptive_name="prod"):
-    ...
+    def __init__(self):
+        self.secretsconfig = SecretsConfig()
+
+    @property
+    def _AWS_SECRET(self) -> Mapping[str, Any]:
+        return self.secretsconfig.AWS_SECRET
+
+    @property
+    def DATABASE_CONFIG(self) -> DatabaseConfig:
+        return ProductionDatabaseConfig()
+
+    @property
+    def SECRET_KEY(self) -> str:
+        return uuid.uuid4().hex
+
+    @property
+    def AUTH0_CALLBACK_URL(self) -> str:
+        # TODO: this needs a realistic value.
+        return ""
 
 
 class ProductionDatabaseConfig(DatabaseConfig):

--- a/src/py/aspen/config/staging.py
+++ b/src/py/aspen/config/staging.py
@@ -1,47 +1,44 @@
 import logging
 import uuid
+from typing import Any, Mapping
 
 from aspen import aws
 
-from .config import Auth0Config, Config, DatabaseConfig
+from .config import Config, DatabaseConfig, SecretsConfig
 
 logger = logging.getLogger(__name__)
 
 
 class StagingConfig(Config, descriptive_name="staging"):
-    @property
-    def DEBUG(self):
-        return True
+    def __init__(self):
+        self.secretsconfig = SecretsConfig()
 
     @property
-    def SECRET_KEY(self):
-        return uuid.uuid4().hex
+    def _AWS_SECRET(self) -> Mapping[str, Any]:
+        return self.secretsconfig.AWS_SECRET
 
     @property
-    def DATABASE_CONFIG(self):
+    def DATABASE_CONFIG(self) -> DatabaseConfig:
         return StagingDatabaseConfig()
 
     @property
-    def AUTH0_CONFIG(self):
-        return StagingAuth0Config()
-
-
-class StagingDatabaseConfig(DatabaseConfig):
-    @property
-    def URI(self):
-        return "postgresql://user_rw:password_rw@localhost:5432/aspen_db"
+    def DEBUG(self) -> bool:
+        return True
 
     @property
-    def SEND_FILE_MAX_AGE_DEFAULT(self):
-        """Ensures that latest static assets are read during frontend dev work."""
-        return 0
+    def SECRET_KEY(self) -> str:
+        return uuid.uuid4().hex
 
-
-class StagingAuth0Config(Auth0Config):
     @property
-    def AUTH0_CALLBACK_URL(self):
+    def AUTH0_CALLBACK_URL(self) -> str:
         eb_env_name = aws.elasticbeanstalk.get_environment_suffix()
         logger.info(f"DETECTED EB_ENV as {eb_env_name}")
         return (
             f"http://aspen-{eb_env_name}.{aws.region()}.elasticbeanstalk.com/callback"
         )
+
+
+class StagingDatabaseConfig(DatabaseConfig):
+    @property
+    def URI(self) -> str:
+        return "postgresql://user_rw:password_rw@localhost:5432/aspen_db"

--- a/src/py/aspen/config/testing.py
+++ b/src/py/aspen/config/testing.py
@@ -1,5 +1,6 @@
 import uuid
 from functools import lru_cache
+from typing import Any, Mapping
 
 from ..database.connection import init_db, SqlAlchemyInterface
 from .config import Config, DatabaseConfig
@@ -7,16 +8,28 @@ from .config import Config, DatabaseConfig
 
 class TestingConfig(Config, descriptive_name="test"):
     @property
-    def SECRET_KEY(self):
-        return uuid.uuid4().hex
+    def _AWS_SECRET(self) -> Mapping[str, Any]:
+        return {
+            "AUTH0_DOMAIN": None,
+            "AUTH0_CLIENT_ID": None,
+            "AUTH0_CLIENT_SECRET": None,
+        }
+
+    @property
+    def DATABASE_CONFIG(self):
+        return TestingDatabaseConfig()
 
     @property
     def TESTING(self):
         return True
 
     @property
-    def DATABASE_CONFIG(self):
-        return TestingDatabaseConfig()
+    def SECRET_KEY(self):
+        return uuid.uuid4().hex
+
+    @property
+    def AUTH0_CALLBACK_URL(self):
+        return None
 
 
 class TestingDatabaseConfig(DatabaseConfig):


### PR DESCRIPTION
### Description
Move most config objects to the top level.  Maintain two second-level config objects:

1. One for holding and caching AWS secrets.  This is separate because we don't always want to trigger AWS secrets at app startup.
2. `DatabaseConfig`, which remains separate because not all fields are defined for every valid configuration.  Flask will retrieve all fields.

Depends on #104 

### Test plan
Deployed to Elastic Beanstalk, and verified I can log in.
