### PR TITLE
[Supa Chill} - fixing .json being in the tree filenames

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -30,7 +30,7 @@ PHYLO_TREE_KEY = "phylo_trees"
 
 def humanize_tree_name(s3_key: str):
     json_filename = s3_key.split("/")[-1]
-    basename = re.sub(r"_\d*\.json", "", json_filename)
+    basename = re.sub(r".json", "", json_filename)
     title_case = basename.replace("_", " ").title()
     if "Ancestors" in title_case:
         title_case = title_case.replace("Ancestors", "Contextual")


### PR DESCRIPTION
### Description

New trees have the file format "Santa Clara Local.json" instead of "santa_clara_local.json" so this regex doesn't work. This just blanket removes the .json

#### Issue
[ch142389](https://app.clubhouse.io/genepi/story/142389)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
