### PR TITLE
Fix flake8 error

### DIFF
--- a/src/py/aspen/database/models/entity.py
+++ b/src/py/aspen/database/models/entity.py
@@ -21,7 +21,7 @@ from aspen.database.models.base import base, idbase
 from aspen.database.models.enum import Enum
 
 if TYPE_CHECKING:
-    from aspen.database.models import accessions
+    from aspen.database.models.accessions import Accession
     from aspen.database.models.workflow import Workflow
 
 
@@ -73,7 +73,7 @@ class Entity(idbase):
         "Workflow", backref=backref("outputs", uselist=True)
     )
 
-    accessions: MutableSequence[accessions.Accession]
+    accessions: MutableSequence[Accession]
 
     def get_parents(
         self,


### PR DESCRIPTION
### Description
Flake8 3.9.0 does not like this redefinition of a variable name that is only used in type checking.  Remove the conflict.

### Test plan
installed flake8 3.9.0, and verified the error goes away.
