### PR TITLE
feat[imdsv2]: support for imdsv2

### DIFF
--- a/src/backend/aspen/aws/elasticbeanstalk.py
+++ b/src/backend/aspen/aws/elasticbeanstalk.py
@@ -6,8 +6,12 @@ from aspen.aws._session import session
 
 
 def _get_instance_id() -> str:
+    # supporting IMDSv2 instances
+    token = requests.put("http://169.254.169.254/latest/api/token",
+                         headers={"X-aws-ec2-metadata-token-ttl-seconds": 21600})
     document = requests.get(
-        "http://169.254.169.254/latest/dynamic/instance-identity/document"
+        "http://169.254.169.254/latest/dynamic/instance-identity/document",
+        headers={"X-aws-ec2-metadata-token": token}
     ).json()
     return document["instanceId"]
 
@@ -51,4 +55,4 @@ def get_environment_suffix(prefix: str = "aspen-") -> str:
     """Get all Elastic Beanstalk environment name, excluding the aspen- prefix."""
     name = _get_environment_name()
     assert name.startswith(prefix)
-    return name[len(prefix) :]
+    return name[len(prefix):]


### PR DESCRIPTION
### Description

This PR updates the `_get_instance_id()` function to support AWS IMDSv2 (version 2 of the AWS metadata endpoint). Right now, prodsec and infrasec are trying to enable this feature to help defend against Server-Side Request Forgery (SSRF) attacks, but it requires that call calls to the metadata endpoint first make a PUT request to grab a short-lived token and then make a GET request to the metadata endpoint with that token in the header.

### References

* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
* https://czi.atlassian.net/wiki/spaces/INFRASEC/pages/2090696711/AWS+Metadata+V2+Migration
* https://github.com/chanzuckerberg/SSRFs-Up
* https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
* https://github.com/chanzuckerberg/SSRFs-Up/wiki/FAQ#i-read-the-other-docs-but-i-still-dont-really-get-why-this-matters-can-you-provide-an-example-of-how-ssrf-affects-my-application