### PR TITLE
Defer the sequence data from being loaded by default

### DIFF
--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import backref, deferred, relationship
 
 from aspen.database.models.base import base
 from aspen.database.models.entity import Entity, EntityType
@@ -146,7 +146,7 @@ class PathogenGenome(Entity):
     __tablename__ = "pathogen_genomes"
 
     entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)
-    sequence = Column(String, nullable=False)
+    sequence = deferred(Column(String, nullable=False))
 
     # statistics for the pathogen genome
 


### PR DESCRIPTION
### Description
Sequence data is too big to load by default.

Too bad sqlalchemy 1.4 is not yet release, as it has an awsesome [`defer(raiseload=True)`](https://docs.sqlalchemy.org/en/14/orm/loading_columns.html#raiseload-for-deferred-columns) feature.

### Test plan
gha.
