### PR TITLE
Ondemand v2

### DIFF
--- a/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
@@ -71,10 +71,12 @@ task nextstrain_workflow {
                --phylo-run-id "~{workflow_id}"                        \
                --county-sequences ncov/data/sequences_aspen.fasta     \
                --county-metadata ncov/data/metadata_aspen.tsv         \
-               --sequences ncov/data/sequences_selected.fasta         \
-               --metadata ncov/data/metadata_selected.tsv             \
+               --selected ncov/data/include.txt                       \
                --builds-file ncov/my_profiles/aspen/builds.yaml       \
     )
+    # If we didn't have any explicitly selected samples, copy the reference genomes to include.txt
+    if [ ! -e ncov/data/include.txt ]; then cp ncov/defaults/include.txt ncov/data/include.txt; fi;
+
     aligned_gisaid_s3_bucket=$(echo "${aligned_gisaid_location}" | jq -r .bucket)
     aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .sequences_key)
     aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .metadata_key)

--- a/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
@@ -74,8 +74,11 @@ task nextstrain_workflow {
                --selected ncov/data/include.txt                       \
                --builds-file ncov/my_profiles/aspen/builds.yaml       \
     )
-    # If we didn't have any explicitly selected samples, copy the reference genomes to include.txt
-    if [ ! -e ncov/data/include.txt ]; then cp ncov/defaults/include.txt ncov/data/include.txt; fi;
+    # If we don't have any county samples, copy the reference genomes to to our county file
+    if [ ! -e ncov/data/sequences_aspen.fasta ]; then
+        cp ncov/data/references_sequences.fasta ncov/data/sequences_aspen.fasta;
+        cp ncov/data/references_metadata.tsv ncov/data/metadata_aspen.tsv;
+    fi;
 
     # If this is a contextual build, disable crowding penalty
     if grep -q group_plus_context ncov/my_profiles/aspen/builds.yaml; then patch ncov/workflow/snakemake_rules/main_workflow.smk < /usr/src/app/aspen/workflows/nextstrain_run/patches/local_ncov_settings.patch; fi

--- a/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
@@ -77,6 +77,9 @@ task nextstrain_workflow {
     # If we didn't have any explicitly selected samples, copy the reference genomes to include.txt
     if [ ! -e ncov/data/include.txt ]; then cp ncov/defaults/include.txt ncov/data/include.txt; fi;
 
+    # If this is a contextual build, disable crowding penalty
+    if grep -q group_plus_context ncov/my_profiles/aspen/builds.yaml; then patch ncov/workflow/snakemake_rules/main_workflow.smk < /usr/src/app/aspen/workflows/nextstrain_run/patches/local_ncov_settings.patch; fi
+
     aligned_gisaid_s3_bucket=$(echo "${aligned_gisaid_location}" | jq -r .bucket)
     aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .sequences_key)
     aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .metadata_key)

--- a/src/backend/aspen/app/views/phylo_runs.py
+++ b/src/backend/aspen/app/views/phylo_runs.py
@@ -97,6 +97,11 @@ def start_phylo_run():
         name=request_data["name"],
     )
 
+    # TODO -- our build pipeline assumes we've selected some samples, and everything stops making
+    # sense if we have an empty includes.txt.
+    if not pathogen_genomes:
+        raise Exception("No valid pathogen genomes found, not running tree build!")
+
     workflow.inputs = list(pathogen_genomes)
     workflow.inputs.append(aligned_gisaid_dump)
 

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/contextual.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/contextual.yaml
@@ -1,13 +1,13 @@
 inputs:
+  - name: "root_ref"
+    metadata: "data/references_metadata.tsv"
+    sequences: "data/references_sequences.fasta"
   - name: "gisaid"
     metadata: "data/metadata_gisaid.tsv"
     sequences: "data/sequences_gisaid.fasta"
   - name: "aspen"
     metadata: "data/metadata_aspen.tsv"
     sequences: "data/sequences_aspen.fasta"
-  - name: "selected"
-    metadata: "data/metadata_selected.tsv"
-    sequences: "data/sequences_selected.fasta"
 
 builds:
   aspen:
@@ -24,6 +24,7 @@ custom_rules:
 
 ## Auxiliary files
 files:
+  include: "my_profiles/aspen/include.txt"
   lat_longs: "my_profiles/aspen/lat_longs.tsv"
   ordering: "my_profiles/aspen/ordering.tsv"
   description: "my_profiles/aspen/covidtrackerca.md"
@@ -32,13 +33,20 @@ files:
 ## Parameters
 refine:
   keep_polytomies: True
+  clock_filter_iqd: 3
 
 ## Subsampling schemas
-# Number of max_sequences will be an external variable total to half of user selected samples
 subsampling:
   group_plus_context:
+    root:
+      exclude: "--exclude-where 'root_ref!=yes'"
     focal:
-      exclude: "--exclude-where 'selected!=yes'"
+      exclude: "--exclude-all"
+    closest:
+      max_sequences: 100
+      priorities:
+        type: "proximity"
+        focus: "focal"
 
     group:
       group_by: "year month"
@@ -75,4 +83,4 @@ subsampling:
     international_serial_sampling:
       group_by: "region year month"
       seq_per_group: 2
-      query: --query "(country != '{{country}}')" 
+      query: --query "(country != '{{country}}')"

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/contextual.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/contextual.yaml
@@ -24,7 +24,7 @@ custom_rules:
 
 ## Auxiliary files
 files:
-  include: "my_profiles/aspen/include.txt"
+  include: "data/include.txt"
   lat_longs: "my_profiles/aspen/lat_longs.tsv"
   ordering: "my_profiles/aspen/ordering.tsv"
   description: "my_profiles/aspen/covidtrackerca.md"

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/local.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/local.yaml
@@ -40,22 +40,8 @@ subsampling:
   group_only:
     root:
       exclude: "--exclude-where 'root_ref!=yes'"
-    focal:
-      exclude: "--exclude-all"
-    closest:
-      max_sequences: 100
-      priorities:
-        type: "proximity"
-        focus: "focal"
+
     same_county:
       group_by: "year month"
       max_sequences: 2000
-      query: --query "(location == '{{location}}') & (division == '{{division}}')"
-      priorities:
-        type: "proximity"
-        focus: "focal"
-
-    county_serial_sampling:
-      group_by: "year month"
-      seq_per_group: 10
       query: --query "(location == '{{location}}') & (division == '{{division}}')"

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/local.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/local.yaml
@@ -1,13 +1,13 @@
 inputs:
+  - name: "root_ref"
+    metadata: "data/references_metadata.tsv"
+    sequences: "data/references_sequences.fasta"
   - name: "gisaid"
     metadata: "data/metadata_gisaid.tsv"
     sequences: "data/sequences_gisaid.fasta"
   - name: "aspen"
     metadata: "data/metadata_aspen.tsv"
     sequences: "data/sequences_aspen.fasta"
-  - name: "selected"
-    metadata: "data/metadata_selected.tsv"
-    sequences: "data/sequences_selected.fasta"
 
 builds:
   aspen:
@@ -24,6 +24,7 @@ custom_rules:
 
 ## Auxiliary files
 files:
+  include: "my_profiles/aspen/include.txt"
   lat_longs: "my_profiles/aspen/lat_longs.tsv"
   ordering: "my_profiles/aspen/ordering.tsv"
   description: "my_profiles/aspen/covidtrackerca.md"
@@ -32,12 +33,20 @@ files:
 ## Parameters
 refine:
   keep_polytomies: True
+  clock_filter_iqd: 3
 
 ## Subsampling schemas
 subsampling:
   group_only:
+    root:
+      exclude: "--exclude-where 'root_ref!=yes'"
     focal:
-      exclude: "--exclude-where 'selected!=yes'"
+      exclude: "--exclude-all"
+    closest:
+      max_sequences: 100
+      priorities:
+        type: "proximity"
+        focus: "focal"
     same_county:
       group_by: "year month"
       max_sequences: 2000
@@ -45,3 +54,8 @@ subsampling:
       priorities:
         type: "proximity"
         focus: "focal"
+
+    county_serial_sampling:
+      group_by: "year month"
+      seq_per_group: 10
+      query: --query "(location == '{{location}}') & (division == '{{division}}')"

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/local.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/local.yaml
@@ -24,7 +24,7 @@ custom_rules:
 
 ## Auxiliary files
 files:
-  include: "my_profiles/aspen/include.txt"
+  include: "data/include.txt"
   lat_longs: "my_profiles/aspen/lat_longs.tsv"
   ordering: "my_profiles/aspen/ordering.tsv"
   description: "my_profiles/aspen/covidtrackerca.md"

--- a/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
+++ b/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
@@ -2,21 +2,26 @@
   "title": "Genomic epidemiology of novel coronavirus",
   "build_url": "https://github.com/nextstrain/ncov",
   "maintainers": [
-    {"name": "Chan Zuckerberg Biohub",
-     "url": "https://www.czbiohub.org"},
+    {"name": "Chan Zuckerberg Initiative",
+     "url": "https://chanzuckerberg.com"},
     {"name": "California Departments of Public Health",
      "url": "https://www.cdph.ca.gov/Pages/LocalHealthServicesAndOffices.aspx#"}
   ],
   "colorings": [
     {
-      "key": "selected",
-      "title": "User selection",
-      "type": "boolean"
+      "key": "emerging_lineage",
+      "title": "Emerging Lineage",
+      "type": "categorical"
     },
     {
       "key": "pangolin_lineage",
       "title": "Pangolin lineage",
       "type": "categorical"
+    },
+    {
+      "key": "S1_mutations",
+      "title": "S1 mutations",
+      "type": "continuous"
     },
     {
       "key": "location",
@@ -39,21 +44,6 @@
       "type": "categorical"
     },
     {
-      "key": "host",
-      "title": "Host",
-      "type": "categorical"
-    },
-    {
-      "key": "age",
-      "title": "Age",
-      "type": "continuous"
-    },
-    {
-      "key": "sex",
-      "title": "Sex",
-      "type": "categorical"
-    },
-    {
       "key": "author",
       "title": "Authors",
       "type": "categorical"
@@ -67,21 +57,6 @@
       "key": "submitting_lab",
       "title": "Submitting Lab",
       "type": "categorical"
-    },
-    {
-      "key": "country_exposure",
-      "title": "Country of exposure",
-      "type": "categorical"
-    },
-    {
-      "key": "division_exposure",
-      "title": "Division of exposure",
-      "type": "categorical"
-    },
-    {
-      "key": "region_exposure",
-      "title": "Region of exposure",
-      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -91,14 +66,13 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "selected",
+    "color_by": "emerging_lineage",
     "distance_measure": "div",
     "geo_resolution": "location",
     "map_triplicate": false,
     "branch_label": "clade"
   },
   "filters": [
-    "selected",
     "clade_membership",
     "region",
     "country",

--- a/src/backend/aspen/workflows/nextstrain_run/patches/local_ncov_settings.patch
+++ b/src/backend/aspen/workflows/nextstrain_run/patches/local_ncov_settings.patch
@@ -1,0 +1,10 @@
+--- original.smk	2021-08-12 11:09:14.000000000 -0700
++++ updated.smk	2021-08-12 11:12:43.000000000 -0700
+@@ -481,6 +481,7 @@
+         """
+         python3 scripts/priorities.py \
+             --sequence-index {input.sequence_index} \
++            --crowding-penalty 0 \
+             --proximities {input.proximity} \
+             --output {output.priorities} 2>&1 | tee {log}
+         """


### PR DESCRIPTION
### Description

This is missing the more interesting functionality (accepting gisaid ID's) but hopefully touches on some of the other functionality we've discussed for improved ondemand-treebuilding. Opening this draft PR for early feedback!

- updated build.yaml files
- write include.txt instead of sequences_selected.fasta
- copy reference genomes to sequences_aspen.fasta if our exported version is empty
- strip off hcov-19 prefix from public identifiers
- Add crowding-penalty flag to ondemand contextual builds

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Write how your changes are tested, or give a convincing reason why they can't be tested automatically.
