### PR TITLE
[easy] Make the output of the import-covidhub-users json-like to simplify parsing

### DIFF
--- a/src/backend/aspen/covidhub_import/import_users.py
+++ b/src/backend/aspen/covidhub_import/import_users.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from dataclasses import dataclass
 from typing import Iterable, Mapping, MutableMapping
@@ -121,7 +122,7 @@ def import_project_users(
             user.group = group
 
         session.commit()
-        print(f"Group id: {group.id}")
+        print(json.dumps({"group_id": group.id}))
 
 
 def retrieve_auth0_users(config: aspen_config.Config) -> Mapping[str, Auth0Entry]:


### PR DESCRIPTION
### Description
Easier to read the output if it's json.

### Test plan
gha
