### PR TITLE
remove linting for workflows

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -1,7 +1,7 @@
 STYLE_CHECK_PYTHON_CODE_DIRECTORIES = .
 STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES = third-party
 TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES = aspen
-TYPE_CHECK_INDIVIDUAL_PYTHON_CODE_DIRECTORIES = database_migrations $(shell ls -d workflows/*)
+TYPE_CHECK_INDIVIDUAL_PYTHON_CODE_DIRECTORIES = database_migrations
 
 
 ### CHECK STYLE #############################################


### PR DESCRIPTION
### Description

Now that workflows have been moved to the aspen directory we don't need to explicitly call it to type check

#### Issue
no issue

### Test plan
GHA
