### PR TITLE
add formatting to Upload Date to remove timestamp

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -39,7 +39,7 @@ def _format_created_date(sample: Sample) -> str:
     elif sample.uploaded_pathogen_genome is not None:
         return api_utils.format_date(sample.uploaded_pathogen_genome.upload_date)
     elif sample.czb_failed_genome_recovery:
-        return api_utils.format_date(None)
+        return api_utils.format_datetime(None)
     else:
         return "not yet uploaded"
 

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -35,11 +35,11 @@ GISIAD_REJECTION_TIME = datetime.timedelta(days=4)
 
 def _format_created_date(sample: Sample) -> str:
     if sample.sequencing_reads_collection is not None:
-        return api_utils.format_datetime(sample.sequencing_reads_collection.upload_date)
+        return api_utils.format_date(sample.sequencing_reads_collection.upload_date)
     elif sample.uploaded_pathogen_genome is not None:
-        return api_utils.format_datetime(sample.uploaded_pathogen_genome.upload_date)
+        return api_utils.format_date(sample.uploaded_pathogen_genome.upload_date)
     elif sample.czb_failed_genome_recovery:
-        return api_utils.format_datetime(None)
+        return api_utils.format_date(None)
     else:
         return "not yet uploaded"
 

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -314,9 +314,7 @@ def test_samples_view_system_admin(
             },
             "private_identifier": sample.private_identifier,
             "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_date(
-                uploaded_pathogen_genome.upload_date
-            ),
+            "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
             "lineage": {
                 "lineage": uploaded_pathogen_genome.pangolin_lineage,
                 "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -377,9 +375,7 @@ def test_samples_view_cansee_metadata(
                 "gisaid_id": uploaded_pathogen_genome.accessions()[0].public_identifier,
             },
             "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_date(
-                uploaded_pathogen_genome.upload_date
-            ),
+            "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
             "lineage": {
                 "lineage": uploaded_pathogen_genome.pangolin_lineage,
                 "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -433,9 +429,7 @@ def test_samples_view_cansee_all(
             },
             "private_identifier": sample.private_identifier,
             "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_date(
-                uploaded_pathogen_genome.upload_date
-            ),
+            "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
             "lineage": {
                 "lineage": uploaded_pathogen_genome.pangolin_lineage,
                 "probability": uploaded_pathogen_genome.pangolin_probability,

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -45,7 +45,7 @@ def test_samples_view(
                 },
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {
@@ -96,7 +96,7 @@ def test_samples_view_gisaid_rejected(
                 "gisaid": {"status": "rejected", "gisaid_id": None},
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {
@@ -141,7 +141,7 @@ def test_samples_view_gisaid_no_info(
                 "gisaid": {"status": "no_info", "gisaid_id": None},
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {
@@ -181,7 +181,7 @@ def test_samples_view_gisaid_not_eligible(
                 "gisaid": {"status": "not_eligible", "gisaid_id": None},
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(None),
+                "upload_date": api_utils.format_date(None),
                 "lineage": {
                     "lineage": None,
                     "probability": None,
@@ -228,7 +228,7 @@ def test_samples_view_gisaid_submitted(
                 "gisaid": {"status": "submitted", "gisaid_id": None},
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {
@@ -314,7 +314,7 @@ def test_samples_view_system_admin(
             },
             "private_identifier": sample.private_identifier,
             "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_datetime(
+            "upload_date": api_utils.format_date(
                 uploaded_pathogen_genome.upload_date
             ),
             "lineage": {
@@ -377,7 +377,7 @@ def test_samples_view_cansee_metadata(
                 "gisaid_id": uploaded_pathogen_genome.accessions()[0].public_identifier,
             },
             "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_datetime(
+            "upload_date": api_utils.format_date(
                 uploaded_pathogen_genome.upload_date
             ),
             "lineage": {
@@ -433,7 +433,7 @@ def test_samples_view_cansee_all(
             },
             "private_identifier": sample.private_identifier,
             "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_datetime(
+            "upload_date": api_utils.format_date(
                 uploaded_pathogen_genome.upload_date
             ),
             "lineage": {
@@ -496,7 +496,7 @@ def test_samples_failed_accession(
                 },
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {
@@ -558,7 +558,7 @@ def test_samples_multiple_accession(
                 },
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {
@@ -609,7 +609,7 @@ def test_samples_view_no_pangolin(
                 },
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_datetime(
+                "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
                 "lineage": {


### PR DESCRIPTION
### Description

This PR applies the same formatting to Upload Date as was already used for Collection Date (removes the timestamp)

#### Issue
[ch137103](https://app.clubhouse.io/genepi/story/<137103>)

### Test plan

Tested locally, resulting Upload Date column looks as follows:
![image](https://user-images.githubusercontent.com/16581273/118028544-0c302180-b318-11eb-9e40-7e3a18e9e4d6.png)
