### PR TITLE
Import rdev  Flask auspice view and explicit download response

### DIFF
--- a/src/py/aspen/app/views/auspice.py
+++ b/src/py/aspen/app/views/auspice.py
@@ -1,23 +1,16 @@
 import logging
 import os
-from typing import Iterable
+from typing import Optional
 
 import boto3
 from flask import make_response
-from sqlalchemy.orm import joinedload
 
 from aspen.app.app import application
 from aspen.database.connection import session_scope
-from aspen.database.models import PhyloRun, PhyloTree, WorkflowStatusType
+from aspen.database.models import PhyloTree
+from aspen.error.recoverable import RecoverableError
 
 logger = logging.getLogger(__name__)
-
-
-def tree_dive(phylo_runs: Iterable[PhyloRun], phylo_tree_id: int):
-    for phylo_run in phylo_runs:
-        for output in phylo_run.outputs:
-            if isinstance(output, PhyloTree) and output.entity_id == phylo_tree_id:
-                return output
 
 
 @application.route(
@@ -25,13 +18,14 @@ def tree_dive(phylo_runs: Iterable[PhyloRun], phylo_tree_id: int):
 )
 def auspice_view(phylo_tree_id: int):
     with session_scope(application.DATABASE_INTERFACE) as db_session:
-        phylo_runs: Iterable[PhyloRun] = (
-            db_session.query(PhyloRun)
-            .options(joinedload(PhyloRun.outputs))
-            .filter(PhyloRun.workflow_status == WorkflowStatusType.COMPLETED)
+        phylo_tree: Optional[PhyloTree] = (
+            db_session.query(PhyloTree)
+            .filter(PhyloTree.entity_id == phylo_tree_id)
+            .one_or_none()
         )
 
-        phylo_tree: PhyloTree = tree_dive(phylo_runs, phylo_tree_id)
+        if not phylo_tree:
+            raise RecoverableError(f"Phylo Tree {phylo_tree_id} not found.")
 
         s3_client = boto3.resource(
             "s3",

--- a/src/py/aspen/app/views/auspice.py
+++ b/src/py/aspen/app/views/auspice.py
@@ -1,8 +1,6 @@
-import os
 import logging
-logger = logging.getLogger(__name__)
-
-from typing import Iterable, Tuple
+import os
+from typing import Iterable
 
 import boto3
 from flask import make_response
@@ -10,39 +8,41 @@ from sqlalchemy.orm import joinedload
 
 from aspen.app.app import application
 from aspen.database.connection import session_scope
-from aspen.database.models import (
-    PhyloRun,
-    PhyloTree,
-    WorkflowStatusType,
-)
+from aspen.database.models import PhyloRun, PhyloTree, WorkflowStatusType
 
-@application.route("/api/auspice/view/<int:phylo_tree_id>/auspice.json", methods=["GET"])
+logger = logging.getLogger(__name__)
+
+
+def tree_dive(phylo_runs: Iterable[PhyloRun], phylo_tree_id: int):
+    for phylo_run in phylo_runs:
+        for output in phylo_run.outputs:
+            if isinstance(output, PhyloTree) and output.entity_id == phylo_tree_id:
+                return output
+
+
+@application.route(
+    "/api/auspice/view/<int:phylo_tree_id>/auspice.json", methods=["GET"]
+)
 def auspice_view(phylo_tree_id: int):
     with session_scope(application.DATABASE_INTERFACE) as db_session:
-        phylo_runs: Iterable[Tuple[PhyloRun, int]] = (
+        phylo_runs: Iterable[PhyloRun] = (
             db_session.query(PhyloRun)
             .options(joinedload(PhyloRun.outputs))
             .filter(PhyloRun.workflow_status == WorkflowStatusType.COMPLETED)
         )
 
-        phylo_tree: PhyloTree
-        for phylo_run in phylo_runs:
-            for output in phylo_run.outputs:
-                if isinstance(output, PhyloTree) and output.entity_id == phylo_tree_id:
-                    phylo_tree = output
-                    found = True
-                    break
+        phylo_tree: PhyloTree = tree_dive(phylo_runs, phylo_tree_id)
 
         s3_client = boto3.resource(
             "s3",
             endpoint_url=os.getenv("BOTO_ENDPOINT_URL") or None,
-            config=boto3.session.Config(signature_version="s3v4")
-            )
+            config=boto3.session.Config(signature_version="s3v4"),
+        )
 
         s3_object = s3_client.Object(phylo_tree.s3_bucket, phylo_tree.s3_key)
-        content = s3_object.get()['Body'].read().decode('utf-8')
+        content = s3_object.get()["Body"].read().decode("utf-8")
 
         response = make_response(content)
-        response.headers['Content-Type'] = 'text/json'
-        response.headers['Content-Disposition'] = 'attachment; filename=auspice.json'
+        response.headers["Content-Type"] = "text/json"
+        response.headers["Content-Disposition"] = "attachment; filename=auspice.json"
         return response

--- a/src/py/aspen/app/views/auspice.py
+++ b/src/py/aspen/app/views/auspice.py
@@ -1,0 +1,48 @@
+import os
+import logging
+logger = logging.getLogger(__name__)
+
+from typing import Iterable, Tuple
+
+import boto3
+from flask import make_response
+from sqlalchemy.orm import joinedload
+
+from aspen.app.app import application
+from aspen.database.connection import session_scope
+from aspen.database.models import (
+    PhyloRun,
+    PhyloTree,
+    WorkflowStatusType,
+)
+
+@application.route("/api/auspice/view/<int:phylo_tree_id>/auspice.json", methods=["GET"])
+def auspice_view(phylo_tree_id: int):
+    with session_scope(application.DATABASE_INTERFACE) as db_session:
+        phylo_runs: Iterable[Tuple[PhyloRun, int]] = (
+            db_session.query(PhyloRun)
+            .options(joinedload(PhyloRun.outputs))
+            .filter(PhyloRun.workflow_status == WorkflowStatusType.COMPLETED)
+        )
+
+        phylo_tree: PhyloTree
+        for phylo_run in phylo_runs:
+            for output in phylo_run.outputs:
+                if isinstance(output, PhyloTree) and output.entity_id == phylo_tree_id:
+                    phylo_tree = output
+                    found = True
+                    break
+
+        s3_client = boto3.resource(
+            "s3",
+            endpoint_url=os.getenv("BOTO_ENDPOINT_URL") or None,
+            config=boto3.session.Config(signature_version="s3v4")
+            )
+
+        s3_object = s3_client.Object(phylo_tree.s3_bucket, phylo_tree.s3_key)
+        content = s3_object.get()['Body'].read().decode('utf-8')
+
+        response = make_response(content)
+        response.headers['Content-Type'] = 'text/json'
+        response.headers['Content-Disposition'] = 'attachment; filename=auspice.json'
+        return response

--- a/src/py/aspen/app/views/phylo_trees.py
+++ b/src/py/aspen/app/views/phylo_trees.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Iterable, Mapping, MutableSequence, Tuple
 
 import boto3
-from flask import jsonify, session
+from flask import jsonify, session, make_response
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
 
@@ -107,5 +107,8 @@ def phylo_tree(phylo_tree_id: int):
 
         # TODO: replace the public identifiers with the private identifiers we have
         # access to.
+        response = make_response(json_data)
+        response.headers['Content-Type'] = 'text/json'
+        response.headers['Content-Disposition'] = f'attachment; filename={phylo_tree_id}.json'
 
-        return jsonify(json_data)
+        return response

--- a/src/py/aspen/app/views/phylo_trees.py
+++ b/src/py/aspen/app/views/phylo_trees.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Iterable, Mapping, MutableSequence, Tuple
 
 import boto3
-from flask import jsonify, session, make_response
+from flask import jsonify, make_response, session
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
 
@@ -108,7 +108,9 @@ def phylo_tree(phylo_tree_id: int):
         # TODO: replace the public identifiers with the private identifiers we have
         # access to.
         response = make_response(json_data)
-        response.headers['Content-Type'] = 'text/json'
-        response.headers['Content-Disposition'] = f'attachment; filename={phylo_tree_id}.json'
+        response.headers["Content-Type"] = "text/json"
+        response.headers[
+            "Content-Disposition"
+        ] = f"attachment; filename={phylo_tree_id}.json"
 
         return response

--- a/src/py/aspen/main.py
+++ b/src/py/aspen/main.py
@@ -1,6 +1,7 @@
 # this is where flask finds the entry point for the application.
 
 from aspen.app.app import application  # noqa: F401
+from aspen.app.views.auspice import auspice_view  # noqa: F401
 from aspen.app.views.auth import callback_handling, login, logout  # noqa: F401
 from aspen.app.views.health import health  # noqa: F401
 from aspen.app.views.index import serve  # noqa: F401


### PR DESCRIPTION
### Description

Imports the changes in `rdev-auspice` pertaining to tree viewing on the backend.

* Adds the less-than-ideal api route for Nextstrain to fetch trees from the app
* Adds explicit content type and disposition to JSON files so they are downloaded and not opened in the browser

#### Issue
[ch119787](https://app.clubhouse.io/genepi/story/119787)

### Test plan

Requires remote dev testing, since this route is intended to be used by Nextstrain.
