### PR TITLE
[EZPZ] rename metadata tsv download

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -220,12 +220,16 @@ const DownloadModal = ({
 
   function getDownloadButton(): JSX.Element | undefined {
     // button will have different functionality depending on download type selected
+    const metadataFilename = `${groupName}_sample_sequences_${downloadDate
+      .toISOString()
+      .slice(0, 10)}_metadata.tsv`;
+
     if (isMetadataSelected && !isFastaSelected) {
       return (
         <CSVLink
           data={tsvRows}
           headers={tsvHeaders}
-          filename="samples_overview.tsv"
+          filename={metadataFilename}
           separator={separator}
           data-test-id="download-tsv-link"
         >
@@ -247,7 +251,7 @@ const DownloadModal = ({
         <CSVLink
           data={tsvRows}
           headers={tsvHeaders}
-          filename="samples_overview.tsv"
+          filename={metadataFilename}
           separator={separator}
           data-test-id="download-tsv-link"
         >

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -58,6 +58,9 @@ const DownloadModal = ({
   const groupName = data?.group?.name.toLowerCase().replace(/ /g, "_"); // format group name for sequences download file
   const downloadDate = new Date();
   const separator = "\t";
+  const downloadPrefix = `${groupName}_sample_sequences_${downloadDate
+    .toISOString()
+    .slice(0, 10)}`;
   const [tsvRows, setTsvRows] = useState<string[][]>([]);
   const [tsvHeaders, setTsvHeaders] = useState<string[]>([]);
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
@@ -94,9 +97,7 @@ const DownloadModal = ({
     onSuccess: (data: any) => {
       const link = document.createElement("a");
       link.href = window.URL.createObjectURL(data);
-      link.download = `${groupName}_sample_sequences_${downloadDate
-        .toISOString()
-        .slice(0, 10)}.fasta`;
+      link.download = `${downloadPrefix}.fasta`;
       link.click();
       link.remove();
       onClose();
@@ -220,9 +221,7 @@ const DownloadModal = ({
 
   function getDownloadButton(): JSX.Element | undefined {
     // button will have different functionality depending on download type selected
-    const metadataFilename = `${groupName}_sample_sequences_${downloadDate
-      .toISOString()
-      .slice(0, 10)}_metadata.tsv`;
+    const metadataFilename = `${downloadPrefix}_metadata.tsv`;
 
     if (isMetadataSelected && !isFastaSelected) {
       return (


### PR DESCRIPTION
### Description

Match tsv download to sequences download file name: 
ex: 
`czi_sample_sequences_2021-08-06_metadata.tsv`
`czi_sample_sequences_2021-08-06.fasta`

#### Issue
no issue

### Test plan
tested locally (can make an rdev, but thought that might be overkill, lmk if you want one!)

