### PR TITLE
Fix path for default db credentials

### DIFF
--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -29,7 +29,7 @@ def db(ctx, config_cls: Type[Config]):
 def set_passwords_from_secret(ctx):
     this_file = Path(__file__)
     root = this_file.parent.parent.parent.parent.parent
-    default_db_credentials_file = root / "terraform" / "default-db-credentials.json"
+    default_db_credentials_file = root / "terraform.tfvars.json"
     with default_db_credentials_file.open("r") as fh:
         default_db_credentials = json.load(fh)
     admin_username = default_db_credentials["admin_username"]


### PR DESCRIPTION
### Description
Revisions to #164 changed where the default db credentials were being stored.  Update `aspen-cli set-passwords-from-secret` to pull from the right place.

### Test plan
yolo
