### PR TITLE
Forward tree json files to nextstrain with magic urls

### DIFF
--- a/src/py/aspen/app/views/magic_key.py
+++ b/src/py/aspen/app/views/magic_key.py
@@ -1,21 +1,15 @@
 import json
-from typing import Any, Iterable, Mapping, MutableSequence, Tuple
 from urllib.parse import urlparse, parse_qsl
 
 import boto3
 from flask import jsonify, session, request
-from sqlalchemy import func, or_
-from sqlalchemy.orm import joinedload
 
 from aspen.app.app import application, requires_auth
-from aspen.app.views.api_utils import format_datetime, get_usergroup_query
 from aspen.database.connection import session_scope
 from aspen.database.models import (
     PhyloRun,
     PhyloTree,
 )
-from aspen.database.models.usergroup import Group, User
-from aspen.error.recoverable import RecoverableError
 
 PRESIGNED_URL_KEY = "presigned_url"
 PRESIGNED_TYPES = { "phylo_tree": PhyloTree }

--- a/src/py/aspen/app/views/magic_key.py
+++ b/src/py/aspen/app/views/magic_key.py
@@ -1,0 +1,53 @@
+import json
+from typing import Any, Iterable, Mapping, MutableSequence, Tuple
+from urllib.parse import urlparse, parse_qsl
+
+import boto3
+from flask import jsonify, session, request
+from sqlalchemy import func, or_
+from sqlalchemy.orm import joinedload
+
+from aspen.app.app import application, requires_auth
+from aspen.app.views.api_utils import format_datetime, get_usergroup_query
+from aspen.database.connection import session_scope
+from aspen.database.models import (
+    PhyloRun,
+    PhyloTree,
+)
+from aspen.database.models.usergroup import Group, User
+from aspen.error.recoverable import RecoverableError
+
+PRESIGNED_URL_KEY = "presigned_url"
+PRESIGNED_TYPES = { "phylo_tree": PhyloTree }
+
+@application.route("/api/get_presigned_url/<string:object_name>/<int:object_id>", methods=["GET"])
+@requires_auth
+def get_presigned_url(object_name: str, object_id: int):
+    object_type = PRESIGNED_TYPES.get(object_name)
+    with session_scope(application.DATABASE_INTERFACE) as db_session:
+        try:
+            target_object = (
+                db_session.query(object_type)
+                .filter(object_type.entity_id == object_id)
+                .one()
+            )
+        except:
+            return jsonify({})
+
+        s3_client = boto3.client("s3")
+
+        presigned_url = (
+            s3_client.generate_presigned_url(
+                "get_object",
+                Params={ "Bucket": target_object.s3_bucket, "Key": target_object.s3_key },
+                ExpiresIn=300 # 5 minutes
+            )
+        )
+
+        parse_result = urlparse(presigned_url)
+        query_strings = parse_qsl(
+            parse_result.query
+        )
+        query_strings.append(("path", parse_result.path))
+
+        return jsonify({PRESIGNED_URL_KEY: dict(query_strings)})

--- a/src/py/aspen/main.py
+++ b/src/py/aspen/main.py
@@ -3,7 +3,7 @@
 from aspen.app.app import application  # noqa: F401
 from aspen.app.views.auth import callback_handling, login, logout  # noqa: F401
 from aspen.app.views.index import serve  # noqa: F401
-from aspen.app.views.magic_key import get_presigned_url
+from aspen.app.views.magic_url import magic_url, get_magic_url
 from aspen.app.views.phylo_trees import phylo_trees  # noqa: F401
 from aspen.app.views.sample import samples  # noqa: F401
 from aspen.app.views.usergroup import usergroup  # noqa: F401

--- a/src/py/aspen/main.py
+++ b/src/py/aspen/main.py
@@ -3,6 +3,7 @@
 from aspen.app.app import application  # noqa: F401
 from aspen.app.views.auth import callback_handling, login, logout  # noqa: F401
 from aspen.app.views.index import serve  # noqa: F401
+from aspen.app.views.magic_key import get_presigned_url
 from aspen.app.views.phylo_trees import phylo_trees  # noqa: F401
 from aspen.app.views.sample import samples  # noqa: F401
 from aspen.app.views.usergroup import usergroup  # noqa: F401


### PR DESCRIPTION
### Description

Gets a presigned url for an s3 object and returns it as a "magic" url that can be fed into nextstrain. When this url is accessed, the server simply redirects to the presigned url. The presigned url has an expiration of 5 minutes.

Example:
![Screenshot from 2021-03-16 22-11-01](https://user-images.githubusercontent.com/24234461/111418238-863f8380-86a4-11eb-8fff-9e7fa996d51c.png)


#### Issue
[ch119787](https://app.clubhouse.io/genepi/stories/space/119787)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
