### PR TITLE
Small fixes, copy fixes

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -98,7 +98,6 @@ const DataSubview: FunctionComponent<Props> = ({
   };
 
   const render = (tableData: TableItem[]) => {
-    console.log(tableData);
     const [tsvHeaders, tsvData] = tsvDataMap(tableData, headers, subheaders);
     const separator = "\t";
 

--- a/src/frontend/src/common/utils/tableUtils.tsx
+++ b/src/frontend/src/common/utils/tableUtils.tsx
@@ -44,7 +44,7 @@ function createTreeModalInfo_(treeId: string): ModalInfo {
   return {
     body:
       "You are leaving Aspen and sending your data to a private " +
-      "visualization on auspice.us, which is not controlled by Aspen.",
+      "visualization on Nextstrain, which is not controlled by Aspen.",
     buttons: [
       {
         Button: createConfirmButton(treeId),
@@ -56,6 +56,6 @@ function createTreeModalInfo_(treeId: string): ModalInfo {
       },
     ],
     header:
-      "Please confirm you're ready to send your data to Auspice to see your tree.",
+      "Please confirm you're ready to send your data to Nextstrain to see your tree.",
   };
 }

--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -763,7 +763,7 @@ const PrivacyPolicy = (): JSX.Element => {
             .
           </span>,
           `We store raw Raw Sequence Data (ex: fastq files) for 90 days following upload. If no abnormalities are found in the resulting Pathogen Consensus Genome, we discard this data. We encourage submission to NCBI’s Sequence Read Archive (SRA) repository for long-term storage and sharing.`,
-          `User Data is retained until Users delete their IDseq account as such data is required to manage the service. Users may submit account deletion requests by emailing privacy@idseq.net. We will delete personal data within 60 days following close of your account.`,
+          `User Data is retained until Users delete their Aspen account as such data is required to manage the service. Users may submit account deletion requests by emailing helloaspen@chanzuckerberg.com. We will delete personal data within 60 days following close of your account.`,
           <span key="1">
             User Data is retained until Users delete their Aspen account because
             this data is required to manage the service. Users may submit

--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -762,7 +762,7 @@ const PrivacyPolicy = (): JSX.Element => {
             </Link>
             .
           </span>,
-          `We store raw Raw Sequence Data (ex: fastq files) for 90 days following upload. If no abnormalities are found in the resulting Pathogen Consensus Genome, we discard this data. We encourage submission to NCBI’s Sequence Read Archive (SRA) repository for long-term storage and sharing.`,
+          `We store Raw Sequence Data (ex: fastq files) for 90 days following upload. If no abnormalities are found in the resulting Pathogen Consensus Genome, we discard this data. We encourage submission to NCBI’s Sequence Read Archive (SRA) repository for long-term storage and sharing.`,
           <span key="1">
             User Data is retained until Users delete their Aspen account because
             this data is required to manage the service. Users may submit

--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -763,7 +763,6 @@ const PrivacyPolicy = (): JSX.Element => {
             .
           </span>,
           `We store raw Raw Sequence Data (ex: fastq files) for 90 days following upload. If no abnormalities are found in the resulting Pathogen Consensus Genome, we discard this data. We encourage submission to NCBI’s Sequence Read Archive (SRA) repository for long-term storage and sharing.`,
-          `User Data is retained until Users delete their Aspen account as such data is required to manage the service. Users may submit account deletion requests by emailing helloaspen@chanzuckerberg.com. We will delete personal data within 60 days following close of your account.`,
           <span key="1">
             User Data is retained until Users delete their Aspen account because
             this data is required to manage the service. Users may submit

--- a/src/frontend/src/views/Terms/index.tsx
+++ b/src/frontend/src/views/Terms/index.tsx
@@ -228,7 +228,7 @@ export default function Terms(): JSX.Element {
     </>
   );
 
-  const renderAuthorizationToUseIdseq = () => (
+  const renderAuthorizationToUseAspen = () => (
     <>
       <H2>
         <Number>2.</Number>Authorization To Use Aspen
@@ -539,7 +539,7 @@ export default function Terms(): JSX.Element {
       {renderIntro()}
       {renderSummaryOfKeyThingsToKnow()}
       {renderUploadAndReportDataTerms()}
-      {renderAuthorizationToUseIdseq()}
+      {renderAuthorizationToUseAspen()}
       {renderLimitationsOnUse()}
       {renderChangesToAspenOrTerms()}
       {renderDisclaimerTerms()}


### PR DESCRIPTION
### Description

@oliviabholmes this changes `visualization on auspice.us, which is not controlled by Aspen` -> `visualization on Nextstrain, which is not controlled by Aspen` since auspice.us is a different website from Nextstrain.

### Test plan

- Tested locally.