### PR TITLE
Do not repeatedly create failed accession workflows

### DIFF
--- a/src/backend/aspen/covidhub_import/import_projects.py
+++ b/src/backend/aspen/covidhub_import/import_projects.py
@@ -320,12 +320,23 @@ def import_project(
                                 workflow_end_datetime=datetime.datetime.now(),
                             )
                 else:
-                    sample.uploaded_pathogen_genome.consuming_workflows.append(
-                        GisaidAccessionWorkflow(
-                            software_versions={},
-                            workflow_status=WorkflowStatusType.FAILED,
-                            start_datetime=datetime.datetime.now(),
+                    # is there already a failed gisaid accession workflow?
+                    for (
+                        consuming_workflow
+                    ) in sample.uploaded_pathogen_genome.consuming_workflows:
+                        if (
+                            isinstance(consuming_workflow, GisaidAccessionWorkflow)
+                            and consuming_workflow.workflow_status
+                            == WorkflowStatusType.FAILED
+                        ):
+                            break
+                    else:
+                        sample.uploaded_pathogen_genome.consuming_workflows.append(
+                            GisaidAccessionWorkflow(
+                                software_versions={},
+                                workflow_status=WorkflowStatusType.FAILED,
+                                start_datetime=datetime.datetime.now(),
+                            )
                         )
-                    )
             else:
                 sample.czb_failed_genome_recovery = True


### PR DESCRIPTION
### Description
Only create a failed accession workflow if one does not already exist.

### Test plan
ran migrate-all.sh locally.
