### PR TITLE
Re-add dev access to the postgres db

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -28,3 +28,25 @@ resource "aws_security_group_rule" "eb-db-access" {
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.eb-security-group.id
 }
+
+resource "aws_security_group_rule" "remote-db-access-ttung" {
+  count             = var.DEPLOYMENT_ENVIRONMENT == "prod" ? 0 : 1
+  security_group_id = aws_security_group.db-security-group.id
+  type              = "ingress"
+  description       = "ttung"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = ["24.4.203.80/32"]
+}
+
+resource "aws_security_group_rule" "remote-db-access-phoenix" {
+  count             = var.DEPLOYMENT_ENVIRONMENT == "prod" ? 0 : 1
+  security_group_id = aws_security_group.db-security-group.id
+  type              = "ingress"
+  description       = "phoenix"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = ["24.6.0.151/32"]
+}


### PR DESCRIPTION
### Description
Setting up the bastion host via terraform and using the bastion host to access the postgres instance via terraform is considerably more effort than we ought to be expending on this at this time.

I added a couple tickets[[1]](https://app.clubhouse.io/genepi/story/126386/add-ssh-bastion-host-that-is-configured-by-terraform)[[2]](https://app.clubhouse.io/genepi/story/126389/existing-tooling-and-terraform-rules-that-access-the-database-should-go-through-the-ssh-bastion-host) to capture this future work.

### Test plan
terraform apply completes
