### PR TITLE
Do not cache the DB interface without the db uri as a cachekey

### DIFF
--- a/src/py/aspen/app/aspen_app.py
+++ b/src/py/aspen/app/aspen_app.py
@@ -25,9 +25,9 @@ class AspenApp(Flask):
         return self._aspen_config
 
     @lru_cache()
-    def _DATABASE_INTERFACE(self) -> aspen_database.SqlAlchemyInterface:
-        return aspen_database.init_db(self.aspen_config.DATABASE_URI)
+    def _DATABASE_INTERFACE(self, uri: str) -> aspen_database.SqlAlchemyInterface:
+        return aspen_database.init_db(uri)
 
     @property
     def DATABASE_INTERFACE(self) -> aspen_database.SqlAlchemyInterface:
-        return self._DATABASE_INTERFACE()
+        return self._DATABASE_INTERFACE(self.aspen_config.DATABASE_URI)


### PR DESCRIPTION
### Description
`@lru_cache` takes the arguments of the method as a cachekey.  Since DB URI can change during the course of a unit test run (we change the database name so each test has its own clean database to work with), we end up pulling a stale db handle.  By adding the db_uri as a parameter to the `_DATABASE_INTERFACE` method, we guarantee the correct interface.

### Test plan
Successfully passed other tests.
