### PR TITLE
Support for a remote db config

### DIFF
--- a/src/py/aspen/config/development.py
+++ b/src/py/aspen/config/development.py
@@ -1,5 +1,3 @@
-import platform
-
 from aspen.config import config
 
 
@@ -7,10 +5,6 @@ class DevelopmentConfig(config.Config, descriptive_name="dev"):
     @config.flaskproperty
     def DEBUG(self) -> bool:
         return True
-
-    @config.flaskproperty
-    def SECRET_KEY(self) -> str:
-        return platform.node()
 
     @property
     def AUTH0_CALLBACK_URL(self) -> str:

--- a/src/py/aspen/config/production.py
+++ b/src/py/aspen/config/production.py
@@ -1,12 +1,10 @@
-import uuid
-
 from aspen.config import config
 
 
-class ProductionConfig(config.Config, descriptive_name="prod"):
+class ProductionConfig(config.RemoteDatabaseConfig, descriptive_name="prod"):
     @config.flaskproperty
-    def SECRET_KEY(self) -> str:
-        return uuid.uuid4().hex
+    def DEBUG(self) -> bool:
+        return False
 
     @property
     def AUTH0_CALLBACK_URL(self) -> str:

--- a/src/py/aspen/config/staging.py
+++ b/src/py/aspen/config/staging.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 
 from aspen import aws
 from aspen.config import config
@@ -7,14 +6,10 @@ from aspen.config import config
 logger = logging.getLogger(__name__)
 
 
-class StagingConfig(config.Config, descriptive_name="staging"):
+class StagingConfig(config.RemoteDatabaseConfig, descriptive_name="staging"):
     @config.flaskproperty
     def DEBUG(self) -> bool:
         return True
-
-    @config.flaskproperty
-    def SECRET_KEY(self) -> str:
-        return uuid.uuid4().hex
 
     @property
     def AUTH0_CALLBACK_URL(self) -> str:
@@ -23,7 +18,3 @@ class StagingConfig(config.Config, descriptive_name="staging"):
         return (
             f"http://aspen-{eb_env_name}.{aws.region()}.elasticbeanstalk.com/callback"
         )
-
-    @property
-    def DATABASE_URI(self) -> str:
-        return "postgresql://user_rw:password_rw@localhost:5432/aspen_db"


### PR DESCRIPTION
### Description
For the most part, accessing the DB is a function of AWS_PROFILE or AWS_ACCESS_KEY_ID/AWS_SECRET_KEY_ID.  We want to have an object that encompasses all the remote db config so we can access the DB from the CLI.

If we didn't do this, then we would require the user to specify --staging or --prod (to initialize `StagingConfig` or `ProductionConfig`), when it actually doesn't matter.

### Test plan
flask run
