### PR TITLE
add link to FAQ

### DIFF
--- a/src/frontend/src/components/NavBar/components/UserMenu/index.tsx
+++ b/src/frontend/src/components/NavBar/components/UserMenu/index.tsx
@@ -55,6 +55,9 @@ const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
         <Link to={ROUTES.PRIVACY} target="_blank" rel="noopener">
           <MenuItem onClick={handleClose}>Privacy Policy</MenuItem>
         </Link>
+        <Link to={ROUTES.FAQ} target="_blank" rel="noopener">
+          <MenuItem onClick={handleClose}>FAQ</MenuItem>
+        </Link>
         <a href={process.env.API_URL + API.LOG_OUT}>
           <MenuItem onClick={handleClose}>Logout</MenuItem>
         </a>


### PR DESCRIPTION
### Description

Add a link to the FAQ in the navbar dropdown so that users can access the FAQ page within the tool. 

#### Issue
[ch137436](https://app.clubhouse.io/genepi/story/137436)

### Test plan

This was tested locally by viewing the navbar and clicking on the FAQ link. It appears as follows:
![image](https://user-images.githubusercontent.com/16581273/118026501-b5c1e380-b315-11eb-8e48-f5dd79848553.png)

