### PR TITLE
Install the same versions of the style check tools as in Pipfile.lock

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -33,12 +33,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: py-tests-code-style-v0-${{ runner.os }}-${{ steps.setup.outputs.python-version }}-${{ hashFiles('.github/workflows/py-tests.yml') }}
+          key: py-tests-code-style-v1-${{ runner.os }}-${{ steps.setup.outputs.python-version }}-${{ hashFiles('.github/workflows/py-tests.yml') }}
       - name: Install and upgrade pip
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip wheel
-          pip install black flake8 isort mypy sqlalchemy-stubs
+          python -m pip install pipenv
+          pip install $(pipenv lock --requirements --dev | egrep '^(flake8|black|isort|mypy|sqlalchemy-stubs)==')
       - name: Verify code style
         run: |
           make -k style


### PR DESCRIPTION
### Description
We are currently always installing the latest version of the style check tools, but this may result in [failures](https://github.com/chanzuckerberg/aspen/runs/2114899925?check_suite_focus=true) when the version we have pinned does not match the behavior of the latest version.  This ensures that developers have a sane experience between their local computers and github acitons.

### Test plan
Github actions.
