### PR TITLE
Update Auspice link hit area

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -38,6 +38,11 @@
   align-items: center;
   margin: $space-xs 0 $space-xs 0;
 
+  .modalTrigger{
+    display: flex;
+    align-items: center;
+  }
+
   .icon {
     margin: 0 $space-l;
     fill: $gray-light;

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -131,9 +131,11 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
           data={createTreeModalInfo(treeID)}
           className={dataTableStyle.cell}
         >
-          {<TreeIcon className={dataTableStyle.icon} />}
-          {stringValue}
-          {<ExternalLinkIcon className={dataTableStyle.icon} />}
+          <div className={dataTableStyle.modalTrigger}>
+            {<TreeIcon className={dataTableStyle.icon} />}
+            {stringValue}
+            {<ExternalLinkIcon className={dataTableStyle.icon} />}
+          </div>
         </Modal>
       </RowContent>
     );


### PR DESCRIPTION
### Description

Updates the Auspice link hit area to a single clickable area that covers the icons and phylo tree name.

Everything in the orange outline is a single clickable area.
![image](https://user-images.githubusercontent.com/53838890/118032480-95495780-b31c-11eb-8998-6324b3d5031e.png)

#### Issue
[ch137514](https://app.clubhouse.io/genepi/story/137514)

### Test plan

Verify that there is 1 hit area that covers the phylo icon, tree name, and link icon, and the cursor doesn't flicker when passing between them.
