### PR TITLE
Add @flaskproperty decorator

### DIFF
--- a/src/py/aspen/app/aspen_app.py
+++ b/src/py/aspen/app/aspen_app.py
@@ -10,11 +10,11 @@ class AspenApp(Flask):
         super().__init__(*args, **kwargs)
         self._aspen_config = aspen_config
         if self._aspen_config is not None:
-            self.config.from_object(self._aspen_config)
+            self.config.from_mapping(**self._aspen_config.flask_properties())
 
     def _inject_config(self, aspen_config: Config):
         self._aspen_config = aspen_config
-        self.config.from_object(aspen_config)
+        self.config.from_mapping(**self._aspen_config.flask_properties())
 
     @property
     def aspen_config(self) -> Config:

--- a/src/py/aspen/app/views/sample.py
+++ b/src/py/aspen/app/views/sample.py
@@ -12,7 +12,9 @@ from aspen.database.models.usergroup import Group, User
 @requires_auth
 def samples():
 
-    with session_scope(application.config["DATABASE_CONFIG"].INTERFACE) as db_session:
+    with session_scope(
+        application.aspen_config.DATABASE_CONFIG.INTERFACE
+    ) as db_session:
         profile = session["profile"]
         sequencing_reads = (
             db_session.query(SequencingReadsCollection)

--- a/src/py/aspen/config/config.py
+++ b/src/py/aspen/config/config.py
@@ -5,15 +5,58 @@ import json
 import os
 from collections import MutableMapping
 from functools import lru_cache
-from typing import Any, Mapping, Type
+from typing import Any, Callable, Mapping, Optional, Set, Type, TypeVar, Union
 
 from botocore.exceptions import ClientError
 
 from aspen import aws
 from aspen.database.connection import SqlAlchemyInterface
 
+ConfigLike = TypeVar("ConfigLike", bound="Config")
+
+
+def flaskproperty(
+    original_method: Callable[[ConfigLike], Any]
+) -> Callable[[ConfigLike], Any]:
+    """Annotation to apply to a method to indicate that it is a property to be passed
+    to flask's config.
+
+    It should be applied to a method in a Config object, and it has to be co-equal in
+    rank to @abc.abstractmethod.  No annotation other than @abc.abstractmethod should
+    follow this one.
+
+    For example, both are acceptable:
+        @flaskproperty
+        @abc.abstractmethod
+        def DEBUG(self):
+            ...
+
+        @abc.abstractmethod
+        @flaskproperty
+        def DEBUG(self):
+            ...
+    """
+    original_method.__is_flaskproperty__ = True  # type: ignore
+    return original_method
+
+
+def _get_flaskproperty_names(obj: Union[Type[Config], Config]) -> Set[str]:
+    """Given a Config object or a Config class, return a collection of method names that
+    have the @flaskproperty annotation."""
+    result: Set[str] = set()
+    for attrib_name in dir(obj):
+        try:
+            attrib_value = getattr(obj, attrib_name)
+            if callable(attrib_value) and getattr(attrib_value, "__is_flaskproperty__"):
+                result.add(attrib_name)
+        except Exception:
+            continue
+
+    return result
+
 
 class Config:
+    _config_flask_properties: Optional[Set[str]] = None
     _subclasses: MutableMapping[str, Type[Config]] = dict()
 
     def __init_subclass__(cls: Type[Config], descriptive_name: str, *args, **kwargs):
@@ -22,9 +65,43 @@ class Config:
         super().__init_subclass__(*args, **kwargs)  # type: ignore
         Config._subclasses[descriptive_name] = cls
 
+        # get a list of @flaskproperties for Config and the subclass of Config, and
+        # compare to see if there are any attributes that were marked as
+        # @flaskproperty in Config but not in the subclass.
+        if Config._config_flask_properties is None:
+            Config._config_flask_properties = _get_flaskproperty_names(Config)
+        flask_properties = _get_flaskproperty_names(cls)
+
+        if not Config._config_flask_properties.issubset(flask_properties):
+            missing_properties = Config._config_flask_properties - flask_properties
+            missing_properties_string = ", ".join(missing_properties)
+            raise Exception(
+                f"Attributes ({missing_properties_string}) defined as flask properties"
+                f" in Config but not in {cls.__name__}"
+            )
+
     @classmethod
     def by_descriptive_name(cls, descriptive_name: str) -> Config:
         return Config._subclasses[descriptive_name]()
+
+    def flask_properties(self) -> Mapping[str, Any]:
+        """Get a mapping from method name to the value from calling the method, for all
+        the methods that are annotated as @flaskproperty."""
+        result: MutableMapping[str, Any] = dict()
+        for attrib_name in dir(self):
+            try:
+                attrib_value = getattr(self, attrib_name)
+                if not (
+                    callable(attrib_value)
+                    and getattr(attrib_value, "__is_flaskproperty__")
+                ):
+                    continue
+            except Exception:
+                continue
+            else:
+                result[attrib_name] = attrib_value()
+
+        return result
 
     ####################################################################################
     # secondary config objects.
@@ -40,16 +117,16 @@ class Config:
 
     ####################################################################################
     # flask properties
-    @property
+    @flaskproperty
     def DEBUG(self) -> bool:
         return False
 
-    @property
+    @flaskproperty
     @abc.abstractmethod
     def SECRET_KEY(self) -> str:
         raise NotImplementedError()
 
-    @property
+    @flaskproperty
     def TESTING(self) -> bool:
         return False
 

--- a/src/py/aspen/config/development.py
+++ b/src/py/aspen/config/development.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from typing import Any, Mapping
 
 from ..database.connection import init_db, SqlAlchemyInterface
-from .config import Config, DatabaseConfig, SecretsConfig
+from .config import Config, DatabaseConfig, flaskproperty, SecretsConfig
 
 
 class DevelopmentConfig(Config, descriptive_name="dev"):
@@ -18,11 +18,11 @@ class DevelopmentConfig(Config, descriptive_name="dev"):
     def _AWS_SECRET(self) -> Mapping[str, Any]:
         return self.secretsconfig.AWS_SECRET
 
-    @property
+    @flaskproperty
     def DEBUG(self) -> bool:
         return True
 
-    @property
+    @flaskproperty
     def SECRET_KEY(self) -> str:
         return uuid.uuid4().hex
 

--- a/src/py/aspen/config/production.py
+++ b/src/py/aspen/config/production.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any, Mapping
 
-from .config import Config, DatabaseConfig, SecretsConfig
+from .config import Config, DatabaseConfig, flaskproperty, SecretsConfig
 
 
 class ProductionConfig(Config, descriptive_name="prod"):
@@ -16,7 +16,7 @@ class ProductionConfig(Config, descriptive_name="prod"):
     def DATABASE_CONFIG(self) -> DatabaseConfig:
         return ProductionDatabaseConfig()
 
-    @property
+    @flaskproperty
     def SECRET_KEY(self) -> str:
         return uuid.uuid4().hex
 

--- a/src/py/aspen/config/staging.py
+++ b/src/py/aspen/config/staging.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping
 
 from aspen import aws
 
-from .config import Config, DatabaseConfig, SecretsConfig
+from .config import Config, DatabaseConfig, flaskproperty, SecretsConfig
 
 logger = logging.getLogger(__name__)
 
@@ -21,11 +21,11 @@ class StagingConfig(Config, descriptive_name="staging"):
     def DATABASE_CONFIG(self) -> DatabaseConfig:
         return StagingDatabaseConfig()
 
-    @property
+    @flaskproperty
     def DEBUG(self) -> bool:
         return True
 
-    @property
+    @flaskproperty
     def SECRET_KEY(self) -> str:
         return uuid.uuid4().hex
 

--- a/src/py/aspen/config/testing.py
+++ b/src/py/aspen/config/testing.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from typing import Any, Mapping
 
 from ..database.connection import init_db, SqlAlchemyInterface
-from .config import Config, DatabaseConfig
+from .config import Config, DatabaseConfig, flaskproperty
 
 
 class TestingConfig(Config, descriptive_name="test"):
@@ -22,11 +22,11 @@ class TestingConfig(Config, descriptive_name="test"):
     def DATABASE_CONFIG(self):
         return TestingDatabaseConfig(self.db_uri)
 
-    @property
+    @flaskproperty
     def TESTING(self):
         return True
 
-    @property
+    @flaskproperty
     def SECRET_KEY(self):
         return uuid.uuid4().hex
 

--- a/src/py/aspen/config/tests/test_config.py
+++ b/src/py/aspen/config/tests/test_config.py
@@ -1,0 +1,27 @@
+import pytest
+
+from aspen.app.aspen_app import AspenApp
+
+from ..config import Config
+from ..testing import TestingConfig
+
+
+def test_subclass_not_flaskproperty():
+    """Subclass Config, and fail to annotate a property that is a @flaskproperty."""
+    with pytest.raises(Exception):
+
+        class FakeConfig(Config, descriptive_name="fake_config"):
+            def DEBUG(self) -> bool:
+                return True
+
+
+def test_flaskproperty_from_testconfig(app: AspenApp):
+    """Grab the flask properties from TestingConfig, and ensure that we get a reasonable
+    list of them."""
+    test_config = app.aspen_config
+    assert isinstance(test_config, TestingConfig)
+    props = test_config.flask_properties()
+    assert len(props) == 3
+    assert "DEBUG" in props
+    assert "SECRET_KEY" in props
+    assert "TESTING" in props


### PR DESCRIPTION
### Description
Only fields decorated as such are fed into flask's flask.config.from_* method.  This allows us to collapse all the config objects!

Depends on #114 

### Test plan
1. pytest
1. run locally
1. run on eb
