### PR TITLE
add workflow status, start/end times for workflows, and fix repository_type column

### DIFF
--- a/database_migrations/versions/20210225_162252_add_workflow_status_start_end_times_for_.py
+++ b/database_migrations/versions/20210225_162252_add_workflow_status_start_end_times_for_.py
@@ -1,0 +1,137 @@
+"""add workflow status, start/end times for workflows, and fix repository_type column
+
+Create Date: 2021-02-25 16:22:54.468221
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20210225_162252"
+down_revision = "20210218_211316"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "workflow_status_types",
+        sa.Column("item_id", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("item_id", name=op.f("pk_workflow_status_types")),
+        schema="aspen",
+    )
+    op.alter_column(
+        "public_repository",
+        "entity_type",
+        new_column_name="repository_type",
+        existing_type=enumtables.enum_column.EnumType(),
+        existing_nullable=False,
+        schema="aspen",
+    )
+    op.drop_constraint(
+        "fk_public_repository_entity_type_public_repository_types",
+        "public_repository",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk_public_repository_repository_type_public_repository_types"),
+        "public_repository",
+        "public_repository_types",
+        ["repository_type"],
+        ["item_id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+    op.add_column(
+        "workflows",
+        sa.Column(
+            "end_datetime",
+            sa.DateTime(),
+            nullable=True,
+            comment="datetime when the workflow is ended.  this is only valid when the workflow's status is COMPLETED.",
+        ),
+        schema="aspen",
+    )
+    op.add_column(
+        "workflows",
+        sa.Column(
+            "start_datetime",
+            sa.DateTime(),
+            nullable=False,
+            comment="datetime when the workflow is started.",
+        ),
+        schema="aspen",
+    )
+    op.add_column(
+        "workflows",
+        sa.Column(
+            "workflow_status",
+            enumtables.enum_column.EnumType(),
+            nullable=False,
+        ),
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        op.f("fk_workflows_workflow_status_workflow_status_types"),
+        "workflows",
+        "workflow_status_types",
+        ["workflow_status"],
+        ["item_id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+    op.drop_column("workflows", "run_date", schema="aspen")
+    op.enum_insert(
+        "workflow_status_types",
+        ["STARTED", "FAILED", "COMPLETED"],
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.add_column(
+        "workflows",
+        sa.Column(
+            "run_date",
+            postgresql.TIMESTAMP(),
+            autoincrement=False,
+            nullable=False,
+        ),
+        schema="aspen",
+    )
+    op.drop_constraint(
+        op.f("fk_workflows_workflow_status_workflow_status_types"),
+        "workflows",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.drop_column("workflows", "workflow_status", schema="aspen")
+    op.drop_column("workflows", "start_datetime", schema="aspen")
+    op.drop_column("workflows", "end_datetime", schema="aspen")
+    op.alter_column(
+        "public_repository",
+        "repository_type",
+        new_column_name="entity_type",
+        existing_type=enumtables.enum_column.EnumType(),
+        existing_nullable=False,
+        schema="aspen",
+    )
+    op.drop_constraint(
+        op.f("fk_public_repository_repository_type_public_repository_types"),
+        "public_repository",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_public_repository_entity_type_public_repository_types",
+        "public_repository",
+        "public_repository_types",
+        ["entity_type"],
+        ["item_id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+    op.drop_table("workflow_status_types", schema="aspen")

--- a/src/py/aspen/database/models/accessions.py
+++ b/src/py/aspen/database/models/accessions.py
@@ -27,7 +27,7 @@ class PublicRepository(idbase):
     """A public repository for genetic or epidemiology data."""
 
     __tablename__ = "public_repository"
-    entity_type = Column(
+    repository_type = Column(
         Enum(PublicRepositoryType),
         ForeignKey(_PublicRepositoryTypeTable.item_id),
         nullable=False,

--- a/src/py/aspen/database/models/tests/test_gisaid_models.py
+++ b/src/py/aspen/database/models/tests/test_gisaid_models.py
@@ -6,6 +6,7 @@ from aspen.database.models.gisaid_dump import (
     ProcessedGisaidDump,
     RawGisaidDump,
 )
+from aspen.database.models.workflow import WorkflowStatusType
 
 
 def test_workflow(session):
@@ -15,7 +16,7 @@ def test_workflow(session):
     download_s3_key = "download_key"
     processed_s3_bucket = "processed_bucket"
     processed_s3_key = "processed_key"
-    run_date = datetime.now()
+    start_datetime = datetime.now()
     software_versions = {"test": "v0.0.1"}
     raw_gisaid_dump = RawGisaidDump(
         download_date=download_date,
@@ -29,7 +30,8 @@ def test_workflow(session):
     )
 
     workflow = GisaidDumpWorkflow(
-        run_date=run_date,
+        start_datetime=start_datetime,
+        workflow_status=WorkflowStatusType.STARTED,
         software_versions=software_versions,
         inputs=[raw_gisaid_dump],
         outputs=[processed_gisaid_dump],

--- a/src/py/aspen/database/models/workflow.py
+++ b/src/py/aspen/database/models/workflow.py
@@ -27,6 +27,21 @@ _WorkflowTypeTable = enumtables.EnumTable(
 )
 
 
+class WorkflowStatusType(enum.Enum):
+    STARTED = "STARTED"
+    FAILED = "FAILED"
+    COMPLETED = "COMPLETED"
+
+
+# Create the enumeration table
+# Pass your enum class and the SQLAlchemy declarative base to enumtables.EnumTable
+_WorkflowStatusTypeTable = enumtables.EnumTable(
+    WorkflowStatusType,
+    base,
+    tablename="workflow_status_types",
+)
+
+
 _workflow_inputs_table = Table(
     "workflow_inputs",
     base.metadata,
@@ -51,10 +66,21 @@ class Workflow(idbase):
         "polymorphic_on": workflow_type
     }
 
-    run_date = Column(
+    start_datetime = Column(
+        DateTime, nullable=False, comment="datetime when the workflow is started."
+    )
+    end_datetime = Column(
         DateTime,
+        nullable=True,
+        comment="datetime when the workflow is ended.  this is only valid when the workflow's status is COMPLETED.",
+    )
+
+    workflow_status = Column(
+        Enum(WorkflowStatusType),
+        ForeignKey(_WorkflowStatusTypeTable.item_id),
         nullable=False,
     )
+
     software_versions = Column(
         JSON,
         nullable=False,


### PR DESCRIPTION
### Description
#### Accessions:
- Rename entity_type to repository_type (copy pasta probably)

#### Workflows:
- Add a status field
- Explode run_date to start_datetime and end_datetime

### Test plan
upgraded migration, downgraded, upgraded, and downgraded.
