### PR TITLE
miniwdl 1.1.5

### DIFF
--- a/.happy/terraform/modules/batch/container_properties.yml
+++ b/.happy/terraform/modules/batch/container_properties.yml
@@ -33,14 +33,14 @@ command:
     put_metric MemoryInUse $(python3 -c 'import psutil; m=psutil.virtual_memory(); print(100*(1-m.available/m.total))');
     sleep 60;
     done &
-  - "mkdir -p /mnt/download_cache; touch /mnt/download_cache/.cleaner_lock"
+  - "mkdir -p /mnt/download_cache; touch /mnt/download_cache/_miniwdl_flock"
   - >-
     clean_wd() {
     (shopt -s nullglob;
     for wf_log in /mnt/20??????_??????_*/workflow.log; do
     flock -n $wf_log rm -rf $(dirname $wf_log) || true;
     done;
-    flock -x /mnt/download_cache/.cleaner_lock clean_download_cache.sh /mnt/download_cache $DOWNLOAD_CACHE_MAX_GB)
+    flock -x /mnt/download_cache/_miniwdl_flock clean_download_cache.sh /mnt/download_cache $DOWNLOAD_CACHE_MAX_GB)
     }
   - "clean_wd"
   - "df -h / /mnt"
@@ -65,7 +65,7 @@ command:
     fi
     }
   - "trap handle_error EXIT"
-  - 'miniwdl run --dir /mnt $(basename "$WDL_WORKFLOW_URI") --input wdl_input.json --verbose --error-json --log-json > wdl_output.json'
+  - 'miniwdl run --dir /mnt $(basename "$WDL_WORKFLOW_URI") --input wdl_input.json --verbose --error-json -o wdl_output.json'
   - "clean_wd"
 environment:
   - name: "AWS_DEFAULT_REGION"

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -278,7 +278,7 @@ module swipe_batch {
   app_name              = "swipe"
   stack_resource_prefix = local.stack_resource_prefix
   batch_role_arn        = local.batch_role_arn
-  swipe_image            = "${local.swipe_image_repo}:rev-5" # FIXME rev shouldn't be hardcoded
+  swipe_image            = "${local.swipe_image_repo}:rev-6" # FIXME rev shouldn't be hardcoded
   custom_stack_name     = local.custom_stack_name
   remote_dev_prefix     = local.remote_dev_prefix
   deployment_stage      = local.deployment_stage


### PR DESCRIPTION
### Description

Applying https://github.com/chanzuckerberg/swipe/pull/4/files which applies https://github.com/chanzuckerberg/idseq/pull/313 (not great I know but better than not getting the fixes).

This updates miniwdl and the treatment of the file system cache to fix an issue where a full cache can lead to a failure even if there is still space on the device.

#### Issue
None

### Test plan

This change has been in production in IDSeq for some time.
