### PR TITLE
refactor flask app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: PYTHONPATH=$(pwd)/src/py/:$(pwd)/third-party/sqlalchemy-enum-tables/ gunicorn --bind localhost:8000 --workers 1 --threads 15 aspen.app
+web: PYTHONPATH=$(pwd)/src/py/:$(pwd)/third-party/sqlalchemy-enum-tables/ gunicorn --bind localhost:8000 --workers 1 --threads 15 aspen.main

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ aspen% . .venv/bin/activate
 ```bash
 (.venv) aspen% npm --prefix src/ts start
 (.venv) aspen% export AWS_REGION=us-west-2
-(.venv) aspen% export FLASK_APP=aspen.app
+(.venv) aspen% export FLASK_APP=aspen.main
 (.venv) aspen% export FLASK_ENV=development
 (.venv) aspen% cd src/py
 (.venv) aspen% flask run --host localhost --port 3000  # host and port needed for auth0

--- a/src/py/aspen/__main__.py
+++ b/src/py/aspen/__main__.py
@@ -1,4 +1,4 @@
-from .app import application
+from .main import application
 
 # Setting debug to True enables debug output. This line should be
 # removed before deploying a production app.

--- a/src/py/aspen/app/app.py
+++ b/src/py/aspen/app/app.py
@@ -1,0 +1,47 @@
+import os
+from functools import wraps
+from pathlib import Path
+
+from authlib.integrations.flask_client import OAuth
+from flask import Flask, redirect, session
+
+from aspen.config import DevelopmentConfig, ProductionConfig, StagingConfig
+
+static_folder = Path(__file__).parent.parent / "static"
+
+# EB looks for an 'application' callable by default.
+application = Flask(__name__, static_folder=str(static_folder))
+
+flask_env = os.environ.get("FLASK_ENV")
+if flask_env == "production":
+    application.config.from_object(ProductionConfig())
+elif flask_env == "development":
+    application.config.from_object(DevelopmentConfig())
+elif flask_env == "staging":
+    application.config.from_object(StagingConfig())
+
+if flask_env in ("production", "development", "staging"):
+    oauth = OAuth(application)
+    auth0 = oauth.register(
+        "auth0",
+        client_id=application.config["AUTH0_CLIENT_ID"],
+        client_secret=application.config["AUTH0_CLIENT_SECRET"],
+        api_base_url=application.config["AUTH0_BASE_URL"],
+        access_token_url=application.config["AUTH0_ACCESS_TOKEN_URL"],
+        authorize_url=application.config["AUTH0_AUTHORIZE_URL"],
+        client_kwargs=application.config["AUTH0_CLIENT_KWARGS"],
+    )
+else:
+    auth0 = None
+
+
+# use this to wrap protected views
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if "profile" not in session:
+            # Redirect to Login page
+            return redirect("/login")
+        return f(*args, **kwargs)
+
+    return decorated

--- a/src/py/aspen/app/views.py
+++ b/src/py/aspen/app/views.py
@@ -1,53 +1,12 @@
-import os
-from functools import wraps
 from pathlib import Path
 from urllib.parse import urlencode
 
-from authlib.integrations.flask_client import OAuth
-from flask import Flask, jsonify, redirect, send_from_directory, session, url_for
+from flask import jsonify, redirect, send_from_directory, session, url_for
 from sqlalchemy.orm import joinedload
 
-from aspen.config import DevelopmentConfig, ProductionConfig, StagingConfig
-
-from .database.connection import session_scope
-from .database.models.usergroup import User
-
-static_folder = Path("static")
-
-# EB looks for an 'application' callable by default.
-application = Flask(__name__, static_folder=str(static_folder))
-
-flask_env = os.environ.get("FLASK_ENV")
-if flask_env == "production":
-    application.config.from_object(ProductionConfig())
-if flask_env == "development":
-    application.config.from_object(DevelopmentConfig())
-if flask_env == "staging":
-    application.config.from_object(StagingConfig())
-
-if flask_env in ("production", "development", "staging"):
-    oauth = OAuth(application)
-    auth0 = oauth.register(
-        "auth0",
-        client_id=application.config["AUTH0_CLIENT_ID"],
-        client_secret=application.config["AUTH0_CLIENT_SECRET"],
-        api_base_url=application.config["AUTH0_BASE_URL"],
-        access_token_url=application.config["AUTH0_ACCESS_TOKEN_URL"],
-        authorize_url=application.config["AUTH0_AUTHORIZE_URL"],
-        client_kwargs=application.config["AUTH0_CLIENT_KWARGS"],
-    )
-
-
-# use this to wrap protected views
-def requires_auth(f):
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        if "profile" not in session:
-            # Redirect to Login page
-            return redirect("/login")
-        return f(*args, **kwargs)
-
-    return decorated
+from aspen.app.app import application, auth0, requires_auth
+from aspen.database.connection import session_scope
+from aspen.database.models.usergroup import User
 
 
 # Catch all routes. If path is a file, send the file;

--- a/src/py/aspen/main.py
+++ b/src/py/aspen/main.py
@@ -1,0 +1,4 @@
+# this is where flask finds the entry point for the application.
+
+from aspen.app import views  # noqa: F401
+from aspen.app.app import application  # noqa: F401

--- a/src/py/aspen/test_app/fixtures.py
+++ b/src/py/aspen/test_app/fixtures.py
@@ -1,7 +1,7 @@
 import pytest
 
-from aspen.app import application
 from aspen.config.testing import TestingConfig
+from aspen.main import application
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
### Description
Break up app.py into the flask app initialization and the routes.  In the long term, we will want to split up the routes into separate python modules and this simplifies that future step.

Depends on #107 

### Test plan
1. pytest
1. run locally
1. run on eb
