### PR TITLE
Update Dockerfile to install sqlalchemy-enum-tables from the correct path

### DIFF
--- a/docker/aspen-batch/Dockerfile
+++ b/docker/aspen-batch/Dockerfile
@@ -21,7 +21,7 @@ RUN git fetch git://github.com/chanzuckerberg/aspen $REVSPEC
 RUN git checkout FETCH_HEAD
 RUN python3.7 -m venv /aspen/.venv
 RUN /aspen/.venv/bin/pip install -U pip
-RUN /aspen/.venv/bin/pip install -e third-party/sqlalchemy-enum-tables/
+RUN /aspen/.venv/bin/pip install -e src/py/third-party/sqlalchemy-enum-tables/
 RUN /aspen/.venv/bin/pip install -e src/py/
 RUN cd /
 RUN rm -rf /tmp/aspen-tmp

--- a/docker/aspen-batch/docker-entrypoint.sh
+++ b/docker/aspen-batch/docker-entrypoint.sh
@@ -21,7 +21,7 @@ else
     git checkout FETCH_HEAD
 
     /aspen/.venv/bin/pip install -U pip
-    /aspen/.venv/bin/pip install -e third-party/sqlalchemy-enum-tables/
+    /aspen/.venv/bin/pip install -e src/py/third-party/sqlalchemy-enum-tables/
     /aspen/.venv/bin/pip install -e src/py/
 
     shift


### PR DESCRIPTION
### Description
It's under src/py now.

### Test plan
tested a [workflow](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/aspen-batch-job-definition$252Fdefault$252F46de3ac1c07449e5a58b23489d359689)
