### PR TITLE
Add name column to phylo runs table

### DIFF
--- a/src/backend/database_migrations/versions/20210727_111359_add_name_field_to_phylo_run_table.py
+++ b/src/backend/database_migrations/versions/20210727_111359_add_name_field_to_phylo_run_table.py
@@ -1,0 +1,26 @@
+"""Add name field to phylo run table
+
+Create Date: 2021-07-27 11:13:59.925534
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20210727_111359"
+down_revision = "20210617_201052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "phylo_runs",
+        sa.Column("name", sa.String(), nullable=True),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_column("phylo_runs", "name", schema="aspen")

--- a/src/backend/database_migrations/versions/20210727_111359_add_name_field_to_phylo_run_table.py
+++ b/src/backend/database_migrations/versions/20210727_111359_add_name_field_to_phylo_run_table.py
@@ -7,7 +7,6 @@ import enumtables  # noqa: F401
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
 revision = "20210727_111359"
 down_revision = "20210617_201052"
 branch_labels = None
@@ -16,11 +15,11 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        "phylo_runs",
+        "phylo_trees",
         sa.Column("name", sa.String(), nullable=True),
         schema="aspen",
     )
 
 
 def downgrade():
-    op.drop_column("phylo_runs", "name", schema="aspen")
+    op.drop_column("phylo_trees", "name", schema="aspen")


### PR DESCRIPTION
### Description

Adds an alembic migration to add a name column to the phylo runs table.

#### Issue
[ch150140](https://app.clubhouse.io/genepi/story/150140)

### Test plan

tested locally with `docker-compose exec -T utility alembic upgrade head`
