### PR TITLE
Rename the tree data with private identifiers

### DIFF
--- a/src/backend/aspen/app/views/tests/data/ncov_aspen.json
+++ b/src/backend/aspen/app/views/tests/data/ncov_aspen.json
@@ -1,5 +1,21 @@
-[
-  {
-    "test_tree": "test_tree"
+{
+  "tree": {
+    "name": "public_identifier_1",
+    "children": [
+      {
+        "name": "public_identifier_2"
+      },
+      {
+        "name": "public_identifier_3"
+      },
+      {
+        "name": "public_identifier_4",
+        "children": [
+          {
+            "name":  "public_identifier_5"
+          }
+        ]
+      }
+    ]
   }
-]
+}

--- a/src/backend/aspen/phylo_tree/identifiers.py
+++ b/src/backend/aspen/phylo_tree/identifiers.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Mapping, Optional, Set
 
 
 def get_names_from_tree(tree) -> Set[str]:
@@ -9,3 +9,24 @@ def get_names_from_tree(tree) -> Set[str]:
             results.update(get_names_from_tree(node["children"]))
 
     return results
+
+
+def rename_nodes_on_tree(
+    tree: list,
+    name_map: Mapping[str, str],
+    save_key: Optional[str] = None,
+) -> None:
+    """Given a tree, a mapping of identifiers to their replacements, rename the nodes on
+    the tree.  If `save_key` is provided, then the original identifier is saved using
+    that as the key."""
+    for node in tree:
+        name = node["name"]
+        renamed_value = name_map.get(name, None)
+        if renamed_value is not None:
+            # we found the replacement value! first, save the old value if the caller
+            # requested.
+            if save_key is not None:
+                node[save_key] = name
+            node["name"] = renamed_value
+        if "children" in node:
+            rename_nodes_on_tree(node["children"], name_map, save_key)

--- a/src/py/aspen/app/views/tests/test_phylo_tree_rename.py
+++ b/src/py/aspen/app/views/tests/test_phylo_tree_rename.py
@@ -1,0 +1,94 @@
+import json
+
+from aspen.app.views.phylo_trees import _process_phylo_tree
+from aspen.database.models import CanSee, DataType
+from aspen.test_infra.models.phylo_tree import phylotree_factory
+from aspen.test_infra.models.sample import sample_factory
+from aspen.test_infra.models.usergroup import group_factory, user_factory
+
+
+def test_phylo_tree_rename(session, mock_s3_resource, test_data_dir):
+    """Create a set of samples belonging to different groups with different levels of
+    can-see relationships.  Rename the nodes according to the can-see rules, and verify
+    that the nodes are renamed correctly."""
+    viewer_group = group_factory()
+    can_see_group = group_factory("can_see", email="can_see@yahoo.com")
+    wrong_can_see_group = group_factory(
+        "wrong_can_see", email="wrong_can_see@hotmail.com"
+    )
+    no_can_see_group = group_factory("no_can_see", email="no_can_see@aol.com")
+    can_see_group.can_be_seen_by.append(
+        CanSee(
+            viewer_group=viewer_group,
+            owner_group=can_see_group,
+            data_type=DataType.PRIVATE_IDENTIFIERS,
+        )
+    )
+    wrong_can_see_group.can_be_seen_by.append(
+        CanSee(
+            viewer_group=viewer_group,
+            owner_group=wrong_can_see_group,
+            data_type=DataType.SEQUENCES,
+        )
+    )
+    session.add_all(
+        [viewer_group, can_see_group, wrong_can_see_group, no_can_see_group]
+    )
+
+    user = user_factory(viewer_group)
+
+    local_sample = sample_factory(
+        viewer_group,
+        private_identifier="private_identifier_1",
+        public_identifier="public_identifier_1",
+    )
+    can_see_sample = sample_factory(
+        can_see_group,
+        private_identifier="private_identifier_2",
+        public_identifier="public_identifier_2",
+    )
+    wrong_can_see_sample = sample_factory(
+        wrong_can_see_group,
+        private_identifier="private_identifer_3",
+        public_identifier="public_identifier_3",
+    )
+    no_can_see_sample = sample_factory(
+        no_can_see_group,
+        private_identifier="private_identifer_4",
+        public_identifier="public_identifier_4",
+    )
+
+    phylo_tree = phylotree_factory(
+        [local_sample, can_see_sample, wrong_can_see_sample, no_can_see_sample]
+    )
+
+    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
+    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+
+    json_test_file = test_data_dir / "ncov_aspen.json"
+    with json_test_file.open() as fh:
+        test_json = json.dumps(json.load(fh))
+
+    mock_s3_resource.Bucket(phylo_tree.s3_bucket).Object(phylo_tree.s3_key).put(
+        Body=test_json
+    )
+
+    # this is mandatory because we use an id to reference the tree.
+    session.commit()
+
+    tree = _process_phylo_tree(session, phylo_tree.entity_id, user.auth0_user_id)
+
+    assert tree == {
+        "tree": {
+            "name": "private_identifier_1",
+            "GISAID_ID": "public_identifier_1",
+            "children": [
+                {"name": "private_identifier_2", "GISAID_ID": "public_identifier_2"},
+                {"name": "public_identifier_3"},
+                {
+                    "name": "public_identifier_4",
+                    "children": [{"name": "public_identifier_5"}],
+                },
+            ],
+        }
+    }


### PR DESCRIPTION
### Description
Nodes on trees should be rewritten with the private identifiers that the user is privy to.

#### Issue
[ch133611](https://app.clubhouse.io/genepi/story/133611/rewrite-tree-data-with-private-identifiers)

### Test plan
Added a test with samples from own-group, can-see (private identifiers), can-see (not private identifiers), no can-see, and not even in the system.

Note that I'm stealing the `ncov_aspen.json` file for the `test_auspice_redirect.py` test; fortunately, that test is agnostic of the content of the test.
