### PR TITLE
Adding gisaid status to sample api return value

### DIFF
--- a/src/backend/aspen/test_infra/models/sample.py
+++ b/src/backend/aspen/test_infra/models/sample.py
@@ -16,6 +16,7 @@ def sample_factory(
     country="USA",
     region=RegionType.NORTH_AMERICA,
     organism="SARS-CoV-2",
+    czb_failed_genome_recovery=False,
 ) -> Sample:
     original_submission = original_submission or {}
     collection_date = collection_date or datetime.now()
@@ -32,4 +33,5 @@ def sample_factory(
         country=country,
         region=region,
         organism=organism,
+        czb_failed_genome_recovery=czb_failed_genome_recovery,
     )

--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -29,6 +29,7 @@ def sequencing_read_factory(
             "gisaid_public_identifier",
         ),
     ),
+    consuming_workflows=[],
 ) -> SequencingReadsCollection:
     sequencing_date = sequencing_date or datetime.datetime.now()
     sequencing_reads = SequencingReadsCollection(
@@ -38,6 +39,7 @@ def sequencing_read_factory(
         sequencing_date=sequencing_date,
         s3_bucket=s3_bucket,
         s3_key=s3_key,
+        consuming_workflows=consuming_workflows,
     )
     for accession_workflow_directive in accessions:
         if accession_workflow_directive.end_datetime is None:


### PR DESCRIPTION
### Description

Adds logic to the view/samples api to return the on of three GISIAD status:

- "Not Eligible" if sample failed genome recovery at czb
- "Rejected" if sample has been rejected by GISAID (if we don't have an ID and it didn't fail genome recovery)
- "Accepted" if sample has been accepted by GISAID (if we have an ID)
- "Submitted" if a sample has been submitted to GISAID (has a consuming workflow) but no accession and it's been less then 4 days. 
- "no_info" if a sample has not been submitted but is eligible WE SHOULD SHOW Eligible, not Submitted

Returns the status as part of the gisaid field. The new format of the return value is 

```
"gisaid": {"status": "STATUS", "gisaid_id": ID_OR_NONE}
```

Relavent for @tihuan ! 

#### Issue
[ch135473](https://app.clubhouse.io/genepi/story/135473)

### Test plan

Added a few tests