### PR TITLE
[ch150281] add the most basic filter panel possible to the sample table

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.module.scss
+++ b/src/frontend/src/common/components/library/data_subview/index.module.scss
@@ -6,13 +6,15 @@
 .samplesRoot {
   align-items: stretch;
   flex-direction: column;
+  padding: $space-xl;
 
   .searchBar {
     display: flex;
     flex-direction: row;
+    align-items: center;
     justify-content: space-between;
     width: 100%;
-    margin-bottom: $space-l;
+    margin-bottom: $space-xxl;
 
     input {
       border-radius: $border-radius-l !important;

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -21,6 +21,7 @@ import {
   StyledDiv,
   StyledDownloadDisabledImage,
   StyledDownloadImage,
+  StyledFlexChildDiv,
   StyledLink,
   StyledSpan,
   TooltipDescriptionText,
@@ -329,7 +330,7 @@ const DataSubview: FunctionComponent<Props> = ({
             onClose={handleDownloadClose}
           />
         )}
-        <div className={style.samplesRoot}>
+        <StyledFlexChildDiv className={style.samplesRoot}>
           <div className={style.searchBar}>
             <div className={style.searchInput}>
               <Input
@@ -383,7 +384,7 @@ const DataSubview: FunctionComponent<Props> = ({
               renderer={renderer}
             />
           </div>
-        </div>
+        </StyledFlexChildDiv>
       </>
     );
   };

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -52,12 +52,6 @@ export const StyledChip = styled(Chip)`
 export const DownloadWrapper = styled.div`
   align-items: center;
   display: flex;
-  ${(props) => {
-    const spacings = getSpacings(props);
-    return `
-      padding-bottom: ${spacings?.xxl}px;
-    `;
-  }}
 `;
 
 export const StyledSpan = styled.span`
@@ -160,4 +154,8 @@ export const TooltipDescriptionText = styled.div`
       color: ${colors?.gray[400]};
   `;
   }}
+`;
+
+export const StyledFlexChildDiv = styled.div`
+  flex: 1 1 0;
 `;

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -1,0 +1,8 @@
+import React, { FC } from "react";
+import { StyledFilterPanel } from "./style";
+
+const FilterPanel: FC = () => {
+  return <StyledFilterPanel>I am a filter panel</StyledFilterPanel>;
+};
+
+export { FilterPanel };

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { getColors, getSpacings } from "czifui";
+
+export const StyledFilterPanel = styled.div`
+  ${(props) => {
+    const colors = getColors(props);
+    const spacings = getSpacings(props);
+    return `
+    border-right: ${spacings?.xxxs}px ${colors?.gray[200]} solid;
+    width: 200px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/Data/index.module.scss
+++ b/src/frontend/src/views/Data/index.module.scss
@@ -5,7 +5,6 @@
 .dataRoot {
   .navigation {
     width: 100%;
-    margin-bottom: $space-xl;
     border-bottom: $space-xxs solid $gray-lightest;
 
     .menu {
@@ -55,7 +54,7 @@
     // This is needed to ensure the div doesn't disappear
     // when the viewport height is too short
     height: calc(100% - 74px);
-    margin: 0 auto; 
+    margin: 0 auto;
     width: calc(100% - 14px);
     max-width:1308px;
   }

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -6,6 +6,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { Menu } from "semantic-ui-react";
 import { fetchSamples, fetchTrees } from "src/common/api";
 import { useProtectedRoute } from "src/common/queries/auth";
+import { FilterPanel } from "src/components/FilterPanel";
 import { DataSubview } from "../../common/components";
 import { EMPTY_OBJECT } from "../../common/constants/empty";
 import { ROUTES } from "../../common/routes";
@@ -13,7 +14,7 @@ import { SampleRenderer, TreeRenderer } from "./cellRenderers";
 import { SampleHeader } from "./headerRenderer";
 import { SAMPLE_HEADERS, SAMPLE_SUBHEADERS, TREE_HEADERS } from "./headers";
 import style from "./index.module.scss";
-import { Container } from "./style";
+import { Container, FlexContainer } from "./style";
 import { TREE_TRANSFORMS } from "./transforms";
 
 const TITLE: Record<string, string> = {
@@ -153,7 +154,8 @@ const Data: FunctionComponent = () => {
           {dataJSX.menuItems}
         </Menu>
       </div>
-      <div className={style.view}>
+      <FlexContainer className={style.view}>
+        {category.text === "Samples" && <FilterPanel />}
         <DataSubview
           key={router.asPath}
           isLoading={category.isDataLoading}
@@ -165,7 +167,7 @@ const Data: FunctionComponent = () => {
           renderer={category.renderer}
           viewName={category.text}
         />
-      </div>
+      </FlexContainer>
     </Container>
   );
 };

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -67,3 +67,7 @@ export const PrivacyIcon = styled.span`
   left: 30px;
   bottom: -2px;
 `;
+
+export const FlexContainer = styled.div`
+  display: flex;
+`;


### PR DESCRIPTION
### Summary
- **What:** Add the most basic filter panel possible to the samples table view
- **Why:** We need a place to organize ui and logic for sample filtering
- **Ticket:** [[ch150281]](https://app.clubhouse.io/genepi/story/150281/enable-filtering-of-the-sample-table-by-genome-recovery)

### Demos
![Screen Shot 2021-08-10 at 6 46 46 PM](https://user-images.githubusercontent.com/7562933/128957158-4abe4c32-3a32-42c4-8af4-f35ae9329c17.png)

### Notes
- Merging into our feature branch, so a half-baked version should be ok.
- I updated some styling on the existing components to get the border between the filter panel and the sample table to go all the way up to the nav bar (there was a gap with the previous styling).

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)