### PR TITLE
write snakemake log to S3

### DIFF
--- a/.happy/terraform/modules/sfn_config/nextstrain.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain.wdl
@@ -98,6 +98,7 @@ task nextstrain_workflow {
     # upload the tree to S3
     key="phylo_run/${build_id}/~{s3_filestem}.json"
     aws s3 cp /ncov/auspice/ncov_aspen.json "s3://${aspen_s3_db_bucket}/${key}"
+    aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/phylo_run/${build_id}/" --recursive
 
     # update aspen
     aspen_workflow_rev=WHATEVER


### PR DESCRIPTION
### Description

Nextstrain snakemake log is in `ncov/.snakemake/log/` folder.
The edits will write the log to S3 where the tree json locates so we can see the content.

### Issue

Nextstrain is giving an error that we don't know what it is.

### Other notes

- I'm not confident in the `aws s3 cp` syntax. Please check!

- Also the `${key}` variable replacement doesn't look pretty. Will fix if we decide to keep the change. 