### PR TITLE
Add right margins to table columns

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -23,6 +23,7 @@
     @include font-header-s;
 
     color: $gray-dark;
+    margin-right: $space-m;
 
     &:hover {
       color: black;

--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -25,6 +25,7 @@ export const RowContent = styled.div`
 
     return `
       padding: ${spacings?.l}px 0;
-    `;
+      margin-right: ${spacings?.m}px;
+  `;
   }}
 `;


### PR DESCRIPTION
### Description

Adds `$space-m` to the right side of all table columns.

**Before:**
![image](https://user-images.githubusercontent.com/53838890/118034420-cfb3f400-b31e-11eb-98ec-887c761829e0.png)

**After:**
(Might be worth getting a look from Janeece to see if we want to resisze any of these columns to give the Public ID more space? Although it might be resolved by ch137076)
![image](https://user-images.githubusercontent.com/53838890/118034439-d3e01180-b31e-11eb-8dc2-9865e0c7683e.png)


#### Issue
[ch137092](https://app.clubhouse.io/genepi/story/137092)

### Test plan

Check that all table columns have a right margin of 10px and content doesn't run into each other anymore.
