### PR TITLE
Try to keep all Aspen samples on the tree

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/group.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/group.yaml
@@ -34,12 +34,20 @@ refine:
 # Sampling groups that end with an `_early` suffix will omit data from the last 18 weeks.  Sampling groups that end with a `_late` suffix will only consider data from the last 18 weeks.
 subsampling:
   group_only:
+    # Do not subsample Aspen data. For genomes on both Aspen and Gisaid, de-duplication keeps the Aspen copy, so none of the Aspen genomes would be removed.
+    # The Aspen fasta here is already filtered by group.
+    allAspen:
+      exclude: "--exclude-where 'aspen!=yes'"
+      
+    # Subsample genomes on Gisaid.
     group_early:
+      exclude: "--exclude-where 'aspen=yes'"
       group_by: "year month"
       max_sequences: 500
       query: --query "(location == '{{location}}') & (division == '{{division}}')"
-
+      
     group_late:
+      exclude: "--exclude-where 'aspen=yes'"
       group_by: "year month"
       max_sequences: 2000
       query: --query "(location == '{{location}}') & (division == '{{division}}')"

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/group.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/group.yaml
@@ -36,7 +36,7 @@ subsampling:
   group_only:
     # Do not subsample Aspen data. 
     # The Aspen fasta here is already filtered by group.
-    allAspen:
+    all_aspen:
       exclude: "--exclude-where 'aspen!=yes'"
       
     # Subsample genomes on Gisaid.

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/group.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/group.yaml
@@ -34,7 +34,7 @@ refine:
 # Sampling groups that end with an `_early` suffix will omit data from the last 18 weeks.  Sampling groups that end with a `_late` suffix will only consider data from the last 18 weeks.
 subsampling:
   group_only:
-    # Do not subsample Aspen data. For genomes on both Aspen and Gisaid, de-duplication keeps the Aspen copy, so none of the Aspen genomes would be removed.
+    # Do not subsample Aspen data. 
     # The Aspen fasta here is already filtered by group.
     allAspen:
       exclude: "--exclude-where 'aspen!=yes'"
@@ -45,7 +45,7 @@ subsampling:
       group_by: "year month"
       max_sequences: 500
       query: --query "(location == '{{location}}') & (division == '{{division}}')"
-      
+
     group_late:
       exclude: "--exclude-where 'aspen=yes'"
       group_by: "year month"


### PR DESCRIPTION
### Description

Inspired by the flexibility of current set up and this: https://nextstrain.github.io/ncov/multiple_inputs.html
try a simple way to make sure trees contain all Aspen genomes. 
- Nextstrain takes 2 input: Aspen data and Gisaid data
- For genomes on both Aspen and Gisaid, de-duplication keeps the Aspen copy, so none of the Aspen genomes would be removed.
- Disable subsample for Aspen data; only subsample Gisaid data
- Side note: Aspen data into a tree build workflow are already filtered by `group`, so no more filter by `division` is needed. This means a county can keep all genomes in its `group` (or can-see group in the future) on its trees regardless of whether those samples were collected in their own counties. This set up is so flexible and quite awesome.

#### Issue

- Anticipated user feedback with subsampling: where are my samples?
- Don't know whether Santa Clara tree will take too long to build with no subsampling.

### Test plan

I do not know how to test.... Will learn how to trigger tree run from Shannon tomorrow.