### PR TITLE
Raise on load for the sequence data

### DIFF
--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -146,7 +146,7 @@ class PathogenGenome(Entity):
     __tablename__ = "pathogen_genomes"
 
     entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)
-    sequence = deferred(Column(String, nullable=False))
+    sequence = deferred(Column(String, nullable=False), raiseload=True)
 
     # statistics for the pathogen genome
 


### PR DESCRIPTION
### Description
We want to raise an error if we ever erroneously load the sequence data because it is expensive to load erroneously.

This is a new feature of sqlalchemy 1.4, which we are bringing in with #189 

### Test plan
Add a test to verify that the `raiseload` does the expected thing.
