### PR TITLE
Fixes for nextstrain batch pipeline

### DIFF
--- a/terraform/nextstrain_batch.tf
+++ b/terraform/nextstrain_batch.tf
@@ -55,7 +55,7 @@ resource "aws_launch_template" "nextstrain-launch-template" {
 
 
 resource "aws_batch_compute_environment" "nextstrain-compute-environment" {
-  compute_environment_name = "aspen-nextstrain"
+  compute_environment_name_prefix = "aspen-nextstrain-"
 
   compute_resources {
     instance_role = aws_iam_instance_profile.nextstrain-ecs-instance-role.arn
@@ -90,6 +90,9 @@ resource "aws_batch_compute_environment" "nextstrain-compute-environment" {
     aws_iam_role_policy_attachment.nextstrain-batch-service-role
   ]
 
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 

--- a/terraform/nextstrain_iam.tf
+++ b/terraform/nextstrain_iam.tf
@@ -1,6 +1,8 @@
 resource "aws_iam_policy" "nextstrain-jobs-access-to-batch" {
   name = "nextstrain-jobs-access-to-batch"
-  policy = file("${path.module}/policies/nextstrain_jobs_access_to_batch.json")
+  policy = templatefile("${path.module}/policies/nextstrain_jobs_access_to_batch.json", {
+    NEXTSTRAIN_JOBS_ROLE = aws_iam_role.nextstrain-ecs-instance-role.name
+  })
 }
 
 

--- a/terraform/policies/nextstrain_jobs_access_to_batch.json
+++ b/terraform/policies/nextstrain_jobs_access_to_batch.json
@@ -19,7 +19,7 @@
             "Sid": "VisualEditor1",
             "Effect": "Allow",
             "Action": "iam:PassRole",
-            "Resource": "arn:aws:iam::*:role/NextstrainJobsRole"
+            "Resource": "arn:aws:iam::*:role/${NEXTSTRAIN_JOBS_ROLE}"
         }
     ]
 }


### PR DESCRIPTION
### Description
I encountered some issues when creating the aspen batch pipeline modeled after the nextstrain pipeline.  These are the fixes:

1. Use `compute_environment_name_prefix` to manage recreations of an aws batch compute environment.  Ideally, it ought to remove the batch compute environment from a job queue, then delete the compute environment, but it doesn't seem to handle that.  The ["fix"](https://github.com/hashicorp/terraform-provider-aws/issues/3207) is to use this random name creation along with [lifecycle -> create_before_destroy=True](https://github.com/hashicorp/terraform-provider-aws/issues/2044) to manage this resource.
2. The jobs role should is not `NextstrainJobsRole`.  It is configured as `nextstrain_ecs_instance_profile`, though we can just pass it in to be safe against future changes.

### Test plan
make deploy-tf
