### PR TITLE
Search on embedded properties of data in sample and tree table

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -26,14 +26,16 @@ interface SearchState {
   results?: TableItem[];
 }
 
-function recursiveTest(item: Record<string | number, JSONPrimitive | Record<string, JSONPrimitive>>, query: RegExp): Boolean {
-  console.log(item)
+function recursiveTest(
+  item: Record<string | number, JSONPrimitive | Record<string, JSONPrimitive>>,
+  query: RegExp
+): boolean {
   return Object.values(item).some((value) => {
     if (typeof value === "object" && value !== null) {
-      return recursiveTest(value, query)
+      return recursiveTest(value, query);
     }
-    return query.test(`${value}`)
-  })
+    return query.test(`${value}`);
+  });
 }
 
 function searchReducer(state: SearchState, action: SearchState): SearchState {
@@ -100,9 +102,7 @@ const DataSubview: FunctionComponent<Props> = ({
     dispatch({ searching: true });
 
     const regex = new RegExp(escapeRegExp(query), "i");
-    const filteredData = data.filter((item) =>
-        recursiveTest(item, regex)
-    );
+    const filteredData = data.filter((item) => recursiveTest(item, regex));
 
     dispatch({ results: filteredData, searching: false });
   };

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -26,6 +26,16 @@ interface SearchState {
   results?: TableItem[];
 }
 
+function recursiveTest(item: Record<string | number, JSONPrimitive | Record<string, JSONPrimitive>>, query: RegExp): Boolean {
+  console.log(item)
+  return Object.values(item).some((value) => {
+    if (typeof value === "object" && value !== null) {
+      return recursiveTest(value, query)
+    }
+    return query.test(`${value}`)
+  })
+}
+
 function searchReducer(state: SearchState, action: SearchState): SearchState {
   return { ...state, ...action };
 }
@@ -91,7 +101,7 @@ const DataSubview: FunctionComponent<Props> = ({
 
     const regex = new RegExp(escapeRegExp(query), "i");
     const filteredData = data.filter((item) =>
-      Object.values(item).some((value) => regex.test(`${value}`))
+        recursiveTest(item, regex)
     );
 
     dispatch({ results: filteredData, searching: false });


### PR DESCRIPTION
### Description

Adds the ability to search sub-objects of Trees or Samples in the table view.

Note: Since we are searching on the literal values of the data **and not what is rendered by the cell, we need to change what the backend sends to be human readable.** Otherwise when you're searching on GISAID statuses and want to find your sample that haven't been submitted, you'll need to search for `no_info` instead of `Not Yet Submitted`.

#### Issue
[ch137225](https://app.clubhouse.io/genepi/story/ch137225)
[ch136817](https://app.clubhouse.io/genepi/story/ch136817)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
