### PR TITLE
Add accessors to pathogen genomes

### DIFF
--- a/src/py/aspen/database/models/sequences.py
+++ b/src/py/aspen/database/models/sequences.py
@@ -141,6 +141,14 @@ class SequencingReadsCollection(Entity, DictMixin):
 
         return results
 
+    @property
+    def pathogen_genomes(self) -> Sequence[CalledPathogenGenome]:
+        return [
+            pathogen_genome
+            for host_filtered_sequencing_reads_collection in self.host_filtered_sequencing_reads
+            for pathogen_genome in host_filtered_sequencing_reads_collection.pathogen_genomes
+        ]
+
 
 class PathogenGenome(Entity):
     __tablename__ = "pathogen_genomes"


### PR DESCRIPTION
### Description
1. Add accessor to retrieve all the pathogen genomes retrieved from a HostFilteredSequencingReadsCollection.
2. Add accessor to retrieve all the pathogen genomes retrieved from a SequencingReadsCollection.

#### Issue
[ch126782](https://app.clubhouse.io/genepi/story/126782/workflow-to-pull-the-data-from-aspen-api-endpoint-and-launch-nextstrain-build)

### Test plan
used in subsequent PR.
