### PR TITLE
thuang-fe-dockerfile-update

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -5,9 +5,9 @@ RUN chown node:node /usr/src/app
 COPY package*.json ./
 ENV NODE_ENV=development
 ENV BUILD_PATH=build
-RUN npm ci --verbose --no-optional && npm cache clean --force
 RUN apt-get update && apt-get install make
 USER node
+RUN npm ci --verbose --no-optional && npm cache clean --force
 COPY . .
 ENTRYPOINT ["./entrypoint.sh"]
 ARG HAPPY_COMMIT="unknown"


### PR DESCRIPTION
### Description

Move `npm ci` command after `USER node`, so the files get stored in `/home/node/.cache/` instead of `/root/.cache/`, since we run `npm` commands with `USER node`, which looks for executables in `/home/node/.cache/`

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
