### PR TITLE
Tooling to import admin users

### DIFF
--- a/scripts/migrate-all.sh
+++ b/scripts/migrate-all.sh
@@ -40,6 +40,13 @@ for county in "${COUNTIES[@]}"; do
     COUNTY_INFO=$(jq -r ".$county.aspen_group_id = $(jq -r .group_id <<< "$import_users_output")" <<< "$COUNTY_INFO")
 done
 
+################################################################################
+# import all the admin users
+aspen_admin_group_info=$(aspen-cli db --local import-covidhub-admins --covidhub-db-secret cliahub/cliahub_rds_read_prod --covidhub-aws-profile biohub)
+
+################################################################################
+# import all the projects
+
 for county in "${COUNTIES[@]}"; do
     aspen_group_id=$(jq -r ".$county".aspen_group_id <<< "$COUNTY_INFO")
     if [ "$(jq ".$county | has(\"internal_project_ids\")" <<< "$COUNTY_INFO")" = "true" ]; then
@@ -55,6 +62,9 @@ for county in "${COUNTIES[@]}"; do
         aspen-cli db --local import-covidhub-project --rr-project-id "$external_project_id" --covidhub-db-secret cliahub/cliahub_rds_read_prod  --covidhub-aws-profile biohub --aspen-group-id "$aspen_group_id"
     fi
 done
+
+################################################################################
+# import all the trees
 
 for county in "${COUNTIES[@]}"; do
     aspen_group_id=$(echo "$COUNTY_INFO" | jq -r ".$county".aspen_group_id <<< "$COUNTY_INFO")

--- a/src/backend/aspen/cli/db.py
+++ b/src/backend/aspen/cli/db.py
@@ -153,6 +153,27 @@ def import_covidhub_users(
     )
 
 
+@db.command("import-covidhub-admins")
+@click.option("--covidhub-aws-profile", type=str, required=True)
+@click.option("--covidhub-db-secret", default="cliahub/cliahub_test_db")
+@click.pass_context
+def import_covidhub_admins(
+    ctx,
+    covidhub_aws_profile,
+    covidhub_db_secret,
+):
+    config, engine = ctx.obj["CONFIG"], ctx.obj["ENGINE"]
+
+    auth0_usermap = covidhub_import.retrieve_auth0_users(config)
+
+    covidhub_import.import_covidhub_admins(
+        engine,
+        covidhub_aws_profile,
+        covidhub_db_secret,
+        auth0_usermap,
+    )
+
+
 @db.command("import-covidhub-project")
 @click.option("--covidhub-aws-profile", type=str, required=True)
 @click.option("--covidhub-db-secret", default="cliahub/cliahub_test_db")

--- a/src/backend/aspen/covidhub_import/__init__.py
+++ b/src/backend/aspen/covidhub_import/__init__.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     ...
 else:
+    from .import_admins import import_covidhub_admins  # noqa: F401
     from .import_projects import import_project  # noqa: F401
     from .import_trees import import_trees  # noqa: F401
     from .import_users import import_project_users  # noqa: F401

--- a/src/backend/aspen/covidhub_import/import_admins.py
+++ b/src/backend/aspen/covidhub_import/import_admins.py
@@ -1,0 +1,67 @@
+import json
+import logging
+from typing import Iterable, Mapping
+
+from sqlalchemy.orm import configure_mappers, Session
+
+from aspen.covidhub_import.utils import (
+    Auth0Entry,
+    covidhub_interface_from_secret,
+    get_or_make_group,
+)
+from aspen.database.connection import session_scope, SqlAlchemyInterface
+from aspen.database.models import Group, User
+from covid_database.models import covidtracker
+
+logger = logging.getLogger(__name__)
+
+
+def import_covidhub_admins(
+    interface: SqlAlchemyInterface,
+    covidhub_aws_profile: str,
+    covidhub_secret_id: str,
+    auth0_usermap: Mapping[str, Auth0Entry],
+    admin_group_name: str = "Admin",
+):
+    configure_mappers()
+    covidhub_interface = covidhub_interface_from_secret(
+        covidhub_aws_profile, covidhub_secret_id
+    )
+    covidhub_session: Session = covidhub_interface.make_session()
+
+    with session_scope(interface) as session:
+        admin_users: Iterable[covidtracker.UsersGroups] = (
+            covidhub_session.query(covidtracker.UsersGroups)
+            .join(covidtracker.Group)
+            .filter(covidtracker.Group.name == admin_group_name)
+        )
+
+        group: Group = get_or_make_group(
+            session,
+            "admin",
+            "n/a",
+        )
+
+        # create the users!
+        for admin_user in admin_users:
+            # try to find the user in the auth0_usermap
+            auth0_user = auth0_usermap.get(admin_user.user_id, None)
+            if auth0_user is None:
+                continue
+
+            # try to create this user in the aspen db.
+            user = (
+                session.query(User).filter(User.email == auth0_user.email).one_or_none()
+            )
+            if user is None:
+                user = User()
+
+            user.name = auth0_user.nickname
+            user.email = auth0_user.email
+            user.auth0_user_id = auth0_user.auth0_token
+            user.group_admin = False
+            user.system_admin = True
+            user.group = group
+
+        session.commit()
+        print(json.dumps({"group_id": group.id}))


### PR DESCRIPTION
### Description
This is pretty similar to the import users script, though simpler.  Added the script to the migrate-all.sh script.

Depends on #387 

#### Issue
[ch135517](https://app.clubhouse.io/genepi/story/135517/port-over-account-info-for-admin-czb-czi-users)

### Test plan
Ran `ASPEN_CONFIG_SECRET_NAME=aspen-secret-ttung-import AWS_PROFILE=genepi-dev AWS_DEFAULT_REGION=us-west-2 aspen-cli db --local import-covidhub-admins --covidhub-db-secret cliahub/cliahub_rds_read_prod  --covidhub-aws-profile biohub`
