### PR TITLE
Remove unused covidhub import module

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -221,22 +221,6 @@ module nextstrain_template_sfn_config {
   }
 }
 
-module covidhub_import_sfn_config {
-  source   = "../sfn_config"
-  app_name = "covidhub-import-sfn"
-  image    = "${local.covidhub_import_image_repo}:june-1-uploaded-by"
-  memory   = 16000
-  wdl_path = "workflows/covidhub-import.wdl"
-  custom_stack_name     = local.custom_stack_name
-  deployment_stage      = local.deployment_stage
-  remote_dev_prefix     = local.remote_dev_prefix
-  stack_resource_prefix = local.stack_resource_prefix
-  swipe_comms_bucket    = local.swipe_comms_bucket
-  swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
-  event_role_arn        = local.event_role_arn
-}
-
 module migrate_db {
   source                = "../migration"
   stack_resource_prefix = local.stack_resource_prefix


### PR DESCRIPTION
### Description

We deleted the covidhub import wdl file but left the terraform module that requests it in place, causing an error when applying it. This PR removes the module. 

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
