### PR TITLE
better error messaging for duplicate samples

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -283,12 +283,21 @@ def create_sample():
         )
         request_data = request.get_json()
 
+        duplicates_in_request: Union[
+            None, Mapping[str, list[str]]
+        ] = api_utils.check_duplicate_data_in_request(request_data)
+        if duplicates_in_request:
+            return Response(
+                f"Error processing data, either duplicate private_identifiers: {duplicates_in_request['duplicate_private_ids']} or duplicate public identifiers: {duplicates_in_request['duplicate_public_ids']} are trying to be uploaded at the same time, please remove duplicates before proceeding with upload.",
+                400,
+            )
+
         already_exists: Union[
             None, Mapping[str, list[str]]
         ] = api_utils.check_duplicate_samples(request_data, db_session)
         if already_exists:
             return Response(
-                f"Duplicate fields found in db private_identifiers {already_exists['existing_private_ids']} and public_identifiers: {already_exists['existing_public_ids']}",
+                f"Error inserting data, private_identifiers {already_exists['existing_private_ids']} or public_identifiers: {already_exists['existing_public_ids']} already exist in our database, please remove these samples before proceeding with upload.",
                 400,
             )
         public_ids = create_public_ids(user.group_id, db_session, len(request_data))

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -288,7 +288,7 @@ def create_sample():
         ] = api_utils.check_duplicate_data_in_request(request_data)
         if duplicates_in_request:
             return Response(
-                f"Error processing data, either duplicate private_identifiers: {duplicates_in_request['duplicate_private_ids']} or duplicate public identifiers: {duplicates_in_request['duplicate_public_ids']} are trying to be uploaded at the same time, please remove duplicates before proceeding with upload.",
+                f"Error processing data, either duplicate private_identifiers: {duplicates_in_request['duplicate_private_ids']} or duplicate public identifiers: {duplicates_in_request['duplicate_public_ids']} exist in the upload files, please rename duplicates before proceeding with upload.",
                 400,
             )
 

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -918,7 +918,7 @@ def test_samples_create_view_fail_duplicate_ids_in_request_data(
     assert res.status == "400 BAD REQUEST"
     assert (
         res.get_data()
-        == b"Error processing data, either duplicate private_identifiers: ['private'] or duplicate public identifiers: [] are trying to be uploaded at the same time, please remove duplicates before proceeding with upload."
+        == b"Error processing data, either duplicate private_identifiers: ['private'] or duplicate public identifiers: [] exist in the upload files, please rename duplicates before proceeding with upload."
     )
 
 

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -847,6 +847,60 @@ def test_samples_create_view_fail_duplicate_ids(
         },
         {
             "sample": {
+                "private_identifier": "private1",
+                "public_identifier": "",
+                "collection_date": api_utils.format_date(datetime.datetime.now()),
+                "location": "Ventura County",
+                "private": True,
+            },
+            "pathogen_genome": {
+                "sequence": "AACTGTNNNN",
+                "sequencing_date": "",
+                "isl_access_number": "test_accession_number2",
+            },
+        },
+    ]
+    res = client.post("/api/samples/create", json=data, content_type="application/json")
+    assert res.status == "400 BAD REQUEST"
+    assert (
+        res.get_data()
+        == b"Error inserting data, private_identifiers ['private'] or public_identifiers: ['public'] already exist in our database, please remove these samples before proceeding with upload."
+    )
+
+
+def test_samples_create_view_fail_duplicate_ids_in_request_data(
+    session,
+    app,
+    client,
+):
+    group = group_factory()
+    user = user_factory(group)
+    session.add(group)
+    sample = sample_factory(
+        group, user, private_identifier="private", public_identifier="public"
+    )
+    session.add(sample)
+    session.commit()
+    with client.session_transaction() as sess:
+        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
+
+    data = [
+        {
+            "sample": {
+                "private_identifier": "private",
+                "public_identifier": "public",
+                "collection_date": api_utils.format_date(datetime.datetime.now()),
+                "location": "Ventura County",
+                "private": True,
+            },
+            "pathogen_genome": {
+                "sequence": "AAAAAXNTCG",
+                "sequencing_date": "",
+                "isl_access_number": "test_accession_number",
+            },
+        },
+        {
+            "sample": {
                 "private_identifier": "private",
                 "public_identifier": "",
                 "collection_date": api_utils.format_date(datetime.datetime.now()),
@@ -864,7 +918,7 @@ def test_samples_create_view_fail_duplicate_ids(
     assert res.status == "400 BAD REQUEST"
     assert (
         res.get_data()
-        == b"Duplicate fields found in db private_identifiers ['private'] and public_identifiers: ['public']"
+        == b"Error processing data, either duplicate private_identifiers: ['private'] or duplicate public identifiers: [] are trying to be uploaded at the same time, please remove duplicates before proceeding with upload."
     )
 
 


### PR DESCRIPTION
### Description

Error messages for duplicate samples were not super specific, this adds better error messaging for if there were duplicates in the request or if a user was trying to add data to the database that already exists

#### Issue
[ch144041](https://app.clubhouse.io/genepi/story/144041)

### Test plan

added unit test, also tested on rdev: https://better-error-messaging-frontend.dev.genepi.czi.technology

new error messages: 
<img width="607" alt="Screen Shot 2021-06-23 at 12 49 52 PM" src="https://user-images.githubusercontent.com/13052132/123159583-099a0f00-d422-11eb-9ae5-a9258d74c663.png">
<img width="600" alt="Screen Shot 2021-06-23 at 12 51 03 PM" src="https://user-images.githubusercontent.com/13052132/123159587-0acb3c00-d422-11eb-9acb-4b055521e02b.png">

