### PR TITLE
strip hCoV-19 when comparing public ID

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/save.py
+++ b/src/backend/aspen/workflows/nextstrain_run/save.py
@@ -121,7 +121,7 @@ def cli(
         included_samples: MutableSequence[Sample] = list()
         for uploaded_pathogen_genome in uploaded_pathogen_genomes:
             if (
-                uploaded_pathogen_genome.sample.public_identifier
+                uploaded_pathogen_genome.sample.public_identifier.replace("hCoV-19/", "")
                 in all_public_identifiers
             ):
                 included_samples.append(uploaded_pathogen_genome.sample)

--- a/src/backend/aspen/workflows/nextstrain_run/save.py
+++ b/src/backend/aspen/workflows/nextstrain_run/save.py
@@ -121,7 +121,9 @@ def cli(
         included_samples: MutableSequence[Sample] = list()
         for uploaded_pathogen_genome in uploaded_pathogen_genomes:
             if (
-                uploaded_pathogen_genome.sample.public_identifier.replace("hCoV-19/", "")
+                uploaded_pathogen_genome.sample.public_identifier.replace(
+                    "hCoV-19/", ""
+                )
                 in all_public_identifiers
             ):
                 included_samples.append(uploaded_pathogen_genome.sample)


### PR DESCRIPTION
### Description

Team debug with Phoenix: trees are not showing the private ID for user-uploaded genomes b/c their public IDs contain "hCoV-19/" which nextstrain strips during tree build and therefore no longer match our database. The workflow is: we pull all sample names from the tree, first filter for those that are in our database [here](https://github.com/chanzuckerberg/aspen/blob/63471f3adf26f13aa0a4a6867708cac14b67317c/src/backend/aspen/workflows/nextstrain_run/save.py) and send them to be renamed [here](https://github.com/chanzuckerberg/aspen/blob/5ca52af0f19a1da1a019024a48d8ebfa1cdbd409/src/backend/aspen/app/views/phylo_trees.py). We fixed the name mismatch in the 2nd step in #506 and now the 1st step in this PR. 

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

I uploaded a few samples with "hCoV-19/" in their public ID to Santa Clara smoke test staging account. Will wait for the tree build on staging tonight to see their IDs on tree. 