### PR TITLE
Make .env.ecr target fail if we fail to get an account id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ oauth/pkcs12/certificate.pfx:
 	sudo chown -R $$(id -u):$$(id -g) $(PWD)/oauth/pkcs12
 
 .env.ecr:
-	echo DOCKER_REPO=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com/ > .env.ecr;
+	export DOCKER_REPO=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \
+	if [ -n "$${DOCKER_REPO}" ]; then \
+		echo DOCKER_REPO=$${DOCKER_REPO}.dkr.ecr.us-west-2.amazonaws.com/ > .env.ecr; \
+	else \
+		false; \
+	fi
 
 .PHONY: local-ecr-login
 local-ecr-login:

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ oauth/pkcs12/certificate.pfx:
 	sudo chown -R $$(id -u):$$(id -g) $(PWD)/oauth/pkcs12
 
 .env.ecr:
-	export DOCKER_REPO=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \
-	if [ -n "$${DOCKER_REPO}" ]; then \
-		echo DOCKER_REPO=$${DOCKER_REPO}.dkr.ecr.us-west-2.amazonaws.com/ > .env.ecr; \
+	export AWS_ACCOUNT_ID=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \
+	if [ -n "$${AWS_ACCOUNT_ID}" ]; then \
+		echo DOCKER_REPO=$${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/ > .env.ecr; \
 	else \
 		false; \
 	fi


### PR DESCRIPTION
### Description
The previous make target would sometimes write an invalid .env.ecr file without an account ID if the AWS CLI command failed. This change ensures that we fail instead of writing an invalid .env.ecr file.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
