### PR TITLE
Support device authorization flow in local dev.

### DIFF
--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -3,12 +3,12 @@
     "ClientId": "local-client-id",
     "ClientSecrets": ["local-client-secret"],
     "Description": "Client for client credentials flow",
-    "AllowedGrantTypes": ["authorization_code"],
+    "AllowedGrantTypes": ["authorization_code", "urn:ietf:params:oauth:grant-type:device_code"],
     "RedirectUris": [
       "https://backend.genepinet.local:3000/callback",
       "http://backend.genepinet.local:3000/callback"
     ],
-    "AllowedScopes": ["openid", "profile", "email", "offline_access"],
+    "AllowedScopes": ["openid", "profile", "email", "offline_access", "device_code"],
     "AllowAccessTokensViaBrowser": true,
     "AlwaysIncludeUserClaimsInIdToken": true,
     "AllowOfflineAccess": true,

--- a/src/backend/aspen/app/app.py
+++ b/src/backend/aspen/app/app.py
@@ -1,11 +1,14 @@
 import os
+import time
 from functools import wraps
 from pathlib import Path
 from typing import Optional
 
+import requests
 import sentry_sdk
 from auth0.v3.authentication.token_verifier import (
     AsymmetricSignatureVerifier,
+    JwksFetcher,
     TokenVerifier,
 )
 from auth0.v3.exceptions import TokenValidationError
@@ -81,6 +84,28 @@ auth0 = oauth.register(
 )
 
 
+class InsecureJwksFetcher(JwksFetcher):
+    def _fetch_jwks(self, force=False):
+        has_expired = self._cache_date + self._cache_ttl < time.time()
+
+        if not force and not has_expired:
+            # Return from cache
+            self._cache_is_fresh = False
+            return self._cache_value
+
+        # Invalidate cache and fetch fresh data
+        self._cache_value = {}
+        response = requests.get(self._jwks_url, verify=False)
+
+        if response.ok:
+            # Update cache
+            jwks = response.json()
+            self._cache_value = self._parse_jwks(jwks)
+            self._cache_is_fresh = True
+            self._cache_date = time.time()
+        return self._cache_value
+
+
 def validate_auth_header(auth_header):
     parts = auth_header.split()
 
@@ -96,11 +121,18 @@ def validate_auth_header(auth_header):
     domain = application.aspen_config.AUTH0_DOMAIN
     client_id = application.aspen_config.AUTH0_CLIENT_ID
 
-    jwks_url = f"https://{domain}/.well-known/jwks.json"
-    issuer = f"https://{domain}/"
+    # TODO, this should probably be a part of aspen config.
+    if "genepinet.local" in domain:
+        jwks_url = f"https://{domain}/.well-known/openid-configuration/jwks"
+        issuer = f"https://{domain}"
+        # Adapted from https://github.com/auth0/auth0-python#id-token-validation
+        sv = AsymmetricSignatureVerifier(jwks_url)
+        sv._fetcher = InsecureJwksFetcher(jwks_url)
+    else:
+        jwks_url = f"https://{domain}/.well-known/jwks.json"
+        issuer = f"https://{domain}/"
+        sv = AsymmetricSignatureVerifier(jwks_url)
 
-    # Adapted from https://github.com/auth0/auth0-python#id-token-validation
-    sv = AsymmetricSignatureVerifier(jwks_url)  # Reusable instance
     payload = sv.verify_signature(id_token)
     tv = TokenVerifier(signature_verifier=sv, issuer=issuer, audience=client_id)
     tv._verify_payload(payload)

--- a/src/backend/scripts/setup_dev_data.sh
+++ b/src/backend/scripts/setup_dev_data.sh
@@ -24,7 +24,7 @@ ${local_aws} secretsmanager update-secret --secret-id aspen-config --secret-stri
   "AUTH0_CLIENT_ID": "local-client-id",
   "AUTH0_CALLBACK_URL": "'"${BACKEND_URL}"'/callback",
   "AUTH0_CLIENT_SECRET": "local-client-secret",
-  "AUTH0_DOMAIN": "oidc",
+  "AUTH0_DOMAIN": "oidc.genepinet.local:8443",
   "AUTH0_BASE_URL": "'"${OIDC_INTERNAL_URL}"'",
   "AUTH0_USERINFO_URL": "connect/userinfo",
   "AUTH0_ACCESS_TOKEN_URL": "'"${OIDC_INTERNAL_URL}"'/connect/token",


### PR DESCRIPTION
### Description

This updates our localdev oidc identity provider, API, and CLI to support device authorization flow in local dev. Most of the changes are pretty straightforward:
- Tell OIDC that it's ok to support device authorization flow
- The localdev OIDC service has different endpoint URL's and response codes than auth0, so we need to support both interfaces now.
- The JWKS signature verifier breaks when it makes requests to our local OIDC service, which is using a self-signed certificate. We're telling the verifier to skip SSL cert verification in local dev.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
