### PR TITLE
[fix] TFE's type checker can't handle map values with different types.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -272,15 +272,15 @@ module nextstrain_scc_contextual_sfn_config {
   sfn_arn               = module.swipe_sfn.step_function_arn
   schedule_expressions  = contains(["prod", "staging"], local.deployment_stage) ? ["cron(0 0 ? * 1-5 *)"] : []
   event_role_arn        = local.ecs_role_arn
-   extra_args            =  {
+  extra_args            =  {
     aspen_config_secret_name = "${local.deployment_stage}/aspen-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Santa Clara County Public Health"
     s3_filestem              = "Santa Clara Contextual"
     template_filename        = "group_plus_context.yaml"
     template_args            = {
-     division = "California"
-     location = "Santa Clara County"
+      division = "California"
+      location = "Santa Clara County"
     }
   }
 }

--- a/.happy/terraform/modules/sfn_config/variables.tf
+++ b/.happy/terraform/modules/sfn_config/variables.tf
@@ -68,7 +68,6 @@ variable deployment_stage {
 }
 
 variable extra_args {
-  type = map(string)
   description = "some stuff"
   default = {}
 }


### PR DESCRIPTION
### Description

Since TFE's type checker can't handle map values with different types (in our case, some values are strings, and others are maps) we can just disable its typechecking for this module

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
