### PR TITLE
Get associated phylo trees in the main query.

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -53,7 +53,10 @@ def phylo_trees():
         g.db_session.query(
             phylo_run_alias,
         )
-        .options(joinedload(phylo_run_alias.outputs))
+        .options(
+            joinedload(phylo_run_alias.outputs),
+            joinedload(phylo_run_alias.outputs.of_type(PhyloTree)),
+        )
         .filter(
             or_(
                 user.system_admin,


### PR DESCRIPTION
### Description

This should resolve the n+1 query issue in our phylo tree endpoint. [We use a similar trick here](https://github.com/chanzuckerberg/aspen/blob/trunk/src/backend/aspen/app/views/sample.py#L300).

#### Issue
[ch150554](https://app.clubhouse.io/genepi/story/150554)

### Test plan

Tests pass, and I verified via logs in local dev that we're only running one query for this endpoint.
