### PR TITLE
Remove email from group

### DIFF
--- a/src/backend/aspen/app/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_rename.py
@@ -12,11 +12,9 @@ def test_phylo_tree_rename(session, mock_s3_resource, test_data_dir):
     can-see relationships.  Rename the nodes according to the can-see rules, and verify
     that the nodes are renamed correctly."""
     viewer_group = group_factory()
-    can_see_group = group_factory("can_see", email="can_see@yahoo.com")
-    wrong_can_see_group = group_factory(
-        "wrong_can_see", email="wrong_can_see@hotmail.com"
-    )
-    no_can_see_group = group_factory("no_can_see", email="no_can_see@aol.com")
+    can_see_group = group_factory("can_see")
+    wrong_can_see_group = group_factory("wrong_can_see")
+    no_can_see_group = group_factory("no_can_see")
     can_see_group.can_be_seen_by.append(
         CanSee(
             viewer_group=viewer_group,

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -46,7 +46,7 @@ def _test_samples_view_cansee(
 ) -> Tuple[Sample, SequencingReadsCollection, Any]:
     user_factory_kwargs = user_factory_kwargs or {}
     owner_group = group_factory()
-    viewer_group = group_factory(name="cdph", email="cdph@cdph.gov")
+    viewer_group = group_factory(name="cdph")
     user = user_factory(viewer_group, **user_factory_kwargs)
     sample = sample_factory(owner_group)
     sequencing_read_collection = sequencing_read_factory(sample)

--- a/src/backend/aspen/covidhub_import/import_users.py
+++ b/src/backend/aspen/covidhub_import/import_users.py
@@ -36,14 +36,13 @@ def covidhub_interface_from_secret(
     return interface
 
 
-def get_or_make_group(session: Session, name: str, address: str, email: str) -> Group:
+def get_or_make_group(session: Session, name: str, address: str) -> Group:
     group = session.query(Group).filter(Group.name == name).one_or_none()
     if group is None:
         # copy the project info into the "group"
         group = Group(
             name=name,
             address=address,
-            email=email,
         )
         session.add(group)
 
@@ -79,8 +78,6 @@ def import_project_users(
             session,
             project.originating_lab,
             project.originating_address,
-            # FIXME: this needs to be updated.
-            email="fakeemail2@dph.gov",
         )
 
         covidhub_users: Iterable[covidtracker.UsersGroups] = covidhub_session.query(

--- a/src/backend/aspen/database/models/tests/test_datatypes.py
+++ b/src/backend/aspen/database/models/tests/test_datatypes.py
@@ -5,8 +5,8 @@ from aspen.database.models import CanSee, DataType, Group
 
 def test_can_see_constructor_with_datatype(session: Session):
     """Test that we can construct a CanSee object with a `data_type` argument."""
-    group1 = Group(name="group1", email="email1@example.com", address="address1")
-    group2 = Group(name="group2", email="email2@example.com", address="address2")
+    group1 = Group(name="group1", address="address1")
+    group2 = Group(name="group2", address="address2")
     can_see = CanSee(viewer_group=group1, owner_group=group2, data_type=DataType.TREES)
 
     session.add_all((group1, group2, can_see))
@@ -17,8 +17,8 @@ def test_can_see_constructor_with_datatype(session: Session):
 
 def test_can_see_datatype_filter(session: Session):
     """Test that we can filter by the datatype."""
-    group1 = Group(name="group1", email="email1@example.com", address="address1")
-    group2 = Group(name="group2", email="email2@example.com", address="address2")
+    group1 = Group(name="group1", address="address1")
+    group2 = Group(name="group2", address="address2")
     can_see = CanSee(
         viewer_group=group1,
         owner_group=group2,

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -19,7 +19,6 @@ class Group(idbase, DictMixin):  # type: ignore
     __tablename__ = "groups"
 
     name = Column(String, unique=True, nullable=False)
-    email = Column(String, unique=True, nullable=False)
     address = Column(String, nullable=True)
 
     can_see: MutableSequence[CanSee]

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -1,8 +1,8 @@
 from aspen.database.models import Group, User
 
 
-def group_factory(name="groupname", email="groupemail", address="123 Main St") -> Group:
-    return Group(name=name, email=email, address=address)
+def group_factory(name="groupname", address="123 Main St") -> Group:
+    return Group(name=name, address=address)
 
 
 def user_factory(

--- a/src/backend/database_migrations/versions/20210427_171625_remove_email_from_group.py
+++ b/src/backend/database_migrations/versions/20210427_171625_remove_email_from_group.py
@@ -1,0 +1,28 @@
+"""remove email from group
+
+Create Date: 2021-04-27 17:16:27.347577
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210427_171625"
+down_revision = "20210426_204155"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("uq_groups_email", "groups", schema="aspen", type_="unique")
+    op.drop_column("groups", "email", schema="aspen")
+
+
+def downgrade():
+    op.add_column(
+        "groups",
+        sa.Column("email", sa.VARCHAR(), autoincrement=False, nullable=False),
+        schema="aspen",
+    )
+    op.create_unique_constraint("uq_groups_email", "groups", ["email"], schema="aspen")

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -21,7 +21,6 @@ def create_test_group(session):
     print("Creating group")
     g = Group(
         name="CZI",
-        email="aspen-testuser@chanzuckerberg.com",
         address="601 Marshall St, Redwood City, CA 94063",
     )
     session.add(g)


### PR DESCRIPTION
### Description
It doesn't look like counties really have a shared contact.  Instead we will just use the group_admin flag on users to find "superusers".

### Test plan
ran migration && GHA
