### PR TITLE
fine tune where we ignore missing imports

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: src/py
         run: |
           python -m pip install pipenv
-          pip install $(pipenv lock --requirements --dev | egrep '^(flake8|black|isort|mypy|sqlalchemy-stubs)==')
+          pip install $(pipenv lock --requirements --dev | egrep '^(flake8|black|isort|mypy|sqlalchemy-stubs|pytest)==')
       - name: Verify code style
         run: |
           make -k style

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,2 +1,38 @@
 [mypy]
 plugins = sqlmypy
+
+[mypy-alembic.*]
+ignore_missing_imports = True
+
+[mypy-auth0.*]
+ignore_missing_imports = True
+
+[mypy-authlib.integrations.flask_client]
+ignore_missing_imports = True
+
+[mypy-boto3.*]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-covidhub.*]
+ignore_missing_imports = True
+
+[mypy-covid_database.*]
+ignore_missing_imports = True
+
+[mypy-enumtables.*]
+ignore_missing_imports = True
+
+[mypy-flask_cors.*]
+ignore_missing_imports = True
+
+[mypy-IPython.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ MYPY_TARGETS = $(foreach stylecheckdir, $(TYPE_CHECK_INDIVIDUAL_PYTHON_CODE_DIRE
 mypy: mypy-base $(MYPY_TARGETS)
 
 mypy-base:
-	mypy --ignore-missing-imports $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
+	mypy $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
 
 $(MYPY_TARGETS): mypy-%: mypy-base
-	mypy --ignore-missing-imports $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES) $*
+	mypy $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES) $*
 
 .PHONY: style lint black isort
 

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -148,3 +148,5 @@ In [3]:
 ## Updating python dependencies
 
 To update python dependencies, update the [`Pipfile`](../../Pipfile) and run `make update-deps`.  This will update [`Pipfile.lock`](../../Pipfile.lock) and [`requirements.txt`](../../src/py/requirements.txt) (used by setup.py), and [`requirements-dev.txt`](../../src/py/requirements-dev.txt) (used by tests).
+
+If you add a third-party library (directly or indirectly) that does not support [python typing](https://docs.python.org/3/library/typing.html), then you may need to add an entry to [`mypy.ini`](../../mypy.ini) to let mypy know [not to expect type hints for that library](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-type-hints-for-third-party-library).

--- a/src/py/aspen/__main__.py
+++ b/src/py/aspen/__main__.py
@@ -1,6 +1,0 @@
-from aspen.app.main import application
-
-# Setting debug to True enables debug output. This line should be
-# removed before deploying a production app.
-application.debug = True
-application.run()


### PR DESCRIPTION
### Description
Rather than ignoring all missing imports, be explicit about which missing imports are okay.  It's discouraged in the [docs](https://mypy.readthedocs.io/en/stable/running_mypy.html), but I'm not sure if it's that valuable.  Open to a debate whether we should do this or not.

Depends on #212

### Test plan
make -j style
