### PR TITLE
fix: improve GHA build times

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Lint ts
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          # Build frontend image
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
           make frontend-check-style
   ts-test:
     runs-on: ubuntu-20.04
@@ -54,6 +56,8 @@ jobs:
       - name: Test ts
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          # Build frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
           make frontend-test
   ts-test-build:
     runs-on: ubuntu-20.04
@@ -76,6 +80,8 @@ jobs:
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           mkdir src/frontend/build
           chmod -R a+w src/frontend/build
+          # Build frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
           make frontend-test-build
   py-lint:
     runs-on: ubuntu-20.04
@@ -96,6 +102,8 @@ jobs:
       - name: Lint Python
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          # Build backend image
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-backend:latest src/backend
           make backend-check-style
   py-test:
     runs-on: ubuntu-20.04
@@ -116,20 +124,57 @@ jobs:
       - name: Test Python
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          # Build backend image
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-backend:latest src/backend
+          # Build frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
           make local-init
           make backend-test
-      - name: Push images
-        if: github.ref == 'refs/heads/trunk'
-        run: |
-          pip install -r .happy/requirements.txt
-          scripts/happy --profile="" push --extra-tag sha-${GITHUB_SHA:0:8} --extra-tag build-${GITHUB_RUN_NUMBER}
-  update-stage:
+  build-push-images:
+    if: github.ref == 'refs/heads/trunk'
+    runs-on: ubuntu-20.04
     needs:
       - ts-lint
       - ts-test
       - ts-test-build
       - py-lint
       - py-test
+    strategy:
+      matrix:
+        image:
+        - dockerfile: src/backend/Dockerfile.gisaid
+          context: ./src/backend/
+          name: aspen-gisaid
+        - dockerfile: src/backend/Dockerfile.nextstrain
+          context: ./src/backend/
+          name: aspen-nextstrain
+        - dockerfile: src/backend/Dockerfile.pangolin
+          context: ./src/backend/
+          name: aspen-pangolin
+        - dockerfile: src/backend/Dockerfile
+          context: ./src/backend/
+          name: aspen-backend
+        - dockerfile: src/frontend/Dockerfile
+          context: ./src/frontend/
+          name: aspen-frontend
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - uses: actions/checkout@v2
+      - run: docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/${{ matrix.image.name }}:branch-trunk --cache-to=type=inline,mode=max -t ${{ secrets.ECR_REPO }}/${{ matrix.image.name }}:sha-${GITHUB_SHA:0:8} -f ${{ matrix.image.dockerfile }} --push ${{ matrix.image.context }}
+  update-stage:
+    needs:
+      - build-push-images
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/trunk'
     steps:
@@ -169,6 +214,5 @@ jobs:
           # See https://github.community/t/can-i-avoid-creating-a-check-run-from-a-job-needed-for-deployments-api/16426
         env:
           GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}
-
 
 

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -171,7 +171,7 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
-      - run: docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/${{ matrix.image.name }}:branch-trunk --cache-to=type=inline,mode=max -t ${{ secrets.ECR_REPO }}/${{ matrix.image.name }}:sha-${GITHUB_SHA:0:8} -f ${{ matrix.image.dockerfile }} --push ${{ matrix.image.context }}
+      - run: docker buildx build --build-arg HAPPY_COMMIT=${GITHUB_SHA} --build-arg HAPPY_BRANCH=${GITHUB_REF} --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/${{ matrix.image.name }}:branch-trunk --cache-to=type=inline,mode=max -t ${{ secrets.ECR_REPO }}/${{ matrix.image.name }}:sha-${GITHUB_SHA:0:8} -f ${{ matrix.image.dockerfile }} --push ${{ matrix.image.context }}
   update-stage:
     needs:
       - build-push-images

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ init-empty-db:
 
 .PHONY: local-init
 local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login ## Launch a new local dev env and populate it with test data.
-	docker-compose $(COMPOSE_OPTS) up -d
+	docker-compose $(COMPOSE_OPTS) up -d database frontend backend localstack oidc utility
 	@docker-compose exec -T database psql "postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@localhost:5432/$(LOCAL_DB_NAME)" -c "alter user $(LOCAL_DB_ADMIN_USERNAME) with password '$(LOCAL_DB_ADMIN_PASSWORD)';"
 	docker-compose exec -T utility pip3 install awscli
 	docker-compose exec -T utility $(BACKEND_APP_ROOT)/scripts/setup_dev_data.sh

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -5,10 +5,10 @@ RUN chown node:node /usr/src/app
 COPY package*.json ./
 ENV NODE_ENV=development
 ENV BUILD_PATH=build
-ARG HAPPY_COMMIT="unknown"
-ENV COMMIT_SHA=${HAPPY_COMMIT}
 RUN npm ci --verbose --no-optional && npm cache clean --force
 RUN apt-get update && apt-get install make
 USER node
 COPY . .
 ENTRYPOINT ["./entrypoint.sh"]
+ARG HAPPY_COMMIT="unknown"
+ENV COMMIT_SHA=${HAPPY_COMMIT}


### PR DESCRIPTION
### Description

This should speed up build times significantly by relying more heavily on docker's build cache for each step in our CI workflow, as well as parallelizing the build&push of all of our docker images for builds of the trunk branch.

Here's an example of what we can expect a build of the trunk branch to look like with a warm cache. The first run with a cold cache will definitely be slower:
https://github.com/chanzuckerberg/aspen/actions/runs/879921918

These changes can(/should) be generalized into the happy CLI, but I want to see how it works in practice for a little while.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
