### PR TITLE
[ch150271] distribute whitespace around samples table according to design

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -140,4 +140,6 @@ export const TooltipDescriptionText = styled.div`
 
 export const StyledFlexChildDiv = styled.div`
   flex: 1 1 0;
+  margin: 0 auto;
+  max-width: 1308px;
 `;

--- a/src/frontend/src/views/Data/index.module.scss
+++ b/src/frontend/src/views/Data/index.module.scss
@@ -49,8 +49,6 @@
     // This is needed to ensure the div doesn't disappear
     // when the viewport height is too short
     height: calc(100% - 74px);
-    margin: 0 auto;
     width: calc(100% - 14px);
-    max-width:1308px;
   }
 }


### PR DESCRIPTION
### Summary
- **What:** Distribute white space around samples table according to designs
- **Why:** right now, the filter panel does not stick to the left side of the screen but it should
- **Ticket:** [[ch150271]](https://app.clubhouse.io/genepi/story/150271)

### Demos
#### Before: 
<img width="1904" alt="Screen Shot 2021-08-25 at 10 11 04 AM" src="https://user-images.githubusercontent.com/7562933/130835103-3d8e103d-4cb9-48e6-9ed4-078478f8393f.png">

#### After: 
<img width="1904" alt="Screen Shot 2021-08-25 at 10 06 44 AM" src="https://user-images.githubusercontent.com/7562933/130834649-052c67d1-4e28-4228-b05a-8432683286e8.png">
<img width="1008" alt="Screen Shot 2021-08-25 at 10 06 38 AM" src="https://user-images.githubusercontent.com/7562933/130834754-d00044c2-5b56-4a0e-a9bc-62ffaf7b6aad.png">
<img width="1904" alt="Screen Shot 2021-08-25 at 10 06 30 AM" src="https://user-images.githubusercontent.com/7562933/130834880-d2fc3e62-48c8-4287-8cef-20c75694a6d2.png">

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)