### PR TITLE
make exported gisaid metadata location the same as our database

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -149,7 +149,7 @@ task TransformGISAID {
     ncov_ingest_git_rev=$(git -C /ncov-ingest rev-parse HEAD)
 
     # modify location rules from ncov-ingest. Southern San Joaquin Valley would be left blank in the default version
-    sed -i -e 's/Southern San Joaquin Valley\tNorth America\/USA\/California\//Southern San Joaquin Valley\tNorth America\/USA\/California\/Southern San Joaquin Valley/' \
+    sed -i -e 's/Southern San Joaquin Valley\tNorth America\/USA\/California\//Southern San Joaquin Valley\tNorth America\/USA\/California\/Tulare County/' \
     -e 's/Orange County CA/Orange County/' \
     -e 's/Monterey County CA/Monterey County/' \
     /ncov-ingest/source-data/gisaid_geoLocationRules.tsv

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -148,6 +148,12 @@ task TransformGISAID {
     git clone --depth 1 git://github.com/nextstrain/ncov-ingest /ncov-ingest
     ncov_ingest_git_rev=$(git -C /ncov-ingest rev-parse HEAD)
 
+    # modify location rules from ncov-ingest. Southern San Joaquin Valley would be left blank in the default version
+    sed -i -e 's/Southern San Joaquin Valley\tNorth America\/USA\/California\//Southern San Joaquin Valley\tNorth America\/USA\/California\/Southern San Joaquin Valley/' \
+    -e 's/Orange County CA/Orange County/' \
+    -e 's/Monterey County CA/Monterey County/' \
+    /ncov-ingest/source-data/gisaid_geoLocationRules.tsv
+
     # decompress the gisaid dataset and transform it.
     aws s3 cp --no-progress "s3://${raw_gisaid_s3_bucket}/${raw_gisaid_s3_key}" - | zstdmt -d > gisaid.ndjson
     /ncov-ingest/bin/transform-gisaid     \


### PR DESCRIPTION
### Description

1. Tulare submitted their samples with location being "California/Southern San Joaquin Valley". However when `ncov-ingest` parses out the metadata from gisaid, they would convert that location to blank. see https://github.com/nextstrain/ncov-ingest/issues/179. 

2. `ncov-ingest` will also append "CA" to Orange County and Monterey County locations. 
![image](https://user-images.githubusercontent.com/20667188/121224575-568cbb80-c84e-11eb-9ee9-94a1bdc678b1.png)

This PR revert these changes `ncov-ingest` makes. Also see [how we did this](https://github.com/czbiohub/covidhub/blob/61001a4ea917ccd30e13110d59544827e128be4d/code/genome_tracking/scripts/prepare_ncov_input.py#L192) in covidhub.

### Issues

Note currently `location` is used to filter both Aspen and Gisaid data. So this change will remove Aspen data **for Tulare tree**, which should be fixed after [this change](https://app.clubhouse.io/genepi/story/141787/split-subsampling-for-aspen-and-gisaid-data). 

### Test plan

The change modified files as expected on bash in EC2. 
We'll see whether the samples will show up in Thursday tree after the changes are deployed.
