### PR TITLE
Get the db-bucket from config instead of hardcoding it.

### DIFF
--- a/scripts/migrate-all.sh
+++ b/scripts/migrate-all.sh
@@ -52,5 +52,5 @@ done
 
 for county in "${COUNTIES[@]}"; do
     aspen_group_id=$(echo "$COUNTY_INFO" | jq -r ".$county".aspen_group_id)
-    aspen-cli db --local import-covidhub-trees --covidhub-aws-profile biohub --s3-src-prefix s3://covidtracker-datasets/cdph/"$county" --s3-dst-prefix s3://aspen-db-data-dev/imported/phylo_trees/"$county" --aspen-group-id "$aspen_group_id"
+    aspen-cli db --local import-covidhub-trees --covidhub-aws-profile biohub --s3-src-prefix s3://covidtracker-datasets/cdph/"$county" --s3-key-prefix /imported/phylo_trees/"$county" --aspen-group-id "$aspen_group_id"
 done

--- a/src/backend/aspen/cli/db.py
+++ b/src/backend/aspen/cli/db.py
@@ -181,23 +181,25 @@ def import_covidhub_project(
 @click.option("--covidhub-aws-profile", type=str, required=True)
 @click.option("--aspen-group-id", type=int, required=True)
 @click.option("--s3-src-prefix", type=str, required=True)
-@click.option("--s3-dst-prefix", type=str, required=True)
+@click.option("--s3-key-prefix", type=str, required=True)
 @click.pass_context
 def import_covidhub_trees(
     ctx,
     covidhub_aws_profile,
     aspen_group_id,
     s3_src_prefix,
-    s3_dst_prefix,
+    s3_key_prefix,
 ):
-    engine = ctx.obj["ENGINE"]
+    config, engine = ctx.obj["CONFIG"], ctx.obj["ENGINE"]
 
+    if not s3_key_prefix.startswith("/"):
+        s3_key_prefix = f"/{s3_key_prefix}"
     covidhub_import.import_trees(
         engine,
         covidhub_aws_profile,
         aspen_group_id,
         s3_src_prefix,
-        s3_dst_prefix,
+        f"s3://{config.DB_BUCKET}{s3_key_prefix}",
     )
 
 

--- a/src/backend/aspen/config/config.py
+++ b/src/backend/aspen/config/config.py
@@ -218,5 +218,9 @@ class Config(object):
     ####################################################################################
     # s3 properties
     @property
+    def DB_BUCKET(self) -> str:
+        return self.AWS_SECRET["S3_db_bucket"]
+
+    @property
     def EXTERNAL_AUSPICE_BUCKET(self) -> str:
         return self.AWS_SECRET["S3_external_auspice_bucket"]


### PR DESCRIPTION
### Description
It's currently in `migrate-all.sh` script.  Move it to config so it can be parameterized.

This is #367 once again.

[ch136573](https://app.clubhouse.io/genepi/story/136573/update-s3-copy-buckets-for-import-data-script-so-that-we-copy-over-trees-to-the-right-location-for-each-county)

### Test plan
run migrate-all.sh
