### PR TITLE
Unscheduling the covid import job so we can just run it on demand

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -245,7 +245,6 @@ module covidhub_import_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = module.swipe_sfn_spot.step_function_arn
-  schedule_expressions  = contains(["prod", "staging"], local.deployment_stage) ? ["cron(0 6 ? * 1-5 *)"] : []
   event_role_arn        = local.event_role_arn
 }
 


### PR DESCRIPTION
### Description

We'd like to change the covid import job to just run on demand as needed when there's new data instead of nightly. 


#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
