### PR TITLE
make gisaid accession public_id nullable

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -366,6 +366,7 @@ def create_sample():
                     # not provide an isl-number, we mark it as UNKNOWN for now.
                     uploaded_pathogen_genome.add_accession(
                         repository_type=PublicRepositoryType.GISAID,
+                        public_identifier=None,
                         workflow_start_datetime=datetime.datetime.now(),
                         workflow_end_datetime=datetime.datetime.now(),
                     )

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -34,7 +34,6 @@ from aspen.error.recoverable import RecoverableError
 DEFAULT_DIVISION = "California"
 DEFAULT_COUNTRY = "USA"
 DEFAULT_ORGANISM = "Severe acute respiratory syndrome coronavirus 2"
-USER_SUBMITTED_TO_GISAID_ISL_NOT_PROVIDED = "Not Provided"
 SAMPLE_KEY = "samples"
 GISIAD_REJECTION_TIME = datetime.timedelta(days=4)
 SAMPLES_POST_REQUIRED_FIELDS = [
@@ -97,13 +96,10 @@ def _format_gisaid_accession(
             # hey there should be an output...
             for output in gisaid_accession_workflow.outputs:
                 assert isinstance(output, GisaidAccession)
-                if (
-                    output.public_identifier
-                    == USER_SUBMITTED_TO_GISAID_ISL_NOT_PROVIDED
-                ):
+                if not output.public_identifier:
                     return {
                         "status": "Submitted",
-                        "gisaid_id": output.public_identifier,
+                        "gisaid_id": "Not Provided",
                     }
                 return {
                     "status": "Accepted",
@@ -370,7 +366,6 @@ def create_sample():
                     # not provide an isl-number, we mark it as UNKNOWN for now.
                     uploaded_pathogen_genome.add_accession(
                         repository_type=PublicRepositoryType.GISAID,
-                        public_identifier=USER_SUBMITTED_TO_GISAID_ISL_NOT_PROVIDED,
                         workflow_start_datetime=datetime.datetime.now(),
                         workflow_end_datetime=datetime.datetime.now(),
                     )

--- a/src/backend/aspen/database/models/accessions.py
+++ b/src/backend/aspen/database/models/accessions.py
@@ -32,7 +32,7 @@ class GisaidAccession(Accession):
 
     entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)
 
-    public_identifier = Column(String, nullable=False)
+    public_identifier = Column(String, nullable=True)
 
     @classmethod
     def attach_to_entity(

--- a/src/backend/aspen/database/models/entity.py
+++ b/src/backend/aspen/database/models/entity.py
@@ -140,7 +140,7 @@ class Entity(idbase):  # type: ignore
     def add_accession(
         self,
         repository_type: PublicRepositoryType,
-        public_identifier: Union[str, None],
+        public_identifier: str,
         workflow_start_datetime: datetime.datetime,
         workflow_end_datetime: datetime.datetime,
     ):

--- a/src/backend/aspen/database/models/entity.py
+++ b/src/backend/aspen/database/models/entity.py
@@ -140,7 +140,7 @@ class Entity(idbase):  # type: ignore
     def add_accession(
         self,
         repository_type: PublicRepositoryType,
-        public_identifier: str,
+        public_identifier: Union[str, None],
         workflow_start_datetime: datetime.datetime,
         workflow_end_datetime: datetime.datetime,
     ):

--- a/src/backend/database_migrations/versions/20210617_201052_make_gisaid_accession_public_id_nullable.py
+++ b/src/backend/database_migrations/versions/20210617_201052_make_gisaid_accession_public_id_nullable.py
@@ -1,0 +1,33 @@
+"""make gisaid accession public_id nullable
+
+Create Date: 2021-06-17 20:10:54.137206
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20210617_201052"
+down_revision = "20210615_155026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "gisaid_accessions",
+        "public_identifier",
+        existing_type=sa.VARCHAR(),
+        nullable=True,
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "gisaid_accessions",
+        "public_identifier",
+        existing_type=sa.VARCHAR(),
+        nullable=False,
+        schema="aspen",
+    )


### PR DESCRIPTION
### Description

allow gisaid accession public_id to be nullable (needed for if submitted to gisaid was marked true but a user does not have isl handy)

#### Issue
no issue

### Test plan

ran tests, will test in #546 in rdev/ locally
https://upload-boolean-fix-frontend.dev.genepi.czi.technology/
