### PR TITLE
Do not return results as top-level constructs

### DIFF
--- a/src/py/aspen/app/views/phylo_trees.py
+++ b/src/py/aspen/app/views/phylo_trees.py
@@ -20,6 +20,8 @@ from aspen.database.models import (
 from aspen.database.models.usergroup import Group, User
 from aspen.error.recoverable import RecoverableError
 
+PHYLO_TREE_KEY = "phylo_trees"
+
 
 @application.route("/api/phylo_trees", methods=["GET"])
 @requires_auth
@@ -70,7 +72,7 @@ def phylo_trees():
                 }
             )
 
-        return jsonify(results)
+        return jsonify({PHYLO_TREE_KEY: results})
 
 
 @application.route("/api/phylo_tree/<int:phylo_tree_id>", methods=["GET"])

--- a/src/py/aspen/app/views/sample.py
+++ b/src/py/aspen/app/views/sample.py
@@ -17,6 +17,8 @@ from aspen.database.models import (
 from aspen.database.models.sample import Sample
 from aspen.database.models.usergroup import Group, User
 
+SAMPLE_KEY = "samples"
+
 
 def _format_created_date(sample: Sample) -> str:
     if sample.sequencing_reads_collection is not None:
@@ -100,4 +102,4 @@ def samples():
 
             results.append(returned_sample_data)
 
-        return jsonify(results)
+        return jsonify({SAMPLE_KEY: results})

--- a/src/py/aspen/test_infra/postgres.py
+++ b/src/py/aspen/test_infra/postgres.py
@@ -39,7 +39,7 @@ def unused_tcp_port():
 
 @pytest.fixture(scope="session")
 def postgres_instance(
-    unused_tcp_port, timeout_s=20.0
+    unused_tcp_port, timeout_s=30.0
 ) -> Generator[PostgresInstance, None, None]:
     """Starts a postgres instance with username/password cliadb/cliadb.  Returns a tuple
     consisting of the container id, and the port the postgres instance can be reached


### PR DESCRIPTION
### Description
Wrap everything with a top-level object, so we can extend the API more easily.

The exception is retrieving a single phylo_tree, which we return the json directly.

Depends on #157 

### Test plan
pytest

But the front end still needs to be updated, hopefully @lvreynoso can add the necessary changes to this PR.
