### PR TITLE
Use the covidtracker group name instead of the project's originating lab

### DIFF
--- a/src/backend/aspen/covidhub_import/import_users.py
+++ b/src/backend/aspen/covidhub_import/import_users.py
@@ -75,7 +75,7 @@ def import_project_users(
 
         group: Group = get_or_make_group(
             session,
-            project.originating_lab,
+            project.covidtracker_group.group.name,
             project.originating_address,
         )
 


### PR DESCRIPTION
### Description
This seems to be a more accurate description of the group name.

#### Issue
[ch137245](https://app.clubhouse.io/genepi/story/137245/tuolumne-account-shows-up-as-ucsf-clinical-microbiology-in-the-header)

### Test plan
migrate-all yo.
