### PR TITLE
Use something more stable as the secret key in dev mode

### DIFF
--- a/src/py/aspen/config/development.py
+++ b/src/py/aspen/config/development.py
@@ -1,4 +1,4 @@
-import uuid
+import platform
 
 from aspen.config import config
 
@@ -10,7 +10,7 @@ class DevelopmentConfig(config.Config, descriptive_name="dev"):
 
     @config.flaskproperty
     def SECRET_KEY(self) -> str:
-        return uuid.uuid4().hex
+        return platform.node()
 
     @property
     def AUTH0_CALLBACK_URL(self) -> str:


### PR DESCRIPTION
### Description
Using a uuid means every time the webserver restarts (possibly because we've edited the code), we get a different secret key and get logged out.

#### Issue
Not exactly [ch124730](https://app.clubhouse.io/genepi/story/124730/ux-design-for-authentication), but might help resolve some of the jankiness we've seen.

### Test plan
None.
