### PR TITLE
Bucket for auspice data.

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -2,3 +2,18 @@ resource "aws_s3_bucket" "aspen-db-data" {
   bucket = join("", ["aspen-db-data-", var.DEPLOYMENT_ENVIRONMENT])
   acl = "private"
 }
+
+
+resource "aws_s3_bucket" "aspen-external-auspice-data" {
+  bucket = join("", ["aspen-external-auspice-data-", var.DEPLOYMENT_ENVIRONMENT])
+  acl = "private"
+
+  lifecycle_rule {
+    id      = "expire"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+}


### PR DESCRIPTION
### Description
This is the bucket for temporary objects that are shared via presigned urls to auspice.

#### Issue
[ch133611](https://app.clubhouse.io/genepi/story/133611/rewrite-tree-data-with-private-identifiers)

### Test plan
`make deploy-tf`
