### PR TITLE
[DO NOT MERGE] smart retries

### DIFF
--- a/.happy/terraform/modules/swipe-sfn/sfn.yml
+++ b/.happy/terraform/modules/swipe-sfn/sfn.yml
@@ -43,33 +43,29 @@ States:
           - Name: SFN_CURRENT_STATE
             Value.$: $$.State.Name
     ResultPath: $.BatchJobDetails.Run
-    Next: RunSPOTReadOutput
+    Next: RunReadOutput
     Retry: &BatchRetryConfig
       - ErrorEquals: ["Batch.AWSBatchException"]
         IntervalSeconds: 15
         MaxAttempts: 3
+        BackoffRate: 2.0
     Catch:
       - ErrorEquals: ["States.ALL"]
         ResultPath: $.BatchJobError.RunSPOT
-        Next: RunSPOTReadOutput
-  RunSPOTReadOutput:
-    Type: Task
-    Resource: arn:aws:states:::lambda:invoke
-    Parameters: &ReadOutputParameters
-      FunctionName: "${process-stage-output}"
-      Payload: *PassthroughStatePayload
-    OutputPath: $.Payload
-    Next: HandleSuccess
-    Catch:
-      - ErrorEquals: &InputErrors
-          - InvalidInputFileError
-          - InsufficientReadsError
-          - BrokenReadPairError
-          - InvalidFileFormatError
-        Next: HandleFailure
-      - ErrorEquals: ["States.ALL"]
-        ResultPath: $.BatchJobError.RunSPOT
+        Next: RunGetCause
+  RunGetCause:
+    Type: Pass
+    Parameters:
+      "Cause.$": "States.StringToJson($.BatchJobError.RunSPOT.Cause)"
+    ResultPath: "$.BatchJobError.RunSPOT"
+    Next: RunDetectError
+  RunDetectError:
+    Type: Choice
+    Choices:
+      - Variable: "$.BatchJobError.RunSPOT.Cause.StatusReason"
+        StringMatches: "Host EC2 (instance i-*) terminated."
         Next: RunEC2
+    Default: RunReadOutput
   RunEC2:
     Type: Task
     Resource: arn:aws:states:::batch:submitJob.sync
@@ -83,16 +79,18 @@ States:
         Memory.$: $.RunEC2Memory
         Environment: *RunEnvironment
     ResultPath: $.BatchJobDetails.Run
-    Next: RunEC2ReadOutput
+    Next: RunReadOutput
     Retry: *BatchRetryConfig
     Catch:
       - ErrorEquals: ["States.ALL"]
         ResultPath: $.BatchJobError.RunEC2
-        Next: RunEC2ReadOutput
-  RunEC2ReadOutput:
+        Next: RunReadOutput
+  RunReadOutput:
     Type: Task
     Resource: arn:aws:states:::lambda:invoke
-    Parameters: *ReadOutputParameters
+    Parameters:
+      FunctionName: "${process-stage-output}"
+      Payload: *PassthroughStatePayload
     OutputPath: $.Payload
     Next: HandleSuccess
     Catch:


### PR DESCRIPTION
### Description

**DO NOT MERGE**: this PR https://github.com/chanzuckerberg/genepi-infra/pull/54 must be deployed at the same time. It contains the lambda elements of this change.

This ports smart retries to aspen: https://github.com/chanzuckerberg/swipe/pull/8.

Right now if the job fails on spot for any reason (except one of our hard-coded idseq-specific error types) it will retry on-demand. This is not ideal because retrying on-demand is only helpful if the failure happened because of spot termination. This change only retries on demand if the job was terminated because the instance shut down (which should only be due to a spot instance termination). This prevents costly, wasteful retries.

I am trying to merge this now because I am about to do the error notifications and I want to bring those into swipe then aspen as well and I didn't want to apply stuff out of order and have things drift out of sync.

#### Issue
None

### Test plan

This change has worked pretty well on the idseq side. There was one bug but it has since been fixed so I am pretty confident. Any test that tests the workflows will also be testing this.
