### PR TITLE
thuang-add-BE-cors

### DIFF
--- a/src/backend/aspen/app/app.py
+++ b/src/backend/aspen/app/app.py
@@ -25,13 +25,22 @@ application = AspenApp(
     static_folder=str(static_folder),
     aspen_config=aspen_config,
 )
-# FIXME(mbarrien): Make this more restrictive
-allowed_origin = ["*"]
+
+deployment = os.getenv("DEPLOYMENT_STAGE")
+
+allowed_origins = []
+frontend_url = os.getenv("FRONTEND_URL")
+
+if deployment not in ["staging", "prod"]:
+    allowed_origins.append(r"^http://localhost:\d+")
+if frontend_url:
+    allowed_origins.append(frontend_url)
+
 CORS(
     application,
     max_age=600,
     supports_credentials=True,
-    origins=allowed_origin,
+    origins=allowed_origins,
     allow_headers=["Content-Type"],
 )
 


### PR DESCRIPTION
### Description

Add CORS!

#### Issue
https://app.clubhouse.io/genepi/story/137309/overly-permissive-cors

### Test plan

1. Authenticate to the website
2. Open a new tab and navigate to https://google.com
3. Open the console and make the following JS execute:

```
fetch("https://thuang-be-cors-backend.dev.genepi.czi.technology/api/usergroup", {credentials: 'include', method: 'GET', mode: 'cors'}).then(r => r.json().then(r => console.log(r)))
```

The call should fail due to CORS error now!

<img width="1011" alt="Screen Shot 2021-05-12 at 4 28 17 PM" src="https://user-images.githubusercontent.com/6309723/118056876-98a20a80-b33f-11eb-93d7-df095614504d.png">
<img width="1708" alt="Screen Shot 2021-05-12 at 4 32 00 PM" src="https://user-images.githubusercontent.com/6309723/118056880-993aa100-b33f-11eb-9de6-60eb42b9f909.png">
