### PR TITLE
Add fields to phylo tree & groups models

### DIFF
--- a/src/backend/aspen/database/models/phylo_tree.py
+++ b/src/backend/aspen/database/models/phylo_tree.py
@@ -42,6 +42,7 @@ class PhyloTree(Entity):
 
     s3_bucket = Column(String, nullable=False)
     s3_key = Column(String, nullable=False)
+    name = Column(String, nullable=True)
 
     constituent_samples = relationship(  # type: ignore
         Sample,

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -26,6 +26,8 @@ class Group(idbase, DictMixin):  # type: ignore
         nullable=False,
         comment="used for creating public identifiers for samples",
     )
+    division = Column(String, nullable=True)
+    location = Column(String, nullable=True)
 
     can_see: MutableSequence[CanSee]
     can_be_seen_by: MutableSequence[CanSee]


### PR DESCRIPTION
### Description

Once db migrations are complete in prod, let's update our models to make use of the new fields.

#### Issue
[ch150139](https://app.clubhouse.io/genepi/story/150139)

### Test plan

Python tests pass locally.
