### PR TITLE
Fetch samples for table from API

### DIFF
--- a/src/ts/src/App.tsx
+++ b/src/ts/src/App.tsx
@@ -1,31 +1,24 @@
 import React, { FunctionComponent, useState, useEffect } from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
-import axios from "axios";
+
+import { fetchUserData } from "common/api";
 
 import Data from "data";
-
 import Landing from "Landing";
 import NavBar from "NavBar";
 
 import style from "App.module.scss";
 
+const App: FunctionComponent = () => {
 
-const fetchUserData = async () => {
-    const response = await axios.get("/api/usergroup");
-    return response.data;
-};
-
-
-const App: FunctionComponent<React.ReactNode> = () => {
-
-    const [user, setUser] = useState();
-    const [org, setOrg] = useState();
+    const [user, setUser] = useState<string | undefined>();
+    const [org, setOrg] = useState<string | undefined>();
 
     useEffect(() => {
         const setUserData = async () => {
-            const usergroup = await fetchUserData();
-            setUser(usergroup.user.name);
-            setOrg(usergroup.group.name);
+            const response = await fetchUserData();
+            setUser(response.user.name);
+            setOrg(response.group.name);
         };
         setUserData();
     }, []);

--- a/src/ts/src/App.tsx
+++ b/src/ts/src/App.tsx
@@ -10,7 +10,6 @@ import NavBar from "NavBar";
 import style from "App.module.scss";
 
 const App: FunctionComponent = () => {
-
     const [user, setUser] = useState<string | undefined>();
     const [org, setOrg] = useState<string | undefined>();
 
@@ -27,7 +26,7 @@ const App: FunctionComponent = () => {
         <Router>
             <div className={style.app}>
                 <div className={style.navBar}>
-                    <NavBar org={org} user={user}/>
+                    <NavBar org={org} user={user} />
                 </div>
                 <div className={style.view}>
                     <Switch>

--- a/src/ts/src/NavBar.tsx
+++ b/src/ts/src/NavBar.tsx
@@ -25,7 +25,6 @@ const DROPDOWN_LINKS: Array<Record<string, string>> = [
 ];
 
 const NavBar: FunctionComponent<Props> = ({ org, user }: Props) => {
-
     const navigationLinks = LINKS.map((link) => {
         return (
             <Link to={link.to} key={link.text}>

--- a/src/ts/src/common/api/index.tsx
+++ b/src/ts/src/common/api/index.tsx
@@ -1,0 +1,36 @@
+// refactor as needed
+import axios from "axios";
+
+const USER_MAP = new Map<string, keyof User>([
+    ["auth0_user_id", "auth0UserId"],
+    ["group_admin", "groupAdmin"],
+    ["system_admin", "systemAdmin"]
+])
+export const fetchUserData = async () => {
+    const response = await axios.get("/api/usergroup");
+    const group: Group = response.data.group as Group
+    const user: User = Object.fromEntries(
+        Object.keys(response.data.user).map(key => {
+            return [USER_MAP.get(key), response.data.user[key]]
+        })
+    )
+    return { group, user }
+};
+
+const SAMPLE_MAP = new Map<string, keyof Sample>([
+    ["collection_date", "collectionDate"],
+    ["collection_location", "collectionLocation"],
+    ["private_identifier", "privateID"],
+    ["public_identifier", "publicID"],
+    ["upload_date", "uploadDate"]
+])
+export const fetchSamples = async () => {
+    const response = await axios.get("/api/samples");
+    const samples: Array<Sample> = response.data.map((entry: Record<string, any>) => Object.fromEntries(
+            Object.keys(entry).map(key => {
+                return [SAMPLE_MAP.get(key), entry[key]]
+            })
+        )
+    )
+    return samples;
+}

--- a/src/ts/src/common/api/index.tsx
+++ b/src/ts/src/common/api/index.tsx
@@ -1,7 +1,7 @@
 // refactor as needed
 import axios from "axios";
 
-import { jsonToType } from "common/utils"
+import { jsonToType } from "common/utils";
 
 const USER_MAP = new Map<string, keyof User>([
     ["auth0_user_id", "auth0UserId"],
@@ -13,7 +13,7 @@ export const fetchUserData = async (): Promise<
 > => {
     const response = await axios.get("/api/usergroup");
     const group = response.data.group as Group;
-    const user = jsonToType<User>(response.data.user, USER_MAP)
+    const user = jsonToType<User>(response.data.user, USER_MAP);
     return { group, user };
 };
 
@@ -26,6 +26,8 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
 ]);
 export const fetchSamples = async (): Promise<Array<Sample>> => {
     const response = await axios.get("/api/samples");
-    const samples: Array<Sample> = response.data.map((entry: Record<string, string>) => jsonToType<Sample>(entry, SAMPLE_MAP));
+    const samples: Array<Sample> = response.data.map(
+        (entry: Record<string, string>) => jsonToType<Sample>(entry, SAMPLE_MAP)
+    );
     return samples;
 };

--- a/src/ts/src/common/api/index.tsx
+++ b/src/ts/src/common/api/index.tsx
@@ -4,17 +4,19 @@ import axios from "axios";
 const USER_MAP = new Map<string, keyof User>([
     ["auth0_user_id", "auth0UserId"],
     ["group_admin", "groupAdmin"],
-    ["system_admin", "systemAdmin"]
-])
-export const fetchUserData = async () => {
+    ["system_admin", "systemAdmin"],
+]);
+export const fetchUserData = async (): Promise<
+    Record<string, Group | User>
+> => {
     const response = await axios.get("/api/usergroup");
-    const group: Group = response.data.group as Group
+    const group: Group = response.data.group as Group;
     const user: User = Object.fromEntries(
-        Object.keys(response.data.user).map(key => {
-            return [USER_MAP.get(key), response.data.user[key]]
+        Object.keys(response.data.user).map((key) => {
+            return [USER_MAP.get(key), response.data.user[key]];
         })
-    )
-    return { group, user }
+    );
+    return { group, user };
 };
 
 const SAMPLE_MAP = new Map<string, keyof Sample>([
@@ -22,15 +24,17 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
     ["collection_location", "collectionLocation"],
     ["private_identifier", "privateID"],
     ["public_identifier", "publicID"],
-    ["upload_date", "uploadDate"]
-])
-export const fetchSamples = async () => {
+    ["upload_date", "uploadDate"],
+]);
+export const fetchSamples = async (): Promise<Array<Sample>> => {
     const response = await axios.get("/api/samples");
-    const samples: Array<Sample> = response.data.map((entry: Record<string, any>) => Object.fromEntries(
-            Object.keys(entry).map(key => {
-                return [SAMPLE_MAP.get(key), entry[key]]
-            })
-        )
-    )
+    const samples: Array<Sample> = response.data.map(
+        (entry: Record<string, string>) =>
+            Object.fromEntries(
+                Object.keys(entry).map((key) => {
+                    return [SAMPLE_MAP.get(key), entry[key]];
+                })
+            )
+    );
     return samples;
-}
+};

--- a/src/ts/src/common/api/index.tsx
+++ b/src/ts/src/common/api/index.tsx
@@ -1,6 +1,8 @@
 // refactor as needed
 import axios from "axios";
 
+import { jsonToType } from "common/utils"
+
 const USER_MAP = new Map<string, keyof User>([
     ["auth0_user_id", "auth0UserId"],
     ["group_admin", "groupAdmin"],
@@ -10,12 +12,8 @@ export const fetchUserData = async (): Promise<
     Record<string, Group | User>
 > => {
     const response = await axios.get("/api/usergroup");
-    const group: Group = response.data.group as Group;
-    const user: User = Object.fromEntries(
-        Object.keys(response.data.user).map((key) => {
-            return [USER_MAP.get(key), response.data.user[key]];
-        })
-    );
+    const group = response.data.group as Group;
+    const user = jsonToType<User>(response.data.user, USER_MAP)
     return { group, user };
 };
 
@@ -28,13 +26,6 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
 ]);
 export const fetchSamples = async (): Promise<Array<Sample>> => {
     const response = await axios.get("/api/samples");
-    const samples: Array<Sample> = response.data.map(
-        (entry: Record<string, string>) =>
-            Object.fromEntries(
-                Object.keys(entry).map((key) => {
-                    return [SAMPLE_MAP.get(key), entry[key]];
-                })
-            )
-    );
+    const samples: Array<Sample> = response.data.map((entry: Record<string, string>) => jsonToType<Sample>(entry, SAMPLE_MAP));
     return samples;
 };

--- a/src/ts/src/common/types/bioinformatics.d.ts
+++ b/src/ts/src/common/types/bioinformatics.d.ts
@@ -14,14 +14,14 @@ type Project = {
     name: string;
 };
 
-type Sample = {
-    id: number;
-    privateId: string;
-    publicId: string;
-    uploadDate: string;
-    collectionDate: string;
-    collectionLocation: string;
-    gisaid?: string;
+interface Sample {
+    [index: string]: string,
+    privateId: string,
+    publicId: string,
+    uploadDate: string,
+    collectionDate: string,
+    collectionLocation: string,
+    gisaid?: string
 };
 
 type Tree = {

--- a/src/ts/src/common/types/bioinformatics.d.ts
+++ b/src/ts/src/common/types/bioinformatics.d.ts
@@ -15,14 +15,14 @@ type Project = {
 };
 
 interface Sample {
-    [index: string]: string,
-    privateId: string,
-    publicId: string,
-    uploadDate: string,
-    collectionDate: string,
-    collectionLocation: string,
-    gisaid?: string
-};
+    [index: string]: string;
+    privateId: string;
+    publicId: string;
+    uploadDate: string;
+    collectionDate: string;
+    collectionLocation: string;
+    gisaid?: string;
+}
 
 type Tree = {
     id: number;

--- a/src/ts/src/common/types/user.d.ts
+++ b/src/ts/src/common/types/user.d.ts
@@ -1,0 +1,22 @@
+/// <reference types="node" />
+/// <reference types="react" />
+/// <reference types="react-dom" />
+
+interface Group {
+    [index: string]: string
+    address: string,
+    email: string,
+    id: number,
+    name: string
+}
+
+interface User {
+    [index: string]: number | string | boolean
+    auth0UserId: string,
+    email: string,
+    groupAdmin: boolean,
+    groupId: number,
+    id: number,
+    name: string,
+    systemAdmin: boolean
+}

--- a/src/ts/src/common/types/user.d.ts
+++ b/src/ts/src/common/types/user.d.ts
@@ -3,20 +3,20 @@
 /// <reference types="react-dom" />
 
 interface Group {
-    [index: string]: string
-    address: string,
-    email: string,
-    id: number,
-    name: string
+    [index: string]: string;
+    address: string;
+    email: string;
+    id: number;
+    name: string;
 }
 
 interface User {
-    [index: string]: number | string | boolean
-    auth0UserId: string,
-    email: string,
-    groupAdmin: boolean,
-    groupId: number,
-    id: number,
-    name: string,
-    systemAdmin: boolean
+    [index: string]: number | string | boolean;
+    auth0UserId: string;
+    email: string;
+    groupAdmin: boolean;
+    groupId: number;
+    id: number;
+    name: string;
+    systemAdmin: boolean;
 }

--- a/src/ts/src/common/utils/typeUtils.tsx
+++ b/src/ts/src/common/utils/typeUtils.tsx
@@ -4,3 +4,15 @@
 export function get<T, K extends keyof T>(o: T, propertyName: K): T[K] {
     return o[propertyName]; // o[propertyName] is of type T[K]
 }
+
+export function jsonToType<T>(inputObject: Record<string, any>, keyMap: Map<string, keyof T>): T {
+    const entries: Array<Array<any>> = []
+    Object.keys(inputObject).forEach(key => {
+        if (keyMap.has(key)) {
+            entries.push([keyMap.get(key), inputObject[key]])
+        } else {
+            entries.push([key, inputObject[key]])
+        }
+    })
+    return Object.fromEntries(entries)
+}

--- a/src/ts/src/common/utils/typeUtils.tsx
+++ b/src/ts/src/common/utils/typeUtils.tsx
@@ -1,6 +1,6 @@
 // credit: Typescript documentation, src
 // https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types
 // gets a property from an object.
-export function get<T, K extends keyof T>(o: T, propertyName: K){
-  return o[propertyName]; // o[propertyName] is of type T[K]
+export function get<T, K extends keyof T>(o: T, propertyName: K): T[K] {
+    return o[propertyName]; // o[propertyName] is of type T[K]
 }

--- a/src/ts/src/common/utils/typeUtils.tsx
+++ b/src/ts/src/common/utils/typeUtils.tsx
@@ -5,14 +5,17 @@ export function get<T, K extends keyof T>(o: T, propertyName: K): T[K] {
     return o[propertyName]; // o[propertyName] is of type T[K]
 }
 
-export function jsonToType<T>(inputObject: Record<string, any>, keyMap: Map<string, keyof T>): T {
-    const entries: Array<Array<any>> = []
-    Object.keys(inputObject).forEach(key => {
+export function jsonToType<T>(
+    inputObject: Record<string, any>,
+    keyMap: Map<string, keyof T>
+): T {
+    const entries: Array<Array<string | number | boolean>> = [];
+    Object.keys(inputObject).forEach((key) => {
         if (keyMap.has(key)) {
-            entries.push([keyMap.get(key), inputObject[key]])
+            entries.push([keyMap.get(key), inputObject[key]]);
         } else {
-            entries.push([key, inputObject[key]])
+            entries.push([key, inputObject[key]]);
         }
-    })
-    return Object.fromEntries(entries)
+    });
+    return Object.fromEntries(entries);
 }

--- a/src/ts/src/data/index.tsx
+++ b/src/ts/src/data/index.tsx
@@ -15,7 +15,7 @@ const Data: FunctionComponent = () => {
     useEffect(() => {
         const setSampleData = async () => {
             const apiSamples = await fetchSamples();
-            setSamples(apiSamples)
+            setSamples(apiSamples);
         };
         setSampleData();
     }, []);
@@ -27,7 +27,7 @@ const Data: FunctionComponent = () => {
             to: "/data/samples",
             text: "Samples",
             data: samples,
-            jsx: <Samples data={samples}/>,
+            jsx: <Samples data={samples} />,
         },
         {
             to: "/data/phylogenetic_trees",
@@ -65,7 +65,7 @@ const Data: FunctionComponent = () => {
         );
     });
 
-    console.log(samples)
+    console.log(samples);
 
     return (
         <div className={style.dataRoot}>

--- a/src/ts/src/data/index.tsx
+++ b/src/ts/src/data/index.tsx
@@ -65,8 +65,6 @@ const Data: FunctionComponent = () => {
         );
     });
 
-    console.log(samples);
-
     return (
         <div className={style.dataRoot}>
             <div className={style.navigation}>

--- a/src/ts/src/data/index.tsx
+++ b/src/ts/src/data/index.tsx
@@ -1,20 +1,25 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useState, useEffect } from "react";
 import { Switch, Route, Link, Redirect } from "react-router-dom";
 import { Menu } from "semantic-ui-react";
+
+import { fetchSamples } from "common/api";
 
 import Samples from "./samples";
 
 import style from "./index.module.scss";
 
-type Props = {
-    samples?: Array<Sample>;
-    trees?: Array<Tree>;
-};
+const Data: FunctionComponent = () => {
+    const [samples, setSamples] = useState<Array<Sample>>([]);
+    const [trees, setTrees] = useState<Array<Tree>>([]);
 
-const Data: FunctionComponent<Props> = ({
-    samples = [],
-    trees = [],
-}: Props) => {
+    useEffect(() => {
+        const setSampleData = async () => {
+            const apiSamples = await fetchSamples();
+            setSamples(apiSamples)
+        };
+        setSampleData();
+    }, []);
+
     // this constant is inside the component so we can associate
     // each category with its respective variable.
     const dataCategories = [
@@ -22,13 +27,13 @@ const Data: FunctionComponent<Props> = ({
             to: "/data/samples",
             text: "Samples",
             data: samples,
-            component: <Samples />,
+            jsx: <Samples data={samples}/>,
         },
         {
             to: "/data/phylogenetic_trees",
             text: "Phylogenetic Trees",
             data: trees,
-            component: undefined,
+            jsx: <div>Phylogenetic Trees</div>,
         },
     ];
 
@@ -51,22 +56,16 @@ const Data: FunctionComponent<Props> = ({
             </Link>
         );
 
-        const categoryView: () => JSX.Element = () => {
-            if (category.component === undefined) {
-                return <div>{category.text}</div>;
-            } else {
-                return category.component;
-            }
-        };
-
         dataJSX.routes.push(
             <Route
                 path={category.to}
                 key={category.text}
-                render={categoryView}
+                render={() => category.jsx}
             />
         );
     });
+
+    console.log(samples)
 
     return (
         <div className={style.dataRoot}>

--- a/src/ts/src/data/samples/index.tsx
+++ b/src/ts/src/data/samples/index.tsx
@@ -1,8 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Table } from "semantic-ui-react";
 
-import { get } from "common/utils";
-
 import style from "./index.module.scss";
 
 type Props = {
@@ -10,8 +8,8 @@ type Props = {
 };
 
 interface Headers {
-    text: string,
-    key: keyof Sample
+    text: string;
+    key: keyof Sample;
 }
 
 const TABLE_HEADERS: Array<Headers> = [
@@ -23,7 +21,7 @@ const TABLE_HEADERS: Array<Headers> = [
     { text: "GISAID", key: "gisaid" },
 ];
 
-const UNDEFINED_TEXT = "---"
+const UNDEFINED_TEXT = "---";
 
 // const dummySamples: Array<Sample> = [
 //     {
@@ -53,15 +51,15 @@ const Samples: FunctionComponent<Props> = ({ data = [] }: Props) => {
 
     const sampleRow = (sample: Sample): Array<JSX.Element> => {
         return TABLE_HEADERS.map((column) => {
-            let displayData = sample[column.key]
+            let displayData = sample[column.key];
             if (displayData === undefined) {
-                displayData = UNDEFINED_TEXT
+                displayData = UNDEFINED_TEXT;
             }
             return (
                 <Table.Cell key={`${sample.privateId}-${column.key}`}>
                     {displayData}
                 </Table.Cell>
-            )
+            );
         });
     };
 

--- a/src/ts/src/data/samples/index.tsx
+++ b/src/ts/src/data/samples/index.tsx
@@ -9,42 +9,42 @@ type Props = {
     data?: Array<Sample>;
 };
 
-type Headers = {
+interface Headers {
     text: string,
     key: keyof Sample
 }
 
 const TABLE_HEADERS: Array<Headers> = [
-    { text: "Private ID", key: "privateId" },
-    { text: "Public ID", key: "publicId" },
+    { text: "Private ID", key: "privateID" },
+    { text: "Public ID", key: "publicID" },
     { text: "Upload Date", key: "uploadDate" },
     { text: "Collection Date", key: "collectionDate" },
     { text: "Collection Location", key: "collectionLocation" },
     { text: "GISAID", key: "gisaid" },
 ];
 
-const dummySamples: Array<Sample> = [
-    {
-        id: 1,
-        privateId: "0865-0004KGK00-001",
-        publicId: "0909EEEE-55-33",
-        uploadDate: "2/1/2021",
-        collectionDate: "12/12/2020",
-        collectionLocation: "Santa Clara County",
-        gisaid: "Accepted",
-    },
-    {
-        id: 2,
-        privateId: "0865-0004KGK00-001",
-        publicId: "0909EEEE-55-33",
-        uploadDate: "2/1/2021",
-        collectionDate: "12/12/2020",
-        collectionLocation: "Santa Clara County",
-        gisaid: "Accepted",
-    },
-];
+const UNDEFINED_TEXT = "---"
 
-const Samples: FunctionComponent<Props> = ({ data = dummySamples }: Props) => {
+// const dummySamples: Array<Sample> = [
+//     {
+//         privateId: "0865-0004KGK00-001",
+//         publicId: "0909EEEE-55-33",
+//         uploadDate: "2/1/2021",
+//         collectionDate: "12/12/2020",
+//         collectionLocation: "Santa Clara County",
+//         gisaid: "Accepted",
+//     },
+//     {
+//         privateId: "0865-0004KGK00-001",
+//         publicId: "0909EEEE-55-33",
+//         uploadDate: "2/1/2021",
+//         collectionDate: "12/12/2020",
+//         collectionLocation: "Santa Clara County",
+//         gisaid: "Accepted",
+//     },
+// ];
+
+const Samples: FunctionComponent<Props> = ({ data = [] }: Props) => {
     const headerRow = TABLE_HEADERS.map((column) => (
         <Table.HeaderCell key={column.key}>
             <span className={style.header}>{column.text}</span>
@@ -52,11 +52,17 @@ const Samples: FunctionComponent<Props> = ({ data = dummySamples }: Props) => {
     ));
 
     const sampleRow = (sample: Sample): Array<JSX.Element> => {
-        return TABLE_HEADERS.map((column) => (
-            <Table.Cell key={`${sample.privateId}-${column.key}`}>
-                {sample[column.key]}
-            </Table.Cell>
-        ));
+        return TABLE_HEADERS.map((column) => {
+            let displayData = sample[column.key]
+            if (displayData === undefined) {
+                displayData = UNDEFINED_TEXT
+            }
+            return (
+                <Table.Cell key={`${sample.privateId}-${column.key}`}>
+                    {displayData}
+                </Table.Cell>
+            )
+        });
     };
 
     const tableRows = (samples: Array<Sample>): Array<JSX.Element> => {

--- a/third-party/sqlalchemy-enum-tables/pyproject.toml
+++ b/third-party/sqlalchemy-enum-tables/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
### Description

Incorporates the api endpoint for fetching samples into the samples table. The data lives in the data layer for easy switching.

#### Issue
[ch66711](https://app.clubhouse.io/genepi/stories/space/66711)

### Test plan

On local server, navigate to Data. They should load automatically.
