### PR TITLE
aspencli should not fail if covidhub is not installed

### DIFF
--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -1,9 +1,9 @@
 import click
 from IPython.terminal.embed import InteractiveShellEmbed
 
+from aspen import covidhub_import
 from aspen.cli.toplevel import cli
 from aspen.config.development import DevelopmentConfig
-from aspen.covidhub_import import import_project
 from aspen.database.connection import enable_profiling, get_db_uri, init_db
 from aspen.database.models import *  # noqa: F401, F403
 from aspen.database.schema import create_tables_and_schema
@@ -56,7 +56,7 @@ def import_covidhub_project(
     # these are injected into the IPython scope, but they appear to be unused.
     engine = ctx.obj["ENGINE"]
 
-    import_project(
+    covidhub_import.import_project(
         engine,
         covidhub_db_secret,
         rr_project_id,


### PR DESCRIPTION
### Description
The imports need to be restructured to avoid an error if covidhub is not installed.  Only when the `aspen-cli db import` is run, should covidhub be required.

### Test plan
Tried it in a virtualenv without covidhub, it works!
