### PR TITLE
phylotree api fix 

### DIFF
--- a/src/py/aspen/app/views/phylo_trees.py
+++ b/src/py/aspen/app/views/phylo_trees.py
@@ -27,6 +27,7 @@ PHYLO_TREE_KEY = "phylo_trees"
 @requires_auth
 def phylo_trees():
     with session_scope(application.DATABASE_INTERFACE) as db_session:
+        # import pdb; pdb.set_trace()
         profile = session["profile"]
         user = (
             get_usergroup_query(db_session, profile["user_id"])
@@ -40,7 +41,8 @@ def phylo_trees():
                 (
                     db_session.query(func.count(1))
                     .select_from(PathogenGenome)
-                    .join(WorkflowInputs, Workflow)
+                    .join(WorkflowInputs)
+                    .join(Workflow)
                     .filter(Workflow.id == PhyloRun.workflow_id)
                 ).label("phylo_run_genome_count"),
             )

--- a/src/py/aspen/app/views/phylo_trees.py
+++ b/src/py/aspen/app/views/phylo_trees.py
@@ -27,7 +27,6 @@ PHYLO_TREE_KEY = "phylo_trees"
 @requires_auth
 def phylo_trees():
     with session_scope(application.DATABASE_INTERFACE) as db_session:
-        # import pdb; pdb.set_trace()
         profile = session["profile"]
         user = (
             get_usergroup_query(db_session, profile["user_id"])


### PR DESCRIPTION
### Description

@jgadling and i were testing this endpoint and were getting this traceback:

```
Traceback (most recent call last):
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 2464, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 2450, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 1867, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/plogan/code/aspen/src/py/aspen/app/app.py", line 52, in decorated
    return f(*args, **kwargs)
  File "/Users/plogan/code/aspen/src/py/aspen/app/views/phylo_trees.py", line 44, in phylo_trees
    .join(WorkflowInputs, Workflow)
  File "<string>", line 2, in join
    
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/sql/base.py", line 96, in _generative
    x = fn(self, *args, **kw)
  File "<string>", line 2, in join
    
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/orm/base.py", line 224, in generate
    fn(self, *args[1:], **kw)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 2307, in join
    for i, prop in enumerate(_props)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 2307, in <genexpr>
    for i, prop in enumerate(_props)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/sql/coercions.py", line 168, in expect
    element, argname=argname, **kw
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/sql/coercions.py", line 380, in _literal_coercion
    self._raise_for_expected(element, argname)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/sql/coercions.py", line 262, in _raise_for_expected
    util.raise_(exc.ArgumentError(msg, code=code), replace_context=err)
  File "/Users/plogan/code/aspen/.venv/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 198, in raise_
    raise exception
sqlalchemy.exc.ArgumentError: SQL expression for ON clause expected, got <class 'aspen.database.models.workflow.Workflow'>.
```

breaking up the joins fixed the issue for me, i think what was happening was that the join was expecting Workflow to be an on clause for the join.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

hit endpoint and got expected response (my local db was empty):
```
{
  "phylo_trees": []
}
```
