### PR TITLE
thuang-click-through-tos-122409

### DIFF
--- a/src/backend/aspen/app/views/tests/test_views.py
+++ b/src/backend/aspen/app/views/tests/test_views.py
@@ -25,7 +25,7 @@ def test_usergroup_view_put_pass(session, app, client):
         sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
 
     data = {"agreed_to_tos": True}
-    res = client.put("/api/usergroup", json=json.dumps(data))
+    res = client.put("/api/usergroup", json=data, content_type="application/json")
 
     # start a new transaction
     session.close()
@@ -46,7 +46,7 @@ def test_usergroup_view_put_fail(session, app, client):
         sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
 
     data = {"fake_field": "even faker"}
-    res = client.put("/api/usergroup", json=json.dumps(data))
+    res = client.put("/api/usergroup", json=data, content_type="application/json")
 
     assert res.status == "400 BAD REQUEST"
 

--- a/src/backend/aspen/app/views/usergroup.py
+++ b/src/backend/aspen/app/views/usergroup.py
@@ -27,9 +27,8 @@ def usergroup():
 
         if request.method == "PUT":
             update_allowed_fields: List[str] = ["name", "email", "agreed_to_tos"]
-            fields_to_update: Dict[str, Union[str, bool]] = json.loads(
-                request.get_json()
-            )
+            fields_to_update: Dict[str, Union[str, bool]] = request.get_json()
+
             for key, value in fields_to_update.items():
                 if hasattr(user, key) and key in update_allowed_fields:
                     setattr(user, key, value)

--- a/src/backend/aspen/app/views/usergroup.py
+++ b/src/backend/aspen/app/views/usergroup.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict, List, Union
 
 from flask import jsonify, request, Response, session

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "case-sensitive-paths-webpack-plugin": "2.3.0",
         "classnames": "^2.2.6",
         "css-loader": "4.3.0",
-        "czifui": "^0.0.18",
+        "czifui": "^0.0.25",
         "dotenv": "8.2.0",
         "dotenv-expand": "5.1.0",
         "eslint": "^7.11.0",
@@ -6504,9 +6504,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "node_modules/czifui": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/czifui/-/czifui-0.0.18.tgz",
-      "integrity": "sha512-ldM379aR2q6uOB3MjVwV2Cbv6qNOBsOd+3oLTH+By3s3fHqrMuIiP4B4UGPWTtyC8+ShRovQMi693wGJQhirTQ=="
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/czifui/-/czifui-0.0.25.tgz",
+      "integrity": "sha512-Whc4pUfDoA2+9T5BCr1JpWmNFaNWF3/9V1R6FcT+L7W0RbMiDSZMuR+cVfVLiXBPLuvgyIqx8qQLNj+43r/vQA=="
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -30594,9 +30594,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "czifui": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/czifui/-/czifui-0.0.18.tgz",
-      "integrity": "sha512-ldM379aR2q6uOB3MjVwV2Cbv6qNOBsOd+3oLTH+By3s3fHqrMuIiP4B4UGPWTtyC8+ShRovQMi693wGJQhirTQ=="
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/czifui/-/czifui-0.0.25.tgz",
+      "integrity": "sha512-Whc4pUfDoA2+9T5BCr1JpWmNFaNWF3/9V1R6FcT+L7W0RbMiDSZMuR+cVfVLiXBPLuvgyIqx8qQLNj+43r/vQA=="
     },
     "d": {
       "version": "1.0.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -41,7 +41,7 @@
     "case-sensitive-paths-webpack-plugin": "2.3.0",
     "classnames": "^2.2.6",
     "css-loader": "4.3.0",
-    "czifui": "^0.0.18",
+    "czifui": "^0.0.25",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0",
     "eslint": "^7.11.0",

--- a/src/frontend/src/App.test.tsx
+++ b/src/frontend/src/App.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import App from "./App";
 
-test("renders the Homepage", () => {
+test("renders the App", () => {
   render(<App />);
-  const linkElement = screen.getByText(/Welcome to Aspen!/i);
+  const linkElement = screen.getByText(/Loading.../i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -2,43 +2,74 @@ import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { StylesProvider, ThemeProvider } from "@material-ui/core/styles";
 import { defaultTheme } from "czifui";
 import React, { FunctionComponent, useEffect, useState } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 import style from "./App.module.scss";
 import { fetchUserData } from "./common/api";
 import { ROUTES } from "./common/routes";
 import NavBar from "./components/NavBar";
+import ProtectedRoute from "./components/ProtectedRoute";
+import AgreeTerms from "./views/AgreeTerms";
 import Data from "./views/Data";
+import Faq from "./views/Faq";
 import Homepage from "./views/Homepage";
+import Privacy from "./views/Privacy";
+import Terms from "./views/Terms";
 
 const App: FunctionComponent = () => {
-  const [user, setUser] = useState<string | undefined>();
-  const [org, setOrg] = useState<string | undefined>();
+  const [user, setUser] = useState<User | null>(null);
+  const [org, setOrg] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const setUserData = async () => {
-      const { group, user } = await fetchUserData();
-      setUser(user.name);
-      setOrg(group.name);
+      try {
+        const { group, user } = await fetchUserData();
+
+        setUser(user);
+        setOrg(group.name);
+        setIsLoading(false);
+      } catch (error) {
+        setIsLoading(false);
+      }
     };
+
+    setIsLoading(true);
     setUserData();
   }, []);
 
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
   return (
-    <Router>
-      <StylesProvider injectFirst>
-        <ThemeProvider theme={defaultTheme}>
-          <EmotionThemeProvider theme={defaultTheme}>
-            <div className={style.app}>
-              <NavBar org={org} user={user} />
-              <Switch>
-                <Route path={ROUTES.DATA} component={Data} />
-                <Route path={ROUTES.HOMEPAGE} component={Homepage} />
-              </Switch>
-            </div>
-          </EmotionThemeProvider>
-        </ThemeProvider>
-      </StylesProvider>
-    </Router>
+    <StylesProvider injectFirst>
+      <ThemeProvider theme={defaultTheme}>
+        <EmotionThemeProvider theme={defaultTheme}>
+          <div className={style.app}>
+            <NavBar org={org} user={user?.name} />
+            <Switch>
+              <ProtectedRoute
+                isLoggedIn={Boolean(user)}
+                hasAgreedTerms={Boolean(user?.agreedToTos)}
+                path={ROUTES.DATA}
+                component={Data}
+              />
+              <ProtectedRoute
+                isLoggedIn={Boolean(user)}
+                hasAgreedTerms={Boolean(user?.agreedToTos)}
+                path={ROUTES.AGREE_TERMS}
+                component={AgreeTerms}
+              />
+              <Route path={ROUTES.TERMS} component={Terms} />
+              <Route path={ROUTES.PRIVACY} component={Privacy} />
+              <Route path={ROUTES.FAQ} component={Faq} />
+              <Route path={ROUTES.TERMS} component={Terms} />
+              <Route path={ROUTES.HOMEPAGE} component={Homepage} />
+            </Switch>
+          </div>
+        </EmotionThemeProvider>
+      </ThemeProvider>
+    </StylesProvider>
   );
 };
 

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -14,6 +14,17 @@ export const DEFAULT_FETCH_OPTIONS: RequestInit = {
   credentials: "include",
 };
 
+export const DEFAULT_PUT_OPTIONS: RequestInit = {
+  credentials: "include",
+  method: "PUT",
+};
+
+export const DEFAULT_HEADERS_MUTATION_OPTIONS: RequestInit = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+};
+
 /** Generic functions to interface with the backend API **/
 
 const API_KEY_TO_TYPE: Record<string, string> = {
@@ -43,6 +54,7 @@ async function apiResponse<T extends APIResponse>(
   const response = await axios.get(process.env.API_URL + endpoint, {
     withCredentials: true,
   });
+
   const convertedData = keys.map((key, index) => {
     type keyType = T[typeof key];
     const typeData = response.data[key];
@@ -70,9 +82,19 @@ const USER_MAP = new Map<string, keyof User>([
   ["auth0_user_id", "auth0UserId"],
   ["group_admin", "groupAdmin"],
   ["system_admin", "systemAdmin"],
+  ["group_id", "groupdId"],
+  ["agreed_to_tos", "agreedToTos"],
 ]);
 export const fetchUserData = (): Promise<UserResponse> =>
   apiResponse<UserResponse>(["group", "user"], [null, USER_MAP], API.USER_DATA);
+
+export const updateUserData = (user: Partial<User>): Promise<Response> => {
+  return fetch(process.env.API_URL + API.USER_DATA, {
+    ...DEFAULT_PUT_OPTIONS,
+    ...DEFAULT_HEADERS_MUTATION_OPTIONS,
+    body: JSON.stringify(user),
+  });
+};
 
 interface SampleResponse extends APIResponse {
   samples: Sample[];
@@ -97,3 +119,7 @@ const TREE_MAP = new Map<string, keyof Tree>([
 ]);
 export const fetchTrees = (): Promise<TreeResponse> =>
   apiResponse<TreeResponse>(["phylo_trees"], [TREE_MAP], API.PHYLO_TREES);
+
+export const logout = (): Promise<Response> => {
+  return fetch(process.env.API_URL + API.LOG_OUT, DEFAULT_FETCH_OPTIONS);
+};

--- a/src/frontend/src/common/routes.ts
+++ b/src/frontend/src/common/routes.ts
@@ -4,4 +4,6 @@ export enum ROUTES {
   TERMS = "/terms",
   PRIVACY = "/privacy",
   CONTACT_US_EMAIL = "mailto:covidtracker-data-requests-ext@chanzuckerberg.com",
+  AGREE_TERMS = "/agreeTerms",
+  FAQ = "/faq",
 }

--- a/src/frontend/src/common/types/react-app-env.d.ts
+++ b/src/frontend/src/common/types/react-app-env.d.ts
@@ -2,6 +2,7 @@ declare namespace NodeJS {
   interface ProcessEnv {
     readonly NODE_ENV: "development" | "production" | "test";
     readonly PUBLIC_URL: string;
+    readonly API_URL: string;
   }
 }
 

--- a/src/frontend/src/common/types/user.d.ts
+++ b/src/frontend/src/common/types/user.d.ts
@@ -17,4 +17,5 @@ interface User {
   id: number;
   name: string;
   systemAdmin: boolean;
+  agreedToTos: boolean;
 }

--- a/src/frontend/src/components/ProtectedRoute/index.tsx
+++ b/src/frontend/src/components/ProtectedRoute/index.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { Redirect, Route, RouteProps, useLocation } from "react-router";
+import { ROUTES } from "src/common/routes";
+
+interface Props extends RouteProps {
+  isLoggedIn: boolean;
+  hasAgreedTerms: boolean;
+}
+
+const ProtectedRoute = (props: Props): JSX.Element => {
+  const location = useLocation();
+
+  const { component, isLoggedIn, hasAgreedTerms } = props;
+
+  if (!isLoggedIn) {
+    return <Redirect to={ROUTES.HOMEPAGE} />;
+  }
+
+  if (!hasAgreedTerms && location.pathname !== ROUTES.AGREE_TERMS) {
+    return <Redirect to={ROUTES.AGREE_TERMS} />;
+  }
+
+  return <Route {...props} component={component} />;
+};
+
+export default ProtectedRoute;

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import "semantic-ui-css/semantic.min.css";
 import App from "./App";
 import "./index.scss";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/frontend/src/views/AgreeTerms/components/DialogActions/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/components/DialogActions/index.tsx
@@ -1,0 +1,9 @@
+import { DialogActionsProps } from "@material-ui/core";
+import React from "react";
+import { StyledDialogActions } from "./style";
+
+const DialogActions = (props: DialogActionsProps): JSX.Element => {
+  return <StyledDialogActions {...props} />;
+};
+
+export default DialogActions;

--- a/src/frontend/src/views/AgreeTerms/components/DialogActions/style.ts
+++ b/src/frontend/src/views/AgreeTerms/components/DialogActions/style.ts
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+import { DialogActions } from "@material-ui/core";
+import { getSpacings } from "czifui";
+
+export const StyledDialogActions = styled(DialogActions)`
+  justify-content: flex-start;
+
+  ${(props) => {
+    const spacings = getSpacings(props);
+
+    return `
+      padding: 0 ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xxl}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/AgreeTerms/components/DialogContent/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/components/DialogContent/index.tsx
@@ -1,0 +1,9 @@
+import { DialogContentProps } from "@material-ui/core";
+import React from "react";
+import { StyledDialogContent } from "./style";
+
+const DialogContent = (props: DialogContentProps): JSX.Element => {
+  return <StyledDialogContent {...props} />;
+};
+
+export default DialogContent;

--- a/src/frontend/src/views/AgreeTerms/components/DialogContent/style.ts
+++ b/src/frontend/src/views/AgreeTerms/components/DialogContent/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { DialogContent } from "@material-ui/core";
+import { getSpacings } from "czifui";
+
+export const StyledDialogContent = styled(DialogContent)`
+  ${(props) => {
+    const spacings = getSpacings(props);
+
+    return `
+    padding: 0 ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/AgreeTerms/components/DialogTitle/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/components/DialogTitle/index.tsx
@@ -1,0 +1,9 @@
+import { DialogTitleProps } from "@material-ui/core";
+import React from "react";
+import { StyledDialogTitle } from "./style";
+
+const DialogTitle = (props: DialogTitleProps): JSX.Element => {
+  return <StyledDialogTitle {...props} />;
+};
+
+export default DialogTitle;

--- a/src/frontend/src/views/AgreeTerms/components/DialogTitle/style.ts
+++ b/src/frontend/src/views/AgreeTerms/components/DialogTitle/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { DialogTitle } from "@material-ui/core";
+import { getSpacings } from "czifui";
+
+export const StyledDialogTitle = styled(DialogTitle)`
+  ${(props) => {
+    const spacings = getSpacings(props);
+
+    return `
+      padding: ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/AgreeTerms/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/index.tsx
@@ -1,0 +1,136 @@
+import { Dialog } from "@material-ui/core";
+import { Button, Link, List, ListItem, ListSubheader } from "czifui";
+import React, { useEffect, useState } from "react";
+import { logout, updateUserData } from "src/common/api";
+import { ROUTES } from "src/common/routes";
+import DialogActions from "./components/DialogActions";
+import DialogContent from "./components/DialogContent";
+import DialogTitle from "./components/DialogTitle";
+import { Container, Details, Title } from "./style";
+
+export default function AgreeTerms(): JSX.Element {
+  const [isLoading, setIsLoading] = useState(false);
+  const [shouldRedirect, setShouldRedirect] = useState(false);
+  const [hasAcceptedTerms, setHasAcceptedTerms] = useState(false);
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      window.location.href = process.env.PUBLIC_URL + ROUTES.DATA;
+    }
+  }, [shouldRedirect]);
+
+  useEffect(() => {
+    if (!hasAcceptedTerms) return;
+
+    agreeTos();
+
+    async function agreeTos() {
+      setIsLoading(true);
+      await updateUserData({ agreed_to_tos: true });
+      setShouldRedirect(true);
+    }
+  }, [hasAcceptedTerms]);
+
+  function handleAcceptClick() {
+    setHasAcceptedTerms(true);
+  }
+
+  async function handleDeclineClick() {
+    setIsLoading(true);
+    try {
+      await logout();
+    } catch {
+      setIsLoading(false);
+    }
+    setIsLoading(false);
+  }
+
+  return (
+    <Container>
+      <Dialog open>
+        <DialogTitle>
+          <Title>
+            First, a note about how we protect and handle your data.
+          </Title>
+        </DialogTitle>
+        <DialogContent>
+          <List>
+            <ListSubheader disableSticky>
+              We take data privacy and security very seriously. Here are a few
+              key things to know:
+            </ListSubheader>
+            <ListItem fontSize="s">
+              You always own and control the data you upload.
+            </ListItem>
+            <ListItem fontSize="s">
+              Only other members of your group can see your data. CDPH can see
+              samples, but not your private, internal identifiers.
+            </ListItem>
+            <ListItem fontSize="s">
+              New sequences will be automatically submitted to GISAID two weeks
+              after upload.
+            </ListItem>
+            <ListItem fontSize="s">
+              You can mark a sample as “private” anytime during the first two
+              weeks after upload. “Private” samples are not shared with CDPH or
+              GISAID, but are visible to your group.{" "}
+            </ListItem>
+            <ListItem fontSize="s">
+              Aspen does not contain any personally identifiable information or
+              protected health information.
+            </ListItem>
+            <ListItem fontSize="s">
+              We utilize industry standard best practices in information
+              security, such as encrypting your data at rest and in transit, to
+              ensure the security of your data.
+            </ListItem>
+            <Details>
+              Take a look at our full{" "}
+              <Link href={ROUTES.TERMS} target="_blank" rel="noopener">
+                Terms of Service
+              </Link>{" "}
+              and{" "}
+              <Link href={ROUTES.PRIVACY} target="_blank" rel="noopener">
+                Privacy Policy
+              </Link>
+              . We’ve put together an{" "}
+              <Link href={ROUTES.FAQ} target="_blank" rel="noopener">
+                FAQ
+              </Link>{" "}
+              to make these easier to understand. Please{" "}
+              <Link
+                href={ROUTES.CONTACT_US_EMAIL}
+                target="_blank"
+                rel="noopener"
+              >
+                get in touch
+              </Link>{" "}
+              if you have any questions or concerns, we’re here to help.
+            </Details>
+          </List>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            disabled={isLoading}
+            color="primary"
+            variant="contained"
+            isRounded
+            autoFocus
+            onClick={handleAcceptClick}
+          >
+            Accept
+          </Button>
+          <Button
+            disabled={isLoading}
+            color="primary"
+            variant="outlined"
+            isRounded
+            onClick={handleDeclineClick}
+          >
+            Decline
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+}

--- a/src/frontend/src/views/AgreeTerms/style.ts
+++ b/src/frontend/src/views/AgreeTerms/style.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+import { fontBodyS, fontHeaderXl, getSpacings } from "czifui";
+import { pageContentHeight } from "src/common/styles/mixins/global";
+
+export const Container = styled.div`
+  ${pageContentHeight}
+`;
+
+export const Title = styled.div`
+  ${fontHeaderXl}
+`;
+
+export const Details = styled.p`
+  ${fontBodyS}
+
+  ${(props) => {
+    const spacings = getSpacings(props);
+
+    return `
+      margin-top: ${spacings?.xl}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/Faq/index.tsx
+++ b/src/frontend/src/views/Faq/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Faq = (): JSX.Element => {
+  return <div>FAQ</div>;
+};
+
+export default Faq;

--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Privacy = (): JSX.Element => {
+  return <div>Privacy</div>;
+};
+
+export default Privacy;

--- a/src/frontend/src/views/Terms/index.tsx
+++ b/src/frontend/src/views/Terms/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Terms = (): JSX.Element => {
+  return <div>ToS</div>;
+};
+
+export default Terms;


### PR DESCRIPTION
### Description

1. Add Agree ToS page `/agreeTerms`
2. Add placeholder pages for `/terms`, `/privacy`, and `/faq`
3. Add `<ProtectedRoute />` component to kick user out of protected pages, such as Samples
4. BE: Update `usergroup.py` to remove `json.loads()` since `request.get_json()` already returns a JSON dict, which caused a runtime error (@phoenixAja PTAL 🙏 Thank you!)
5. Update `<App />` component to block loading content while fetching user data, so we want determine whether we should send them to `/agreeTerms` page
6. Add `updateUserData()` PUT API call and `logout()` API call
7. Add component Dialog matching [specs in Figma](https://www.figma.com/file/uHpPNuDSBupK97ORCkH1op/Aspen-v0-and-v2?node-id=72%3A3911). I didn't have time to pull that into the component library yet, due to the time crunch. Will do it next week!
8. Add List and Link components in component library [PR](https://github.com/chanzuckerberg/sci-components/pull/19)

#### Issue
https://app.clubhouse.io/genepi/story/122409/add-tos-clickthrough-to-aspen-site-upon-user-s-first-login

### Test plan

1. Visit live link: https://thuang-agree-tos-frontend.dev.genepi.czi.technology (currently not working, rdev seems to need database migration?) --- use local dev first!
2. Log in as a user
3. You should get redirected to `/agreeTerms`
4. Click "Decline" and nothing will happen, because I think Auth0 logout is not working yet
5. Click "Accept" and you will get dropped into Samples page!

<img width="1291" alt="Screen Shot 2021-04-29 at 7 43 39 AM" src="https://user-images.githubusercontent.com/6309723/116571798-4208eb00-a8c0-11eb-8dab-e6e0ade7b553.png">

![demo](https://user-images.githubusercontent.com/6309723/116573968-2272c200-a8c2-11eb-9a20-d45eedb27f72.gif)
