### PR TITLE
[Small] Explicitly exclude .terraform folder in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,6 +312,7 @@ static
 /.terraform.*/
 /.terraform.lock.hcl
 /terraform/variables.tf
+.terraform
 
 # VS Code
 .vscode


### PR DESCRIPTION
### Description

The previous patterns to exclude Terraform folders did not filter out the `.terraform/` folder on my machine, so this explicitly excludes it.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Run `git add .` then `git status` and see that the folder is not included.
