### PR TITLE
Add tree name to backend API response and use name in frontend table

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -33,6 +33,10 @@ def humanize_tree_name(s3_key: str):
     title_case = basename.replace("_", " ").title()
     if "Ancestors" in title_case:
         title_case = title_case.replace("Ancestors", "Contextual")
+    if " Public" in title_case:
+        title_case = title_case.replace(" Public", "")
+    if " Private" in title_case:
+        title_case = title_case.replace(" Private", "")
     return title_case
 
 

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+import re
 from typing import Any, Iterable, Mapping, MutableSequence, Set, Tuple
 
 import boto3
@@ -25,6 +26,13 @@ from aspen.phylo_tree.identifiers import rename_nodes_on_tree
 
 PHYLO_TREE_KEY = "phylo_trees"
 
+def humanize_tree_name(s3_key: str):
+    json_filename = s3_key.split('/')[-1]
+    basename = re.sub(r'_\d*\.json', '', json_filename)
+    title_case = basename.replace('_', ' ').title()
+    if "Ancestors" in title_case:
+        title_case = title_case.replace('Ancestors', 'Contextual')
+    return title_case
 
 @application.route("/api/phylo_trees", methods=["GET"])
 @requires_auth
@@ -85,6 +93,7 @@ def phylo_trees():
             results.append(
                 {
                     "phylo_tree_id": phylo_tree.entity_id,
+                    "name": humanize_tree_name(phylo_tree.s3_key),
                     "pathogen_genome_count": genome_count,
                     "completed_date": format_datetime(phylo_run.end_datetime),
                 }

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -1,7 +1,7 @@
 import json
 import os
-import uuid
 import re
+import uuid
 from typing import Any, Iterable, Mapping, MutableSequence, Set, Tuple
 
 import boto3
@@ -26,13 +26,15 @@ from aspen.phylo_tree.identifiers import rename_nodes_on_tree
 
 PHYLO_TREE_KEY = "phylo_trees"
 
+
 def humanize_tree_name(s3_key: str):
-    json_filename = s3_key.split('/')[-1]
-    basename = re.sub(r'_\d*\.json', '', json_filename)
-    title_case = basename.replace('_', ' ').title()
+    json_filename = s3_key.split("/")[-1]
+    basename = re.sub(r"_\d*\.json", "", json_filename)
+    title_case = basename.replace("_", " ").title()
     if "Ancestors" in title_case:
-        title_case = title_case.replace('Ancestors', 'Contextual')
+        title_case = title_case.replace("Ancestors", "Contextual")
     return title_case
+
 
 @application.route("/api/phylo_trees", methods=["GET"])
 @requires_auth

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -30,7 +30,7 @@ interface Sample extends BioinformaticsType {
 interface Tree extends BioinformaticsType {
   type: "Tree";
   id: number;
-  name?: string;
+  name: string;
   pathogenGenomeCount: number;
   creationDate: string;
   downloadLink?: string;

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -125,7 +125,7 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   },
   name: ({ value, item }): JSX.Element => {
     const stringValue = stringGuard(value);
-    const treeID = item.id
+    const treeID = item.id;
     return (
       <RowContent>
         <Modal

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -123,10 +123,9 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
       </RowContent>
     );
   },
-  name: ({ value }): JSX.Element => {
+  name: ({ value, item }): JSX.Element => {
     const stringValue = stringGuard(value);
-
-    const treeID = stringValue.split(" ")[0];
+    const treeID = item.id
     return (
       <RowContent>
         <Modal

--- a/src/frontend/src/views/Data/transforms.tsx
+++ b/src/frontend/src/views/Data/transforms.tsx
@@ -1,21 +1,5 @@
 export const TREE_TRANSFORMS: Transform[] = [
   {
-    inputs: ["id", "creationDate"],
-    key: "name",
-    method: (inputs: (number | string)[]): string => {
-      // temporary until we use ISO 8601
-      if (typeof inputs[1] !== "string") {
-        return `${inputs[0]} Ancestors ??????`;
-      }
-      const re = /\d\d(\d\d)-(\d\d)-(\d\d)/;
-      const matchArray = re.exec(inputs[1]);
-      if (matchArray === null) {
-        return `${inputs[0]} Ancestors ??????`;
-      }
-      return `${inputs[0]} Ancestors ${matchArray[1]}${matchArray[2]}${matchArray[3]}`;
-    },
-  },
-  {
     inputs: ["id"],
     key: "downloadLink",
     method: (inputs: number[]): string | undefined => {


### PR DESCRIPTION
### Description

Adds a `name` field to the phylo tree API response. Updates frontend table to use name field for the tree name.

![Screenshot from 2021-05-12 14-29-51](https://user-images.githubusercontent.com/24234461/118046724-91263580-b32e-11eb-9b84-1913075d35fb.png)
![Screenshot from 2021-05-12 14-28-22](https://user-images.githubusercontent.com/24234461/118046729-93888f80-b32e-11eb-8fcc-2b4db4fcee08.png)


#### Issue
[ch137015](https://app.clubhouse.io/genepi/story/137015)
[ch137507](https://app.clubhouse.io/genepi/story/137507)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
