### PR TITLE
remove extraneous paren

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -188,7 +188,6 @@ export const DataTable: FunctionComponent<Props> = ({
           ) : (
             <EmptyState numOfColumns={headers.length} />
           )}
-          )
         </TableRow>
       );
     }


### PR DESCRIPTION
### Summary
- **What:** Remove extraneous parenthesis in every row on aspen 😱 
- **Why:** I accidentally introduced in it #626 
- **Ticket:** [[ch149228]](https://app.clubhouse.io/genepi/story/149228/loading-animation-not-showing-up-in-sampletable)

### Demos
#### Before: 
![Screen Shot 2021-08-09 at 4 47 59 PM](https://user-images.githubusercontent.com/7562933/128788375-a97d57c2-9e70-4868-9acb-f7ba15549464.png)

#### After: 
![Screen Shot 2021-08-09 at 4 47 36 PM](https://user-images.githubusercontent.com/7562933/128788305-80b76abf-121b-44a5-a3ce-d11d5b8fe29a.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)