### PR TITLE
Upgrade batch base image.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -217,7 +217,7 @@ module swipe_batch {
   app_name              = "swipe"
   stack_resource_prefix = local.stack_resource_prefix
   batch_role_arn        = local.batch_role_arn
-  swipe_image            = "${local.swipe_image_repo}:rev-3" # FIXME rev shouldn't be hardcoded
+  swipe_image            = "${local.swipe_image_repo}:rev-4" # FIXME rev shouldn't be hardcoded
   custom_stack_name     = local.custom_stack_name
   remote_dev_prefix     = local.remote_dev_prefix
   deployment_stage      = local.deployment_stage


### PR DESCRIPTION
### Description

The base batch/miniwdl image is built against a [branch of miniwdl plugins](https://github.com/chanzuckerberg/miniwdl-plugins/compare/akislyuk-swipe-aspen-vars) that we've modified to allow some core aspen env vars to be passed through to worker steps. The remote-dev environment uses an env var called REMOTE_DEV_PREFIX, but the staging and prod envs do not. Our patched version of miniwdl-plugins was *requiring* that env var to be set. I've rebuilt the image with a patch that allows the REMOTE_DEV_PREFIX env var to be missing

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
