### PR TITLE
fix county location filter

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -372,7 +372,7 @@ module nextstrain_monterey_local_sfn_config {
     template_filename        = "group.yaml"
     template_args            = {
      division = "California"
-     location = "Monterey County"
+     location = "Monterey County CA"
     }
   }
 }
@@ -401,7 +401,7 @@ module nextstrain_monterey_contextual_sfn_config {
     template_filename        = "group_plus_context.yaml"
     template_args            = {
       division = "California"
-      location = "Monterey County"
+      location = "Monterey County CA"
     }
   }
 }
@@ -430,7 +430,7 @@ module nextstrain_orange_local_sfn_config {
     template_filename        = "group.yaml"
     template_args            = {
      division = "California"
-     location = "Orange County"
+     location = "Orange County CA"
     }
   }
 }
@@ -459,7 +459,7 @@ module nextstrain_orange_contextual_sfn_config {
     template_filename        = "group_plus_context.yaml"
     template_args            = {
       division = "California"
-      location = "Orange County"
+      location = "Orange County CA"
     }
   }
 }
@@ -720,7 +720,7 @@ module nextstrain_tulare_local_sfn_config {
     template_filename        = "group.yaml"
     template_args            = {
      division = "California"
-     location = "Tulare County"
+     location = "Southern San Joaquin Valley"
     }
   }
 }
@@ -749,7 +749,7 @@ module nextstrain_tulare_contextual_sfn_config {
     template_filename        = "group_plus_context.yaml"
     template_args            = {
       division = "California"
-      location = "Tulare County"
+      location = "Southern San Joaquin Valley"
     }
   }
 }

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -148,6 +148,9 @@ task TransformGISAID {
     git clone --depth 1 git://github.com/nextstrain/ncov-ingest /ncov-ingest
     ncov_ingest_git_rev=$(git -C /ncov-ingest rev-parse HEAD)
 
+    # modify location rules from ncov-ingest. Southern San Joaquin Valley would be left blank in the default version
+    sed -i 's/Southern San Joaquin Valley\tNorth America\/USA\/California\//Southern San Joaquin Valley\tNorth America\/USA\/California\/Southern San Joaquin Valley/' /ncov-ingest/source-data/gisaid_geoLocationRules.tsv
+
     # decompress the gisaid dataset and transform it.
     aws s3 cp --no-progress "s3://${raw_gisaid_s3_bucket}/${raw_gisaid_s3_key}" - | zstdmt -d > gisaid.ndjson
     /ncov-ingest/bin/transform-gisaid     \


### PR DESCRIPTION
### Description

1. Tulare submitted their samples with location being "California/Southern San Joaquin Valley". However when `ncov-ingest` parses out the metadata from gisaid, they would convert that location to blank. see https://github.com/nextstrain/ncov-ingest/issues/179. Modified this in `32fb423`

2. `ncov-ingest` will also append "CA" to Orange County and Monterey County locations. So modified those so Gisaid data get sorted properly to county trees in `9032a8b`
![image](https://user-images.githubusercontent.com/20667188/121224575-568cbb80-c84e-11eb-9ee9-94a1bdc678b1.png)
Also see [how we did this](https://github.com/czbiohub/covidhub/blob/61001a4ea917ccd30e13110d59544827e128be4d/code/genome_tracking/scripts/prepare_ncov_input.py#L192) in covidhub.

### Issues

Note currently `location` is used to filter both Aspen and Gisaid data. So this change will remove Aspen data from these county trees, which should be fixed after this change: https://app.clubhouse.io/genepi/story/141787/split-subsampling-for-aspen-and-gisaid-data

### Test plan

I tested the `sed` line in `32fb423` on bash in EC2. We'll see whether the samples will show up in Thursday tree after the changes are deployed.
