### PR TITLE
Add a czb_failed_genome_recovery column

### DIFF
--- a/src/py/aspen/database/models/sample.py
+++ b/src/py/aspen/database/models/sample.py
@@ -5,11 +5,13 @@ from typing import Optional, TYPE_CHECKING, Union
 
 import enumtables
 from sqlalchemy import (
+    Boolean,
     Column,
     Date,
     ForeignKey,
     Integer,
     JSON,
+    sql,
     String,
     text,
     UniqueConstraint,
@@ -190,6 +192,17 @@ class Sample(idbase, DictMixin):  # type: ignore
                 "PHA4GE": "specimen_processing",
             }
         },
+    )
+
+    czb_failed_genome_recovery = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=sql.expression.true(),
+        comment=(
+            "This is set to true iff this is sample sequenced by CZB and failed genome "
+            "recovery."
+        ),
     )
 
     sequencing_reads_collection: Optional[SequencingReadsCollection]

--- a/src/py/database_migrations/versions/20210416_195853_add_czb_failed_genome_recovery_to_.py
+++ b/src/py/database_migrations/versions/20210416_195853_add_czb_failed_genome_recovery_to_.py
@@ -1,0 +1,32 @@
+"""add czb_failed_genome_recovery to Sample class
+
+Create Date: 2021-04-16 19:58:54.716138
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210416_195853"
+down_revision = "20210405_170924"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "samples",
+        sa.Column(
+            "czb_failed_genome_recovery",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+            comment="This is set to true iff this is sample sequenced by CZB and failed genome recovery.",
+        ),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_column("samples", "czb_failed_genome_recovery", schema="aspen")


### PR DESCRIPTION
### Description
Only set this to true if it's imported from CZB and genome recovery failed.

Depends on #273 

#### Issue
[ch127348](https://app.clubhouse.io/genepi/story/127348/port-over-failed-samples-from-covidtracker-just-metadata-not-fasta-q)

### Test plan
ran migration.
