### PR TITLE
Cleanly handle the case where an auth0 user is not in the db

### DIFF
--- a/src/backend/aspen/app/app.py
+++ b/src/backend/aspen/app/app.py
@@ -180,7 +180,14 @@ def requires_auth(f):
             return redirect("/login")
         with session_scope(application.DATABASE_INTERFACE) as db_session:
             g.db_session = db_session
-            g.auth_user = setup_userinfo(auth0_user_id)
+            found_auth_user = setup_userinfo(auth0_user_id)
+            if not found_auth_user:
+                # login attempt from user not in DB
+                # TODO: return response to user that they do not have an account with aspen.
+                return redirect("/login")
+            else:
+                g.auth_user = found_auth_user
+            
             if not g.auth_user:
                 return redirect("/login")
             return f(*args, **kwargs)

--- a/src/backend/aspen/app/app.py
+++ b/src/backend/aspen/app/app.py
@@ -151,14 +151,14 @@ def setup_userinfo(user_id):
         sentry_sdk.capture_message(
             f"Requested auth0_user_id {user_id} not found in usergroup query."
         )
-        return redirect("/login")
-    g.auth_user = user
+        return None
     sentry_sdk.set_user(
         {
             "id": user.id,
             "auth0_uid": user.auth0_user_id,
         }
     )
+    return user
 
 
 # use this to wrap protected views
@@ -180,7 +180,7 @@ def requires_auth(f):
             return redirect("/login")
         with session_scope(application.DATABASE_INTERFACE) as db_session:
             g.db_session = db_session
-            setup_userinfo(auth0_user_id)
+            g.auth_user = setup_userinfo(auth0_user_id)
             if not g.auth_user:
                 return redirect("/login")
             return f(*args, **kwargs)

--- a/src/backend/aspen/app/app.py
+++ b/src/backend/aspen/app/app.py
@@ -187,9 +187,6 @@ def requires_auth(f):
                 return redirect("/login")
             else:
                 g.auth_user = found_auth_user
-            
-            if not g.auth_user:
-                return redirect("/login")
             return f(*args, **kwargs)
 
     return decorated


### PR DESCRIPTION
### Description

We have a few login attempts from auth0 users who are not in the db. Currently the `setup_userinfo()` function returns a redirect but does not stop execution in the parent `requires_auth()` function, raising an `AttributeError` when we check for `if not g.auth_user` since that attribute does not exist on `g`. This PR properly sets `g.auth_user` to `None`.

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Tested locally, logged in and logged out cases.
