### PR TITLE
[easy] fix mimetype for json

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -141,7 +141,7 @@ def phylo_tree(phylo_tree_id: int):
         )
 
     response = make_response(phylo_tree_data)
-    response.headers["Content-Type"] = "text/json"
+    response.headers["Content-Type"] = "application/json"
     response.headers[
         "Content-Disposition"
     ] = f"attachment; filename={phylo_tree_id}.json"


### PR DESCRIPTION
### Description
The correct type is application/json, not text/json.

This is built on top of #288.

### Test plan
YOLO!
Also see https://www.ietf.org/rfc/rfc4627.txt
