### PR TITLE
Use postgres 13.1 instead of 11.5

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -58,7 +58,7 @@ jobs:
           python-version: 3.7
       - name: Pull the docker image
         run: |
-          docker pull czbiohub/covidhub-postgres:11.5-alpine
+          docker pull czbiohub/covidhub-postgres:13.1-alpine
       - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v2

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LOCAL_DB_RW_USERNAME = user_rw
 LOCAL_DB_RW_PASSWORD = password_rw
 LOCAL_DB_RO_USERNAME = user_ro
 LOCAL_DB_RO_PASSWORD = password_ro
-DOCKER_IMAGE = czbiohub/covidhub-postgres:11.5-alpine
+DOCKER_IMAGE = czbiohub/covidhub-postgres:13.1-alpine
 
 start-local-db:
 	@if [ "$(LOCAL_DB_CONTAINER_ID)" == "" ]; then \


### PR DESCRIPTION
### Description
RDS uses 13.1 so we should use the same thing locally.

### Test plan
GHA.
