### PR TITLE
remove error states for if filename has spaces

### DIFF
--- a/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
@@ -14,7 +14,7 @@ const ERROR_CODE_MESSAGES: Record<ERROR_CODE, string> = {
   [ERROR_CODE.DEFAULT]:
     "Something went wrong and we are unable to read this file. Please check the file or contact us for help.",
   [ERROR_CODE.INVALID_NAME]:
-    "File or Sample Private ID did not meet our requirements, please update and retry. File and sample names must be no longer than 120 characters and can only contain letters from the English alphabet (A-Z, upper and lower case), numbers (0-9), periods (.), hyphens (-), underscores (_), and backslashes (/). Spaces are not allowed.  ",
+    "Sample Private ID did not meet our requirements, please update and retry. Sample names must be no longer than 120 characters and can only contain letters from the English alphabet (A-Z, upper and lower case), numbers (0-9), periods (.), hyphens (-), underscores (_), and backslashes (/). Spaces are not allowed.  ",
   [ERROR_CODE.MISSING_FIELD]: "placeholder",
   [ERROR_CODE.OVER_MAX_SAMPLES]:
     "This file contains more than 500 samples, which exceeds the maximum for each upload process. Please limit the samples to 500 or less",

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -121,10 +121,10 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
                 fasta.zip
               </span>,
               <span key="3">
-                Sample names must be no longer than 120 characters and
-                can only contain letters from the English alphabet (A-Z, upper
-                and lower case), numbers (0-9), periods (.), hyphens (-),
-                underscores (_), and backslashes (/). Spaces are not allowed.
+                Sample names must be no longer than 120 characters and can only
+                contain letters from the English alphabet (A-Z, upper and lower
+                case), numbers (0-9), periods (.), hyphens (-), underscores (_),
+                and backslashes (/). Spaces are not allowed.
               </span>,
               <span key="4">
                 The maximum number of samples accommodated per upload is 500.

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -121,7 +121,7 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
                 fasta.zip
               </span>,
               <span key="3">
-                File and sample names must be no longer than 120 characters and
+                Sample names must be no longer than 120 characters and
                 can only contain letters from the English alphabet (A-Z, upper
                 and lower case), numbers (0-9), periods (.), hyphens (-),
                 underscores (_), and backslashes (/). Spaces are not allowed.

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -51,9 +51,6 @@ export async function handleFile(
   filename: string,
   file: Uint8Array
 ): Promise<ParseOutcome> {
-  if (filename.includes(" ") || filename.length > MAX_NAME_LENGTH) {
-    return { errors: { [ERROR_CODE.INVALID_NAME]: [filename] }, result: {} };
-  }
 
   if (filename.includes(".zip")) {
     return handleZip(file);

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -51,7 +51,6 @@ export async function handleFile(
   filename: string,
   file: Uint8Array
 ): Promise<ParseOutcome> {
-
   if (filename.includes(".zip")) {
     return handleZip(file);
   }


### PR DESCRIPTION
### Description

removing error state if filename contains spaces (as samples can still be uploaded from file with spaces and we're not storing filename in our database)

#### Issue
[ch143670](https://app.clubhouse.io/genepi/story/143670)

### Test plan
Tested locally and in rdev here: https://upload-wording-fix-frontend.dev.genepi.czi.technology/upload/1

