### PR TITLE
Use ambiguity score, not `conflict` to assign pango confidence

### DIFF
--- a/src/backend/aspen/workflows/pangolin/save.py
+++ b/src/backend/aspen/workflows/pangolin/save.py
@@ -22,7 +22,6 @@ def get_probability(ambiguity_score: float) -> int:
     that had to be imputed from the reference sequence.
     Round and multiply by 100 --> percentage for easier user comprehension.
     """
-    assert 0 <= ambiguity_score <= 1
     return round((1 - ambiguity_score) * 100)
 
 
@@ -39,7 +38,8 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
         taxon_to_pango_info: Mapping[int, Mapping[str, Union[str, float]]] = {
             int(row["taxon"]): {
                 "lineage": row["lineage"],
-                "probability": get_probability(float(row["ambiguity_score"])),
+                "probability": get_probability(float(row["ambiguity_score"]))
+                if row["ambiguity_score"] else 100,
                 "version": row["pangoLEARN_version"],
             }
             for row in pango_csv

--- a/src/backend/aspen/workflows/pangolin/save.py
+++ b/src/backend/aspen/workflows/pangolin/save.py
@@ -22,7 +22,7 @@ def get_probability(ambiguity_score: float) -> int:
     that had to be imputed from the reference sequence.
     Round and multiply by 100 --> percentage for easier user comprehension.
     """
-    return round((1 - ambiguity_score) * 100)
+    return round(ambiguity_score * 100)
 
 
 @click.command("save")
@@ -39,7 +39,8 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
             int(row["taxon"]): {
                 "lineage": row["lineage"],
                 "probability": get_probability(float(row["ambiguity_score"]))
-                if row["ambiguity_score"] else 100,
+                if row["ambiguity_score"]
+                else None,
                 "version": row["pangoLEARN_version"],
             }
             for row in pango_csv

--- a/src/backend/aspen/workflows/pangolin/tests/data/lineage_report.csv
+++ b/src/backend/aspen/workflows/pangolin/tests/data/lineage_report.csv
@@ -1,3 +1,3 @@
-taxon,lineage,conflict,pangolin_version,pangoLEARN_version,pango_version,status,note
-1,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,
-2,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,
+taxon,lineage,conflict,pangolin_version,pangoLEARN_version,pango_version,status,note,ambiguity_score
+1,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,,
+2,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,1.0

--- a/src/backend/aspen/workflows/pangolin/tests/data/lineage_report.csv
+++ b/src/backend/aspen/workflows/pangolin/tests/data/lineage_report.csv
@@ -1,3 +1,3 @@
 taxon,lineage,conflict,pangolin_version,pangoLEARN_version,pango_version,status,note,ambiguity_score
-1,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,,
-2,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,1.0
+1,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,,1.0
+2,B.1.590,0.0,2.4.2,2021-04-23,1.1.23,passed_qc,,1.0

--- a/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
+++ b/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
@@ -106,7 +106,7 @@ def test_pangolin_save(mocker, session, postgres_database):
 
     for pathogen_genome in session.query(UploadedPathogenGenome).all():
         assert pathogen_genome.pangolin_lineage == "B.1.590"
-        assert pathogen_genome.pangolin_probability == 1.0
+        assert pathogen_genome.pangolin_probability == 100.0
         assert pathogen_genome.pangolin_last_updated == datetime.strptime(
             "05-03-2021", "%m-%d-%Y"
         )


### PR DESCRIPTION
### Description

Should be using the `ambiguity_score` to estimate pangolin confidence, rather than `conflicts`. Hopefully this also solves the  weird issue where some pangolin lineages weren't able to be parsed and assigned because of empty string values in `conflicts`. 

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Does someone mind kicking off the pangolin job for me and checking that:
1.  `USA/CA-CZB-32366/2021` gets correctly assigned as `B.1.617.something`
2. The `probability` values in the app now range from 0 -> 100, and we see a range of these values (although heavily skewed towards 100)