### PR TITLE
We don't need to create tables if we're starting with a db snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,6 @@ local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login ## Launch a ne
 	docker-compose exec -T utility $(BACKEND_APP_ROOT)/scripts/setup_dev_data.sh
 	docker-compose exec -T utility python scripts/setup_localdata.py
 	docker-compose exec -T utility pip install .
-	docker-compose exec -T utility aspen-cli db --docker create
 	docker-compose exec -T utility alembic upgrade head
 
 .PHONY: backend-debugger


### PR DESCRIPTION
### Description

Local dockerized dev env was running into trouble running migrations since this `aspen-cli db create` step isn't idempotent. Since we're starting the local dev db as a snapshot, we don't need this.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
