### PR TITLE
thuang-style-private-column

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/style.ts
@@ -50,7 +50,7 @@ export const IsPrivateTableCell = styled(StyledTableCell)`
     const spacings = getSpacings(props);
 
     return `
-      padding: ${spacings?.l}px 0;
+      padding: ${spacings?.l}px ${spacings?.l}px;
       border-left: solid 2px ${colors?.gray[200]};
       border-right: solid 2px ${colors?.gray[200]};
     `;


### PR DESCRIPTION
### Description

I ended up using spacings.large / 14px, otherwise it'd still be too tight somehow. Hope that's okay!

<img width="1200" alt="Screen Shot 2021-06-15 at 4 26 34 PM" src="https://user-images.githubusercontent.com/6309723/122136075-9deaed00-cdf6-11eb-9f6e-1e21dcb65362.png">

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
