### PR TITLE
[ch143538] hide columns when no samples have been submitted to gisaid

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/index.tsx
@@ -13,14 +13,15 @@ export default function FreeTextField({
   fieldKey,
   formik,
   isShown,
-}: Props): JSX.Element {
+}: Props): JSX.Element | null {
   const { handleChange, handleBlur, values, touched, errors } = formik;
 
   const errorMessage = touched[fieldKey] && errors[fieldKey];
 
+  if (!isShown) return null;
+
   return (
     <StyledTextField
-      isShown={isShown}
       name={fieldKey}
       margin="dense"
       variant="outlined"

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/style.ts
@@ -1,25 +1,14 @@
 import styled from "@emotion/styled";
 import TextField from "@material-ui/core/TextField";
-import { getSpacings, Props as CommonProps } from "czifui";
+import { getSpacings, Props } from "czifui";
 
-interface Props extends CommonProps {
-  isShown: boolean;
-}
-
-// (thuang): Please keep this in sync with the props used in `Props`
-const doNotForwardProps = ["isShown"];
-
-export const StyledTextField = styled(TextField, {
-  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
-})`
+export const StyledTextField = styled(TextField)`
   ${(props: Props) => {
     const spacings = getSpacings(props);
-    const { isShown } = props;
 
     return `
       width: ${(spacings?.l || 0) + 200}px;
       padding-right: ${spacings?.l}px;
-      visibility: ${isShown ? "default" : "hidden"};
       margin: 0;
     `;
   }}

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/index.tsx
@@ -53,7 +53,7 @@ export default function Table({
     );
 
     return () => clearTimeout(timeout);
-  }, []);
+  }, [metadata]);
 
   useEffect(() => {
     if (hasImportedFile) {
@@ -65,7 +65,7 @@ export default function Table({
     const isValid = Object.values(rowValidation).every((isValid) => isValid);
 
     setIsValid(isValid);
-  }, [rowValidation]);
+  }, [rowValidation, setIsValid]);
 
   const handleRowValidation_ = (id: string, isValid: boolean) => {
     if (rowValidation[id] === isValid) return;
@@ -73,7 +73,9 @@ export default function Table({
     setRowValidation((prevState) => ({ ...prevState, [id]: isValid }));
   };
 
-  const handleRowValidation = useCallback(handleRowValidation_, []);
+  const handleRowValidation = useCallback(handleRowValidation_, [
+    rowValidation,
+  ]);
 
   const handleRowMetadata_ = (id: string, sampleMetadata: Metadata) => {
     setMetadata((prevMetadata) => {
@@ -100,7 +102,7 @@ export default function Table({
     });
   };
 
-  const applyToAllColumn = useCallback(applyToAllColumn_, []);
+  const applyToAllColumn = useCallback(applyToAllColumn_, [setMetadata]);
 
   if (!isReadyToRenderTable) {
     return (

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/index.tsx
@@ -1,4 +1,5 @@
 import { Table as MuiTable, TableBody, TableHead } from "@material-ui/core";
+import { reduce } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
 import {
@@ -112,6 +113,16 @@ export default function Table({
     );
   }
 
+  const shouldShowGISAIDFields = reduce(
+    metadata,
+    (shouldShow, data) => {
+      if (shouldShow) return true;
+      if (data?.submittedToGisaid) return true;
+      return false;
+    },
+    false
+  );
+
   return (
     <Overflow>
       <form autoComplete="off">
@@ -137,12 +148,16 @@ export default function Table({
                 <SubmittedToGisaidTableCell align="center" component="div">
                   {METADATA_KEYS_TO_HEADERS.submittedToGisaid}
                 </SubmittedToGisaidTableCell>
-                <StyledTableCell component="div">
-                  {METADATA_KEYS_TO_HEADERS.publicId}
-                </StyledTableCell>
-                <StyledTableCell component="div">
-                  {METADATA_KEYS_TO_HEADERS.islAccessionNumber}
-                </StyledTableCell>
+                {shouldShowGISAIDFields && (
+                  <>
+                    <StyledTableCell component="div">
+                      {METADATA_KEYS_TO_HEADERS.publicId}
+                    </StyledTableCell>
+                    <StyledTableCell component="div">
+                      {METADATA_KEYS_TO_HEADERS.islAccessionNumber}
+                    </StyledTableCell>
+                  </>
+                )}
               </StyledTableRow>
             </TableHead>
             {metadata && (


### PR DESCRIPTION
### Summary
- **What:** Hide Sample ID and ISL # fields on metadata upload page if no samples have been submitted to GISAID yet
- **Why:** design request
- **Ticket**: [ch143538](https://app.clubhouse.io/genepi/story/143538/hide-public-id-and-isl-columns-if-no-samples-have-been-submitted-to-gisaid)

### Demos
#### Before: 
![Screen Shot 2021-08-06 at 1 46 05 PM](https://user-images.githubusercontent.com/7562933/128577864-7fb5106d-0f66-407a-ac7c-503c769e5663.png)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/128577968-01a9633e-1d48-47a5-83f9-14af6a28d007.gif)

### Notes
Since the `isShown` property was only used in this particular case, I removed it to keep things clean :)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)