### PR TITLE
fix public ID not converting to private ID on tree

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -172,7 +172,7 @@ def _process_phylo_tree(
             return sample.submitting_group_id in can_see_group_ids_pi
 
     identifier_map: Mapping[str, str] = {
-        sample.public_identifier: sample.private_identifier
+        sample.public_identifier.replace("hCoV-19/","") : sample.private_identifier
         for sample in phylo_tree.constituent_samples
         if sample_filter(sample)
     }

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -172,7 +172,9 @@ def _process_phylo_tree(
             return sample.submitting_group_id in can_see_group_ids_pi
 
     identifier_map: Mapping[str, str] = {
-        sample.public_identifier.replace("hCoV-19/","") : sample.private_identifier
+        sample.public_identifier.replace(
+            "hCoV-19/",""
+        ) : sample.private_identifier
         for sample in phylo_tree.constituent_samples
         if sample_filter(sample)
     }

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -173,7 +173,7 @@ def _process_phylo_tree(
 
     identifier_map: Mapping[str, str] = {
         sample.public_identifier.replace(
-            "hCoV-19/",""
+            "hCoV-19/", ""
         ) : sample.private_identifier
         for sample in phylo_tree.constituent_samples
         if sample_filter(sample)

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -172,7 +172,7 @@ def _process_phylo_tree(
             return sample.submitting_group_id in can_see_group_ids_pi
 
     identifier_map: Mapping[str, str] = {
-        sample.public_identifier.replace("hCoV-19/", "") : sample.private_identifier
+        sample.public_identifier.replace("hCoV-19/", ""): sample.private_identifier
         for sample in phylo_tree.constituent_samples
         if sample_filter(sample)
     }

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -172,9 +172,7 @@ def _process_phylo_tree(
             return sample.submitting_group_id in can_see_group_ids_pi
 
     identifier_map: Mapping[str, str] = {
-        sample.public_identifier.replace(
-            "hCoV-19/", ""
-        ) : sample.private_identifier
+        sample.public_identifier.replace("hCoV-19/", "") : sample.private_identifier
         for sample in phylo_tree.constituent_samples
         if sample_filter(sample)
     }


### PR DESCRIPTION
### Description

Trees' public ID gets converted to private ID before uploaded to Aspen. The public ID Humboldt uploaded is the full Gisiad ID that looks like "hCoV-19/USA/CA-HC-P2117185/2021", but the "hCoV-19/" part got stripped by Nextstrain in the tree building. So the step to convert public ID to private ID didn't work b/c the ID in tree json doesn't match the public ID in our database. 

I don't know whether it makes more sense to strip "hCoV-19/" in our database instead of the fix proposed here.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

The added piece worked in Python console. 
