### PR TITLE
Convert the sample download endpoint to a POST request

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -146,7 +146,7 @@ def _format_lineage(sample: Sample) -> dict[str, Any]:
     return lineage
 
 
-@application.route("/api/sequences", methods=["GET"])
+@application.route("/api/sequences", methods=["POST"])
 @requires_auth
 def prepare_sequences_download():
     # stream output file

--- a/src/backend/aspen/app/views/tests/test_prepare_sequences_download.py
+++ b/src/backend/aspen/app/views/tests/test_prepare_sequences_download.py
@@ -26,7 +26,7 @@ def test_prepare_sequences_download(
             "sample_ids": [sample.public_identifier],
         }
     }
-    res = client.get("/api/sequences", json=data)
+    res = client.post("/api/sequences", json=data)
     assert res.status == "200 OK"
     expected_filename = f"{user.group.name}_sample_sequences.fasta"
     assert (
@@ -65,7 +65,7 @@ def test_prepare_sequences_download_no_access(
         }
     }
 
-    res = client.get("/api/sequences", json=data)
+    res = client.post("/api/sequences", json=data)
     assert res.status == "403 FORBIDDEN"
     assert res.get_data() == b"User does not have access to the requested sequences"
 
@@ -100,7 +100,7 @@ def test_prepare_sequences_download_no_private_id_access(
             "sample_ids": [sample.public_identifier],
         }
     }
-    res = client.get("/api/sequences", json=data)
+    res = client.post("/api/sequences", json=data)
     assert res.status == "200 OK"
     expected_filename = f"{user.group.name}_sample_sequences.fasta"
     assert (

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -105,6 +105,12 @@ class ApiClient:
         url = f"{self.url}{path}"
         return requests.get(url, headers=headers, allow_redirects=False, **kwargs)
 
+    def post(self, path, **kwargs):
+        access_token = self.token_handler.get_id_token()
+        headers = {"Authorization": f"Bearer {access_token}"}
+        url = f"{self.url}{path}"
+        return requests.post(url, headers=headers, allow_redirects=False, **kwargs)
+
 
 class CliConfig:
     api_urls = {
@@ -201,7 +207,7 @@ def samples():
 def download_samples(ctx, sample_ids):
     api_client = ctx.obj["api_client"]
     payload = {"requested_sequences": {"sample_ids": sample_ids}}
-    resp = api_client.get("/api/sequences", json=payload)
+    resp = api_client.post("/api/sequences", json=payload)
     print(resp.headers)
     print(resp.text)
 


### PR DESCRIPTION
### Description

- [CloudFront doesn't allow GET requests with a body](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustom-get-body) (this is pretty annoying since it's a pretty common pattern for REST api's)
- Most web browsers / server software has a limit on the length of a valid URL - 2000 characters is common.
- If our sample ID's are typically about 20 characters long, this limits us to being able to download about 100 samples at a time, and I think our goal is to be able to support larger batch downloads.

#### Issue
[ch144294](https://app.clubhouse.io/genepi/story/144294)

### Test plan

I've tested the CLI and API changes locally, I'm still able to download sequences
