### PR TITLE
simplify models for accessions and add genbank as a public repository

### DIFF
--- a/database_migrations/versions/20210225_180155_simplify_accessions_and_add_genbank.py
+++ b/database_migrations/versions/20210225_180155_simplify_accessions_and_add_genbank.py
@@ -1,0 +1,127 @@
+"""simplify accessions and add GENBANK
+
+Create Date: 2021-02-25 18:01:56.487930
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210225_180155"
+down_revision = "20210225_162252"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "uq_accessions_public_repository_id",
+        "accessions",
+        schema="aspen",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "fk_accessions_public_repository_id_public_repository",
+        "accessions",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.drop_table("public_repository", schema="aspen")
+    op.add_column(
+        "accessions",
+        sa.Column(
+            "repository_type",
+            enumtables.enum_column.EnumType(),
+            nullable=False,
+        ),
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        op.f("uq_accessions_repository_type"),
+        "accessions",
+        ["repository_type", "public_identifier"],
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        op.f("fk_accessions_repository_type_public_repository_types"),
+        "accessions",
+        "public_repository_types",
+        ["repository_type"],
+        ["item_id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+    op.drop_column("accessions", "public_repository_id", schema="aspen")
+    op.enum_insert("public_repository_types", ["GENBANK"], schema="aspen")
+
+
+def downgrade():
+    op.enum_delete("public_repository_types", ["GENBANK"], schema="aspen")
+    op.add_column(
+        "accessions",
+        sa.Column(
+            "public_repository_id",
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=False,
+        ),
+        schema="aspen",
+    )
+    op.drop_constraint(
+        op.f("fk_accessions_repository_type_public_repository_types"),
+        "accessions",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("uq_accessions_repository_type"),
+        "accessions",
+        schema="aspen",
+        type_="unique",
+    )
+    op.drop_column("accessions", "repository_type", schema="aspen")
+    op.create_table(
+        "public_repository",
+        sa.Column(
+            "id",
+            sa.INTEGER(),
+            server_default=sa.text(
+                "nextval('aspen.public_repository_id_seq'::regclass)"
+            ),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "repository_type",
+            sa.VARCHAR(),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("name", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column("website", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["repository_type"],
+            ["aspen.public_repository_types.item_id"],
+            name="fk_public_repository_repository_type_public_repository_types",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_public_repository"),
+        sa.UniqueConstraint("name", name="uq_public_repository_name"),
+        sa.UniqueConstraint("website", name="uq_public_repository_website"),
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        "uq_accessions_public_repository_id",
+        "accessions",
+        ["public_repository_id", "public_identifier"],
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        "fk_accessions_public_repository_id_public_repository",
+        "accessions",
+        "public_repository",
+        ["public_repository_id"],
+        ["id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )

--- a/docs/backend/schema.ddl
+++ b/docs/backend/schema.ddl
@@ -113,20 +113,14 @@ Table WorkflowInputs {
 ///////////////////////////////////////////////////
 // Public accession ids
 
-Table PublicRepository {
-  id INT [pk, increment]
-  name VARCHAR [not null, unique]
-  website VARCHAR [unique]
-}
-
 Table Accession {
   entity_id INT [not null, ref: > Entity.id]
-  public_repository_id INT [not null, ref: > PublicRepository.id]
+  // internally, repository_type is an enum
+  repository_type VARCHAR [not null]
   public_identifier VARCHAR [not null]
 
   Indexes {
-    (entity_id, public_repository_id) [unique]
-    (public_repository_id, public_identifier) [unique]
+    (repository_type, public_identifier) [unique]
   }
 }
 

--- a/src/py/aspen/database/models/__init__.py
+++ b/src/py/aspen/database/models/__init__.py
@@ -1,4 +1,7 @@
-from aspen.database.models.accessions import Accession, PublicRepository  # noqa: F401
+from aspen.database.models.accessions import (  # noqa: F401
+    Accession,
+    PublicRepositoryType,
+)
 from aspen.database.models.align_read import AlignRead, Bam  # noqa: F401
 from aspen.database.models.base import meta  # noqa: F401
 from aspen.database.models.cansee import CanSee, DataType  # noqa: F401

--- a/src/py/aspen/database/models/accessions.py
+++ b/src/py/aspen/database/models/accessions.py
@@ -12,6 +12,7 @@ from aspen.database.models.enum import Enum
 class PublicRepositoryType(enum.Enum):
     GISAID = "GISAID"
     NCBI_SRA = "NCBI_SRA"
+    GENBANK = "GENBANK"
 
 
 # Create the enumeration table
@@ -23,25 +24,11 @@ _PublicRepositoryTypeTable = enumtables.EnumTable(
 )
 
 
-class PublicRepository(idbase):
-    """A public repository for genetic or epidemiology data."""
-
-    __tablename__ = "public_repository"
-    repository_type = Column(
-        Enum(PublicRepositoryType),
-        ForeignKey(_PublicRepositoryTypeTable.item_id),
-        nullable=False,
-    )
-
-    name = Column(String, nullable=False, unique=True)
-    website = Column(String, nullable=False, unique=True)
-
-
 class Accession(idbase):
     """A single accession of an entity."""
 
     __tablename__ = "accessions"
-    __table_args__ = (UniqueConstraint("public_repository_id", "public_identifier"),)
+    __table_args__ = (UniqueConstraint("repository_type", "public_identifier"),)
 
     entity_id = Column(
         Integer,
@@ -50,14 +37,10 @@ class Accession(idbase):
     )
     entity = relationship(Entity, backref=backref("accessions", uselist=True))
 
-    public_repository_id = Column(
-        Integer,
-        ForeignKey(PublicRepository.id),
-        primary_key=True,
-    )
-    public_repository = relationship(
-        PublicRepository,
-        backref=backref("accessions", uselist=True),
+    repository_type = Column(
+        Enum(PublicRepositoryType),
+        ForeignKey(_PublicRepositoryTypeTable.item_id),
+        nullable=False,
     )
 
     public_identifier = Column(String, nullable=False)

--- a/src/py/aspen/database/models/entity.py
+++ b/src/py/aspen/database/models/entity.py
@@ -21,6 +21,7 @@ from aspen.database.models.base import base, idbase
 from aspen.database.models.enum import Enum
 
 if TYPE_CHECKING:
+    from aspen.database.models import accessions
     from aspen.database.models.workflow import Workflow
 
 
@@ -70,6 +71,8 @@ class Entity(idbase):
     producing_workflow = relationship(
         "Workflow", backref=backref("outputs", uselist=True)
     )
+
+    accessions: MutableSequence[accessions.Accession]
 
     def get_parents(
         self,


### PR DESCRIPTION
### Description
Rather than link an accession to a public repository object, just label each accession with the repository enum.

### Test plan
ran migration upgrade and downgrade.  ran import in next pr.
