### PR TITLE
sample table field updates

### DIFF
--- a/src/backend/aspen/database/models/sample.py
+++ b/src/backend/aspen/database/models/sample.py
@@ -76,6 +76,7 @@ class Sample(idbase, DictMixin):  # type: ignore
     original_submission = Column(
         JSON,
         nullable=False,
+        default={},
         comment="This is the original metadata submitted by the user.",
     )
 
@@ -203,7 +204,7 @@ class Sample(idbase, DictMixin):  # type: ignore
 
     czb_failed_genome_recovery = Column(
         Boolean,
-        nullable=False,
+        nullable=True,
         default=False,
         server_default=sql.expression.false(),
         comment=(

--- a/src/backend/database_migrations/versions/20210602_211244_small_modifications_to_samples_table.py
+++ b/src/backend/database_migrations/versions/20210602_211244_small_modifications_to_samples_table.py
@@ -1,0 +1,36 @@
+"""small modifications to samples table
+
+Create Date: 2021-06-02 21:12:45.468074
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20210602_211244"
+down_revision = "20210526_162747"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "samples",
+        "czb_failed_genome_recovery",
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        existing_comment="This is set to true iff this is sample sequenced by CZB and failed genome recovery.",
+        existing_server_default=sa.text("true"),
+        schema="aspen",
+    )
+
+    update_organism_sql = sa.sql.text(
+        "UPDATE aspen.samples SET organism ='Severe acute respiratory syndrome coronavirus 2'"
+    )
+
+    conn = op.get_bind()
+    conn.execute(update_organism_sql)
+
+
+def downgrade():
+    raise NotImplementedError("Downgrading the database is not allowed")


### PR DESCRIPTION
### Description

made some small updates to the samples table and backfilled organism column from `sars-cov-2` to `Severe acute respiratory syndrome coronavirus 2`

#### Issue
no issue

### Test plan
ran migration, checked db fields had changed
