### PR TITLE
Make target to start up an empty db with schema.

### DIFF
--- a/docker-compose-emptydb.yml
+++ b/docker-compose-emptydb.yml
@@ -1,0 +1,5 @@
+version: '3.8'
+
+services:
+  database:
+    image: "postgres"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_USER=user_rw
-      - POSTGRES_PASSWORD=password_rw
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password_postgres
       - POSTGRES_DB=aspen_db
     command: ["postgres"]
   frontend:


### PR DESCRIPTION
### Description

This adds a make target for starting up an empty Postgres DB, then having SQLAlchemy create DB structures without any data added.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
