### PR TITLE
Processed gisaid dumps are stored in two separate files (metadata and sequences)

### DIFF
--- a/database_migrations/versions/20210323_135758_processed_gisaid_dumps_should_have_both_.py
+++ b/database_migrations/versions/20210323_135758_processed_gisaid_dumps_should_have_both_.py
@@ -1,0 +1,74 @@
+"""processed gisaid dumps should have both a sequences and a metadata file
+
+Create Date: 2021-03-23 13:58:00.002121
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210323_135758"
+down_revision = "20210226_220143"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "processed_gisaid_dump",
+        sa.Column("metadata_s3_key", sa.String(), nullable=False),
+        schema="aspen",
+    )
+    op.add_column(
+        "processed_gisaid_dump",
+        sa.Column("sequences_s3_key", sa.String(), nullable=False),
+        schema="aspen",
+    )
+    op.drop_constraint(
+        "uq_processed_gisaid_dump_s3_bucket",
+        "processed_gisaid_dump",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_processed_gisaid_dump_s3_bucket_key",
+        "processed_gisaid_dump",
+        ["s3_bucket", "metadata_s3_key"],
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        "uq_processed_gisaid_dump_s3_bucket_sequences",
+        "processed_gisaid_dump",
+        ["s3_bucket", "sequences_s3_key"],
+        schema="aspen",
+    )
+    op.drop_column("processed_gisaid_dump", "s3_key", schema="aspen")
+
+
+def downgrade():
+    op.add_column(
+        "processed_gisaid_dump",
+        sa.Column("s3_key", sa.VARCHAR(), autoincrement=False, nullable=False),
+        schema="aspen",
+    )
+    op.drop_constraint(
+        "uq_processed_gisaid_dump_s3_bucket_sequences",
+        "processed_gisaid_dump",
+        schema="aspen",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_processed_gisaid_dump_s3_bucket_key",
+        "processed_gisaid_dump",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_processed_gisaid_dump_s3_bucket",
+        "processed_gisaid_dump",
+        ["s3_bucket", "s3_key"],
+        schema="aspen",
+    )
+    op.drop_column("processed_gisaid_dump", "sequences_s3_key", schema="aspen")
+    op.drop_column("processed_gisaid_dump", "metadata_s3_key", schema="aspen")

--- a/src/py/aspen/database/models/gisaid_dump.py
+++ b/src/py/aspen/database/models/gisaid_dump.py
@@ -32,11 +32,23 @@ class RawGisaidDump(Entity):
 
 class ProcessedGisaidDump(Entity):
     __tablename__ = "processed_gisaid_dump"
-    __table_args__ = (UniqueConstraint("s3_bucket", "s3_key"),)
+    __table_args__ = (
+        UniqueConstraint(
+            "s3_bucket",
+            "sequences_s3_key",
+            name="uq_processed_gisaid_dump_s3_bucket_sequences",
+        ),
+        UniqueConstraint(
+            "s3_bucket",
+            "metadata_s3_key",
+            name="uq_processed_gisaid_dump_s3_bucket_key",
+        ),
+    )
 
     entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)
     s3_bucket = Column(String, nullable=False)
-    s3_key = Column(String, nullable=False)
+    sequences_s3_key = Column(String, nullable=False)
+    metadata_s3_key = Column(String, nullable=False)
 
     __mapper_args__ = {"polymorphic_identity": EntityType.PROCESSED_GISAID_DUMP}
 

--- a/src/py/aspen/database/models/tests/test_gisaid_models.py
+++ b/src/py/aspen/database/models/tests/test_gisaid_models.py
@@ -15,7 +15,8 @@ def test_workflow(session):
     download_s3_bucket = "download_bucket"
     download_s3_key = "download_key"
     processed_s3_bucket = "processed_bucket"
-    processed_s3_key = "processed_key"
+    processed_sequences_s3_key = "processed_sequences_key"
+    processed_metadata_s3_key = "processed_metadata_key"
     start_datetime = datetime.now()
     software_versions = {"test": "v0.0.1"}
     raw_gisaid_dump = RawGisaidDump(
@@ -26,7 +27,8 @@ def test_workflow(session):
 
     processed_gisaid_dump = ProcessedGisaidDump(
         s3_bucket=processed_s3_bucket,
-        s3_key=processed_s3_key,
+        sequences_s3_key=processed_sequences_s3_key,
+        metadata_s3_key=processed_metadata_s3_key,
     )
 
     workflow = GisaidDumpWorkflow(


### PR DESCRIPTION
### Description
See description.

#### Issue
[ch126776](https://app.clubhouse.io/genepi/story/126776/workflow-to-download-and-process-raw-gisaid-data)

### Test plan
applied migration to local database