### PR TITLE
Add clickable sorting by column to data table

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -8,8 +8,9 @@ import style from "./index.module.scss";
 
 interface Props {
   data?: TableItem[];
+  defaultSortKey: string[];
   headers: Header[];
-  subheaders: Record<string, Header[]>;
+  subheaders: Record<string, SubHeader[]>;
   isLoading: boolean;
   renderer?: CustomRenderer;
   headerRenderer?: CustomRenderer;
@@ -45,7 +46,7 @@ function searchReducer(state: SearchState, action: SearchState): SearchState {
 function tsvDataMap(
   tableData: TableItem[],
   headers: Header[],
-  subheaders: Record<string, Header[]>
+  subheaders: Record<string, SubHeader[]>
 ): [string[], string[][]] {
   const tsvData = tableData.map((entry) => {
     return headers.flatMap((header) => {
@@ -73,6 +74,7 @@ function tsvDataMap(
 
 const DataSubview: FunctionComponent<Props> = ({
   data,
+  defaultSortKey,
   headers,
   subheaders,
   isLoading,
@@ -107,12 +109,11 @@ const DataSubview: FunctionComponent<Props> = ({
     dispatch({ results: filteredData, searching: false });
   };
 
-  const render = (tableData: TableItem[]) => {
-    const [tsvHeaders, tsvData] = tsvDataMap(tableData, headers, subheaders);
-    const separator = "\t";
-
+  const render = (tableData?: TableItem[]) => {
     let downloadButton: JSX.Element | null = null;
-    if (viewName === "Samples") {
+    if (viewName === "Samples" && tableData !== undefined) {
+      const [tsvHeaders, tsvData] = tsvDataMap(tableData, headers, subheaders);
+      const separator = "\t";
       downloadButton = (
         <CSVLink
           data={tsvData}
@@ -149,6 +150,7 @@ const DataSubview: FunctionComponent<Props> = ({
           <DataTable
             isLoading={isLoading}
             data={tableData}
+            defaultSortKey={defaultSortKey}
             headers={headers}
             headerRenderer={headerRenderer}
             renderer={renderer}
@@ -159,7 +161,7 @@ const DataSubview: FunctionComponent<Props> = ({
   };
 
   if (state.results === undefined) {
-    let tableData: TableItem[] = [];
+    let tableData = undefined;
     if (data !== undefined) {
       dispatch({ results: data });
       tableData = data;

--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -18,6 +18,12 @@
     display: flex;
     width: 100%;
     flex-direction: row;
+    align-items: baseline;
+
+    svg {
+      fill: $black;
+      width: $icon-xs;
+    }
   }
 
   .headerCell {
@@ -31,7 +37,7 @@
     margin-right: $space-xxs;
 
     &:hover {
-      color: black;
+      color: $black;
       cursor: default;
     }
   }

--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -14,16 +14,21 @@
   padding-right: $space-l;
   border-bottom: 3px solid $gray-lightest !important;
 
+  .headerMetaCell {
+    display: flex;
+    width: 100%;
+    flex-direction: row;
+  }
+
   .headerCell {
     padding-bottom: $space-m;
-    width: 100%;
   }
 
   .headerCellContent {
     @include font-header-s;
 
     color: $gray-dark;
-    margin-right: $space-m;
+    margin-right: $space-xxs;
 
     &:hover {
       color: black;

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -72,22 +72,26 @@ interface TableAction {
 }
 
 function reducer(state: TableState, action: TableAction) {
-  let newData = state.data;
-  if (action.type === "initialize") {
-    newData = action.newState.data;
+  const newState = action.newState;
+  if (newState.data === undefined) {
+    newState.data = state.data;
   }
-  if (newData === undefined) {
+  return initializeData(newState)
+}
+
+function initializeData(state: TableState): TableState {
+  if (state.data === undefined) {
     return state;
   }
   const newSort = sortData(
-    newData,
-    action.newState.sortKey,
-    action.newState.ascending
+    state.data,
+    state.sortKey,
+    state.ascending
   );
   return {
-    ascending: action.newState.ascending,
+    ascending: state.ascending,
     data: newSort,
-    sortKey: action.newState.sortKey,
+    sortKey: state.sortKey,
   };
 }
 
@@ -99,11 +103,7 @@ export const DataTable: FunctionComponent<Props> = ({
   renderer = defaultCellRenderer,
   isLoading,
 }: Props) => {
-  const [state, dispatch] = useReducer(reducer, {
-    ascending: false,
-    data: data,
-    sortKey: defaultSortKey,
-  });
+  const [state, dispatch] = useReducer(reducer, { data, sortKey: defaultSortKey, ascending: false }, initializeData);
 
   const indexingKey = headers[0].key;
 

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -1,6 +1,7 @@
-import React, { Fragment, FunctionComponent } from "react";
+import React, { Fragment, FunctionComponent, useReducer } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
+import { get, isEqual } from "lodash/fp";
 import { EmptyState } from "../data_subview/components/EmptyState";
 import style from "./index.module.scss";
 import { RowContent, TableRow } from "./style";
@@ -8,6 +9,7 @@ import { RowContent, TableRow } from "./style";
 interface Props {
   data?: TableItem[];
   headers: Header[];
+  defaultSortKey: string[];
   isLoading: boolean;
   renderer?: CustomRenderer;
   headerRenderer?: HeaderRenderer;
@@ -42,18 +44,75 @@ export function defaultHeaderRenderer({
   );
 }
 
+function sortData(data: TableItem[], sortKey: string[], ascending: boolean): TableItem[] {
+  return data.sort((a, b): number => {
+    let order = String(get(sortKey, a)).localeCompare(String(get(sortKey, b)))
+    if (!ascending) {
+      order = order * -1
+    }
+    return order
+  })
+}
+
+interface TableState {
+  data?: TableItem[];
+  sortKey: string[];
+  ascending: boolean;
+}
+
+interface TableAction {
+  type: "sort" | "initialize";
+  newState: TableState;
+}
+
+function reducer(state: TableState, action: TableAction) {
+  let newData = state.data;
+  if (action.type === "initialize") {
+    newData = action.newState.data;
+  }
+  if (newData === undefined) {
+    return state;
+  }
+  const newSort = sortData(newData, action.newState.sortKey, action.newState.ascending)
+  return { data: newSort, sortKey: action.newState.sortKey, ascending: action.newState.ascending }
+}
+
 export const DataTable: FunctionComponent<Props> = ({
-  data = [],
+  data,
   headers,
+  defaultSortKey,
   headerRenderer = defaultHeaderRenderer,
   renderer = defaultCellRenderer,
   isLoading,
 }: Props) => {
+  const [state, dispatch] = useReducer(reducer, { data: data, sortKey: defaultSortKey, ascending: false })
+
   const indexingKey = headers[0].key;
 
+  const handleSortClick = (newSortKey: string[]) => {
+    let ascending = false;
+    if (isEqual(newSortKey, state.sortKey)) {
+      ascending = !state.ascending;
+    }
+    dispatch({ type: "sort", newState: { sortKey: newSortKey, ascending: ascending }})
+  }
+
   // render functions
-  const headerRow = headers.map((header: Header, index) =>
-    headerRenderer({ header, index })
+  const headerRow = headers.map((header: Header, index) => {
+      const headerJSX = headerRenderer({ header, index })
+      let sortIndicator = null;
+      if (isEqual(header.sortKey, state.sortKey)) {
+        sortIndicator = "▼"
+        if (state.ascending) {
+          sortIndicator = "▲"
+        }
+      }
+      return (
+        <div onClick={() => handleSortClick(header.sortKey)} key={header.sortKey.join("-")} className={style.headerCell}>
+          {headerJSX}{sortIndicator}
+        </div>
+      )
+    }
   );
 
   const sampleRow = (item: TableItem): React.ReactNode => {
@@ -72,32 +131,43 @@ export const DataTable: FunctionComponent<Props> = ({
     });
   };
 
-  function renderRow(props: ListChildComponentProps) {
-    const item = data[props.index];
+  const render = (tableData: TableItem[]) => {
+    function renderRow(props: ListChildComponentProps) {
+      const item = tableData[props.index];
 
-    return <TableRow style={props.style}>{sampleRow(item)}</TableRow>;
+      return <TableRow style={props.style}>{sampleRow(item)}</TableRow>;
+    }
+    return (
+      <div className={style.container}>
+        <div className={style.header}>{headerRow}</div>
+        <div className={style.tableContent}>
+          <AutoSizer>
+            {({ height, width }) => {
+              return (
+                <FixedSizeList
+                  height={height}
+                  itemData={tableData}
+                  itemCount={isLoading ? LOADING_STATE_ROW_COUNT : tableData.length}
+                  itemSize={ITEM_HEIGHT_PX}
+                  width={width}
+                >
+                  {renderRow}
+                </FixedSizeList>
+              );
+            }}
+          </AutoSizer>
+        </div>
+      </div>
+    );
   }
 
-  return (
-    <div className={style.container}>
-      <div className={style.header}>{headerRow}</div>
-      <div className={style.tableContent}>
-        <AutoSizer>
-          {({ height, width }) => {
-            return (
-              <FixedSizeList
-                height={height}
-                itemData={data}
-                itemCount={isLoading ? LOADING_STATE_ROW_COUNT : data.length}
-                itemSize={ITEM_HEIGHT_PX}
-                width={width}
-              >
-                {renderRow}
-              </FixedSizeList>
-            );
-          }}
-        </AutoSizer>
-      </div>
-    </div>
-  );
+  if (state.data === undefined) {
+    let tableData: TableItem[] = [];
+    if (data !== undefined) {
+      dispatch({ type: "initialize", newState: { data: data, sortKey: defaultSortKey, ascending: false }});
+      tableData = sortData(data, defaultSortKey, false);
+    }
+    return render(tableData);
+  }
+  return render(state.data);
 };

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -2,7 +2,11 @@ import React, { Fragment, FunctionComponent, useReducer } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { get, isEqual } from "lodash/fp";
+
 import { EmptyState } from "../data_subview/components/EmptyState";
+import { ReactComponent as SortArrowDownIcon } from "src/common/icons/IconArrowDownSmall.svg"
+import { ReactComponent as SortArrowUpIcon } from "src/common/icons/IconArrowUpSmall.svg"
+
 import style from "./index.module.scss";
 import { RowContent, TableRow } from "./style";
 
@@ -100,11 +104,11 @@ export const DataTable: FunctionComponent<Props> = ({
   // render functions
   const headerRow = headers.map((header: Header, index) => {
       const headerJSX = headerRenderer({ header, index })
-      let sortIndicator = null;
+      let sortIndicator: JSX.Element | null = null;
       if (isEqual(header.sortKey, state.sortKey)) {
-        sortIndicator = "▼"
+        sortIndicator = <SortArrowDownIcon/>
         if (state.ascending) {
-          sortIndicator = "▲"
+          sortIndicator = <SortArrowUpIcon/>
         }
       }
       return (

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -76,18 +76,14 @@ function reducer(state: TableState, action: TableAction) {
   if (newState.data === undefined) {
     newState.data = state.data;
   }
-  return initializeData(newState)
+  return initializeData(newState);
 }
 
 function initializeData(state: TableState): TableState {
   if (state.data === undefined) {
     return state;
   }
-  const newSort = sortData(
-    state.data,
-    state.sortKey,
-    state.ascending
-  );
+  const newSort = sortData(state.data, state.sortKey, state.ascending);
   return {
     ascending: state.ascending,
     data: newSort,
@@ -103,7 +99,11 @@ export const DataTable: FunctionComponent<Props> = ({
   renderer = defaultCellRenderer,
   isLoading,
 }: Props) => {
-  const [state, dispatch] = useReducer(reducer, { data, sortKey: defaultSortKey, ascending: false }, initializeData);
+  const [state, dispatch] = useReducer(
+    reducer,
+    { ascending: false, data, sortKey: defaultSortKey },
+    initializeData
+  );
 
   const indexingKey = headers[0].key;
 

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -108,7 +108,7 @@ export const DataTable: FunctionComponent<Props> = ({
         }
       }
       return (
-        <div onClick={() => handleSortClick(header.sortKey)} key={header.sortKey.join("-")} className={style.headerCell}>
+        <div onClick={() => handleSortClick(header.sortKey)} key={header.sortKey.join("-")} className={style.headerMetaCell}>
           {headerJSX}{sortIndicator}
         </div>
       )

--- a/src/frontend/src/common/icons/IconArrowDownSmall.svg
+++ b/src/frontend/src/common/icons/IconArrowDownSmall.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>IconArrowDownSmall@1x</title>
+    <g id="Icons" stroke="none" stroke-width="1" fill-rule="evenodd">
+        <g id="Icons-/-Small-/-IconArrowDownSmall">
+            <polygon id="Shape" points="6.973 8.977 1.78238929 3.64902546 0.643884085 4.72673552 6.97100296 11.2164883 13.3457069 4.79405362 12.4597917 3.83076772 12.2757797 3.75 12.2210034 3.75 12.0427826 3.82467934"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/frontend/src/common/icons/IconArrowUpSmall.svg
+++ b/src/frontend/src/common/icons/IconArrowUpSmall.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>IconArrowUpSmall@1x</title>
+    <g id="Icons" stroke="none" stroke-width="1" fill-rule="evenodd">
+        <g id="Icons-/-Small-/-IconArrowUpSmall">
+            <polygon id="Shape" transform="translate(6.994792, 7.431327) scale(1, -1) translate(-6.994792, -7.431327) " points="6.973 8.975 1.78238779 3.64909743 0.643808853 4.7264284 6.97100328 11.2135557 13.3457756 4.79372708 12.4597566 3.83072953 12.2757797 3.75 12.2210034 3.75 12.0428191 3.82464223"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/frontend/src/common/styles/spacing.scss
+++ b/src/frontend/src/common/styles/spacing.scss
@@ -8,3 +8,9 @@ $space-m: 10px;
 $space-l: 14px;
 $space-xl: 22px;
 $space-xxl: 38px;
+
+// icon sizes
+$icon-xs: 10px;
+$icon-s: 14px;
+$icon-l: 22px;
+$icon-xl: 32px;

--- a/src/frontend/src/common/types/data.d.ts
+++ b/src/frontend/src/common/types/data.d.ts
@@ -6,11 +6,12 @@ interface Transform {
 
 interface DataCategory {
   data: BioinformaticsDataArray | undefined;
+  defaultSortKey: string[];
   headerRenderer?: CustomRenderer;
   headers: Header[];
   isDataLoading: boolean;
   renderer?: CustomRenderer;
-  subheaders: Record<string, Header[]>;
+  subheaders: Record<string, SubHeader[]>;
   text: string;
   to: string;
   transforms?: Transform[];

--- a/src/frontend/src/common/types/table.d.ts
+++ b/src/frontend/src/common/types/table.d.ts
@@ -1,7 +1,12 @@
 interface Header {
-  [index: string]: string;
+  [index: string]: string | number | string[];
   text: string;
   key: string | number;
+  sortKey: string[];
+}
+
+interface SubHeader extends Header {
+  sortKey?: string[];
 }
 
 type TableItem = Record<

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -1,35 +1,42 @@
 export const SAMPLE_HEADERS: Header[] = [
   {
     key: "privateId",
+    sortKey: ["privateId"],
     text: "Private ID",
   },
   {
     key: "publicId",
+    sortKey: ["publicId"],
     text: "Public ID",
   },
   {
     key: "uploadDate",
+    sortKey: ["uploadDate"],
     text: "Upload Date",
   },
   {
     key: "collectionDate",
+    sortKey: ["collectionDate"],
     text: "Collection Date",
   },
   {
     key: "collectionLocation",
+    sortKey: ["collectionLocation"],
     text: "Collection Location",
   },
   {
     key: "lineage",
+    sortKey: ["lineage", "lineage"],
     text: "Lineage",
   },
   {
     key: "gisaid",
+    sortKey: ["gisaid", "status"],
     text: "GISAID",
   },
 ];
 
-export const SAMPLE_SUBHEADERS: Record<string, Header[]> = {
+export const SAMPLE_SUBHEADERS: Record<string, SubHeader[]> = {
   gisaid: [
     {
       key: "status",
@@ -63,14 +70,17 @@ export const SAMPLE_SUBHEADERS: Record<string, Header[]> = {
 export const TREE_HEADERS: Header[] = [
   {
     key: "name",
+    sortKey: ["name"],
     text: "Tree Name",
   },
   {
     key: "creationDate",
+    sortKey: ["creationDate"],
     text: "Creation Date",
   },
   {
     key: "downloadLink",
+    sortKey: ["downloadLink"],
     text: "",
   },
 ];

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -11,11 +11,6 @@ import style from "./index.module.scss";
 import { Container } from "./style";
 import { TREE_TRANSFORMS } from "./transforms";
 
-const sortByKeys: Record<string, string> = {
-  "Phylogenetic Trees": "creationDate",
-  Samples: "uploadDate",
-};
-
 const Data: FunctionComponent = () => {
   const [samples, setSamples] = useState<Sample[] | undefined>();
   const [trees, setTrees] = useState<Tree[] | undefined>();
@@ -47,6 +42,7 @@ const Data: FunctionComponent = () => {
   const dataCategories: DataCategory[] = [
     {
       data: samples,
+      defaultSortKey: ["uploadDate"],
       headerRenderer: SampleHeader,
       headers: SAMPLE_HEADERS,
       isDataLoading,
@@ -57,6 +53,7 @@ const Data: FunctionComponent = () => {
     },
     {
       data: trees,
+      defaultSortKey: ["creationDate"],
       headers: TREE_HEADERS,
       isDataLoading,
       renderer: TreeRenderer,
@@ -86,23 +83,6 @@ const Data: FunctionComponent = () => {
     });
 
     category.data = transformedData as BioinformaticsDataArray;
-  });
-
-  // sort data by creation date
-  dataCategories.forEach((category) => {
-    if (category.data === undefined) {
-      return;
-    }
-    const sortKey = sortByKeys[category.text];
-    const tempData: BioinformaticsDataArray = category.data.map(
-      (item: BioinformaticsData) => item
-    );
-    const sortedData: BioinformaticsDataArray = tempData.sort(
-      (a: BioinformaticsData, b: BioinformaticsData) => {
-        return String(a[sortKey]).localeCompare(String(b[sortKey])) * -1;
-      }
-    );
-    category.data = sortedData;
   });
 
   const dataJSX: Record<string, Array<JSX.Element>> = {
@@ -135,6 +115,7 @@ const Data: FunctionComponent = () => {
           <DataSubview
             isLoading={category.isDataLoading}
             data={category.data}
+            defaultSortKey={category.defaultSortKey}
             headers={category.headers}
             subheaders={category.subheaders}
             headerRenderer={category.headerRenderer}


### PR DESCRIPTION
### Description

Allows users to sort by columns in the data table, either in ascending or descending order. Default sort order is provided.

![Screenshot from 2021-05-19 11-44-15](https://user-images.githubusercontent.com/24234461/118867288-c0412780-b897-11eb-8c6f-e972e58175a2.png)


#### Issue
[ch136816](https://app.clubhouse.io/genepi/story/136816)

### Test plan

Navigate to data tables, try sorting all the columns!

Live link: https://thuang-sort-frontend.dev.genepi.czi.technology