### PR TITLE
thuang-disable-navigation-prompt

### DIFF
--- a/src/frontend/.eslintrc.js
+++ b/src/frontend/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "plugin:jest-playwright/recommended",
     "prettier",
     "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended",
   ],
   overrides: [
     // Override some TypeScript rules just for .js files

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
@@ -23,17 +23,25 @@ interface Props {
   isDisabled: boolean;
   samples: Samples | null;
   metadata: SampleIdToMetadata | null;
+  cancelPrompt: () => void;
 }
 
 export default function Upload({
   isDisabled,
   samples,
   metadata,
+  cancelPrompt,
 }: Props): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
 
-  const { mutate, isLoading, isSuccess, isError, error } =
-    useMutation(createSamples);
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation(
+    createSamples,
+    {
+      onSuccess: () => {
+        cancelPrompt();
+      },
+    }
+  );
 
   return (
     <>

--- a/src/frontend/src/views/Upload/components/Review/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/index.tsx
@@ -24,7 +24,11 @@ import {
   ContentTitleWrapper,
 } from "./style";
 
-export default function Review({ samples, metadata }: Props): JSX.Element {
+export default function Review({
+  samples,
+  metadata,
+  cancelPrompt,
+}: Props): JSX.Element {
   const { data } = useUserInfo();
   const [isConsentChecked, setIsConsentChecked] = useState(false);
 
@@ -101,6 +105,7 @@ export default function Review({ samples, metadata }: Props): JSX.Element {
             samples={samples}
             metadata={metadata}
             isDisabled={!isConsentChecked}
+            cancelPrompt={cancelPrompt}
           />
           <NextLink href={ROUTES.UPLOAD_STEP2} passHref>
             <a href="passHref">

--- a/src/frontend/src/views/Upload/components/common/types.ts
+++ b/src/frontend/src/views/Upload/components/common/types.ts
@@ -65,6 +65,7 @@ export interface Props {
   setSamples: React.Dispatch<React.SetStateAction<Samples | null>>;
   metadata: SampleIdToMetadata | null;
   setMetadata: React.Dispatch<React.SetStateAction<SampleIdToMetadata | null>>;
+  cancelPrompt: () => void;
 }
 
 export type SampleIdToMetadata = Record<string, Metadata>;

--- a/src/frontend/src/views/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/index.tsx
@@ -28,7 +28,7 @@ export default function Upload(): JSX.Element | null {
 
   const router = useRouter();
 
-  useNavigationPrompt();
+  const cancelPrompt = useNavigationPrompt();
 
   useEffect(() => {
     if (!samples) {
@@ -60,6 +60,7 @@ export default function Upload(): JSX.Element | null {
           setSamples={setSamples}
           metadata={metadata}
           setMetadata={setMetadata}
+          cancelPrompt={cancelPrompt}
         />
       )}
     </StyledPageContent>


### PR DESCRIPTION
### Description

1. Add a callback function to cancel prompt for `useNavigationPrompt` hook, we then invoke the callback when samples are successfully created!

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
