### PR TITLE
Fix backfill migration to check for uploaded pathogen genomes

### DIFF
--- a/src/backend/database_migrations/versions/20210728_213140_backfill_gisaid_epi_ids.py
+++ b/src/backend/database_migrations/versions/20210728_213140_backfill_gisaid_epi_ids.py
@@ -1497,12 +1497,13 @@ def upgrade():
     )
     for sample in samples_to_update:
         epi_isl = MISSING_EPI_ISL_MAPPING[sample.public_identifier]
-        sample.uploaded_pathogen_genome.add_accession(
-            repository_type=PublicRepositoryType.GISAID,
-            public_identifier=epi_isl,
-            workflow_start_datetime=datetime.datetime.now(),
-            workflow_end_datetime=datetime.datetime.now(),
-        )
+        if sample.uploaded_pathogen_genome:
+            sample.uploaded_pathogen_genome.add_accession(
+                repository_type=PublicRepositoryType.GISAID,
+                public_identifier=epi_isl,
+                workflow_start_datetime=datetime.datetime.now(),
+                workflow_end_datetime=datetime.datetime.now(),
+            )
     session.commit()
 
 


### PR DESCRIPTION
### Description

The 20210728 backfill migration is breaking in rdev because it's trying to call `add_accession()` on a sample's `uploaded_pathogen_genome` but it seems that at least one of them doesn't exist. This just adds a conditional statement to safely run the migration.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Tested by creating an rdev stack and successfully applying the migrations.
