### PR TITLE
Grant aspen batch jobs additional permissions

### DIFF
--- a/terraform/aspen_batch_iam.tf
+++ b/terraform/aspen_batch_iam.tf
@@ -1,6 +1,65 @@
+data "aws_secretsmanager_secret" "gisaid-download-credentials" {
+  name = "gisaid-download-credentials"
+}
+
 resource "aws_iam_role" "aspen-batch-jobs-role" {
   name = "aspen-batch-jobs-role"
   assume_role_policy = templatefile("${path.module}/iam_templates/trust_policy.json", {
     trust_services = ["ecs-tasks"]
   })
+}
+
+
+resource "aws_iam_policy" "aspen-batch-jobs-policies" {
+  name = "aspen-batch-jobs-policies"
+  policy = <<-POLICY
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": "secretsmanager:GetSecretValue",
+              "Resource": [
+                  "${data.aws_secretsmanager_secret.aspen_config.arn}",
+                  "${data.aws_secretsmanager_secret.gisaid-download-credentials.arn}"
+              ]
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "batch:SubmitJob"
+              ],
+              "Resource": [
+                  "arn:aws:batch:*:*:job-definition/${aws_batch_job_definition.aspen-batch-job-definition.name}",
+                  "arn:aws:batch:*:*:job-queue/${aws_batch_job_queue.aspen-batch-job-queue.name}"
+              ]
+          },
+          {
+              "Effect": "Allow",
+              "Action": "rds:DescribeDBInstances",
+              "Resource": [
+                  "${aws_db_instance.db.arn}"
+              ]
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "s3:GetObject",
+                  "s3:PutObject"
+              ],
+              "Resource": [
+                  "arn:aws:s3:::${aws_s3_bucket.aspen-db-data.bucket}/raw_gisaid_dump/*",
+                  "arn:aws:s3:::${aws_s3_bucket.aspen-db-data.bucket}/processed_gisaid_dump/*",
+                  "arn:aws:s3:::${aws_s3_bucket.aspen-db-data.bucket}/aligned_gisaid_dump/*"
+              ]
+          }
+      ]
+  }
+  POLICY
+}
+
+
+resource "aws_iam_role_policy_attachment" "aspen-batch-job-policies" {
+  role       = aws_iam_role.aspen-batch-jobs-role.name
+  policy_arn = aws_iam_policy.aspen-batch-jobs-policies.arn
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket" "aspen-data" {
+resource "aws_s3_bucket" "aspen-db-data" {
   bucket = join("", ["aspen-db-data-", var.DEPLOYMENT_ENVIRONMENT])
   acl = "private"
 }


### PR DESCRIPTION
### Description
1. This allows aspen batch jobs access to the secret that holds the gisaid credentials.
1. This allows aspen batch jobs access to the aspen-config secret.
1. This allows aspen batch jobs access to create more batch jobs.
1. This allows aspen batch jobs access to S3.

Depends on #202, #204

#### Issue
[ch126776](https://app.clubhouse.io/genepi/story/126776/workflow-to-download-and-process-raw-gisaid-data)

### Test plan
`make deploy-tf`
