### PR TITLE
Allow the staging stack to drop the contents of its database

### DIFF
--- a/.happy/config.json
+++ b/.happy/config.json
@@ -15,7 +15,7 @@
             "aws_profile": "genepi-dev",
             "secret_arn": "happy/env-staging-config",
             "terraform_directory": ".happy/terraform/envs/staging",
-            "delete_protected": true,
+            "delete_protected": false,
             "auto_run_migrations": true,
             "log_group_prefix": "/aspen/staging"
         },

--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -8,7 +8,7 @@ module stack {
   priority            = var.priority
   stack_name          = var.stack_name
   deployment_stage    = "staging"
-  delete_protected    = true
+  delete_protected    = false
   require_okta        = false
   sql_import_file     = "db_snapshots/dev_backup.sql"
   frontend_url        = "https://staging.genepi.czi.technology"


### PR DESCRIPTION
We need to be able to drop the staging DB on demand so we can reimport it from a snapshot on S3 on demand.

### Description
We initially assumed the staging db would be long-lived, and only updated via alembic migrations. We wrote those assumptions into our happy env configuration and terraform code to make it very difficult to delete the staging db. 

In actuality, we need to be able to replace the data/schema in the staging DB on a regular basis. Since this is something we need to do in the remote-dev environment pretty frequently, there's already support for dropping a db and importing it from a snapshot on S3. This PR includes 2 key changes:

- Tell the Happy CLI that it's ok to run db drop operations in staging
- Create an ECS task definition in staging that's capable of dropping the staging db. This task definition will be invoked by the Happy CLI when we need to load a new snapshot.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
