### PR TITLE
Phoenix/change sample table ordering

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -56,9 +56,9 @@ export function defaultHeaderRenderer({
   );
 }
 
-function defaultSorting(a: TableItem[], b: TableItem[], sortKey: string[]) {
+function defaultSorting(a: TableItem, b: TableItem, sortKey: string[]) {
   return String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
-};
+}
 
 function sortData(
   data: TableItem[],

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -56,6 +56,10 @@ export function defaultHeaderRenderer({
   );
 }
 
+function defaultSorting(a: TableItem[], b: TableItem[], sortKey: string[]) {
+  return String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
+};
+
 function sortData(
   data: TableItem[],
   sortKey: string[],
@@ -73,10 +77,10 @@ function sortData(
       } else if (uploadDateBIsNA && !uploadDateAIsNA) {
         order = 1;
       } else {
-        order = String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
+        order = defaultSorting(a, b, sortKey);
       }
     } else {
-      order = String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
+      order = defaultSorting(a, b, sortKey);
     }
 
     if (!ascending) {

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -62,11 +62,28 @@ function sortData(
   ascending: boolean
 ): TableItem[] {
   return data.sort((a, b): number => {
-    let order = String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
-    if (!ascending) {
-      order = order * -1;
+    let order = 0;
+    if (sortKey[0] === "uploadDate") {
+      const uploadDateAIsNA = a["uploadDate"] === "N/A";
+      const uploadDateBIsNA = b["uploadDate"] === "N/A";
+      if (uploadDateAIsNA && uploadDateBIsNA) {
+        order = 0;
+      } else if (uploadDateAIsNA && !uploadDateBIsNA) {
+        order = -1;
+      } else if (uploadDateBIsNA && !uploadDateAIsNA) {
+        order = 1;
+      } else {
+        order = String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
+      }
+    } else {
+      order = String(get(sortKey, a)).localeCompare(String(get(sortKey, b)));
     }
-    return order;
+
+    if (!ascending) {
+      return order * -1;
+    } else {
+      return order;
+    }
   });
 }
 


### PR DESCRIPTION
### Description

change sample table ordering (failed genome recovery on bottom, most recent upload dates at the top)


#### Issue
[ch150409](https://app.clubhouse.io/genepi/story/150409)

### Test plan
updated tests, tested locally,  and rdev: https://sample-table-ordering-frontend.dev.genepi.czi.technology/data/samples

