### PR TITLE
Validate input to the deploy script

### DIFF
--- a/scripts/happy-deploy.py
+++ b/scripts/happy-deploy.py
@@ -100,11 +100,15 @@ def trigger_deploy(github_api_token, deployment_stage, github_sha, dry_run):
 
     print("Deployment successful")
 
+def validate_sha(ctx, param, value):
+    if len(value) < 8:
+        raise click.BadParameter("Github SHA must be at least 8 characters!")
+    return value
 
 @click.command()
 @click.argument("deployment_stage")
-@click.option("--github_sha", help="github sha to be deployed", default=None)
-@click.option("--dry_run", help="do not perform actual deployment", default=False, is_flag=True)
+@click.option("--github-sha", callback=validate_sha, help="github sha to be deployed", default=None)
+@click.option("--dry-run", help="do not perform actual deployment", default=False, is_flag=True)
 def happy_deploy(deployment_stage, github_sha, dry_run):
     api_token = os.getenv("GITHUB_TOKEN")
     if api_token is None:


### PR DESCRIPTION
### Description
- Use dashes instead of underscores for argument names
- Validate that the SHA is at least 8 characters long

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Tested the argument validation locally, got errors for sha values < 8 characters, and the command proceeded for values >= 8 chars
