### PR TITLE
fix samples endpoint

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -1,32 +1,33 @@
 import datetime
-from typing import (
-    Any,
-    Mapping,
-    MutableMapping,
-    MutableSequence,
-    Optional,
-    Sequence,
-    Set,
-)
+from collections import defaultdict
+from typing import Any, Mapping, MutableSequence, Optional, Sequence, Set
 
 from flask import jsonify, session
-from sqlalchemy import and_, or_
-from sqlalchemy.orm import aliased, joinedload
+from sqlalchemy import or_
+from sqlalchemy.orm import joinedload
 
 from aspen.app.app import application, requires_auth
 from aspen.app.views import api_utils
 from aspen.app.views.api_utils import get_usergroup_query
 from aspen.database.connection import session_scope
 from aspen.database.models import (
+    AlignRead,
+    Bam,
+    CallConsensus,
+    CalledPathogenGenome,
     DataType,
     Entity,
+    FilterRead,
     GisaidAccession,
-    Workflow,
+    GisaidAccessionWorkflow,
+    HostFilteredSequencingReadsCollection,
+    SequencingReadsCollection,
+    UploadedPathogenGenome,
     WorkflowStatusType,
-    WorkflowType,
 )
 from aspen.database.models.sample import Sample
 from aspen.database.models.usergroup import Group, User
+from aspen.error.recoverable import RecoverableError
 
 SAMPLE_KEY = "samples"
 GISIAD_REJECTION_TIME = datetime.timedelta(days=4)
@@ -44,29 +45,42 @@ def _format_created_date(sample: Sample) -> str:
 
 
 def _format_gisaid_accession(
-    sample: Sample, entity_id_to_accession_map: Mapping[int, GisaidAccession]
+    sample: Sample,
+    entity_id_to_gisaid_accession_workflow_map: defaultdict[
+        int, list[GisaidAccessionWorkflow]
+    ],
 ) -> Mapping[str, Optional[str]]:
     if sample.czb_failed_genome_recovery:
         # todo need to add the private option here for v3 a user uploads and flags a private sample
         return {"status": "not_eligible", "gisaid_id": None}
 
     uploaded_entity = sample.get_uploaded_entity()
-    consuming_workflows = uploaded_entity.consuming_workflows
-    accession = entity_id_to_accession_map.get(uploaded_entity.entity_id, None)
-    if accession is not None:
-        return {"status": "accepted", "gisaid_id": accession.public_identifier}
-    for workflow in consuming_workflows:
-        if (
-            workflow.workflow_type == WorkflowType.GISAID_REPOSITORY_SUBMISSION
-            and workflow.workflow_status == WorkflowStatusType.STARTED
-        ):
-            date_since_submitted = (
-                datetime.date.today() - workflow.start_datetime.date()
-            )
-            if date_since_submitted < GISIAD_REJECTION_TIME:
-                return {"status": "submitted", "gisaid_id": None}
+    gisaid_accession_workflows = entity_id_to_gisaid_accession_workflow_map.get(
+        uploaded_entity.entity_id, []
+    )
+    for gisaid_accession_workflow in gisaid_accession_workflows:
+        if gisaid_accession_workflow.workflow_status == WorkflowStatusType.COMPLETED:
+            # hey there should be an output...
+            for output in gisaid_accession_workflow.outputs:
+                assert isinstance(output, GisaidAccession)
+                return {
+                    "status": "accepted",
+                    "gisaid_id": output.public_identifier,
+                }
             else:
-                return {"status": "rejected", "gisaid_id": None}
+                raise RecoverableError(
+                    "Successful accession workflow for sample"
+                    f" {sample.public_identifier} does not seem to have an accession"
+                    " output."
+                )
+
+        date_since_submitted = (
+            datetime.date.today() - gisaid_accession_workflow.start_datetime.date()
+        )
+        if date_since_submitted < GISIAD_REJECTION_TIME:
+            return {"status": "submitted", "gisaid_id": None}
+        else:
+            return {"status": "rejected", "gisaid_id": None}
     return {"status": "no_info", "gisaid_id": None}
 
 
@@ -105,48 +119,69 @@ def samples():
             )
             .options(
                 joinedload(Sample.uploaded_pathogen_genome),
-                joinedload(Sample.sequencing_reads_collection),
+                joinedload(Sample.sequencing_reads_collection)
+                .joinedload(
+                    SequencingReadsCollection.consuming_workflows.of_type(FilterRead)
+                )
+                .joinedload(
+                    FilterRead.outputs.of_type(HostFilteredSequencingReadsCollection)
+                )
+                .joinedload(
+                    HostFilteredSequencingReadsCollection.consuming_workflows.of_type(
+                        AlignRead
+                    )
+                )
+                .joinedload(AlignRead.outputs.of_type(Bam))
+                .joinedload(Bam.consuming_workflows.of_type(CallConsensus))
+                .joinedload(CallConsensus.outputs.of_type(CalledPathogenGenome)),
             )
             .all()
         )
-        sample_entity_ids: Sequence[int] = [
-            sample_entity_id
-            for sample_entity_id in [
-                sample.uploaded_pathogen_genome.entity_id
-                if sample.uploaded_pathogen_genome is not None
-                else sample.sequencing_reads_collection.entity_id
-                if sample.sequencing_reads_collection is not None
-                else None
-                for sample in samples
-            ]
-            if sample_entity_id is not None
-        ]
+        sample_entity_ids: MutableSequence[int] = list()
+        for sample in samples:
+            if sample.uploaded_pathogen_genome is not None:
+                sample_entity_ids.append(sample.uploaded_pathogen_genome.entity_id)
+            elif sample.sequencing_reads_collection is not None:
+                # TODO: get the best called pathogen genome for the sequencing read
+                # collection.
+                ...
 
-        # load the accessions.
-        entity_alias = aliased(Entity)
-        accessions: Sequence[GisaidAccession] = (
-            db_session.query(GisaidAccession)
-            .distinct(GisaidAccession.entity_id)
-            .join(GisaidAccession.producing_workflow)
-            .join(entity_alias, Workflow.inputs)
-            .order_by(GisaidAccession.entity_id, Workflow.end_datetime.desc())
-            .filter(
-                and_(
-                    Workflow.workflow_type == WorkflowType.GISAID_REPOSITORY_SUBMISSION,
-                    entity_alias.id.in_(sample_entity_ids),
-                )
-            )
+        # load the gisaid_accessioning workflows.
+        gisaid_accession_workflows: Sequence[GisaidAccessionWorkflow] = (
+            db_session.query(GisaidAccessionWorkflow)
+            .join(GisaidAccessionWorkflow.inputs)
+            .filter(Entity.id.in_(sample_entity_ids))
             .options(
-                joinedload(GisaidAccession.producing_workflow).joinedload(
-                    Workflow.inputs
-                )
+                joinedload(GisaidAccessionWorkflow.inputs),
+                joinedload(GisaidAccessionWorkflow.outputs.of_type(GisaidAccession)),
             )
             .all()
         )
-        entity_id_to_accession_map: MutableMapping[int, GisaidAccession] = dict()
-        for accession in accessions:
-            for workflow_input in accession.producing_workflow.inputs:
-                entity_id_to_accession_map[workflow_input.entity_id] = accession
+        entity_id_to_gisaid_accession_workflow_map: defaultdict[
+            int, list[GisaidAccessionWorkflow]
+        ] = defaultdict(list)
+        for gisaid_accession_workflow in gisaid_accession_workflows:
+            for workflow_input in gisaid_accession_workflow.inputs:
+                if isinstance(
+                    workflow_input, (UploadedPathogenGenome, SequencingReadsCollection)
+                ):
+                    entity_id_to_gisaid_accession_workflow_map[
+                        workflow_input.entity_id
+                    ].append(gisaid_accession_workflow)
+        for (
+            gisaid_accession_workflow_list
+        ) in entity_id_to_gisaid_accession_workflow_map.values():
+            # sort by success, date.
+            gisaid_accession_workflow_list.sort(
+                key=lambda gisaid_accession_workflow: (
+                    1
+                    if gisaid_accession_workflow.workflow_status
+                    == WorkflowStatusType.COMPLETED
+                    else 0,
+                    gisaid_accession_workflow.start_datetime,
+                ),
+                reverse=True,
+            )
 
         # filter for only information we need in sample table view
         results: MutableSequence[Mapping[str, Any]] = list()
@@ -156,7 +191,9 @@ def samples():
                 "upload_date": _format_created_date(sample),
                 "collection_date": api_utils.format_date(sample.collection_date),
                 "collection_location": sample.location,
-                "gisaid": _format_gisaid_accession(sample, entity_id_to_accession_map),
+                "gisaid": _format_gisaid_accession(
+                    sample, entity_id_to_gisaid_accession_workflow_map
+                ),
                 "czb_failed_genome_recovery": sample.czb_failed_genome_recovery,
             }
 

--- a/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
@@ -25,7 +25,7 @@ def test_phylo_tree_view(
         )
         for ix in range(n_samples)
     ]
-    _ = [uploaded_pathogen_genome_factory(sample) for sample in samples]
+    _ = [uploaded_pathogen_genome_factory(sample, accessions=()) for sample in samples]
 
     # make up to 3 trees, each with a random sample of uploaded pathogen genomes.
     trees = [

--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Tuple
+from typing import Sequence
 
 from aspen.database.models import (
     PublicRepositoryType,
@@ -21,14 +21,6 @@ def sequencing_read_factory(
     sequencing_date=None,
     s3_bucket="bucket",
     s3_key="key",
-    accessions: Tuple[AccessionWorkflowDirective, ...] = (
-        AccessionWorkflowDirective(
-            PublicRepositoryType.GISAID,
-            datetime.datetime.now(),
-            datetime.datetime.now(),
-            "gisaid_public_identifier",
-        ),
-    ),
     consuming_workflows=[],
 ) -> SequencingReadsCollection:
     sequencing_date = sequencing_date or datetime.datetime.now()
@@ -41,27 +33,6 @@ def sequencing_read_factory(
         s3_key=s3_key,
         consuming_workflows=consuming_workflows,
     )
-    for accession_workflow_directive in accessions:
-        if accession_workflow_directive.end_datetime is None:
-            public_repository_metadata: PublicRepositoryTypeMetadata = (
-                accession_workflow_directive.repository_type.value
-            )
-            sequencing_reads.consuming_workflows.append(
-                public_repository_metadata.accession_workflow_cls(
-                    software_versions={},
-                    workflow_status=WorkflowStatusType.FAILED,
-                    start_datetime=accession_workflow_directive.start_datetime,
-                )
-            )
-        else:
-            assert accession_workflow_directive.repository_type is not None
-            assert accession_workflow_directive.public_identifier is not None
-            sequencing_reads.add_accession(
-                repository_type=accession_workflow_directive.repository_type,
-                public_identifier=accession_workflow_directive.public_identifier,
-                workflow_start_datetime=accession_workflow_directive.start_datetime,
-                workflow_end_datetime=accession_workflow_directive.end_datetime,
-            )
     return sequencing_reads
 
 
@@ -77,8 +48,16 @@ def uploaded_pathogen_genome_factory(
     pangolin_last_updated=None,
     sequencing_depth=0.1,
     upload_date=datetime.datetime.now(),
+    accessions: Sequence[AccessionWorkflowDirective] = (
+        AccessionWorkflowDirective(
+            PublicRepositoryType.GISAID,
+            datetime.datetime.now(),
+            datetime.datetime.now(),
+            "gisaid_public_identifier",
+        ),
+    ),
 ):
-    return UploadedPathogenGenome(
+    uploaded_pathogen_genome = UploadedPathogenGenome(
         sample=sample,
         sequence=sequence,
         num_unambiguous_sites=num_unambiguous_sites,
@@ -91,3 +70,26 @@ def uploaded_pathogen_genome_factory(
         sequencing_depth=sequencing_depth,
         upload_date=upload_date,
     )
+    for accession_workflow_directive in accessions:
+        if accession_workflow_directive.end_datetime is None:
+            public_repository_metadata: PublicRepositoryTypeMetadata = (
+                accession_workflow_directive.repository_type.value
+            )
+            uploaded_pathogen_genome.consuming_workflows.append(
+                public_repository_metadata.accession_workflow_cls(
+                    software_versions={},
+                    workflow_status=WorkflowStatusType.FAILED,
+                    start_datetime=accession_workflow_directive.start_datetime,
+                )
+            )
+        else:
+            assert accession_workflow_directive.repository_type is not None
+            assert accession_workflow_directive.public_identifier is not None
+            uploaded_pathogen_genome.add_accession(
+                repository_type=accession_workflow_directive.repository_type,
+                public_identifier=accession_workflow_directive.public_identifier,
+                workflow_start_datetime=accession_workflow_directive.start_datetime,
+                workflow_end_datetime=accession_workflow_directive.end_datetime,
+            )
+
+    return uploaded_pathogen_genome

--- a/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
+++ b/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
@@ -24,7 +24,8 @@ def create_test_data(session):
         )
         session.add(sample)
         pathogen_genome: UploadedPathogenGenome = uploaded_pathogen_genome_factory(
-            sample
+            sample,
+            accessions=(),
         )
         session.add(pathogen_genome)
         session.commit()


### PR DESCRIPTION
### Description
This allows us to not execute N queries during the samples endpoint for the gisaid data.

Depends on #361 

### Test plan
turned on profiling and verified that the samples endpoint executes 3 queries now.
