### PR TITLE
Grant access to postgres if an EC2 instance is in the right security group

### DIFF
--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -72,6 +72,10 @@ aspen% .venv-ebcli/bin/eb open aspen-myusername
 aspen% .venv-ebcli/bin/eb terminate aspen-myusername
 ```
 
+### Granting access to the database.
+
+Access to the database is only granted if an EC2 instance is within the security group `eb-security-group`.  Locate your environment in the [Elastic Beanstalk configuration](https://us-west-2.console.aws.amazon.com/elasticbeanstalk/home) page.  Find the configuration page for your environment.  Then under the category "Instances", click edit.  Under EC2 Security Groups, add `eb-security-group` to your launch configuration and restart your environment.
+
 ## Database concerns
 
 ### Interacting with the local database in sql

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,3 +1,8 @@
+resource "aws_security_group" "eb-security-group" {
+  name        = "eb-security-group"
+  description = "security group for eb instances"
+}
+
 resource "aws_security_group" "db-security-group" {
   name        = "db"
   description = "security group for database"
@@ -10,13 +15,16 @@ resource "aws_security_group" "db-security-group" {
   }
 }
 
-resource "aws_security_group_rule" "remote-db-access" {
-  count             = var.DEPLOYMENT_ENVIRONMENT == "prod" ? 0 : 1
-  security_group_id = aws_security_group.db-security-group.id
-  type              = "ingress"
-  description       = "ttung"
-  from_port         = 5432
-  to_port           = 5432
-  protocol          = "tcp"
-  cidr_blocks       = ["24.4.203.80/32"]
+output "aws_security_group_id" {
+  value = aws_security_group.eb-security-group.id
+}
+
+resource "aws_security_group_rule" "eb-db-access" {
+  security_group_id        = aws_security_group.db-security-group.id
+  type                     = "ingress"
+  description              = "Access given to the security group applied to all EB instances"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.eb-security-group.id
 }


### PR DESCRIPTION
### Description
The security group policy denies public access to the database by default.  This creates a security group that can access the database.  Instructions are provided for how to update an elastic beanstalk environment to be in that security group.

#### Issue
[ch125756](https://app.clubhouse.io/genepi/story/125756/fix-how-elastic-beanstalk-instances-connect-to-the-db)

### Test plan
1. applied these terraform changes
2. verified I can connect to the db.
