### PR TITLE
[easy] Load DphCZBID fields

### DIFF
--- a/src/py/aspen/covidhub_import/implementation.py
+++ b/src/py/aspen/covidhub_import/implementation.py
@@ -217,7 +217,7 @@ def import_project(
             )
             .options(
                 joinedload(ConsensusGenome.sample_fastqs)
-                .joinedload(SampleFastqs.czb_id)
+                .joinedload(SampleFastqs.czb_id.of_type(DphCZBID))
                 .joinedload(CZBID.genome_submission_info),
             )
             .all()


### PR DESCRIPTION
### Description
`.joinedload(...czb_id)` only loads the fields in the `CZBID` table.  We want all the fields from the DphCZBID table as well.

### Test plan
import is much faster.
