### PR TITLE
fix[auth-bug]: github fixed their auth bug

### DIFF
--- a/.github/workflows/sastisfaction.yml
+++ b/.github/workflows/sastisfaction.yml
@@ -17,13 +17,11 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          # NOTE(el): There is a bug in GitHub <-> ghcr.io that prevents reading "internal" images using secrets.GITHUB_TOKEN
-          #           for now, use a scoped PAT
-          username: cziprodsec
-          password: ${{ secrets.SASTISFACTION_DOCKER_READ_KEY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker pull
         run: docker pull ghcr.io/chanzuckerberg/sastisfaction:main
       - name: Run SASTisfaction
         uses: ./.github/actions/sastisfaction
         with:
-          snowflake_private_key: ${{ secrets.SASTISFACTION_READ_KEY }}
+          snowflake_private_key: ${{ secrets.SASTISFACTION_RSA_KEY }}


### PR DESCRIPTION
### Description

We've been working with GitHub support and they have fixed a bug with their github actions <-> docker ghcr.io access. We can now clean up this action a bit.

Also, renaming the SASTISFACTION secret to be a bit more clear about its purpose.