### PR TITLE
[easy] Do not use cache when building docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ frontend-%: .env.ecr ## Run make commands in the backend container (src/frontend
 build-docker: export ASPEN_DOCKER_IMAGE_VERSION=$(shell date +%Y%m%d_%H%M)
 build-docker:
 	docker pull nextstrain/base
-	docker build -t cziaspen/batch:latest --build-arg ASPEN_DOCKER_IMAGE_VERSION=$${ASPEN_DOCKER_IMAGE_VERSION} docker/aspen-batch
+	docker build --no-cache -t cziaspen/batch:latest --build-arg ASPEN_DOCKER_IMAGE_VERSION=$${ASPEN_DOCKER_IMAGE_VERSION} docker/aspen-batch
 	docker tag cziaspen/batch:latest cziaspen/batch:$${ASPEN_DOCKER_IMAGE_VERSION}
 	@echo "Please push the tags cziaspen/batch:latest and cziaspen/batch:$${ASPEN_DOCKER_IMAGE_VERSION} when done, i.e.,"
 	@echo "  docker push cziaspen/batch:latest"


### PR DESCRIPTION
### Description
This caches the repo checkout, which we do not want.

### Test plan
made the docker image successfully.
