### PR TITLE
[easy] stamp the alembic head after creating the empty db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ init-empty-db:
 	-docker-compose exec -T database psql "postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@localhost:5432/$(LOCAL_DB_NAME)" -c "CREATE USER $(LOCAL_DB_RO_USERNAME) WITH PASSWORD '$(LOCAL_DB_RO_PASSWORD)';"
 	-docker-compose exec -T database psql "postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@localhost:5432/$(LOCAL_DB_NAME)" -c "GRANT ALL PRIVILEGES ON DATABASE $(LOCAL_DB_NAME) TO $(LOCAL_DB_RW_USERNAME);"
 	docker-compose exec -T utility aspen-cli db --docker create
+	docker-compose exec -T utility alembic stamp head
 
 
 .PHONY: local-init


### PR DESCRIPTION
### Description
This is necessary for alembic to function.

### Test plan
make init-empty-db
