### PR TITLE
thuang-123772-sample-table-loading-state

### DIFF
--- a/src/ts/src/common/components/library/data_subview/components/EmptyState/index.module.scss
+++ b/src/ts/src/common/components/library/data_subview/components/EmptyState/index.module.scss
@@ -1,0 +1,52 @@
+@import "src/common/styles/loading";
+
+@mixin commonCell {
+  @include loadingAnimation;
+  flex: unset;
+}
+
+.cell {
+  @include commonCell;
+
+  width: 72px;
+  height: 12px;
+}
+
+@mixin commonBar {
+  @include commonCell;
+
+  margin: 4px 0;
+}
+
+.firstColumn {
+  display: flex;
+  flex: unset;
+
+  .square {
+    @include commonCell;
+
+    width: 40px;
+    height: 40px;
+
+    margin-right: 12px;
+  }
+
+  .bars {
+    display: flex;
+    flex-direction: column;
+
+    .long {
+      @include commonBar;
+
+      width: 365px;
+      height: 12px;
+    }
+
+    .short {
+      @include commonBar;
+
+      width: 315px;
+      height: 9px;
+    }
+  }
+}

--- a/src/ts/src/common/components/library/data_subview/components/EmptyState/index.tsx
+++ b/src/ts/src/common/components/library/data_subview/components/EmptyState/index.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Table } from "semantic-ui-react";
+import style from "./index.module.scss";
+
+const DEFAULT_ROW_COUNT = 10;
+
+interface Props {
+  numOfColumns: number;
+}
+
+const EmptyState = ({ numOfColumns }: Props): JSX.Element => {
+  return (
+    <>
+      {Array.from(Array(DEFAULT_ROW_COUNT)).map((_, index) => (
+        <Table.Row key={index}>
+          <EmptyCells numOfColumns={numOfColumns} />
+        </Table.Row>
+      ))}
+    </>
+  );
+};
+
+function EmptyCells({ numOfColumns = 0 }): JSX.Element {
+  return (
+    <>
+      {Array.from(Array(numOfColumns)).map((_, index) => {
+        return (
+          <Table.Cell key={index}>
+            {index ? <div className={style.cell} /> : <FirstColumn />}
+          </Table.Cell>
+        );
+      })}
+    </>
+  );
+}
+
+function FirstColumn() {
+  return (
+    <div className={style.firstColumn}>
+      <div className={style.square} />
+      <div className={style.bars}>
+        <div className={style.long} />
+        <div className={style.short} />
+      </div>
+    </div>
+  );
+}
+
+export { EmptyState };

--- a/src/ts/src/common/components/library/data_subview/index.tsx
+++ b/src/ts/src/common/components/library/data_subview/index.tsx
@@ -7,6 +7,7 @@ import style from "./index.module.scss";
 interface Props {
   data?: TableItem[];
   headers: Header[];
+  isLoading: boolean;
   renderer?: CustomRenderer;
 }
 
@@ -27,6 +28,7 @@ function searchReducer(state: SearchState, action: SearchState): SearchState {
 const DataSubview: FunctionComponent<Props> = ({
   data,
   headers,
+  isLoading,
   renderer,
 }: Props) => {
   // we are modifying state using hooks, so we need a reducer
@@ -71,7 +73,12 @@ const DataSubview: FunctionComponent<Props> = ({
           />
         </div>
         <div className={style.samplesTable}>
-          <DataTable data={tableData} headers={headers} renderer={renderer} />
+          <DataTable
+            isLoading={isLoading}
+            data={tableData}
+            headers={headers}
+            renderer={renderer}
+          />
         </div>
       </div>
     );

--- a/src/ts/src/common/components/library/data_table/index.tsx
+++ b/src/ts/src/common/components/library/data_table/index.tsx
@@ -1,11 +1,13 @@
 import React, { FunctionComponent } from "react";
 import { Table } from "semantic-ui-react";
+import { EmptyState } from "../data_subview/components/EmptyState";
 import style from "./index.module.scss";
 
 interface Props {
   data?: TableItem[];
   headers: Header[];
   renderer?: CustomRenderer;
+  isLoading: boolean;
 }
 
 const UNDEFINED_TEXT = "---";
@@ -23,7 +25,8 @@ function defaultCellRenderer({ value }: CustomTableRenderProps): JSX.Element {
 const DataTable: FunctionComponent<Props> = ({
   data = [],
   headers,
-  renderer,
+  renderer = defaultCellRenderer,
+  isLoading,
 }: Props) => {
   const indexingKey = headers[0].key;
 
@@ -37,9 +40,7 @@ const DataTable: FunctionComponent<Props> = ({
   const sampleRow = (item: TableItem): Array<JSX.Element> => {
     return headers.map((header, index) => {
       const value = item[header.key];
-      if (renderer === undefined) {
-        renderer = defaultCellRenderer;
-      }
+
       return (
         <Table.Cell key={`${item[indexingKey]}-${header.key}`}>
           {renderer({ header, index, item, value })}
@@ -48,7 +49,11 @@ const DataTable: FunctionComponent<Props> = ({
     });
   };
 
-  function tableRows(data: TableItem[]): Array<JSX.Element> {
+  function tableRows(data: TableItem[]): React.ReactNode {
+    if (isLoading) {
+      return <EmptyState numOfColumns={headers.length} />;
+    }
+
     return data.map((item) => (
       <Table.Row key={`${item[indexingKey]}`}>{sampleRow(item)}</Table.Row>
     ));

--- a/src/ts/src/common/styles/loading.scss
+++ b/src/ts/src/common/styles/loading.scss
@@ -1,0 +1,27 @@
+@import "./colors";
+
+@keyframes loadingBackgroundAnimation {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: 10% 0;
+  }
+}
+
+@mixin loadingAnimation {
+  animation-name: loadingBackgroundAnimation;
+  animation-duration: 2s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+
+  background: linear-gradient(
+    to right,
+    $gray-off-white 10%,
+    $gray-lightest 18%,
+    $gray-lightest 22%,
+    $gray-off-white 30%
+  );
+  background-position: 0% 0;
+  background-size: 200%;
+}

--- a/src/ts/src/data/index.tsx
+++ b/src/ts/src/data/index.tsx
@@ -12,18 +12,26 @@ import { TREE_TRANSFORMS } from "./transforms";
 const Data: FunctionComponent = () => {
   const [samples, setSamples] = useState<Sample[] | undefined>();
   const [trees, setTrees] = useState<Tree[] | undefined>();
+  const [isDataLoading, setIsDataLoading] = useState(false);
 
   useEffect(() => {
     const setBioinformaticsData = async () => {
+      setIsDataLoading(true);
+
       const [sampleResponse, treeResponse] = await Promise.all([
         fetchSamples(),
         fetchTrees(),
       ]);
+
+      setIsDataLoading(false);
+
       const apiSamples = sampleResponse["samples"];
       const apiTrees = treeResponse["phylo_trees"];
+
       setSamples(apiSamples);
       setTrees(apiTrees);
     };
+
     setBioinformaticsData();
   }, []);
 
@@ -33,6 +41,7 @@ const Data: FunctionComponent = () => {
     {
       data: samples,
       headers: SAMPLE_HEADERS,
+      isDataLoading,
       renderer: SampleRenderer,
       text: "Samples",
       to: "/data/samples",
@@ -40,6 +49,7 @@ const Data: FunctionComponent = () => {
     {
       data: trees,
       headers: TREE_HEADERS,
+      isDataLoading,
       renderer: TreeRenderer,
       text: "Phylogenetic Trees",
       to: "/data/phylogenetic_trees",
@@ -91,6 +101,7 @@ const Data: FunctionComponent = () => {
         key={category.text}
         render={() => (
           <DataSubview
+            isLoading={category.isDataLoading}
             data={category.data}
             headers={category.headers}
             renderer={category.renderer}


### PR DESCRIPTION
### Description

1. Add loading animation when both samples and trees are being fetched
2. The animation is created by using IDseq's CSS mixin, and the shapes are just setting different width/height for each divs accordingly
3. Add loading state in `dataCategories`, so the table knows what to do!

#### Issue
https://app.clubhouse.io/genepi/story/123772/create-loading-state-for-sample-table

### Test plan

1. Pull the branch and load up the app, you should now see the loading state 🎉 

https://user-images.githubusercontent.com/6309723/114745738-d3466200-9d03-11eb-8122-926f1ac9d540.mov

PTAL thank you!
