### PR TITLE
updating imdsv2

### DIFF
--- a/.happy/terraform/modules/batch/container_properties.yml
+++ b/.happy/terraform/modules/batch/container_properties.yml
@@ -17,7 +17,7 @@ command:
   - "set +a"
   - >-
     while true; do
-    if TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" && curl -H "X-aws-ec2-metadata-token: $TOKEN" -sf http://169.254.169.254/latest/meta-data/spot/instance-action; then
+    if TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" -sf http://169.254.169.254/latest/meta-data/spot/instance-action; then
     echo WARNING: THIS SPOT INSTANCE HAS BEEN SCHEDULED FOR TERMINATION >> /dev/stderr;
     fi;
     sleep 10;

--- a/.happy/terraform/modules/batch/container_properties.yml
+++ b/.happy/terraform/modules/batch/container_properties.yml
@@ -9,7 +9,7 @@ image: "${batch_docker_image}"
 command:
   - "/bin/bash"
   - "-c"
-  - "for i in \"$@\"; do eval \"$i\"; done; cd /"
+  - 'for i in "$@"; do eval "$i"; done; cd /'
   - "swipe"
   - "set -a"
   - "if [ -f /etc/environment ]; then source /etc/environment; fi"
@@ -17,7 +17,7 @@ command:
   - "set +a"
   - >-
     while true; do
-    if curl -sf http://169.254.169.254/latest/meta-data/spot/instance-action; then
+    if TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" && curl -H "X-aws-ec2-metadata-token: $TOKEN" -sf http://169.254.169.254/latest/meta-data/spot/instance-action; then
     echo WARNING: THIS SPOT INSTANCE HAS BEEN SCHEDULED FOR TERMINATION >> /dev/stderr;
     fi;
     sleep 10;
@@ -126,10 +126,10 @@ ulimits:
 privileged: false
 readonlyRootFilesystem: false
 logConfiguration:
-    logDriver: "awslogs"
-    options:
-      awslogs-group: "${log_group}"
-      awslogs-region: "${aws_region}"
+  logDriver: "awslogs"
+  options:
+    awslogs-group: "${log_group}"
+    awslogs-region: "${aws_region}"
 
 # The AWS Batch API requires two resource quotas: vCPU and memory. Memory contention or starvation is more dangerous
 # than CPU contention (an OOM condition will cause a job to fail, while lower than expected CPU will just cause it to


### PR DESCRIPTION
### Description
This PR updates the Swipe configuration to utilize IMDSv2. Right now, prodsec and infrasec are trying to enable this feature to help defend against Server-Side Request Forgery (SSRF) attacks, but it requires the caller to the metadata endpoint first make a PUT request to grab a short-lived token and then make a GET request to the metadata endpoint with that token in the header.

I'm making this change here and also https://github.com/chanzuckerberg/swipe/issues/13

### References
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
https://czi.atlassian.net/wiki/spaces/INFRASEC/pages/2090696711/AWS+Metadata+V2+Migration
https://github.com/chanzuckerberg/SSRFs-Up
https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
https://github.com/chanzuckerberg/SSRFs-Up/wiki/FAQ#i-read-the-other-docs-but-i-still-dont-really-get-why-this-matters-can-you-provide-an-example-of-how-ssrf-affects-my-application