### PR TITLE
thuang-autocorrect-private

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -14,7 +14,7 @@ import Warning from "./components/Alerts/Warning";
 import DownloadTemplate from "./components/DownloadTemplate";
 import Instructions from "./components/Instructions";
 import { EXAMPLES } from "./constants";
-import { parseFile, ParseResult } from "./parseFile";
+import { parseFile, ParseResult, SampleIdToWarningMessages } from "./parseFile";
 import { IntroWrapper, Title, TitleWrapper, Wrapper } from "./style";
 
 interface Props {
@@ -69,7 +69,7 @@ export default function ImportFile({
     );
 
     const autocorrectCount =
-      warningMessages.get(WARNING_CODE.AUTO_CORRECT)?.size || 0;
+      getAutocorrectCount(warningMessages.get(WARNING_CODE.AUTO_CORRECT)) || 0;
 
     setHasImportedFile(true);
     setMissingFields(missingFields);
@@ -188,4 +188,10 @@ function isParseResultCompletelyUnused(
   const { data } = parseResult;
 
   return unusedSampleIds.length === Object.keys(data).length;
+}
+
+function getAutocorrectCount(
+  sampleIdToWarningMessages: SampleIdToWarningMessages = {}
+) {
+  return Object.keys(sampleIdToWarningMessages).length;
 }

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/index.tsx
@@ -47,7 +47,7 @@ interface Props {
   isFirstRow: boolean;
   handleRowValidation: (id: string, isValid: boolean) => void;
   isTouched: boolean;
-  isAutocorrected: boolean;
+  warnings?: Set<keyof Metadata>;
 }
 
 export default React.memo(function Row({
@@ -58,7 +58,7 @@ export default React.memo(function Row({
   isFirstRow,
   handleRowValidation,
   isTouched,
-  isAutocorrected,
+  warnings = new Set(),
 }: Props): JSX.Element {
   const formik = useFormik({
     enableReinitialize: true,
@@ -79,11 +79,11 @@ export default React.memo(function Row({
     }
 
     setTouched(newTouched, true);
-  }, [isTouched, values]);
+  }, [isTouched, setTouched, values]);
 
   useEffect(() => {
     handleRowValidation(id, isValid);
-  }, [isValid]);
+  }, [isValid, handleRowValidation, id]);
 
   useEffect(() => {
     validateForm(values);
@@ -127,6 +127,7 @@ export default React.memo(function Row({
           formik={formik}
           fieldKey="keepPrivate"
           isDisabled={Boolean(values.submittedToGisaid)}
+          isAutocorrected={warnings.has("keepPrivate")}
         />
       </IsPrivateTableCell>
       <StyledTableCell align="center" component="div">
@@ -134,7 +135,7 @@ export default React.memo(function Row({
           formik={formik}
           fieldKey="submittedToGisaid"
           isDisabled={Boolean(values.keepPrivate)}
-          isAutocorrected={isAutocorrected}
+          isAutocorrected={warnings.has("submittedToGisaid")}
         />
       </StyledTableCell>
       <StyledTableCell component="div">

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/index.tsx
@@ -6,6 +6,7 @@ import {
   SAMPLE_COUNT,
 } from "../../../common/constants";
 import { Metadata, Props as CommonProps } from "../../../common/types";
+import { SampleIdToWarningMessages } from "../ImportFile/parseFile";
 import Row from "./components/Row";
 import {
   IdColumn,
@@ -23,7 +24,7 @@ interface Props {
   setMetadata: CommonProps["setMetadata"];
   setIsValid: React.Dispatch<React.SetStateAction<boolean>>;
   hasImportedFile: boolean;
-  autocorrectWarnings: string[];
+  autocorrectWarnings: SampleIdToWarningMessages;
 }
 
 export default function Table({
@@ -80,7 +81,7 @@ export default function Table({
     });
   };
 
-  const handleRowMetadata = useCallback(handleRowMetadata_, []);
+  const handleRowMetadata = useCallback(handleRowMetadata_, [setMetadata]);
 
   const applyToAllColumn_ = (fieldKey: keyof Metadata, value: unknown) => {
     setMetadata((prevMetadata) => {
@@ -156,7 +157,7 @@ export default function Table({
                         handleMetadata={handleRowMetadata}
                         applyToAllColumn={applyToAllColumn}
                         handleRowValidation={handleRowValidation}
-                        isAutocorrected={autocorrectWarnings.includes(sampleId)}
+                        warnings={autocorrectWarnings[sampleId]}
                       />
                     );
                   }

--- a/src/frontend/src/views/Upload/components/Metadata/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/index.tsx
@@ -2,7 +2,7 @@ import { Button, Link } from "czifui";
 import Head from "next/head";
 import NextLink from "next/link";
 import React, { useState } from "react";
-import { EMPTY_ARRAY } from "src/common/constants/empty";
+import { EMPTY_OBJECT } from "src/common/constants/empty";
 import { ROUTES } from "src/common/routes";
 import {
   Metadata as IMetadata,
@@ -21,7 +21,10 @@ import {
   Title,
 } from "../common/style";
 import ImportFile from "./components/ImportFile";
-import { ParseResult } from "./components/ImportFile/parseFile";
+import {
+  ParseResult,
+  SampleIdToWarningMessages,
+} from "./components/ImportFile/parseFile";
 import Table from "./components/Table";
 
 export const EMPTY_METADATA: IMetadata = {
@@ -42,7 +45,7 @@ export default function Metadata({
   const [isValid, setIsValid] = useState(false);
   const [hasImportedFile, setHasImportedFile] = useState(false);
   const [autocorrectWarnings, setAutocorrectWarnings] =
-    useState<string[]>(EMPTY_ARRAY);
+    useState<SampleIdToWarningMessages>(EMPTY_OBJECT);
 
   function handleMetadata(result: ParseResult) {
     const { data: sampleIdToMetadata, warningMessages } = result;
@@ -57,8 +60,9 @@ export default function Metadata({
     }
 
     setMetadata(newMetadata);
+
     setAutocorrectWarnings(
-      Array.from(warningMessages.get(WARNING_CODE.AUTO_CORRECT) || [])
+      warningMessages.get(WARNING_CODE.AUTO_CORRECT) || EMPTY_OBJECT
     );
     setHasImportedFile(true);
   }


### PR DESCRIPTION
### Description

If we detect Public ID or Accession Number exists, we will check if we need to autocorrect the boolean fields!

<img width="1588" alt="Screen Shot 2021-06-17 at 12 55 26 PM" src="https://user-images.githubusercontent.com/6309723/122468873-1d9cc700-cf71-11eb-96e4-4afddc88d730.png">


#### Issue
https://app.clubhouse.io/genepi/story/143965/you-shouldn-t-be-able-to-mark-a-sample-as-private-and-give-it-a-public-id-through-the-metadata-upload

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
