### PR TITLE
create an aspen app class

### DIFF
--- a/src/py/aspen/app/app.py
+++ b/src/py/aspen/app/app.py
@@ -1,35 +1,43 @@
 import os
 from functools import wraps
 from pathlib import Path
+from typing import Optional
 
 from authlib.integrations.flask_client import OAuth
-from flask import Flask, redirect, session
+from flask import redirect, session
 
-from aspen.config import DevelopmentConfig, ProductionConfig, StagingConfig
+from aspen.config import config, DevelopmentConfig, ProductionConfig, StagingConfig
+
+from .aspen_app import AspenApp
 
 static_folder = Path(__file__).parent.parent / "static"
 
 # EB looks for an 'application' callable by default.
-application = Flask(__name__, static_folder=str(static_folder))
-
 flask_env = os.environ.get("FLASK_ENV")
+aspen_config: Optional[config.Config]
 if flask_env == "production":
-    application.config.from_object(ProductionConfig())
+    aspen_config = ProductionConfig()
 elif flask_env == "development":
-    application.config.from_object(DevelopmentConfig())
+    aspen_config = DevelopmentConfig()
 elif flask_env == "staging":
-    application.config.from_object(StagingConfig())
+    aspen_config = StagingConfig()
+else:
+    aspen_config = None
+
+application = AspenApp(
+    __name__, static_folder=str(static_folder), aspen_config=aspen_config
+)
 
 if flask_env in ("production", "development", "staging"):
     oauth = OAuth(application)
     auth0 = oauth.register(
         "auth0",
-        client_id=application.config["AUTH0_CLIENT_ID"],
-        client_secret=application.config["AUTH0_CLIENT_SECRET"],
-        api_base_url=application.config["AUTH0_BASE_URL"],
-        access_token_url=application.config["AUTH0_ACCESS_TOKEN_URL"],
-        authorize_url=application.config["AUTH0_AUTHORIZE_URL"],
-        client_kwargs=application.config["AUTH0_CLIENT_KWARGS"],
+        client_id=application.aspen_config.AUTH0_CLIENT_ID,
+        client_secret=application.aspen_config.AUTH0_CLIENT_SECRET,
+        api_base_url=application.aspen_config.AUTH0_BASE_URL,
+        access_token_url=application.aspen_config.AUTH0_ACCESS_TOKEN_URL,
+        authorize_url=application.aspen_config.AUTH0_AUTHORIZE_URL,
+        client_kwargs=application.aspen_config.AUTH0_CLIENT_KWARGS,
     )
 else:
     auth0 = None

--- a/src/py/aspen/app/aspen_app.py
+++ b/src/py/aspen/app/aspen_app.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from flask import Flask
+
+from aspen.config.config import Config
+
+
+class AspenApp(Flask):
+    def __init__(self, *args, aspen_config: Optional[Config], **kwargs):
+        super().__init__(*args, **kwargs)
+        self._aspen_config = aspen_config
+        if self._aspen_config is not None:
+            self.config.from_object(self._aspen_config)
+
+    def _inject_config(self, aspen_config: Config):
+        self._aspen_config = aspen_config
+        self.config.from_object(aspen_config)
+
+    @property
+    def aspen_config(self) -> Config:
+        if self._aspen_config is None:
+            raise ValueError("aspen config not set")
+        return self._aspen_config

--- a/src/py/aspen/app/views.py
+++ b/src/py/aspen/app/views.py
@@ -40,7 +40,7 @@ def callback_handling():
 @application.route("/login")
 def login():
     return auth0.authorize_redirect(
-        redirect_uri=application.config["AUTH0_CALLBACK_URL"]
+        redirect_uri=application.aspen_config.AUTH0_CALLBACK_URL
     )
 
 
@@ -51,7 +51,7 @@ def logout():
     # Redirect user to logout endpoint
     params = {
         "returnTo": url_for("serve", _external=True),
-        "client_id": application.config["AUTH0_CLIENT_ID"],
+        "client_id": application.aspen_config.AUTH0_CLIENT_ID,
     }
     return redirect(auth0.api_base_url + "/v2/logout?" + urlencode(params))
 
@@ -59,7 +59,9 @@ def logout():
 @application.route("/api/usergroup", methods=["GET"])
 @requires_auth
 def usergroup():
-    with session_scope(application.config["DATABASE_CONFIG"].INTERFACE) as db_session:
+    with session_scope(
+        application.aspen_config.DATABASE_CONFIG.INTERFACE
+    ) as db_session:
         # since authentication is required to access view this information is guaranteed to be in session
         profile = session["profile"]
         user = (

--- a/src/py/aspen/config/testing.py
+++ b/src/py/aspen/config/testing.py
@@ -7,6 +7,9 @@ from .config import Config, DatabaseConfig
 
 
 class TestingConfig(Config, descriptive_name="test"):
+    def __init__(self, db_uri):
+        self.db_uri = db_uri
+
     @property
     def _AWS_SECRET(self) -> Mapping[str, Any]:
         return {
@@ -17,7 +20,7 @@ class TestingConfig(Config, descriptive_name="test"):
 
     @property
     def DATABASE_CONFIG(self):
-        return TestingDatabaseConfig()
+        return TestingDatabaseConfig(self.db_uri)
 
     @property
     def TESTING(self):
@@ -33,16 +36,12 @@ class TestingConfig(Config, descriptive_name="test"):
 
 
 class TestingDatabaseConfig(DatabaseConfig):
-    def __init__(self):
-        self._uri = None
+    def __init__(self, db_uri):
+        self.db_uri = db_uri
 
     @property
     def URI(self):
-        return self._uri
-
-    @URI.setter
-    def URI(self, uri):
-        self._uri = uri
+        return self.db_uri
 
     @lru_cache()
     def _INTERFACE(self) -> SqlAlchemyInterface:

--- a/src/py/aspen/test_app/fixtures.py
+++ b/src/py/aspen/test_app/fixtures.py
@@ -6,8 +6,7 @@ from aspen.main import application
 
 @pytest.fixture(scope="function")
 def app(postgres_database):
-    application.config.from_object(TestingConfig())
-    application.config["DATABASE_CONFIG"].URI = postgres_database.as_uri()
+    application._inject_config(TestingConfig(postgres_database.as_uri()))
     yield application
 
 


### PR DESCRIPTION
### Description
This has an explicit `aspen_config` object attached to it that we can reference, instead of reaching through the config.

Other globals such as db handles can also live in this aspen app class.

Depends on #113 

### Test plan
1. pytest
1. run locally
1. run on eb
