### PR TITLE
[easy] Fix the backref relationship type hints

### DIFF
--- a/src/py/aspen/database/models/usergroup.py
+++ b/src/py/aspen/database/models/usergroup.py
@@ -22,6 +22,9 @@ class Group(idbase, DictMixin):  # type: ignore
     email = Column(String, unique=True, nullable=False)
     address = Column(String, nullable=True)
 
+    can_see: MutableSequence[CanSee]
+    can_be_seen_by: MutableSequence[CanSee]
+
     def __repr__(self):
         return f"Group <{self.name}>"
 
@@ -39,9 +42,6 @@ class User(idbase, DictMixin):  # type: ignore
 
     group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     group = relationship(Group, backref=backref("users", uselist=True))  # type: ignore
-
-    can_see: MutableSequence[CanSee]
-    can_be_seen_by: MutableSequence[CanSee]
 
     def __repr__(self):
         return f"User <{self.name}>"


### PR DESCRIPTION
### Description
The can_see* attributes should be on `Group` and not on `User`.

### Test plan
checked the [`relationship` declarations](https://github.com/chanzuckerberg/aspen/blob/ca6dc1e3a59a410a79c1aec39ea9ae8514f59266/src/py/aspen/database/models/cansee.py#L40-L48)
