### PR TITLE
Add get_uploaded_entity helper

### DIFF
--- a/src/py/aspen/app/views/sample.py
+++ b/src/py/aspen/app/views/sample.py
@@ -27,18 +27,10 @@ def _format_created_date(sample: Sample) -> str:
 def _format_gisaid_accession(
     sample: Sample, entity_id_to_accession_map: Mapping[int, Accession]
 ) -> str:
-    if sample.uploaded_pathogen_genome is not None:
-        accession = entity_id_to_accession_map.get(
-            sample.uploaded_pathogen_genome.entity_id, None
-        )
-        if accession is not None:
-            return accession.public_identifier
-    if sample.sequencing_reads_collection is not None:
-        accession = entity_id_to_accession_map.get(
-            sample.sequencing_reads_collection.entity_id, None
-        )
-        if accession is not None:
-            return accession.public_identifier
+    uploaded_entity = sample.get_uploaded_entity()
+    accession = entity_id_to_accession_map.get(uploaded_entity.entity_id, None)
+    if accession is not None:
+        return accession.public_identifier
     return "NOT SUBMITTED"
 
 

--- a/src/py/aspen/database/models/sample.py
+++ b/src/py/aspen/database/models/sample.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Union
 
 from sqlalchemy import (
     Column,
@@ -167,3 +167,14 @@ class Sample(idbase, DictMixin):  # type: ignore
 
     sequencing_reads_collection: Optional[SequencingReadsCollection]
     uploaded_pathogen_genome: Optional[UploadedPathogenGenome]
+
+    def get_uploaded_entity(
+        self,
+    ) -> Union[SequencingReadsCollection, UploadedPathogenGenome]:
+        if self.sequencing_reads_collection is not None:
+            return self.sequencing_reads_collection
+        elif self.uploaded_pathogen_genome is not None:
+            return self.uploaded_pathogen_genome
+        raise ValueError(
+            "Sample has neither sequencing reads nor uploaded pathogen genome."
+        )


### PR DESCRIPTION
### Description
This simplifies the logic when we're going from sample to whatever was uploaded to represent the sample.

Depends on #230 

### Test plan
make -j style unit-tests
