### PR TITLE
Fix External Accessions / Sample Name TSV for trees

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import uuid
 from typing import Any, Iterable, Mapping, MutableSequence, Set, Tuple
 

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -162,6 +162,7 @@ def _extract_accessions(accessions_list: list, node: dict):
     if "external_accession" in node_attributes:
         accessions_list.append(node_attributes["external_accession"]["value"])
     if "name" in node:
+        # NODE_ is some sort of generic name and not useful
         if not re.match("NODE_", node["name"]):
             accessions_list.append(node["name"])
     if "children" in node:

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -161,7 +161,8 @@ def _extract_accessions(accessions_list: list, node: dict):
     if "external_accession" in node_attributes:
         accessions_list.append(node_attributes["external_accession"]["value"])
     if "name" in node:
-        accessions_list.append(node["name"])
+        if not re.match("NODE_", node["name"]):
+            accessions_list.append(node["name"])
     if "children" in node:
         for child in node["children"]:
             _extract_accessions(accessions_list, child)

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -160,6 +160,8 @@ def _extract_accessions(accessions_list: list, node: dict):
     node_attributes = node["node_attrs"]
     if "external_accession" in node_attributes:
         accessions_list.append(node_attributes["external_accession"]["value"])
+    if "name" in node:
+        accessions_list.append(node["name"])
     if "children" in node:
         for child in node["children"]:
             _extract_accessions(accessions_list, child)


### PR DESCRIPTION
### Description

Extracts external accessions both from the old key (`node["node_attrs"]["external_accession"]) and the new key (node["name"]). Leaves out names that begin with `NODE_`.

#### Issue
[ch137187](https://app.clubhouse.io/genepi/story/137187)

### Test plan

Tested in Python REPL with a staging tree json.
