### PR TITLE
add bullet point to ToS pop-up re human data

### DIFF
--- a/src/frontend/src/views/AgreeTerms/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/index.tsx
@@ -70,6 +70,11 @@ export default function AgreeTerms(): JSX.Element {
               protected health information.
             </ListItem>
             <ListItem fontSize="s">
+              Any human genetic data contained within the Raw Sequence Data is 
+              filtered out and deleted following upload, leaving genomic data 
+              only about the pathogen.
+            </ListItem>
+            <ListItem fontSize="s">
               We utilize industry standard best practices in information
               security, such as encrypting your data at rest and in transit, to
               ensure the security of your data.


### PR DESCRIPTION
### Description

This adds an additional bullet point to the ToS pop-up on sign-in to address concerns about human data.

#### Issue
[ch137236](https://app.clubhouse.io/genepi/story/137236)

### Test plan

Tested locally by setting the user `agreed_to_tos` false and replicating the flow. The result looks as follows:
![image](https://user-images.githubusercontent.com/16581273/118024306-65498680-b313-11eb-8bdc-fb463601717f.png)

