### PR TITLE
src/App.module.scss

### DIFF
--- a/src/frontend/src/App.module.scss
+++ b/src/frontend/src/App.module.scss
@@ -4,7 +4,7 @@
   height: 100vh;
   flex-flow: column wrap;
   justify-content: center;
-  * {
+  :not(i) {
     font-family: Open Sans, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
       Helvetica Neue, Helvetica, Arial, sans-serif !important;
   }


### PR DESCRIPTION
### Description

Fix the icon font bug lol

BAD:
<img width="568" alt="Screen Shot 2021-05-05 at 3 53 38 PM" src="https://user-images.githubusercontent.com/6309723/117219431-1c954900-adba-11eb-8308-bd560a629935.png">

GOOD:
<img width="640" alt="Screen Shot 2021-05-05 at 3 51 50 PM" src="https://user-images.githubusercontent.com/6309723/117219451-261eb100-adba-11eb-9336-6bf750e8b7e3.png">

I was applying Open Sans font too broadly, which affected Semantic UI’s CSS, since they still use icon font instead of SVG!

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Check the Samples page search bar and the icon should now be te magnifier again!

Thank you!
