### PR TITLE
redirect to data samples view (protect index view)

### DIFF
--- a/src/py/aspen/app/views/auth.py
+++ b/src/py/aspen/app/views/auth.py
@@ -18,7 +18,7 @@ def callback_handling():
         "user_id": userinfo["sub"],
         "name": userinfo["name"],
     }
-    return redirect("/")
+    return redirect("/data/samples")
 
 
 @application.route("/login")

--- a/src/py/aspen/app/views/index.py
+++ b/src/py/aspen/app/views/index.py
@@ -2,13 +2,14 @@ from pathlib import Path
 
 from flask import send_from_directory
 
-from aspen.app.app import application
+from aspen.app.app import application, requires_auth
 
 
 # Catch all routes. If path is a file, send the file;
 # else send index.html. Allows reloading React app from any route.
 @application.route("/", defaults={"path": ""})
 @application.route("/<path:path>")
+@requires_auth
 def serve(path):
     if path != "" and Path(application.static_folder + "/" + path).exists():
         return send_from_directory(application.static_folder, path)


### PR DESCRIPTION
### Description
as discussed in design we want to circumvent the index page/sign in link and direct users to login directly, and then we want them to be redirected to the sample data view

### Test plan

cleared cache and launched app and checked that redirection was happening correctly
