### PR TITLE
Revert "remove read output lambda reference (#579)"

### DIFF
--- a/.happy/terraform/modules/swipe-sfn/sfn.yml
+++ b/.happy/terraform/modules/swipe-sfn/sfn.yml
@@ -43,7 +43,7 @@ States:
           - Name: SFN_CURRENT_STATE
             Value.$: $$.State.Name
     ResultPath: $.BatchJobDetails.Run
-    Next: HandleSuccess
+    Next: RunReadOutput
     Retry: &BatchRetryConfig
       - ErrorEquals: ["Batch.AWSBatchException"]
         IntervalSeconds: 15
@@ -65,7 +65,7 @@ States:
       - Variable: "$.BatchJobError.RunSPOT.Cause.StatusReason"
         StringMatches: "Host EC2 (instance i-*) terminated."
         Next: RunEC2
-    Default: HandleFailure
+    Default: RunReadOutput
   RunEC2:
     Type: Task
     Resource: arn:aws:states:::batch:submitJob.sync
@@ -79,11 +79,22 @@ States:
         Memory.$: $.RunEC2Memory
         Environment: *RunEnvironment
     ResultPath: $.BatchJobDetails.Run
-    Next: HandleSuccess
+    Next: RunReadOutput
     Retry: *BatchRetryConfig
     Catch:
       - ErrorEquals: ["States.ALL"]
         ResultPath: $.BatchJobError.RunEC2
+        Next: RunReadOutput
+  RunReadOutput:
+    Type: Task
+    Resource: arn:aws:states:::lambda:invoke
+    Parameters:
+      FunctionName: "${process-stage-output}"
+      Payload: *PassthroughStatePayload
+    OutputPath: $.Payload
+    Next: HandleSuccess
+    Catch:
+      - ErrorEquals: ["States.ALL"]
         Next: HandleFailure
   HandleSuccess:
     Type: Task


### PR DESCRIPTION
This reverts commit 13f7d0fc994a4bfa62446746483a5e114c6127ff.

### Description

This was not a good idea. It won't break anything for you but I can't do this for compatibility reasons so I will push a different fix like I did for IDSeq. See the IDSeq PR: https://github.com/chanzuckerberg/idseq/pull/346

#### Issue
N/A

### Test plan

None, reversion
