### PR TITLE
Targets for connecting to remote dev dbs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,22 @@ help: ## display help for this makefile
 rm-pycache: ## remove all __pycache__ files (run if encountering issues with pycharm debugger (containers exiting prematurely))
 	find . -name '__pycache__' | xargs rm -rf
 
+### Connecting to remote dbs #########################################
+remotedb: # Get a psql console on a remote db (from OSX only!)
+	export ENV=$${ENV:=rdev}; \
+	export config=$$(aws --profile $(AWS_DEV_PROFILE) secretsmanager get-secret-value --secret-id $${ENV}/aspen-config | jq -r .SecretString ); \
+	export DB_URI=$$(jq -r '"postgresql://\(.DB.admin_username):\(.DB.admin_password)@127.0.0.1:5556/$(STACK)"' <<< $$config); \
+	ssh -f -o ExitOnForwardFailure=yes -L 5556:$$(jq -r .DB.address <<< $$config):5432 $$(jq -r .bastion_host <<< $$config) sleep 10; \
+	psql $${DB_URI}
+
+remoteconsole: .env.ecr # Get a python console on a remote db (from OSX only!)
+	export ENV=$${ENV:=rdev}; \
+	export config=$$(aws --profile $(AWS_DEV_PROFILE) secretsmanager get-secret-value --secret-id $${ENV}/aspen-config | jq -r .SecretString ); \
+	export OSX_IP=$$(ipconfig getifaddr en0 || ipconfig getifaddr en1); \
+	export DB_URI=$$(jq -r '"postgresql://\(.DB.admin_username):\(.DB.admin_password)@'$${OSX_IP}':5555/$(STACK)"' <<< $$config); \
+	ssh -f -o ExitOnForwardFailure=yes -L $${OSX_IP}:5555:$$(jq -r .DB.address <<< $$config):5432 $$(jq -r .bastion_host <<< $$config) sleep 10; \
+	docker-compose $(COMPOSE_OPTS) run -e DB_URI backend aspen-cli db --remote interact --connect
+
 ### DOCKER LOCAL DEV #########################################
 oauth/pkcs12/certificate.pfx:
 	# All calls to the openssl cli happen in the oidc-server-mock container.

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ rm-pycache: ## remove all __pycache__ files (run if encountering issues with pyc
 	find . -name '__pycache__' | xargs rm -rf
 
 ### Connecting to remote dbs #########################################
-remotedb: # Get a psql console on a remote db (from OSX only!)
+remote-pgconsole: # Get a psql console on a remote db (from OSX only!)
 	export ENV=$${ENV:=rdev}; \
 	export config=$$(aws --profile $(AWS_DEV_PROFILE) secretsmanager get-secret-value --secret-id $${ENV}/aspen-config | jq -r .SecretString ); \
 	export DB_URI=$$(jq -r '"postgresql://\(.DB.admin_username):\(.DB.admin_password)@127.0.0.1:5556/$(STACK)"' <<< $$config); \
 	ssh -f -o ExitOnForwardFailure=yes -L 5556:$$(jq -r .DB.address <<< $$config):5432 $$(jq -r .bastion_host <<< $$config) sleep 10; \
 	psql $${DB_URI}
 
-remoteconsole: .env.ecr # Get a python console on a remote db (from OSX only!)
+remote-dbconsole: .env.ecr # Get a python console on a remote db (from OSX only!)
 	export ENV=$${ENV:=rdev}; \
 	export config=$$(aws --profile $(AWS_DEV_PROFILE) secretsmanager get-secret-value --secret-id $${ENV}/aspen-config | jq -r .SecretString ); \
 	export OSX_IP=$$(ipconfig getifaddr en0 || ipconfig getifaddr en1); \

--- a/docs/REMOTE_DEV.md
+++ b/docs/REMOTE_DEV.md
@@ -34,7 +34,7 @@ If you forget which stacks you've created, just run `./scripts/happy list` at an
 ### Connecting to remote dev databases
 NOTE - You'll need to [install and configure blessclient](https://wiki.czi.team/display/SI/Install+BlessClient) first!
 
-From the root of this repo, run `make remotedb STACK=STACK_NAME_HERE` (replace STACK_NAME_HERE with the name of your stack!) to open a psql console on the remote dev db, or `make remoteconsole STACK=STACK_NAME_HERE` to get a python console connected to the remote dev db.
+From the root of this repo, run `make remote-dbconsole STACK=STACK_NAME_HERE` (replace STACK_NAME_HERE with the name of your stack!) to open a psql console on the remote dev db, or `make remote-pgconsole STACK=STACK_NAME_HERE` to get a python console connected to the remote dev db.
 
 ### General CLI Usage
 The CLI utility is evolving rapidly, so the best reference for which commands are available and how to use them is the CLI itself. All commands support a `--help` flag to print usage docs. For example:
@@ -48,7 +48,6 @@ Usage: happy create [OPTIONS] STACK_NAME
 Options:
   --tag TEXT          Tag name for docker image. Leave empty to generate one
                       automatically.
-
   --wait / --no-wait  wait for this to complete
   --help              Show this message and exit.
 ```

--- a/docs/REMOTE_DEV.md
+++ b/docs/REMOTE_DEV.md
@@ -32,6 +32,8 @@ The general remote dev workflow is:
 If you forget which stacks you've created, just run `./scripts/happy list` at any time to list the current remote dev stacks.
 
 ### Connecting to remote dev databases
+NOTE - You'll need to [install and configure blessclient](https://wiki.czi.team/display/SI/Install+BlessClient) first!
+
 From the root of this repo, run `make remotedb STACK=STACK_NAME_HERE` (replace STACK_NAME_HERE with the name of your stack!) to open a psql console on the remote dev db, or `make remoteconsole STACK=STACK_NAME_HERE` to get a python console connected to the remote dev db.
 
 ### General CLI Usage

--- a/docs/REMOTE_DEV.md
+++ b/docs/REMOTE_DEV.md
@@ -31,6 +31,9 @@ The general remote dev workflow is:
 
 If you forget which stacks you've created, just run `./scripts/happy list` at any time to list the current remote dev stacks.
 
+### Connecting to remote dev databases
+From the root of this repo, run `make remotedb STACK=STACK_NAME_HERE` (replace STACK_NAME_HERE with the name of your stack!) to open a psql console on the remote dev db, or `make remoteconsole STACK=STACK_NAME_HERE` to get a python console connected to the remote dev db.
+
 ### General CLI Usage
 The CLI utility is evolving rapidly, so the best reference for which commands are available and how to use them is the CLI itself. All commands support a `--help` flag to print usage docs. For example:
 

--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -159,7 +159,7 @@ def interact(ctx, profile, connect):
     # prevent an ssh tunnel from closing while we're composing queries.
     if connect:
         engine._engine.connect()
-        session = engine.make_session()
+        session = engine.make_session() # pylint: disable=F841
 
     shell = InteractiveShellEmbed()
     shell()

--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -155,6 +155,8 @@ def interact(ctx, profile, connect):
     if profile:
         enable_profiling()
 
+    # This forces an immediate connection to our database, which is useful to
+    # prevent an ssh tunnel from closing while we're composing queries.
     if connect:
         engine._engine.connect()
         session = engine.make_session()

--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -146,13 +146,18 @@ def import_data(s3_path, db_uri):
 
 @db.command("interact")
 @click.option("--profile/--no-profile", default=False)
+@click.option("--connect/--no-connect", default=False, help="Connect to the db immediately")
 @click.pass_context
-def interact(ctx, profile):
+def interact(ctx, profile, connect):
     # these are injected into the IPython scope, but they appear to be unused.
     engine = ctx.obj["ENGINE"]  # noqa: F841
 
     if profile:
         enable_profiling()
+
+    if connect:
+        engine._engine.connect()
+        session = engine.make_session()
 
     shell = InteractiveShellEmbed()
     shell()

--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -146,7 +146,9 @@ def import_data(s3_path, db_uri):
 
 @db.command("interact")
 @click.option("--profile/--no-profile", default=False)
-@click.option("--connect/--no-connect", default=False, help="Connect to the db immediately")
+@click.option(
+    "--connect/--no-connect", default=False, help="Connect to the db immediately"
+)
 @click.pass_context
 def interact(ctx, profile, connect):
     # these are injected into the IPython scope, but they appear to be unused.

--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -159,7 +159,7 @@ def interact(ctx, profile, connect):
     # prevent an ssh tunnel from closing while we're composing queries.
     if connect:
         engine._engine.connect()
-        session = engine.make_session() # pylint: disable=F841
+        session = engine.make_session()  # noqa: F841
 
     shell = InteractiveShellEmbed()
     shell()

--- a/src/py/aspen/config/config.py
+++ b/src/py/aspen/config/config.py
@@ -230,6 +230,9 @@ class RemoteDatabaseConfig(Config):
 
     @property
     def DATABASE_URI(self) -> str:
+        # Allow db uri to be overridden by env var.
+        if os.getenv("DB_URI"):
+            return os.getenv("DB_URI")
         username = self.AWS_SECRET["DB"]["rw_username"]
         password = self.AWS_SECRET["DB"]["rw_password"]
 

--- a/src/py/aspen/config/config.py
+++ b/src/py/aspen/config/config.py
@@ -232,7 +232,7 @@ class RemoteDatabaseConfig(Config):
     def DATABASE_URI(self) -> str:
         # Allow db uri to be overridden by env var.
         if os.getenv("DB_URI"):
-            return os.getenv("DB_URI")
+            return os.environ["DB_URI"]
         username = self.AWS_SECRET["DB"]["rw_username"]
         password = self.AWS_SECRET["DB"]["rw_password"]
 


### PR DESCRIPTION
### Description

This adds some make targets to allow connecting from OSX to the remote dev database, either via psql (installed via homebrew) or the ipython console in a backend container.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
