### PR TITLE
thuang-tree-icon-colors

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -50,12 +50,6 @@
   align-items: center;
   margin: $space-xs 0 $space-xs 0;
 
-  .modalTrigger {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-  }
-
   .icon {
     margin: 0 $space-l;
     fill: $gray-light;

--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { getColors, getSpacings } from "czifui";
+import { getColors, getSpacings, Props } from "czifui";
 
 export const TableRow = styled.div`
   display: flex;
@@ -20,6 +20,7 @@ export const RowContent = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
+
   ${(props) => {
     const spacings = getSpacings(props);
 
@@ -29,3 +30,13 @@ export const RowContent = styled.div`
   `;
   }}
 `;
+
+export const icon = (props: Props) => {
+  const colors = getColors(props);
+  const spacings = getSpacings(props);
+
+  return `
+    margin: 0 ${spacings?.l}px;
+    fill: ${colors?.gray[500]};
+  `;
+};

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
 import dataTableStyle from "src/common/components/library/data_table/index.module.scss";
-import { RowContent } from "src/common/components/library/data_table/style";
-import { ReactComponent as ExternalLinkIcon } from "src/common/icons/ExternalLink.svg";
 import { ReactComponent as TreeIcon } from "src/common/icons/PhyloTree.svg";
 import { createTreeModalInfo } from "src/common/utils";
 import TreeVizModal from "../TreeVizModal";
+import { CellWrapper, StyledExternalLinkIcon, StyledRowContent } from "./style";
 
 interface NameProps {
   value: string;
@@ -25,18 +24,23 @@ const TreeTableNameCell = ({ value, item }: NameProps): JSX.Element => {
   const treeId = item.id;
 
   return (
-    <RowContent className={dataTableStyle.cell}>
+    <>
       <TreeVizModal
         open={open}
         onClose={handleClose}
         info={createTreeModalInfo(treeId)}
       />
-      <div onClick={handleClickOpen} className={dataTableStyle.modalTrigger}>
-        <TreeIcon className={dataTableStyle.icon} />
-        {value}
-        <ExternalLinkIcon className={dataTableStyle.icon} />
-      </div>
-    </RowContent>
+      <StyledRowContent
+        className={dataTableStyle.cell}
+        onClick={handleClickOpen}
+      >
+        <CellWrapper>
+          <TreeIcon className={dataTableStyle.icon} />
+          {value}
+          <StyledExternalLinkIcon />
+        </CellWrapper>
+      </StyledRowContent>
+    </>
   );
 };
 

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -1,0 +1,42 @@
+import styled from "@emotion/styled";
+import { getColors } from "czifui";
+import { RowContent } from "src/common/components/library/data_table/style";
+import { ReactComponent as ExternalLinkIcon } from "src/common/icons/ExternalLink.svg";
+import { icon } from "../../../../common/components/library/data_table/style";
+
+export const StyledExternalLinkIcon = styled(ExternalLinkIcon)`
+  ${icon}
+`;
+
+export const StyledRowContent = styled(RowContent)`
+  cursor: pointer;
+
+  :hover {
+    ${StyledExternalLinkIcon} {
+      ${(props) => {
+        const colors = getColors(props);
+
+        return `
+          fill: ${colors?.primary[400]};
+        `;
+      }}
+    }
+  }
+
+  :active {
+    ${StyledExternalLinkIcon} {
+      ${(props) => {
+        const colors = getColors(props);
+
+        return `
+          fill: ${colors?.primary[600]};
+        `;
+      }}
+    }
+  }
+`;
+
+export const CellWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;


### PR DESCRIPTION
### Description

1. Update the open in new tab icon to have darker default color
2. Update the open in new tab icon to have hover and active state colors
3. Update click target to be the whole "tree name" cell

#### Issue
https://app.clubhouse.io/genepi/story/137094/update-phylogenetic-tree-link-icon-states-fill-colors

### Test plan

1. Visit https://thuang-tree-colors-frontend.dev.genepi.czi.technology/data/phylogenetic_trees
2. Hovering over the "tree name" cell will change the open in new tab icon color
3. Clicking on the "tree name" cell (mouse down) will change the open in new tab icon color to a deeper primary color

<img width="916" alt="Screen Shot 2021-05-21 at 4 09 06 PM" src="https://user-images.githubusercontent.com/6309723/119206216-5e2b2280-ba4f-11eb-8f94-8ffd406c2713.png">

![demo](https://user-images.githubusercontent.com/6309723/119206254-7438e300-ba4f-11eb-8491-84f46548e72b.gif)

