### PR TITLE
remove read output lambda reference

### DIFF
--- a/.happy/terraform/modules/swipe-sfn/sfn.yml
+++ b/.happy/terraform/modules/swipe-sfn/sfn.yml
@@ -43,7 +43,7 @@ States:
           - Name: SFN_CURRENT_STATE
             Value.$: $$.State.Name
     ResultPath: $.BatchJobDetails.Run
-    Next: RunReadOutput
+    Next: HandleSuccess
     Retry: &BatchRetryConfig
       - ErrorEquals: ["Batch.AWSBatchException"]
         IntervalSeconds: 15
@@ -65,7 +65,7 @@ States:
       - Variable: "$.BatchJobError.RunSPOT.Cause.StatusReason"
         StringMatches: "Host EC2 (instance i-*) terminated."
         Next: RunEC2
-    Default: RunReadOutput
+    Default: HandleFailure
   RunEC2:
     Type: Task
     Resource: arn:aws:states:::batch:submitJob.sync
@@ -79,22 +79,11 @@ States:
         Memory.$: $.RunEC2Memory
         Environment: *RunEnvironment
     ResultPath: $.BatchJobDetails.Run
-    Next: RunReadOutput
+    Next: HandleSuccess
     Retry: *BatchRetryConfig
     Catch:
       - ErrorEquals: ["States.ALL"]
         ResultPath: $.BatchJobError.RunEC2
-        Next: RunReadOutput
-  RunReadOutput:
-    Type: Task
-    Resource: arn:aws:states:::lambda:invoke
-    Parameters:
-      FunctionName: "${process-stage-output}"
-      Payload: *PassthroughStatePayload
-    OutputPath: $.Payload
-    Next: HandleSuccess
-    Catch:
-      - ErrorEquals: ["States.ALL"]
         Next: HandleFailure
   HandleSuccess:
     Type: Task


### PR DESCRIPTION
### Description

This fixes a bug and also makes stuff simpler. It turns out with smart retries we don't even need this lambda here (it is just needed for our main pipeline which is more complex). I already removed it on our end: https://github.com/chanzuckerberg/idseq/pull/344 and in swipe: https://github.com/chanzuckerberg/swipe/pull/11.

#### Issue
N/A

### Test plan

Tested in IDSeq
