### PR TITLE
[easy] Add an error module

### DIFF
--- a/src/py/aspen/error/recoverable.py
+++ b/src/py/aspen/error/recoverable.py
@@ -1,0 +1,5 @@
+class RecoverableError(Exception):
+    """Placeholder exception for states where we should really just log an error and
+    continue."""
+
+    ...


### PR DESCRIPTION
### Description
Key addition is a RecoverableError exception, which is just a placeholder where we throw an exception now but probably should convert to a centralized logging solution once we have the time to do so.

### Test plan
Used in subsequent PR.
