### PR TITLE
Add --local/--remote flags for aspendb-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ setup-local-db:
 init-local-db:
 	@$(MAKE) setup-local-db
 	aspen-cli db create
-	DB=dev alembic stamp head
+	DB=local alembic stamp head
 
 stop-local-db:
 	@if [ "$(LOCAL_DB_CONTAINER_RUNNING_ID)" != "" ]; then \

--- a/database_migrations/env.py
+++ b/database_migrations/env.py
@@ -1,16 +1,18 @@
 import os
 from logging.config import fileConfig
+from typing import Mapping, Type
 
 import enumtables  # noqa: F401
 from alembic import context
 from sqlalchemy import create_engine
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
-from aspen.config.config import Config
+from aspen.config import DevelopmentConfig
+from aspen.config.config import Config, RemoteDatabaseConfig
 from aspen.database.connection import get_db_uri
 from aspen.database.models import meta
 
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
 config = context.config
 
 # Interpret the config file for Python logging.
@@ -47,9 +49,13 @@ def get_uri():
         db_env = os.environ["DB"]
     else:
         # TODO: generate the appropriate list of "RuntimeEnvironment"s from the enum.
-        raise ValueError("Must provide env variable DB=[dev, staging, prod]")
+        raise ValueError("Must provide env variable DB=[local, remote]")
 
-    return get_db_uri(Config.by_descriptive_name(db_env))
+    config_mapper: Mapping[str, Type[Config]] = {
+        "local": DevelopmentConfig,
+        "remote": RemoteDatabaseConfig,
+    }
+    return get_db_uri(config_mapper[db_env]())
 
 
 def run_migrations_offline():

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -131,9 +131,9 @@ In [3]:
 ### Autogeneration of schema migration
 
 1. Make changes to the models.
-2. Run `ENV=dev alembic revision --autogenerate -m "SOME DESCRIPTIVE MESSAGE" --rev-id $(date +%Y%m%d_%H%M%S)`
+2. Run `DB=local alembic revision --autogenerate -m "SOME DESCRIPTIVE MESSAGE" --rev-id $(date +%Y%m%d_%H%M%S)`
 3. Verify that the schema migration generated in `database_migrations/versions/` is sane.
-4. Run `ENV=dev alembic upgrade head` to test the schema migration on your local database.
+4. Run `DB=local alembic upgrade head` to test the schema migration on your local database.
 
 ## Updating python dependencies
 

--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Type
 
 import boto3
 import click
@@ -7,7 +8,7 @@ from IPython.terminal.embed import InteractiveShellEmbed
 
 from aspen import covidhub_import
 from aspen.cli.toplevel import cli
-from aspen.config.config import RemoteDatabaseConfig
+from aspen.config.config import Config, RemoteDatabaseConfig
 from aspen.config.development import DevelopmentConfig
 from aspen.database.connection import enable_profiling, get_db_uri, init_db
 from aspen.database.models import *  # noqa: F401, F403
@@ -15,10 +16,12 @@ from aspen.database.schema import create_tables_and_schema
 
 
 @cli.group()
+@click.option("--local", "config_cls", flag_value=DevelopmentConfig)
+@click.option("--remote", "config_cls", flag_value=RemoteDatabaseConfig)
 @click.pass_context
-def db(ctx):
-    # TODO: support multiple runtime environments.
-    ctx.obj["ENGINE"] = init_db(get_db_uri(DevelopmentConfig()))
+def db(ctx, config_cls: Type[Config]):
+    config = config_cls()
+    ctx.obj["ENGINE"] = init_db(get_db_uri(config))
 
 
 @db.command("set-passwords-from-secret")


### PR DESCRIPTION
### Description
This allows us to initialize a remote database.  Mirror the same for alembic's config.

Finally, updated the docs.

Depends on #166 

#### Issue
[ch68094](https://app.clubhouse.io/genepi/stories/space/68094)

### Test plan
ran:

`aspen-cli db --remote create`
and
`DB=remote alembic stamp head`
