### PR TITLE
[easy] Allow both m5 and r5 instances for running jobs on the aspen batch queue

### DIFF
--- a/terraform/aspen_batch.tf
+++ b/terraform/aspen_batch.tf
@@ -75,6 +75,7 @@ resource "aws_batch_compute_environment" "aspen-batch-compute-environment" {
     ec2_key_pair = "phoenix"
 
     instance_type = [
+      "m5",
       "r5",
     ]
 


### PR DESCRIPTION
### Description
ingest and transform are both very single threaded, and require r5 instances.  align requires both cpu and memory, and m5 instances are more suitable.

### Test plan
test in prod.
