### PR TITLE
Add region to sample table

### DIFF
--- a/src/py/aspen/covidhub_import/implementation.py
+++ b/src/py/aspen/covidhub_import/implementation.py
@@ -32,6 +32,7 @@ from aspen.database.models import (
     PhyloRun,
     PhyloTree,
     PublicRepositoryType,
+    RegionType,
     Sample,
     UploadedPathogenGenome,
     User,
@@ -280,6 +281,7 @@ def import_project(
             sample.location = project.location
             sample.division = "California"
             sample.country = "USA"
+            sample.region = RegionType.NORTH_AMERICA
             sample.organism = "SARS-CoV-2"
 
             if sample.uploaded_pathogen_genome is None:

--- a/src/py/aspen/database/models/__init__.py
+++ b/src/py/aspen/database/models/__init__.py
@@ -21,7 +21,7 @@ from aspen.database.models.host_filtering import (  # noqa: F401
     HostFilteredSequencingReadsCollection,
 )
 from aspen.database.models.phylo_tree import PhyloRun, PhyloTree  # noqa: F401
-from aspen.database.models.sample import Sample  # noqa: F401
+from aspen.database.models.sample import RegionType, Sample  # noqa: F401
 from aspen.database.models.sequences import (  # noqa: F401
     CallConsensus,
     CalledPathogenGenome,

--- a/src/py/aspen/database/models/sample.py
+++ b/src/py/aspen/database/models/sample.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import enum
 from typing import Optional, TYPE_CHECKING, Union
 
+import enumtables
 from sqlalchemy import (
     Column,
     Date,
@@ -15,12 +17,31 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import backref, relationship
 
-from aspen.database.models.base import idbase
+from aspen.database.models.base import base, idbase
+from aspen.database.models.enum import Enum
 from aspen.database.models.mixins import DictMixin
 from aspen.database.models.usergroup import Group
 
 if TYPE_CHECKING:
     from .sequences import SequencingReadsCollection, UploadedPathogenGenome
+
+
+class RegionType(enum.Enum):
+    AFRICA = "Africa"
+    ASIA = "Asia"
+    EUROPE = "Europe"
+    NORTH_AMERICA = "North America"
+    OCEANIA = "Oceania"
+    SOUTH_AMERICA = "South America"
+
+
+# Create the enumeration table
+# Pass your enum class and the SQLAlchemy declarative base to enumtables.EnumTable
+_RegionTypeTable = enumtables.EnumTable(
+    RegionType,
+    base,
+    tablename="region_types",
+)
 
 
 class Sample(idbase, DictMixin):  # type: ignore
@@ -122,6 +143,11 @@ class Sample(idbase, DictMixin):  # type: ignore
                 "PHA4GE": "geo_loc_name_country",
             }
         },
+    )
+    region = Column(
+        Enum(RegionType),
+        ForeignKey(_RegionTypeTable.item_id),
+        nullable=False,
     )
 
     organism = Column(

--- a/src/py/aspen/database/models/tests/test_sequences.py
+++ b/src/py/aspen/database/models/tests/test_sequences.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import undefer
 
-from aspen.database.models.sample import Sample
+from aspen.database.models.sample import RegionType, Sample
 from aspen.database.models.sequences import (
     SequencingInstrumentType,
     SequencingProtocolType,
@@ -27,6 +27,7 @@ def test_sequencing_reads(session):
         location="Santa Clara County",
         division="California",
         country="USA",
+        region=RegionType.NORTH_AMERICA,
         organism="SARS-CoV-2",
     )
     sequencing_reads = SequencingReadsCollection(
@@ -61,6 +62,7 @@ def test_uploaded_pathogen_genome(session):
         location="Santa Clara County",
         division="California",
         country="USA",
+        region=RegionType.NORTH_AMERICA,
         organism="SARS-CoV-2",
     )
     uploaded_pathogen_genome = UploadedPathogenGenome(

--- a/src/py/aspen/test_infra/models/sample.py
+++ b/src/py/aspen/test_infra/models/sample.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from aspen.database.models import Sample
+from aspen.database.models import RegionType, Sample
 
 
 def sample_factory(
@@ -14,6 +14,7 @@ def sample_factory(
     location="Santa Clara County",
     division="California",
     country="USA",
+    region=RegionType.NORTH_AMERICA,
     organism="SARS-CoV-2",
 ) -> Sample:
     original_submission = original_submission or {}
@@ -29,5 +30,6 @@ def sample_factory(
         location=location,
         division=division,
         country=country,
+        region=region,
         organism=organism,
     )

--- a/src/py/database_migrations/versions/20210405_170924_add_region_column_for_sample.py
+++ b/src/py/database_migrations/versions/20210405_170924_add_region_column_for_sample.py
@@ -1,0 +1,74 @@
+"""add region column for sample
+
+Create Date: 2021-04-05 17:09:26.078925
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210405_170924"
+down_revision = "20210401_211915"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "region_types",
+        sa.Column("item_id", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("item_id", name=op.f("pk_region_types")),
+        schema="aspen",
+    )
+    op.enum_insert(
+        "region_types",
+        [
+            "North America",
+            "Oceania",
+            "Asia",
+            "Europe",
+            "South America",
+            "Africa",
+        ],
+        schema="aspen",
+    )
+    op.add_column(
+        "samples",
+        sa.Column(
+            "region",
+            sa.String(),
+            nullable=True,
+            comment="This is the continent this sample was collected from.",
+        ),
+        schema="aspen",
+    )
+    op.execute("""UPDATE aspen.samples SET region='North America'""")
+    op.alter_column(
+        "samples",
+        "region",
+        existing_type=sa.VARCHAR(),
+        nullable=False,
+        existing_comment="This is the continent this sample was collected from.",
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        op.f("fk_samples_region_region_types"),
+        "samples",
+        "region_types",
+        ["region"],
+        ["item_id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_samples_region_region_types"),
+        "samples",
+        schema="aspen",
+        type_="foreignkey",
+    )
+    op.drop_column("samples", "region", schema="aspen")
+    op.drop_table("region_types", schema="aspen")

--- a/src/py/scripts/setup_localdata.py
+++ b/src/py/scripts/setup_localdata.py
@@ -4,6 +4,7 @@ from aspen.config.local import LocalConfig
 from aspen.database.connection import get_db_uri, init_db
 from aspen.database.models import (
     Group,
+    RegionType,
     Sample,
     SequencingInstrumentType,
     SequencingProtocolType,
@@ -66,6 +67,7 @@ def create_sample(session, group):
         location="Santa Clara County",
         division="California",
         country="USA",
+        region=RegionType.NORTH_AMERICA,
         organism="SARS-CoV-2",
     )
     session.add(sample)


### PR DESCRIPTION
### Description
Added a migration that manually writes "North America" to all samples.  I'm not aware of any biohub samples that were from outside of North America, and even if there were, there are certainly no plans to import them into aspen.

Depends on #235 

### Test plan
ran the migration
