### PR TITLE
update CZB gisaid dump using the latest processed gisaid dump in aspen

### DIFF
--- a/src/py/aspen/cli/db.py
+++ b/src/py/aspen/cli/db.py
@@ -153,7 +153,7 @@ def import_data(s3_path, db_uri):
     "--connect/--no-connect", default=False, help="Connect to the db immediately"
 )
 @click.pass_context
-def interact(ctx, profile, connect):
+def interact(ctx, connect):
     # these are injected into the IPython scope, but they appear to be unused.
     engine = ctx.obj["ENGINE"]  # noqa: F841
 

--- a/src/py/workflows/update_czb_gisaid/lookup_latest_processed_gisaid.py
+++ b/src/py/workflows/update_czb_gisaid/lookup_latest_processed_gisaid.py
@@ -1,0 +1,41 @@
+import json
+
+import click
+
+from aspen.config.config import RemoteDatabaseConfig
+from aspen.database.connection import (
+    get_db_uri,
+    init_db,
+    session_scope,
+    SqlAlchemyInterface,
+)
+from aspen.database.models import ProcessedGisaidDump, Workflow, WorkflowStatusType
+
+
+@click.command("lookup")
+def cli():
+    interface: SqlAlchemyInterface = init_db(get_db_uri(RemoteDatabaseConfig()))
+
+    with session_scope(interface) as session:
+        latest_processed_gisaid_dump: ProcessedGisaidDump = (
+            session.query(ProcessedGisaidDump)
+            .join(ProcessedGisaidDump.producing_workflow)
+            .order_by(Workflow.end_datetime.desc())
+            .filter(Workflow.workflow_status == WorkflowStatusType.COMPLETED)
+            .limit(1)
+            .one()
+        )
+
+        print(
+            json.dumps(
+                {
+                    "bucket": latest_processed_gisaid_dump.s3_bucket,
+                    "sequences_key": latest_processed_gisaid_dump.sequences_s3_key,
+                    "metadata_key": latest_processed_gisaid_dump.metadata_s3_key,
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/py/workflows/update_czb_gisaid/update.sh
+++ b/src/py/workflows/update_czb_gisaid/update.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -Eeuxo pipefail
+shopt -s inherit_errexit
+
+# install jq
+apt-get install -y jq
+
+czb_credentials=$(aws secretsmanager get-secret-value --secret-id czb-aws-access --query SecretString --output text)
+aws_access_key_id=$(echo "$czb_credentials" | jq -r .AWS_ACCESS_KEY_ID)
+aws_secret_access_key=$(echo "$czb_credentials" | jq -r .AWS_SECRET_ACCESS_KEY)
+
+# get the bucket/key from the object id
+processed_gisaid_location=$(/aspen/.venv/bin/python src/py/workflows/update_czb_gisaid/lookup_latest_processed_gisaid.py)
+processed_gisaid_s3_bucket=$(echo "${processed_gisaid_location}" | jq -r .bucket)
+processed_gisaid_sequences_s3_key=$(echo "${processed_gisaid_location}" | jq -r .sequences_key)
+processed_gisaid_metadata_s3_key=$(echo "${processed_gisaid_location}" | jq -r .metadata_key)
+
+start_time=$(date +%s)
+build_id=$(date +%Y%m%d-%H%M)
+
+# fetch the gisaid dataset
+aws s3 cp --no-progress s3://"${processed_gisaid_s3_bucket}"/"${processed_gisaid_sequences_s3_key}" - | xz -d | gzip -c > /sequences.fasta.gz
+aws s3 cp --no-progress s3://"${processed_gisaid_s3_bucket}"/"${processed_gisaid_metadata_s3_key}" - | gzip -c > /metadata.tsv.gz
+
+# upload the files to S3
+bucket=czb-covid-results
+sequences_key=gisaid/sequences.fasta.gz
+metadata_key=gisaid/metadata.tsv.gz
+AWS_ACCESS_KEY_ID="$aws_access_key_id" AWS_SECRET_ACCESS_KEY="$aws_secret_access_key" aws s3 cp /sequences.fasta.gz s3://"${bucket}"/"${sequences_key}"
+AWS_ACCESS_KEY_ID="$aws_access_key_id" AWS_SECRET_ACCESS_KEY="$aws_secret_access_key" aws s3 cp /metadata.tsv.gz s3://"${bucket}"/"${metadata_key}"


### PR DESCRIPTION
### Description
This is a stop-gap solution for gisaid ingest for the existing covidtracker infrastructure.  The github action is out of disk space and further investment in that pipeline is not worth it.  This is a small isolated hack that we can do to provide gisaid data to covidtracker.

#### Issue
[ch133367](https://app.clubhouse.io/genepi/story/133367/gisaid-data-ingest-in-biohub-s-infrastructure-is-broken)

### Test plan
`aws batch submit-job --job-name 'update-czb-gisaid' --job-queue aspen-batch --job-definition aspen-batch-job-definition --container-overrides '{"command": ["ttung/czb-gisaid", "src/py/workflows/update_czb_gisaid/update.sh"]}'`
