### PR TITLE
Import rdev frontend changes

### DIFF
--- a/src/ts/src/common/components/library/modal/index.module.scss
+++ b/src/ts/src/common/components/library/modal/index.module.scss
@@ -12,7 +12,7 @@
   width: 100vw;
   display: flex;
   background-color: $gray-lightest;
-  opacity: 90%;
+  opacity: 0.9;
 }
 
 .modal {

--- a/src/ts/src/common/utils/tableUtils.tsx
+++ b/src/ts/src/common/utils/tableUtils.tsx
@@ -7,13 +7,10 @@ function createTableCellRenderer(
   defaultRenderer: CellRenderer
 ): CustomRenderer {
   return ({ header, value, item, index }: CustomTableRenderProps) => {
-    let unwrappedValue;
-    if (value === undefined) {
+    let unwrappedValue = value;
+    if (unwrappedValue === undefined) {
       unwrappedValue = UNDEFINED_TEXT;
-    } else {
-      unwrappedValue = value;
     }
-
     if (customRenderers[header.key] !== undefined) {
       const cellRenderFunction = customRenderers[header.key];
       return cellRenderFunction(unwrappedValue, item, index);

--- a/src/ts/src/common/utils/typeUtils.tsx
+++ b/src/ts/src/common/utils/typeUtils.tsx
@@ -27,3 +27,10 @@ export function jsonToType<T>(
   });
   return Object.fromEntries(entries);
 }
+
+export function stringGuard(value: any): string {
+  if (typeof value !== "string") {
+    return String(value);
+  }
+  return value;
+}

--- a/src/ts/src/data/cellRenderers.tsx
+++ b/src/ts/src/data/cellRenderers.tsx
@@ -17,15 +17,12 @@ const DEFAULT_RENDERER = (value: JSONPrimitive): JSX.Element => {
 };
 
 const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
-  privateId: (value: JSONPrimitive): JSX.Element => {
-    const stringValue = stringGuard(value);
-    return (
-      <div className={style.cell}>
-        {<SampleIcon className={style.icon} />}
-        {stringValue}
-      </div>
-    );
-  },
+  privateId: (value: JSONPrimitive): JSX.Element => (
+    <div className={style.cell}>
+      {<SampleIcon className={style.icon} />}
+      {value}
+    </div>
+  ),
 };
 
 const SampleRenderer = createTableCellRenderer(

--- a/src/ts/src/data/cellRenderers.tsx
+++ b/src/ts/src/data/cellRenderers.tsx
@@ -5,7 +5,11 @@ import { Modal } from "src/common/components";
 import { ReactComponent as ExternalLinkIcon } from "src/common/icons/ExternalLink.svg";
 import { ReactComponent as TreeIcon } from "src/common/icons/PhyloTree.svg";
 import { ReactComponent as SampleIcon } from "src/common/icons/Sample.svg";
-import { createTableCellRenderer, createTreeModalInfo } from "src/common/utils";
+import {
+  createTableCellRenderer,
+  createTreeModalInfo,
+  stringGuard,
+} from "src/common/utils";
 import style from "./index.module.scss";
 
 const DEFAULT_RENDERER = (value: JSONPrimitive): JSX.Element => {
@@ -14,10 +18,11 @@ const DEFAULT_RENDERER = (value: JSONPrimitive): JSX.Element => {
 
 const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   privateId: (value: JSONPrimitive): JSX.Element => {
+    const stringValue = stringGuard(value);
     return (
       <div className={style.cell}>
         {<SampleIcon className={style.icon} />}
-        {value}
+        {stringValue}
       </div>
     );
   },
@@ -29,18 +34,28 @@ const SampleRenderer = createTableCellRenderer(
 );
 
 const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
-  downloadLink: (value: JSONPrimitive): JSX.Element => (
-    <div className={style.cell}>
-      <a href={`${value}`} download>
-        Download
-      </a>
-    </div>
-  ),
-  name: (value: JSONPrimitive): JSX.Element => {
+  downloadLink: (value: JSONPrimitive): JSX.Element => {
+    const stringValue = stringGuard(value);
     return (
-      <Modal data={createTreeModalInfo("")} className={style.cell}>
+      <div className={style.cell}>
+        <a href={stringValue} download>
+          Download
+        </a>
+      </div>
+    );
+  },
+  name: (value: JSONPrimitive): JSX.Element => {
+    const stringValue = stringGuard(value);
+    const treeID = stringValue.split(" ")[0];
+    return (
+      <Modal
+        data={createTreeModalInfo(
+          `https://nextstrain.org/fetch/${process.env.API_URL}/api/auspice/view/${treeID}/auspice.json`
+        )}
+        className={style.cell}
+      >
         {<TreeIcon className={style.icon} />}
-        {value}
+        {stringValue}
         {<ExternalLinkIcon className={style.icon} />}
       </Modal>
     );


### PR DESCRIPTION
### Description

Imports frontend changes made in the `rdev-auspice` branch.

* Fixes the module background opacity to use the proper type (decimal 0-1)
* simplifies the `createTableCellRenderer` utility function
* Adds the Nextstrain fetch link to the tree table modal
* Adds better type checking to custom table cell renderers

#### Issue
[ch120777](https://app.clubhouse.io/genepi/story/120777)

### Test plan

Navigate to Tree Table, test each of the above changes.
