### PR TITLE
disable tree build button when greater than 2000 samples are selected

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -137,6 +137,7 @@ const DataSubview: FunctionComponent<Props> = ({
   const [showCheckboxes, setShowCheckboxes] = useState<boolean>(false);
   const [isDownloadModalOpen, setDownloadModalOpen] = useState(false);
   const [isDownloadDisabled, setDownloadDisabled] = useState<boolean>(true);
+  const [isCreateTreeDisabled, setCreateTreeDisabled] = useState<boolean>(true);
   const [failedSamples, setFailedSamples] = useState<any[]>([]);
   const [downloadFailed, setDownloadFailed] = useState<boolean>(false);
   const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
@@ -173,10 +174,16 @@ const DataSubview: FunctionComponent<Props> = ({
 
   useEffect(() => {
     // disable sample download if no samples are selected
-    if (checkedSamples.length === 0) {
+    const numberCheckedSamples = checkedSamples.length;
+    if (numberCheckedSamples === 0) {
       setDownloadDisabled(true);
     } else {
       setDownloadDisabled(false);
+      if (numberCheckedSamples > 2000) {
+        setCreateTreeDisabled(true);
+      } else {
+        setCreateTreeDisabled(false);
+      }
     }
   }, [checkedSamples]);
 
@@ -259,7 +266,7 @@ const DataSubview: FunctionComponent<Props> = ({
           <Divider />
           <IconButton
             onClick={handleCreateTreeClickOpen}
-            disabled={isDownloadDisabled}
+            disabled={isCreateTreeDisabled}
             svgDisabled={<StyledTreeBuildDisabledImage />}
             svgEnabled={<StyledTreeBuildImage />}
             tooltipTextDisabled={TREE_BUILD_TOOLTIP_TEXT_DISABLED}


### PR DESCRIPTION
### Description

disable tree build button when checkedSamples length is greater than 2000

#### Issue
no issue

### Test plan

tested locally
