### PR TITLE
Add undefined guard to table row rendering

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable sonarjs/cognitive-complexity */
+/** TODO: Re-evaluate if there really is a complexity problem here **/
+
 import { get, isEqual } from "lodash/fp";
 import React, { Fragment, FunctionComponent, useReducer } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -138,20 +141,15 @@ export const DataTable: FunctionComponent<Props> = ({
   };
 
   const render = (tableData: TableItem[]) => {
-    
     function renderRow(props: ListChildComponentProps) {
       const item = tableData[props.index];
-      if (item == undefined) {
-        return;
-      } else {
-        return (
-          <TableRow style={props.style} data-test-id="table-row">
-            {sampleRow(item)}
-          </TableRow>
-        );
-      }
+      return (
+        <TableRow style={props.style} data-test-id="table-row">
+          {item === undefined ? null : sampleRow(item)}
+        </TableRow>
+      );
     }
-    
+
     return (
       <div className={style.container}>
         <div className={style.header} data-test-id="header-row">

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -138,15 +138,20 @@ export const DataTable: FunctionComponent<Props> = ({
   };
 
   const render = (tableData: TableItem[]) => {
+    
     function renderRow(props: ListChildComponentProps) {
       const item = tableData[props.index];
-
-      return (
-        <TableRow style={props.style} data-test-id="table-row">
-          {sampleRow(item)}
-        </TableRow>
-      );
+      if (item == undefined) {
+        return;
+      } else {
+        return (
+          <TableRow style={props.style} data-test-id="table-row">
+            {sampleRow(item)}
+          </TableRow>
+        );
+      }
     }
+    
     return (
       <div className={style.container}>
         <div className={style.header} data-test-id="header-row">


### PR DESCRIPTION
### Description

Prevents the `sampleRow()` functioned from being called with undefined data, which might create errors (and @phoenixAja has run into problems with this and expanding table functionality)

#### Issue
[ch146170](https://app.clubhouse.io/genepi/story/146170)

### Test plan

Tested with console logging.
