### PR TITLE
Strip protocol from process.env.API_URL for nextstrain tree link

### DIFF
--- a/src/ts/src/common/utils/index.tsx
+++ b/src/ts/src/common/utils/index.tsx
@@ -1,2 +1,3 @@
 export * from "./tableUtils";
 export * from "./typeUtils";
+export * from "./urlUtils";

--- a/src/ts/src/common/utils/urlUtils.tsx
+++ b/src/ts/src/common/utils/urlUtils.tsx
@@ -1,7 +1,7 @@
 export function stripProtocol(url: string | undefined): string | undefined {
-    if (url === undefined) {
-        return undefined;
-    }
-    const re = /^.*:\/\//i;
-    return url.replace(re, "")
+  if (url === undefined) {
+    return undefined;
+  }
+  const re = /^.*:\/\//i;
+  return url.replace(re, "");
 }

--- a/src/ts/src/common/utils/urlUtils.tsx
+++ b/src/ts/src/common/utils/urlUtils.tsx
@@ -1,0 +1,7 @@
+export function stripProtocol(url: string | undefined): string | undefined {
+    if (url === undefined) {
+        return undefined;
+    }
+    const re = /^.*:\/\//i;
+    return url.replace(re, "")
+}

--- a/src/ts/src/data/cellRenderers.tsx
+++ b/src/ts/src/data/cellRenderers.tsx
@@ -9,6 +9,7 @@ import {
   createTableCellRenderer,
   createTreeModalInfo,
   stringGuard,
+  stripProtocol,
 } from "src/common/utils";
 import style from "./index.module.scss";
 
@@ -44,10 +45,11 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   name: (value: JSONPrimitive): JSX.Element => {
     const stringValue = stringGuard(value);
     const treeID = stringValue.split(" ")[0];
+    const treeLocation = `${stripProtocol(process.env.API_URL)}/api/auspice/view/${treeID}/auspice.json`
     return (
       <Modal
         data={createTreeModalInfo(
-          `https://nextstrain.org/fetch/${process.env.API_URL}/api/auspice/view/${treeID}/auspice.json`
+          `https://nextstrain.org/fetch/${treeLocation}`
         )}
         className={style.cell}
       >

--- a/src/ts/src/data/cellRenderers.tsx
+++ b/src/ts/src/data/cellRenderers.tsx
@@ -45,7 +45,9 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   name: (value: JSONPrimitive): JSX.Element => {
     const stringValue = stringGuard(value);
     const treeID = stringValue.split(" ")[0];
-    const treeLocation = `${stripProtocol(process.env.API_URL)}/api/auspice/view/${treeID}/auspice.json`
+    const treeLocation = `${stripProtocol(
+      process.env.API_URL
+    )}/api/auspice/view/${treeID}/auspice.json`;
     return (
       <Modal
         data={createTreeModalInfo(


### PR DESCRIPTION
### Description

Strips `https://` from the `nextstraing.org/fetch` link. Adds a `stripProtocol()` utility function.

#### Issue
[ch120777](https://app.clubhouse.io/genepi/story/12077)

### Test plan

Open tree modal; check the generated link doesn't have the protocol included after `nextstrain.org/fetch`.
