### PR TITLE
Change cache version

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: py-tests-tests-v0-${{ runner.os }}-${{ steps.setup.outputs.python-version }}-${{ hashFiles('src/py/setup.py', 'src/py/requirements-dev.txt', '.github/workflows/py-tests.yml') }}
+          key: py-tests-tests-v1-${{ runner.os }}-${{ steps.setup.outputs.python-version }}-${{ hashFiles('src/py/setup.py', 'src/py/requirements-dev.txt', '.github/workflows/py-tests.yml') }}
       - name: Install dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
### Description
Looks like github actions has some subtle OS upgrade that breaks installs.  See [here](https://github.community/t/libffi-so-6-error-on-ubuntu-latest/165571) for conversation.

### Test plan
Github actions
