### PR TITLE
thuang-logout-return-https

### DIFF
--- a/src/backend/aspen/app/views/auth.py
+++ b/src/backend/aspen/app/views/auth.py
@@ -35,7 +35,7 @@ def logout():
     session.clear()
     # Redirect user to logout endpoint
     params = {
-        "returnTo": url_for("serve", _external=True),
+        "returnTo": url_for("serve", _external=True, _scheme="https"),
         "client_id": application.aspen_config.AUTH0_CLIENT_ID,
     }
     return redirect(auth0.api_base_url + "/v2/logout?" + urlencode(params))


### PR DESCRIPTION
### Description

This PR fixes staging and prod logout flow

#### Issue
N/A

### Test plan

1. Visit https://thuang-return-https-frontend.dev.genepi.czi.technology
2. Log in
3. Log out
4. You should be dropped back to Auth0 login page
5. Log in again, and you'll be back at the app!
