### PR TITLE
Create generic, smooth API interface

### DIFF
--- a/src/ts/src/App.tsx
+++ b/src/ts/src/App.tsx
@@ -15,9 +15,9 @@ const App: FunctionComponent = () => {
 
     useEffect(() => {
         const setUserData = async () => {
-            const response = await fetchUserData();
-            setUser(response.user.name);
-            setOrg(response.group.name);
+            const [groupResponse, userResponse] = await fetchUserData();
+            setUser(userResponse.name);
+            setOrg(groupResponse.name);
         };
         setUserData();
     }, []);

--- a/src/ts/src/common/api/index.tsx
+++ b/src/ts/src/common/api/index.tsx
@@ -45,7 +45,7 @@ const USER_MAP = new Map<string, keyof User>([
     ["group_admin", "groupAdmin"],
     ["system_admin", "systemAdmin"],
 ]);
-export const fetchUserData = async (): [Group, User] =>
+export const fetchUserData = async (): Promise<[Group, User]> =>
     apiSplitResponse<[Group, User]>([new Map([]), USER_MAP], "/api/usergroup");
 
 const SAMPLE_MAP = new Map<string, keyof Sample>([
@@ -55,7 +55,7 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
     ["public_identifier", "publicId"],
     ["upload_date", "uploadDate"],
 ]);
-export const fetchSamples = async (): Sample[] =>
+export const fetchSamples = async (): Promise<Sample[]> =>
     apiCollectionResponse<Sample>(SAMPLE_MAP, "/api/samples");
 
 const TREE_MAP = new Map<string, keyof Tree>([
@@ -63,5 +63,5 @@ const TREE_MAP = new Map<string, keyof Tree>([
     ["pathogen_genome_count", "pathogenGenomeCount"],
     ["completed_date", "dateCompleted"],
 ]);
-export const fetchTrees = async (): Tree[] =>
+export const fetchTrees = async (): Promise<Tree[]> =>
     apiCollectionResponse<Tree>(TREE_MAP, "/api/phylo_trees");

--- a/src/ts/src/common/api/index.tsx
+++ b/src/ts/src/common/api/index.tsx
@@ -3,34 +3,50 @@ import axios from "axios";
 
 import { jsonToType } from "common/utils";
 
-async function apiSingleResponse<T>(mapping: Map<string, keyof T>, endpoint: string): Promise<T> {
+/** Generic functions to interface with the backend API **/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function apiSingleResponse<T>(
+    mapping: Map<string, keyof T>,
+    endpoint: string
+): Promise<T> {
     const response = await axios.get(endpoint);
-    const singleType = jsonToType<T>(response.data, mapping)
+    const singleType = jsonToType<T>(response.data, mapping);
     return singleType;
 }
-
-async function apiSplitResponse<T extends any[]>(mappings: Array<Map<string, any>>, endpoint: string): Promise<T> {
+async function apiSplitResponse<T extends any[]>(
+    mappings: Array<Map<string, any>>,
+    endpoint: string
+): Promise<T> {
     const response = await axios.get(endpoint);
-    const splitTypeArray = Object.keys(response.data).map(
-        (key: string, index: number) => jsonToType(response.data[key], mappings[index])
-    ) as T // this array maps to the tuple type T (e.g. [K, U])
-    return splitTypeArray
+    const splitTypeArray = Object.keys(
+        response.data
+    ).map((key: string, index: number) =>
+        jsonToType(response.data[key], mappings[index])
+    ) as T; // this array maps to the tuple type T (e.g. [K, U])
+    return splitTypeArray;
 }
 
-async function apiCollectionResponse<T>(mapping: Map<string, keyof T>, endpoint: string): Promise<Array<T>> {
+async function apiCollectionResponse<T>(
+    mapping: Map<string, keyof T>,
+    endpoint: string
+): Promise<Array<T>> {
     const response = await axios.get(endpoint);
     const collectionType: Array<T> = response.data.map(
         (entry: Record<string, JSONPrimitive>) => jsonToType<T>(entry, mapping)
     );
     return collectionType;
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** Calls to specific API endpoints **/
 
 const USER_MAP = new Map<string, keyof User>([
     ["auth0_user_id", "auth0UserId"],
     ["group_admin", "groupAdmin"],
     ["system_admin", "systemAdmin"],
 ]);
-export const fetchUserData = async () => apiSplitResponse<[Group, User]>([new Map([]), USER_MAP], "/api/usergroup")
+export const fetchUserData = async (): [Group, User] =>
+    apiSplitResponse<[Group, User]>([new Map([]), USER_MAP], "/api/usergroup");
 
 const SAMPLE_MAP = new Map<string, keyof Sample>([
     ["collection_date", "collectionDate"],
@@ -39,11 +55,13 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
     ["public_identifier", "publicId"],
     ["upload_date", "uploadDate"],
 ]);
-export const fetchSamples = async () => apiCollectionResponse<Sample>(SAMPLE_MAP, "/api/samples")
+export const fetchSamples = async (): Sample[] =>
+    apiCollectionResponse<Sample>(SAMPLE_MAP, "/api/samples");
 
 const TREE_MAP = new Map<string, keyof Tree>([
     ["phylo_tree_id", "id"],
     ["pathogen_genome_count", "pathogenGenomeCount"],
     ["completed_date", "dateCompleted"],
 ]);
-export const fetchTrees = async () => apiCollectionResponse<Tree>(TREE_MAP, "/api/phylo_trees")
+export const fetchTrees = async (): Tree[] =>
+    apiCollectionResponse<Tree>(TREE_MAP, "/api/phylo_trees");

--- a/src/ts/src/common/types/network.d.ts
+++ b/src/ts/src/common/types/network.d.ts
@@ -1,0 +1,1 @@
+type JSONPrimitive = string | number | boolean;

--- a/src/ts/src/common/types/user.d.ts
+++ b/src/ts/src/common/types/user.d.ts
@@ -3,7 +3,7 @@
 /// <reference types="react-dom" />
 
 interface Group {
-    [index: string]: string;
+    [index: string]: JSONPrimitive;
     address: string;
     email: string;
     id: number;
@@ -11,7 +11,7 @@ interface Group {
 }
 
 interface User {
-    [index: string]: number | string | boolean;
+    [index: string]: JSONPrimitive;
     auth0UserId: string;
     email: string;
     groupAdmin: boolean;

--- a/src/ts/src/common/utils/typeUtils.tsx
+++ b/src/ts/src/common/utils/typeUtils.tsx
@@ -11,7 +11,6 @@ export function get<T, K extends keyof T>(o: T, propertyName: K): T[K] {
 // and converts the data to an object of that type with the right keys.
 // Any keys not explicitly set in the mapping will be transferred to the
 // new object.
-type JSONPrimitive = string | number | boolean;
 
 export function jsonToType<T>(
     inputObject: Record<string, JSONPrimitive>,


### PR DESCRIPTION
### Description

Adds three generic functions that cover a broad variety of API responses:

* `apiSingleResponse<T>`. This is when the JSON response is a flat mapping of keys that corresponds to a single object, and we want to extract the information from the response and map it onto a type we use in the Typescript app.
* `apiSplitResponse<T extends any[]>`. This is when the JSON response is an object with multiple keys, and each key corresponds to a type. The function is used with a tuple type, eg `apiSplitResponse<[Group, User]>(...)`
* `apiCollectionResponse<T>`. This is when the JSON response is an array of objects, all of the same type; the function returns any array of objects of type T.

This makes adding new API endpoints very, very easy; all you have to do is define a type, define a mapping if any of the keys are different cases, and call one of the generics.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/stories/space/<fill_in_issue_number>)

### Test plan

Right now it's kind of tested ad hoc, with the existing api interfaces.
