### PR TITLE
adding utility to rebuild [THE EASIEST]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ local-status: ## Show the status of the containers in the dev environment.
 
 .PHONY: local-rebuild
 local-rebuild: .env.ecr local-ecr-login ## Rebuild local dev without re-importing data
-	docker-compose $(COMPOSE_OPTS) build frontend backend
+	docker-compose $(COMPOSE_OPTS) build frontend backend utility
 	docker-compose $(COMPOSE_OPTS) up -d
 
 .PHONY: local-sync


### PR DESCRIPTION
### Description

I notice that you need to add utility to rebuild if you want dependencies to be updated in that container for running pytest. 

#### Issue
[ch135049](https://app.clubhouse.io/genepi/story/135049/migrate-other-counties)

### Test plan
running `make local-sync`