### PR TITLE
Split the import from covidhub into user/groups and data

### DIFF
--- a/src/backend/aspen/cli/db.py
+++ b/src/backend/aspen/cli/db.py
@@ -167,12 +167,37 @@ def interact(ctx, connect):
     shell()
 
 
+@db.command("import-covidhub-users")
+@click.option("--covidhub-aws-profile", type=str, required=True)
+@click.option("--covidhub-db-secret", default="cliahub/cliahub_test_db")
+@click.option("--rr-project-id", type=str, required=True)
+@click.pass_context
+def import_covidhub_users(
+    ctx,
+    covidhub_aws_profile,
+    covidhub_db_secret,
+    rr_project_id,
+):
+    config, engine = ctx.obj["CONFIG"], ctx.obj["ENGINE"]
+
+    auth0_usermap = covidhub_import.retrieve_auth0_users(config)
+
+    covidhub_import.import_project_users(
+        engine,
+        covidhub_aws_profile,
+        covidhub_db_secret,
+        rr_project_id,
+        auth0_usermap,
+    )
+
+
 @db.command("import-covidhub-project")
 @click.option("--covidhub-aws-profile", type=str, required=True)
 @click.option("--covidhub-db-secret", default="cliahub/cliahub_test_db")
 @click.option("--rr-project-id", type=str, required=True)
 @click.option("--s3-src-prefix", type=str, required=True)
 @click.option("--s3-dst-prefix", type=str, required=True)
+@click.option("--aspen-group-id", type=int, required=True)
 @click.pass_context
 def import_covidhub_project(
     ctx,
@@ -181,20 +206,18 @@ def import_covidhub_project(
     rr_project_id,
     s3_src_prefix,
     s3_dst_prefix,
+    aspen_group_id,
 ):
-    # these are injected into the IPython scope, but they appear to be unused.
-    config, engine = ctx.obj["CONFIG"], ctx.obj["ENGINE"]
-
-    auth0_usermap = covidhub_import.retrieve_auth0_users(config)
+    engine = ctx.obj["ENGINE"]
 
     covidhub_import.import_project(
         engine,
         covidhub_aws_profile,
         covidhub_db_secret,
         rr_project_id,
+        aspen_group_id,
         s3_src_prefix,
         s3_dst_prefix,
-        auth0_usermap,
     )
 
 

--- a/src/backend/aspen/covidhub_import/__init__.py
+++ b/src/backend/aspen/covidhub_import/__init__.py
@@ -3,4 +3,5 @@ try:
 except ImportError:
     ...
 else:
-    from .implementation import import_project, retrieve_auth0_users  # noqa: F401
+    from .implementation import import_project  # noqa: F401
+    from .import_users import import_project_users, retrieve_auth0_users  # noqa: F401

--- a/src/backend/aspen/covidhub_import/implementation.py
+++ b/src/backend/aspen/covidhub_import/implementation.py
@@ -3,7 +3,6 @@ import json
 import logging
 import re
 import warnings
-from dataclasses import dataclass
 from typing import (
     Any,
     Collection,
@@ -18,13 +17,10 @@ from typing import (
 import boto3
 import pytz
 import tqdm
-from auth0.v3 import authentication as auth0_authentication
-from auth0.v3 import management as auth0_management
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import configure_mappers, joinedload, Session
 
 from aspen.aws.s3 import S3UrlParser
-from aspen.config import config as aspen_config
 from aspen.database.connection import session_scope, SqlAlchemyInterface
 from aspen.database.models import (
     Group,
@@ -34,7 +30,6 @@ from aspen.database.models import (
     RegionType,
     Sample,
     UploadedPathogenGenome,
-    User,
     WorkflowStatusType,
 )
 from aspen.phylo_tree.identifiers import get_names_from_tree
@@ -52,13 +47,6 @@ from covid_database.models.ngs_sample_tracking import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class Auth0Entry:
-    nickname: str
-    email: str
-    auth0_token: str
 
 
 def covidhub_interface_from_secret(
@@ -86,28 +74,14 @@ def list_bucket(s3_resource, bucket: str, key_prefix: str) -> Iterator[str]:
         nexttoken = results["NextContinuationToken"]
 
 
-def get_or_make_group(session: Session, name: str, address: str, email: str) -> Group:
-    group = session.query(Group).filter(Group.name == name).one_or_none()
-    if group is None:
-        # copy the project info into the "group"
-        group = Group(
-            name=name,
-            address=address,
-            email=email,
-        )
-        session.add(group)
-
-    return group
-
-
 def import_project(
     interface: SqlAlchemyInterface,
     covidhub_aws_profile: str,
     covidhub_secret_id: str,
     rr_project_id: str,
+    aspen_group_id: int,
     s3_src_prefix: str,
     s3_dst_prefix: str,
-    auth0_usermap: Mapping[str, Auth0Entry],
 ):
     configure_mappers()
     covidhub_interface = covidhub_interface_from_secret(
@@ -126,77 +100,7 @@ def import_project(
             .filter(Project.rr_project_id == rr_project_id)
             .one()
         )
-
-        group, admin_group, cdph_group = (
-            get_or_make_group(
-                session,
-                project.originating_lab,
-                project.originating_address,
-                # FIXME: this needs to be updated.
-                email="fakeemail@dph.gov",
-            ),
-            get_or_make_group(
-                session,
-                "ADMIN",
-                "123 Main St.",
-                # FIXME: this needs to be updated.
-                email="FAKE_EMAIL@gmail.com",
-            ),
-            get_or_make_group(
-                session,
-                "CDPH",
-                "3701 N Freeway Blvd, Sacramento, CA 95834",
-                # FIXME: this needs to be updated.
-                email="cdph.internetadmin@cdph.ca.gov",
-            ),
-        )
-        covidhub_group_to_aspen_group = {
-            project.covidtracker_group.group: group,
-            covidhub_session.query(covidtracker.Group)
-            .filter(covidtracker.Group.name == "Admin")
-            .one(): admin_group,
-            covidhub_session.query(covidtracker.Group)
-            .filter(covidtracker.Group.name == "CDPH")
-            .one(): cdph_group,
-        }
-
-        covidhub_users: Iterable[covidtracker.UsersGroups] = covidhub_session.query(
-            covidtracker.UsersGroups
-        ).filter(
-            or_(
-                covidtracker.UsersGroups.group_id.in_(
-                    covidhub_session.query(covidtracker.Group.id).filter(
-                        covidtracker.Group.name.in_(["Admin", "CDPH"])
-                    )
-                ),
-                covidtracker.UsersGroups.group_id.in_(
-                    covidhub_session.query(covidtracker.GroupToProjects.group_id)
-                    .join(Project)
-                    .filter(Project.rr_project_id == rr_project_id)
-                ),
-            ),
-        )
-
-        # create the users!
-        for covidhub_user in covidhub_users:
-            # try to find the user in the auth0_usermap
-            auth0_user = auth0_usermap.get(covidhub_user.user_id, None)
-            if auth0_user is None:
-                continue
-
-            # try to create this user in the aspen db.
-            user = (
-                session.query(User).filter(User.email == auth0_user.email).one_or_none()
-            )
-            if user is None:
-                user = User()
-
-            user.name = auth0_user.nickname
-            user.email = auth0_user.email
-            user.auth0_user_id = auth0_user.auth0_token
-            user.group_admin = False
-            user.system_admin = covidhub_user.group.name == "Admin"
-            user.group = covidhub_group_to_aspen_group[covidhub_user.group]
+        group: Group = session.query(Group).filter(Group.id == aspen_group_id).one()
 
         logger.info("Retrieving from COVIDHUB DB...")
         consensus_genomes: Collection[ConsensusGenome] = (
@@ -412,37 +316,3 @@ def format_sample_for_dphczbid(
         sample.czb_failed_genome_recovery = True
 
     return sample
-
-
-def retrieve_auth0_users(config: aspen_config.Config) -> Mapping[str, Auth0Entry]:
-    """Retrieves an auth0 token and then retrieve a user list.  Each element of the list
-    is a tuple of (name, email, auth0_token)."""
-    domain = config.AUTH0_DOMAIN
-    client_id = config.AUTH0_MANAGEMENT_CLIENT_ID
-    client_secret = config.AUTH0_MANAGEMENT_CLIENT_SECRET
-
-    get_token_response = auth0_authentication.GetToken(domain)
-    token = get_token_response.client_credentials(
-        client_id, client_secret, "https://{}/api/v2/".format(domain)
-    )
-    mgmt_api_token = token["access_token"]
-    auth0_client = auth0_management.Auth0(domain, mgmt_api_token)
-
-    all_users: MutableMapping[str, Auth0Entry] = dict()
-    page = 0
-    while True:
-        try:
-            users_response = auth0_client.users.list(page=page)
-            if users_response["length"] == 0:
-                # done!
-                break
-
-            # concatenate the results to all_users.
-            for user in users_response["users"]:
-                all_users[user["user_id"]] = Auth0Entry(
-                    user["nickname"], user["email"], user["user_id"]
-                )
-        finally:
-            page += 1
-
-    return all_users

--- a/src/backend/aspen/covidhub_import/import_users.py
+++ b/src/backend/aspen/covidhub_import/import_users.py
@@ -1,0 +1,158 @@
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping
+
+from auth0.v3 import authentication as auth0_authentication
+from auth0.v3 import management as auth0_management
+from sqlalchemy import or_
+from sqlalchemy.orm import configure_mappers, joinedload, Session
+
+from aspen.config import config as aspen_config
+from aspen.database.connection import session_scope, SqlAlchemyInterface
+from aspen.database.models import Group, User
+from covid_database import init_db as covidhub_init_db
+from covid_database import SqlAlchemyInterface as CSqlAlchemyInterface
+from covid_database import util as covidhub_database_util
+from covid_database.models import covidtracker
+from covid_database.models.ngs_sample_tracking import Project
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Auth0Entry:
+    nickname: str
+    email: str
+    auth0_token: str
+
+
+def covidhub_interface_from_secret(
+    covidhub_aws_profile: str, secret_id: str
+) -> CSqlAlchemyInterface:
+    interface = covidhub_init_db(
+        covidhub_database_util.get_db_uri(secret_id, aws_profile=covidhub_aws_profile)
+    )
+    return interface
+
+
+def get_or_make_group(session: Session, name: str, address: str, email: str) -> Group:
+    group = session.query(Group).filter(Group.name == name).one_or_none()
+    if group is None:
+        # copy the project info into the "group"
+        group = Group(
+            name=name,
+            address=address,
+            email=email,
+        )
+        session.add(group)
+
+    return group
+
+
+def import_project_users(
+    interface: SqlAlchemyInterface,
+    covidhub_aws_profile: str,
+    covidhub_secret_id: str,
+    rr_project_id: str,
+    auth0_usermap: Mapping[str, Auth0Entry],
+):
+    configure_mappers()
+    covidhub_interface = covidhub_interface_from_secret(
+        covidhub_aws_profile, covidhub_secret_id
+    )
+    covidhub_session: Session = covidhub_interface.make_session()
+
+    with session_scope(interface) as session:
+        project = (
+            covidhub_session.query(Project)
+            .options(
+                joinedload(
+                    Project.covidtracker_group, covidtracker.GroupToProjects.group
+                )
+            )
+            .filter(Project.rr_project_id == rr_project_id)
+            .one()
+        )
+
+        group: Group = get_or_make_group(
+            session,
+            project.originating_lab,
+            project.originating_address,
+            # FIXME: this needs to be updated.
+            email="fakeemail2@dph.gov",
+        )
+
+        covidhub_users: Iterable[covidtracker.UsersGroups] = covidhub_session.query(
+            covidtracker.UsersGroups
+        ).filter(
+            or_(
+                covidtracker.UsersGroups.group_id.in_(
+                    covidhub_session.query(covidtracker.Group.id).filter(
+                        covidtracker.Group.name.in_(["Admin", "CDPH"])
+                    )
+                ),
+                covidtracker.UsersGroups.group_id.in_(
+                    covidhub_session.query(covidtracker.GroupToProjects.group_id)
+                    .join(Project)
+                    .filter(Project.rr_project_id == rr_project_id)
+                ),
+            ),
+        )
+
+        # create the users!
+        for covidhub_user in covidhub_users:
+            # try to find the user in the auth0_usermap
+            auth0_user = auth0_usermap.get(covidhub_user.user_id, None)
+            if auth0_user is None:
+                continue
+
+            # try to create this user in the aspen db.
+            user = (
+                session.query(User).filter(User.email == auth0_user.email).one_or_none()
+            )
+            if user is None:
+                user = User()
+
+            user.name = auth0_user.nickname
+            user.email = auth0_user.email
+            user.auth0_user_id = auth0_user.auth0_token
+            user.group_admin = False
+            user.system_admin = covidhub_user.group.name == "Admin"
+            user.group = group
+
+        session.commit()
+        print(f"Group id: {group.id}")
+
+
+def retrieve_auth0_users(config: aspen_config.Config) -> Mapping[str, Auth0Entry]:
+    """Retrieves an auth0 token and then retrieve a user list.  Each element of the list
+    is a tuple of (name, email, auth0_token)."""
+    domain = config.AUTH0_DOMAIN
+    client_id = config.AUTH0_MANAGEMENT_CLIENT_ID
+    client_secret = config.AUTH0_MANAGEMENT_CLIENT_SECRET
+
+    get_token_response = auth0_authentication.GetToken(domain)
+    token = get_token_response.client_credentials(
+        client_id, client_secret, "https://{}/api/v2/".format(domain)
+    )
+    mgmt_api_token = token["access_token"]
+    auth0_client = auth0_management.Auth0(domain, mgmt_api_token)
+
+    all_users: MutableMapping[str, Auth0Entry] = dict()
+    page = 0
+    while True:
+        try:
+            users_response = auth0_client.users.list(page=page)
+            if users_response["length"] == 0:
+                # done!
+                break
+
+            # concatenate the results to all_users.
+            for user in users_response["users"]:
+                all_users[user["user_id"]] = Auth0Entry(
+                    user["nickname"], user["email"], user["user_id"]
+                )
+        finally:
+            page += 1
+
+    return all_users


### PR DESCRIPTION
### Description
Turns out some of the internal CZB projects do not have names that match aspen's expectations.

#### Issue
[ch133318](https://app.clubhouse.io/genepi/story/133318/port-over-internal-samples-from-covidhub-db-into-appropriate-projects-about-500)

### Test plan
imported users and data for marin successfully.
