### PR TITLE
Phoenix/add user tos

### DIFF
--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -39,6 +39,7 @@ class User(idbase, DictMixin):  # type: ignore
     auth0_user_id = Column(String, unique=True, nullable=False)
     group_admin = Column(Boolean, nullable=False)
     system_admin = Column(Boolean, nullable=False)
+    agreed_to_tos = Column(Boolean, nullable=False, default=False)
 
     group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     group = relationship(Group, backref=backref("users", uselist=True))  # type: ignore

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -12,7 +12,7 @@ def user_factory(
     email="test_user@dph.org",
     group_admin=False,
     system_admin=False,
-    agreed_to_tos=True
+    agreed_to_tos=True,
 ) -> User:
     return User(
         name=name,

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -12,6 +12,7 @@ def user_factory(
     email="test_user@dph.org",
     group_admin=False,
     system_admin=False,
+    agreed_to_tos=True
 ) -> User:
     return User(
         name=name,
@@ -19,5 +20,6 @@ def user_factory(
         email=email,
         group_admin=group_admin,
         system_admin=system_admin,
+        agreed_to_tos=agreed_to_tos,
         group=group,
     )

--- a/src/backend/database_migrations/versions/20210426_204155_tos_column_to_user.py
+++ b/src/backend/database_migrations/versions/20210426_204155_tos_column_to_user.py
@@ -8,7 +8,6 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from alembic import op
 
-# revision identifiers, used by Alembic.
 revision = "20210426_204155"
 down_revision = "20210420_231414"
 branch_labels = None

--- a/src/backend/database_migrations/versions/20210426_204155_tos_column_to_user.py
+++ b/src/backend/database_migrations/versions/20210426_204155_tos_column_to_user.py
@@ -5,8 +5,8 @@ Create Date: 2021-04-26 20:41:56.570401
 """
 import enumtables  # noqa: F401
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "20210426_204155"
 down_revision = "20210420_231414"
@@ -26,9 +26,7 @@ def upgrade():
     # set existing users agreed_to_tos column as false
     conn = op.get_bind()
     sql = sa.sql.text(
-        "UPDATE aspen.users "
-        "SET agreed_to_tos = false "
-        "WHERE agreed_to_tos is NULL"
+        "UPDATE aspen.users " "SET agreed_to_tos = false " "WHERE agreed_to_tos is NULL"
     )
 
     conn.execute(sql)

--- a/src/backend/database_migrations/versions/20210426_204155_tos_column_to_user.py
+++ b/src/backend/database_migrations/versions/20210426_204155_tos_column_to_user.py
@@ -1,0 +1,48 @@
+"""tos column to user
+
+Create Date: 2021-04-26 20:41:56.570401
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210426_204155"
+down_revision = "20210420_231414"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    # add new column to users as nullable
+    op.add_column(
+        "users",
+        sa.Column("agreed_to_tos", sa.Boolean(), nullable=True),
+        schema="aspen",
+    )
+
+    # set existing users agreed_to_tos column as false
+    conn = op.get_bind()
+    sql = sa.sql.text(
+        "UPDATE aspen.users "
+        "SET agreed_to_tos = false "
+        "WHERE agreed_to_tos is NULL"
+    )
+
+    conn.execute(sql)
+
+    # set agreed_to_tos to be non-nullable
+    op.alter_column(
+        "users",
+        "agreed_to_tos",
+        existing_type=postgresql.BOOLEAN(),
+        nullable=False,
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_column("users", "agreed_to_tos", schema="aspen")


### PR DESCRIPTION
### Description

adding `agreed_to_tos` field to User table

`usergroups` view will now return: 
```
{
  "group": {
    "address": "601 Marshall St, Redwood City, CA 94063", 
    "email": "aspen-testuser@chanzuckerberg.com", 
    "id": 34, 
    "name": "CZI"
  }, 
  "user": {
    "agreed_to_tos": false, 
    "auth0_user_id": "User1", 
    "email": "aspen-testuser@chanzuckerberg.com", 
    "group_admin": true, 
    "group_id": 34, 
    "id": 1, 
    "name": "Test User", 
    "system_admin": true
  }
}
```

#### Issue
[ch134397](https://app.clubhouse.io/genepi/story/134397)

### Test plan
ran migration, checked DB populated correctly, relied on existing usergroup tests
