### PR TITLE
[easy] Add back missing comment for Sample.region field

### DIFF
--- a/src/py/aspen/database/models/sample.py
+++ b/src/py/aspen/database/models/sample.py
@@ -148,6 +148,7 @@ class Sample(idbase, DictMixin):  # type: ignore
         Enum(RegionType),
         ForeignKey(_RegionTypeTable.item_id),
         nullable=False,
+        comment="This is the continent this sample was collected from.",
     )
 
     organism = Column(


### PR DESCRIPTION
### Description
This was in there in a previous version of the PR, but dropped accidentally.  The migration code, however, creates it, and causes a mismatch in the schema depending on if it was created from scratch or through migrations.

### Test plan
subsequent autogenerated migrations are empty.
