### PR TITLE
[ch149228] showing table loading animation before data is loaded

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -135,9 +135,6 @@ export const DataTable: FunctionComponent<Props> = ({
   });
 
   const sampleRow = (item: TableItem): React.ReactNode => {
-    if (isLoading) {
-      return <EmptyState numOfColumns={headers.length} />;
-    }
     return headers.map((header, index) => {
       const value = item[header.key];
 
@@ -186,7 +183,12 @@ export const DataTable: FunctionComponent<Props> = ({
       return (
         <TableRow style={props.style} data-test-id="table-row">
           {showCheckboxes && rowCheckbox(item)}
-          {item ? sampleRow(item) : null}
+          {item ? (
+            sampleRow(item)
+          ) : (
+            <EmptyState numOfColumns={headers.length} />
+          )}
+          )
         </TableRow>
       );
     }


### PR DESCRIPTION
### Summary
- **What:** Display sample table loading animation when sample table is still in the loading state
- **Why:** To let users know the app is not broken while we load data
- **Ticket:** [[ch149228]](https://app.clubhouse.io/genepi/story/149228/loading-animation-not-showing-up-in-sampletable)

### Testing
1. Load Aspen
1. Verify loading animation appears while data is loading

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/128765783-75567261-e248-499e-956d-918b7a53bd80.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/128765796-a5c3523e-fc5d-4ce7-8b8d-d2a37f82eb86.gif)

### Notes
Resolves regression introduced [here](https://github.com/chanzuckerberg/aspen/pull/580/files).

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)