### PR TITLE
Make some models public

### DIFF
--- a/src/py/aspen/database/models/__init__.py
+++ b/src/py/aspen/database/models/__init__.py
@@ -19,10 +19,16 @@ from aspen.database.models.sample import Sample  # noqa: F401
 from aspen.database.models.sequences import (  # noqa: F401
     CallConsensus,
     CalledPathogenGenome,
+    PathogenGenome,
     SequencingInstrumentType,
     SequencingProtocolType,
     SequencingReadsCollection,
     UploadedPathogenGenome,
 )
 from aspen.database.models.usergroup import Group, User  # noqa: F401
-from aspen.database.models.workflow import Workflow, WorkflowType  # noqa: F401
+from aspen.database.models.workflow import (  # noqa: F401
+    Workflow,
+    WorkflowInputs,
+    WorkflowStatusType,
+    WorkflowType,
+)

--- a/src/py/aspen/database/models/workflow.py
+++ b/src/py/aspen/database/models/workflow.py
@@ -42,7 +42,7 @@ _WorkflowStatusTypeTable = enumtables.EnumTable(
 )
 
 
-_workflow_inputs_table = Table(
+WorkflowInputs = Table(
     "workflow_inputs",
     base.metadata,
     Column("entity_id", ForeignKey(Entity.id), primary_key=True),
@@ -92,7 +92,7 @@ class Workflow(idbase):
 
     inputs = relationship(
         Entity,
-        secondary=_workflow_inputs_table,
+        secondary=WorkflowInputs,
         backref="consuming_workflows",
         uselist=True,
     )


### PR DESCRIPTION
### Description
1. Make `PathogenGenome` public because sometimes we want to join against PathogenGenomes, regardless of its source.
2. Make `WorkflowInputs` public because that's the only way to join Workflows and their inputs.

### Test plan
used in subsequent PR.
