### PR TITLE
Add lint check for WDL files

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - jgadling/lint-wdl
   pull_request:
     branches: "**"
 
@@ -15,6 +16,15 @@ env:
   DOCKER_REPO: ${{ secrets.ECR_REPO }}/
 
 jobs:
+  wdl-lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: run wdl check
+        run: |
+          pip3 install miniwdl==1.1.4
+          sudo apt-get install -y shellcheck
+          make wdl-lint
   tf-lint:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - trunk
-      - jgadling/lint-wdl
   pull_request:
     branches: "**"
 

--- a/.happy/terraform/modules/sfn_config/pangolin.wdl
+++ b/.happy/terraform/modules/sfn_config/pangolin.wdl
@@ -22,7 +22,6 @@ task pangolin_workflow {
     command <<<
     cd /usr/src/app/aspen/workflows/pangolin
     /usr/local/bin/python3.9 find_samples.py
-    >>>
 
     runtime {
         docker: docker_image_id

--- a/.happy/terraform/modules/sfn_config/pangolin.wdl
+++ b/.happy/terraform/modules/sfn_config/pangolin.wdl
@@ -22,6 +22,7 @@ task pangolin_workflow {
     command <<<
     cd /usr/src/app/aspen/workflows/pangolin
     /usr/local/bin/python3.9 find_samples.py
+    >>>
 
     runtime {
         docker: docker_image_id

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,11 @@ build-docker:
 	@echo "If you wish to clean up some of your old aspen docker images, run:"
 	@echo "  docker image rm \$\$$(docker image ls -q cziaspen/batch -f 'before=cziaspen/batch:latest')"
 
+### WDL ###################################################
+.PHONY: wdl-lint
+wdl-lint:
+	set -e; for i in $$(find .happy/terraform/modules/sfn_config -name '*.wdl'); do echo $${i}; miniwdl check $${i}; done
+
 
 ### TERRAFORM ###################################################
 .PHONY: tf-lint


### PR DESCRIPTION
### Description

This adds a simple lint check for WDL files. There are a few warnings we should probably fix, but warnings are allowed for now. We can look into making them more strict when we're ready.

### Test plan

There's an example of a successful / failed lint check below in the commits listed as part of this PR.
