### PR TITLE
Convert accessions to use a workflow model

### DIFF
--- a/src/py/aspen/app/views/tests/test_samples_view.py
+++ b/src/py/aspen/app/views/tests/test_samples_view.py
@@ -31,7 +31,7 @@ def test_samples_view(
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
                 "upload_date": api_utils.format_datetime(sequencing_read.upload_date),
-                "gisaid": sequencing_read.accessions[0].public_identifier,
+                "gisaid": sequencing_read.accessions()[0].public_identifier,
             }
         ]
     }
@@ -104,7 +104,7 @@ def test_samples_view_system_admin(
             "upload_date": api_utils.format_datetime(
                 sequencing_read_collection.upload_date
             ),
-            "gisaid": sequencing_read_collection.accessions[0].public_identifier,
+            "gisaid": sequencing_read_collection.accessions()[0].public_identifier,
         }
     ]
 
@@ -155,7 +155,7 @@ def test_samples_view_cansee_metadata(
             "upload_date": api_utils.format_datetime(
                 sequencing_read_collection.upload_date
             ),
-            "gisaid": sequencing_read_collection.accessions[0].public_identifier,
+            "gisaid": sequencing_read_collection.accessions()[0].public_identifier,
         }
     ]
 
@@ -198,6 +198,6 @@ def test_samples_view_cansee_all(
             "upload_date": api_utils.format_datetime(
                 sequencing_read_collection.upload_date
             ),
-            "gisaid": sequencing_read_collection.accessions[0].public_identifier,
+            "gisaid": sequencing_read_collection.accessions()[0].public_identifier,
         }
     ]

--- a/src/py/aspen/database/models/__init__.py
+++ b/src/py/aspen/database/models/__init__.py
@@ -1,5 +1,10 @@
-from aspen.database.models.accessions import Accession  # noqa: F401
-from aspen.database.models.accessions import PublicRepositoryType  # noqa: F401
+from sqlalchemy.orm import configure_mappers
+
+from aspen.database.models.accessions import (  # noqa: F401
+    Accession,
+    AccessionWorkflow,
+    PublicRepositoryType,
+)
 from aspen.database.models.align_read import AlignRead, Bam  # noqa: F401
 from aspen.database.models.base import meta  # noqa: F401
 from aspen.database.models.cansee import CanSee, DataType  # noqa: F401
@@ -17,8 +22,8 @@ from aspen.database.models.host_filtering import (  # noqa: F401
 )
 from aspen.database.models.phylo_tree import PhyloRun, PhyloTree  # noqa: F401
 from aspen.database.models.sample import Sample  # noqa: F401
-from aspen.database.models.sequences import CallConsensus  # noqa: F401
 from aspen.database.models.sequences import (  # noqa: F401
+    CallConsensus,
     CalledPathogenGenome,
     PathogenGenome,
     SequencingInstrumentType,
@@ -33,3 +38,5 @@ from aspen.database.models.workflow import (  # noqa: F401
     WorkflowStatusType,
     WorkflowType,
 )
+
+configure_mappers()

--- a/src/py/aspen/database/models/accessions.py
+++ b/src/py/aspen/database/models/accessions.py
@@ -1,12 +1,14 @@
+import datetime
 import enum
+from typing import Optional
 
 import enumtables
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
-from sqlalchemy.orm import backref, relationship
 
-from aspen.database.models.base import base, idbase
-from aspen.database.models.entity import Entity
+from aspen.database.models.base import base
+from aspen.database.models.entity import Entity, EntityType
 from aspen.database.models.enum import Enum
+from aspen.database.models.workflow import Workflow, WorkflowStatusType, WorkflowType
 
 
 class PublicRepositoryType(enum.Enum):
@@ -24,18 +26,14 @@ _PublicRepositoryTypeTable = enumtables.EnumTable(
 )
 
 
-class Accession(idbase):  # type: ignore
+class Accession(Entity):
     """A single accession of an entity."""
 
     __tablename__ = "accessions"
     __table_args__ = (UniqueConstraint("repository_type", "public_identifier"),)
+    __mapper_args__ = {"polymorphic_identity": EntityType.PUBLIC_REPOSITORY_SUBMISSION}
 
-    entity_id = Column(
-        Integer,
-        ForeignKey(Entity.id),
-        nullable=False,
-    )
-    entity = relationship(Entity, backref=backref("accessions", uselist=True))  # type: ignore
+    entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)
 
     repository_type = Column(
         Enum(PublicRepositoryType),
@@ -44,3 +42,35 @@ class Accession(idbase):  # type: ignore
     )
 
     public_identifier = Column(String, nullable=False)
+
+    @staticmethod
+    def attach_to_entity(
+        entity: Entity,
+        repository_type: PublicRepositoryType,
+        public_identifier: str,
+        workflow_start_datetime: Optional[datetime.datetime] = None,
+        workflow_end_datetime: Optional[datetime.datetime] = None,
+    ):
+        assert not isinstance(entity, Accession)
+
+        accession = Accession(
+            repository_type=repository_type,
+            public_identifier=public_identifier,
+        )
+        workflow = AccessionWorkflow(
+            software_versions={},
+            workflow_status=WorkflowStatusType.COMPLETED,
+            start_datetime=workflow_start_datetime,
+            end_datetime=workflow_end_datetime,
+        )
+        accession.producing_workflow = workflow
+        entity.consuming_workflows.append(workflow)
+
+
+class AccessionWorkflow(Workflow):
+    __tablename__ = "accession_workflows"
+    __mapper_args__ = {
+        "polymorphic_identity": WorkflowType.PUBLIC_REPOSITORY_SUBMISSION
+    }
+
+    workflow_id = Column(Integer, ForeignKey(Workflow.id), primary_key=True)

--- a/src/py/aspen/database/models/entity.py
+++ b/src/py/aspen/database/models/entity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import enum
 from typing import (
     Mapping,
@@ -21,7 +22,7 @@ from aspen.database.models.base import base, idbase
 from aspen.database.models.enum import Enum
 
 if TYPE_CHECKING:
-    from aspen.database.models.accessions import Accession
+    from aspen.database.models.accessions import Accession, PublicRepositoryType
     from aspen.database.models.workflow import Workflow
 
 
@@ -38,6 +39,7 @@ class EntityType(enum.Enum):
     PROCESSED_GISAID_DUMP = "PROCESSED_GISAID_DUMP"
     ALIGNED_GISAID_DUMP = "ALIGNED_GISAID_DUMP"
     PHYLO_TREE = "PHYLO_TREE"
+    PUBLIC_REPOSITORY_SUBMISSION = "PUBLIC_REPOSITORY_SUBMISSION"
 
 
 # Create the enumeration table
@@ -73,8 +75,6 @@ class Entity(idbase):  # type: ignore
     producing_workflow = relationship(  # type: ignore
         "Workflow", backref=backref("outputs", uselist=True)
     )
-
-    accessions: MutableSequence[Accession]
 
     def get_parents(
         self,
@@ -123,3 +123,29 @@ class Entity(idbase):  # type: ignore
                 results.append(tup)
 
         return results
+
+    def accessions(self) -> Sequence[Accession]:
+        from .accessions import Accession
+
+        results: MutableSequence[Accession] = list()
+        for workflow, accessions in self.get_children(Accession):
+            results.extend(accessions)
+        return results
+
+    def add_accession(
+        self,
+        repository_type: PublicRepositoryType,
+        public_identifier: str,
+        workflow_start_datetime: Optional[datetime.datetime] = None,
+        workflow_end_datetime: Optional[datetime.datetime] = None,
+    ):
+        """Adds an accession to this object."""
+        from .accessions import Accession
+
+        Accession.attach_to_entity(
+            self,
+            repository_type,
+            public_identifier,
+            workflow_start_datetime,
+            workflow_end_datetime,
+        )

--- a/src/py/aspen/database/models/workflow.py
+++ b/src/py/aspen/database/models/workflow.py
@@ -17,6 +17,7 @@ class WorkflowType(enum.Enum):
     PROCESS_GISAID_DUMP = "PROCESS_GISAID_DUMP"
     ALIGN_GISAID_DUMP = "ALIGN_GISAID_DUMP"
     PHYLO_RUN = "PHYLO_RUN"
+    PUBLIC_REPOSITORY_SUBMISSION = "PUBLIC_REPOSITORY_SUBMISSION"
 
 
 # Create the enumeration table
@@ -68,7 +69,7 @@ class Workflow(idbase):  # type: ignore
     }
 
     start_datetime = Column(
-        DateTime, nullable=False, comment="datetime when the workflow is started."
+        DateTime, nullable=True, comment="datetime when the workflow is started."
     )
     end_datetime = Column(
         DateTime,

--- a/src/py/aspen/test_infra/models/sequences.py
+++ b/src/py/aspen/test_infra/models/sequences.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from aspen.database.models import (
-    Accession,
     PublicRepositoryType,
     Sample,
     SequencingInstrumentType,
@@ -31,10 +30,8 @@ def sequencing_read_factory(
         s3_key=s3_key,
     )
     for public_repository_type, public_identifier in accessions.items():
-        sequencing_reads.accessions.append(
-            Accession(
-                repository_type=public_repository_type,
-                public_identifier=public_identifier,
-            )
+        sequencing_reads.add_accession(
+            repository_type=public_repository_type,
+            public_identifier=public_identifier,
         )
     return sequencing_reads

--- a/src/py/database_migrations/versions/20210330_120956_accessions_to_workflow_model.py
+++ b/src/py/database_migrations/versions/20210330_120956_accessions_to_workflow_model.py
@@ -1,0 +1,46 @@
+"""accessions to workflow model
+
+Create Date: 2021-03-30 12:09:58.581873
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20210330_120956"
+down_revision = "20210324_165817"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DELETE FROM aspen.accessions")
+
+    op.create_table(
+        "accession_workflows",
+        sa.Column("workflow_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["aspen.workflows.id"],
+            name=op.f("fk_accession_workflows_workflow_id_workflows"),
+        ),
+        sa.PrimaryKeyConstraint("workflow_id", name=op.f("pk_accession_workflows")),
+        schema="aspen",
+    )
+    op.drop_column("accessions", "id", schema="aspen")
+    op.alter_column(
+        "workflows",
+        "start_datetime",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_comment="datetime when the workflow is started.",
+        schema="aspen",
+    )
+    op.enum_insert("entity_types", ["PUBLIC_REPOSITORY_SUBMISSION"], schema="aspen")
+    op.enum_insert("workflow_types", ["PUBLIC_REPOSITORY_SUBMISSION"], schema="aspen")
+
+
+def downgrade():
+    raise NotImplementedError("Reversing this migration is not supported")


### PR DESCRIPTION
### Description
This turned out to be a lot more complicated than I expected.  Most of the complexity lies in the conversion logic (which we are **not** doing) and the logic for sample view.  The latter is required and now adds another roundtrip to the server.  I suspect it should be possible to do what we want in one query, but I can't seem to massage sqlalchemy to do what I want.

Rest of this is pretty straightforward.

#### Issue
[ch123630](https://app.clubhouse.io/genepi/story/123630/move-accessions-to-a-workflow-model)

### Test plan
make -j style unit-tests
