### PR TITLE
Clarify AWS profiles

### DIFF
--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -76,31 +76,28 @@ def interact(ctx, profile):
 
 
 @db.command("import-covidhub-project")
+@click.option("--covidhub-aws-profile", type=str, required=True)
 @click.option("--covidhub-db-secret", default="cliahub/cliahub_test_db")
 @click.option("--rr-project-id", type=str, required=True)
 @click.option("--s3-src-prefix", type=str, required=True)
-@click.option("--s3-src-profile", type=str, required=True)
 @click.option("--s3-dst-prefix", type=str, required=True)
-@click.option("--s3-dst-profile", type=str, required=True)
 @click.pass_context
 def import_covidhub_project(
     ctx,
+    covidhub_aws_profile,
     covidhub_db_secret,
     rr_project_id,
     s3_src_prefix,
-    s3_src_profile,
     s3_dst_prefix,
-    s3_dst_profile,
 ):
     # these are injected into the IPython scope, but they appear to be unused.
     engine = ctx.obj["ENGINE"]
 
     covidhub_import.import_project(
         engine,
+        covidhub_aws_profile,
         covidhub_db_secret,
         rr_project_id,
         s3_src_prefix,
-        s3_src_profile,
         s3_dst_prefix,
-        s3_dst_profile,
     )


### PR DESCRIPTION
### Description
src/dst is confusing.  Make it explicitly covidhub vs aspen.  This makes it easier to manage multiple connections, which we will need to import to a staging db hosted on AWS.

### Test plan
None.
