### PR TITLE
Fix installation of edit mode packages

### DIFF
--- a/src/py/setup.py
+++ b/src/py/setup.py
@@ -10,7 +10,7 @@ with requirements_file.open("r") as fh:
     requirement_lines = [
         line
         for line in fh.readlines()
-        if not (line.startswith("-i") or line.startswith("./"))
+        if not (line.startswith("-e") or line.startswith("-i") or line.startswith("./"))
     ]
 
 setuptools.setup(


### PR DESCRIPTION
### Description
Ignore them.  The authoritative list is in Pipfile

#### Issue
[ch121281](https://app.clubhouse.io/genepi/stories/space/121281)

### Test plan
regenerated `src/py/requirements.txt` to add auth0-python, and verified that `pip install -e src/py` works.
