### PR TITLE
Ingest and transform workflows for gisaid data

### DIFF
--- a/workflows/ingest_gisaid/ingest.sh
+++ b/workflows/ingest_gisaid/ingest.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+shopt -s inherit_errexit
+
+# install jq
+apt-get install -y jq
+
+start_time=$(date +%s)
+build_id=$(date +%Y%m%d-%H%M)
+
+# fetch the gisaid dataset and transform it.
+gisaid_credentials=$(aws secretsmanager get-secret-value --secret-id gisaid-download-credentials --query SecretString --output text)
+gisaid_username=$(echo "${gisaid_credentials}" | jq -r .username)
+gisaid_password=$(echo "${gisaid_credentials}" | jq -r .password)
+
+curl "https://www.epicov.org/epi3/3p/exp3/export/export.json.bz2" --user "${gisaid_username}":"${gisaid_password}" | bunzip2 | xz -2 -c > /aspen/gisaid.ndjson.xz
+
+bucket=aspen-data-"${DEPLOYMENT_ENVIRONMENT}"
+key=raw_gisaid_dump/"${build_id}"/gisaid.ndjson.xz
+aws s3 cp /aspen/gisaid.ndjson.xz s3://"${bucket}"/"${key}"
+
+cd /aspen/
+
+# update aspen
+aspen_workflow_rev=$(git rev-parse HEAD)
+git fetch git://github.com/chanzuckerberg/aspen "${ASPEN_GIT_REVSPEC}"
+git checkout FETCH_HEAD
+aspen_creation_rev=$(git rev-parse HEAD)
+
+if [ "${aspen_workflow_rev}" != "${aspen_creation_rev}" ]; then
+    # reinstall aspen
+    /aspen/.venv/bin/pip install -e src/py
+fi
+
+end_time=$(date +%s)
+
+# create the objects
+entity_id=$(/aspen/.venv/bin/python workflows/ingest_gisaid/save.py              \
+                                    --aspen-workflow-rev "${aspen_workflow_rev}" \
+                                    --aspen-creation-rev "${aspen_creation_rev}" \
+                                    --start-time "${start_time}"                 \
+                                    --end-time "${end_time}"                     \
+                                    --gisaid-s3-bucket "${bucket}"               \
+                                    --gisaid-s3-key "${key}"                     \
+         )
+
+# invoke the next workflow
+aws batch submit-job \
+    --job-name "transform-gisaid"                \
+    --job-queue aspen-batch                      \
+    --job-definition aspen-batch-job-definition  \
+    --container-overrides "
+      {
+        \"command\": [\"${ASPEN_GIT_REVSPEC}\", \"workflows/transform_gisaid/transform.sh\", \"${entity_id}\"],
+        \"memory\": 15000
+      }"

--- a/workflows/ingest_gisaid/save.py
+++ b/workflows/ingest_gisaid/save.py
@@ -1,0 +1,47 @@
+import datetime
+
+import click
+
+from aspen.config.config import RemoteDatabaseConfig
+from aspen.database.connection import (
+    get_db_uri,
+    init_db,
+    session_scope,
+    SqlAlchemyInterface,
+)
+from aspen.database.models import RawGisaidDump
+
+
+@click.command("save")
+@click.option("--aspen-workflow-rev", type=str, required=True)
+@click.option("--aspen-creation-rev", type=str, required=True)
+@click.option("--start-time", type=int, required=True)
+@click.option("--end-time", type=int, required=True)
+@click.option("--gisaid-s3-bucket", type=str, required=True)
+@click.option("--gisaid-s3-key", type=str, required=True)
+def cli(
+    aspen_workflow_rev: str,
+    aspen_creation_rev: str,
+    start_time: int,
+    end_time: int,
+    gisaid_s3_bucket: str,
+    gisaid_s3_key: str,
+):
+    start_time_datetime = datetime.datetime.fromtimestamp(start_time)
+
+    interface: SqlAlchemyInterface = init_db(get_db_uri(RemoteDatabaseConfig()))
+
+    entity = RawGisaidDump(
+        download_date=start_time_datetime,
+        s3_bucket=gisaid_s3_bucket,
+        s3_key=gisaid_s3_key,
+    )
+
+    with session_scope(interface) as session:
+        session.add(entity)
+        session.flush()
+        print(entity.entity_id)
+
+
+if __name__ == "__main__":
+    cli()

--- a/workflows/transform_gisaid/lookup_raw_gisaid_object.py
+++ b/workflows/transform_gisaid/lookup_raw_gisaid_object.py
@@ -1,0 +1,40 @@
+import json
+
+import click
+
+from aspen.config.config import RemoteDatabaseConfig
+from aspen.database.connection import (
+    get_db_uri,
+    init_db,
+    session_scope,
+    SqlAlchemyInterface,
+)
+from aspen.database.models import RawGisaidDump
+
+
+@click.command("lookup")
+@click.option("--raw-gisaid-object-id", type=int, required=True)
+def cli(
+    raw_gisaid_object_id: int,
+):
+    interface: SqlAlchemyInterface = init_db(get_db_uri(RemoteDatabaseConfig()))
+
+    with session_scope(interface) as session:
+        raw_gisaid_dump: RawGisaidDump = (
+            session.query(RawGisaidDump)
+            .filter(RawGisaidDump.id == raw_gisaid_object_id)
+            .one()
+        )
+
+        print(
+            json.dumps(
+                {
+                    "bucket": raw_gisaid_dump.s3_bucket,
+                    "key": raw_gisaid_dump.s3_key,
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/workflows/transform_gisaid/save.py
+++ b/workflows/transform_gisaid/save.py
@@ -1,0 +1,79 @@
+import datetime
+
+import click
+
+from aspen.config.config import RemoteDatabaseConfig
+from aspen.database.connection import (
+    get_db_uri,
+    init_db,
+    session_scope,
+    SqlAlchemyInterface,
+)
+from aspen.database.models import (
+    GisaidDumpWorkflow,
+    ProcessedGisaidDump,
+    RawGisaidDump,
+    WorkflowStatusType,
+)
+from aspen.database.models.workflow import SoftwareNames
+
+
+@click.command("save")
+@click.option("--aspen-workflow-rev", type=str, required=True)
+@click.option("--aspen-creation-rev", type=str, required=True)
+@click.option("--ncov-ingest-rev", type=str, required=True)
+@click.option("--start-time", type=int, required=True)
+@click.option("--end-time", type=int, required=True)
+@click.option("--raw-gisaid-object-id", type=int, required=True)
+@click.option("--gisaid-s3-bucket", type=str, required=True)
+@click.option("--gisaid-sequences-s3-key", type=str, required=True)
+@click.option("--gisaid-metadata-s3-key", type=str, required=True)
+def cli(
+    aspen_workflow_rev: str,
+    aspen_creation_rev: str,
+    ncov_ingest_rev: str,
+    start_time: int,
+    end_time: int,
+    raw_gisaid_object_id: int,
+    gisaid_s3_bucket: str,
+    gisaid_sequences_s3_key: str,
+    gisaid_metadata_s3_key: str,
+):
+    start_time_datetime = datetime.datetime.fromtimestamp(start_time)
+    end_time_datetime = datetime.datetime.fromtimestamp(end_time)
+
+    interface: SqlAlchemyInterface = init_db(get_db_uri(RemoteDatabaseConfig()))
+    with session_scope(interface) as session:
+        raw_gisaid_dump: RawGisaidDump = (
+            session.query(RawGisaidDump)
+            .filter(RawGisaidDump.id == raw_gisaid_object_id)
+            .one()
+        )
+
+        # create an output
+        processed_gisaid_dump = ProcessedGisaidDump(
+            s3_bucket=gisaid_s3_bucket,
+            sequences_s3_key=gisaid_sequences_s3_key,
+            metadata_s3_key=gisaid_metadata_s3_key,
+        )
+
+        # attach a workflow
+        workflow = GisaidDumpWorkflow(
+            start_datetime=start_time_datetime,
+            end_datetime=end_time_datetime,
+            workflow_status=WorkflowStatusType.COMPLETED,
+            software_versions={
+                SoftwareNames.ASPEN_WORKFLOW: aspen_workflow_rev,
+                SoftwareNames.ASPEN_CREATION: aspen_creation_rev,
+                SoftwareNames.NCOV_INGEST: ncov_ingest_rev,
+            },
+        )
+
+        workflow.inputs.append(raw_gisaid_dump)
+        workflow.outputs.append(processed_gisaid_dump)
+        session.flush()
+        print(processed_gisaid_dump.entity_id)
+
+
+if __name__ == "__main__":
+    cli()

--- a/workflows/transform_gisaid/transform.sh
+++ b/workflows/transform_gisaid/transform.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+shopt -s inherit_errexit
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <raw_gisaid_object_id>"
+    exit 1
+fi
+
+# install jq and gcc (gcc is for netifaces, a python package)
+apt-get install -y jq gcc
+
+# get the bucket/key from the object id
+raw_gisaid_location=$(/aspen/.venv/bin/python workflows/transform_gisaid/lookup_raw_gisaid_object.py --raw-gisaid-object-id "${1}")
+raw_gisaid_s3_bucket=$(echo "${raw_gisaid_location}" | jq -r .bucket)
+raw_gisaid_s3_key=$(echo "${raw_gisaid_location}" | jq -r .key)
+
+start_time=$(date +%s)
+build_id=$(date +%Y%m%d-%H%M)
+
+# set up ncov-ingest's environment
+mkdir -p /ncov-ingest/data/gisaid
+cd /ncov-ingest
+git init
+git fetch git://github.com/nextstrain/ncov-ingest.git
+git checkout FETCH_HEAD
+ncov_ingest_git_rev=$(git rev-parse HEAD)
+python3.7 -m venv /ncov-ingest/.venv
+source /ncov-ingest/.venv/bin/activate
+pip install -U pip pipenv
+pipenv install
+
+# fetch the gisaid dataset and transform it.
+aws s3 cp --no-progress s3://"${raw_gisaid_s3_bucket}"/"${raw_gisaid_s3_key}" - | xz -d > data/gisaid.ndjson
+./bin/transform-gisaid /ncov-ingest/data/gisaid.ndjson                            \
+                       --output-metadata /ncov-ingest/data/gisaid/metadata.tsv    \
+                       --output-fasta /ncov-ingest/data/gisaid/sequences.fasta    \
+                       --output-unix-newline
+
+xz -2 /ncov-ingest/data/gisaid/sequences.fasta
+ls -lR data
+
+# upload the files to S3
+bucket=aspen-data-"${DEPLOYMENT_ENVIRONMENT}"
+sequences_key=processed_gisaid_dump/"${build_id}"/sequences.fasta.xz
+metadata_key=processed_gisaid_dump/"${build_id}"/metadata.tsv
+aws s3 cp /ncov-ingest/data/gisaid/sequences.fasta.xz s3://"${bucket}"/"${sequences_key}"
+aws s3 cp /ncov-ingest/data/gisaid/metadata.tsv s3://"${bucket}"/"${metadata_key}"
+
+cd /aspen/
+
+# update aspen
+aspen_workflow_rev=$(git rev-parse HEAD)
+git fetch git://github.com/chanzuckerberg/aspen "$ASPEN_GIT_REVSPEC"
+git checkout FETCH_HEAD
+aspen_creation_rev=$(git rev-parse HEAD)
+
+if [ "${aspen_workflow_rev}" != "${aspen_creation_rev}" ]; then
+    # reinstall aspen
+    /aspen/.venv/bin/pip install -e src/py
+fi
+
+end_time=$(date +%s)
+
+# create the objects
+entity_id=$(/aspen/.venv/bin/python workflows/transform_gisaid/save.py           \
+                                    --aspen-workflow-rev "${aspen_workflow_rev}" \
+                                    --aspen-creation-rev "${aspen_creation_rev}" \
+                                    --ncov-ingest-rev "${ncov_ingest_git_rev}"   \
+                                    --start-time "${start_time}"                 \
+                                    --end-time "${end_time}"                     \
+                                    --raw-gisaid-object-id "${1}"                \
+                                    --gisaid-s3-bucket "${bucket}"               \
+                                    --gisaid-sequences-s3-key "${sequences_key}" \
+                                    --gisaid-metadata-s3-key "${metadata_key}"   \
+         )


### PR DESCRIPTION
### Description
This encompasses the workflows for both the ingest and transform workflows.

Some interesting notes:
1. I did not add an object to the db indicating workflow start (followed by an update to reflect workflow completion).  Rationale is that these workflows are so simple and mostly not-user-facing so that it's really not worth tracking failed workflows.
1. To circumvent the issue where the db/codebase may have moved forward from the time we start the workflow and the time we are ready to write to the DB, we update the local checkout.  This implies that we should be running workflows against a git tag that accurately reflects the state of the database.  i.e., if we run a migration on the database, it is important to advance the tag.

Depends on #206, #207, #208

#### Issue
[ch126776](https://app.clubhouse.io/genepi/story/126776/workflow-to-download-and-process-raw-gisaid-data)

### Test plan
Successfully ran the workflows!
