### PR TITLE
thuang-fix-tos

### DIFF
--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -1,5 +1,12 @@
 import { useRouter } from "next/router";
-import { useQuery, UseQueryResult } from "react-query";
+import { useEffect } from "react";
+import {
+  useMutation,
+  UseMutationResult,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from "react-query";
 import ENV from "src/common/constants/ENV";
 import {
   API,
@@ -41,13 +48,28 @@ const USER_MAP = new Map<string, keyof User>([
 export const fetchUserInfo = (): Promise<UserResponse> =>
   apiResponse<UserResponse>(["group", "user"], [null, USER_MAP], API.USER_INFO);
 
-export const updateUserInfo = (user: Partial<User>): Promise<Response> => {
+const updateUserInfo = (user: Partial<User>): Promise<Response> => {
   return fetch(API_URL + API.USER_INFO, {
     ...DEFAULT_PUT_OPTIONS,
     ...DEFAULT_HEADERS_MUTATION_OPTIONS,
     body: JSON.stringify(user),
   });
 };
+
+export function useUpdateUserInfo(): UseMutationResult<
+  Response,
+  unknown,
+  Partial<User>,
+  unknown
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation(updateUserInfo, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([USE_USER_INFO]);
+    },
+  });
+}
 
 export function useUserInfo(): UseQueryResult<UserResponse, unknown> {
   return useQuery([USE_USER_INFO], fetchUserInfo, {
@@ -62,13 +84,17 @@ export function useProtectedRoute(): UseQueryResult<UserResponse, unknown> {
   const { isLoading, data } = result;
   const agreedToTOS = data?.user?.agreedToTos;
 
-  if (!isLoading && !data) {
-    router.push(ROUTES.HOMEPAGE);
-  }
+  useEffect(() => {
+    if (!isLoading && !data) {
+      router.push(ROUTES.HOMEPAGE);
+    }
+  }, [isLoading, data, router]);
 
-  if (!isLoading && !agreedToTOS && router.asPath !== ROUTES.AGREE_TERMS) {
-    router.push(ROUTES.AGREE_TERMS);
-  }
+  useEffect(() => {
+    if (!isLoading && !agreedToTOS && router.asPath !== ROUTES.AGREE_TERMS) {
+      router.push(ROUTES.AGREE_TERMS);
+    }
+  }, [isLoading, data, router, agreedToTOS]);
 
   return result;
 }

--- a/src/frontend/src/views/AgreeTerms/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/index.tsx
@@ -8,17 +8,21 @@ import DialogActions from "src/common/components/library/Dialog/components/Dialo
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import ENV from "src/common/constants/ENV";
-import { updateUserInfo, useProtectedRoute } from "src/common/queries/auth";
+import { useUpdateUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
 import { PageContent } from "../../common/styles/mixins/global";
 import { Details, Title } from "./style";
 
 export default function AgreeTerms(): JSX.Element {
-  useProtectedRoute();
   const [isLoading, setIsLoading] = useState(false);
   const [shouldRedirect, setShouldRedirect] = useState(false);
   const [hasAcceptedTerms, setHasAcceptedTerms] = useState(false);
   const router = useRouter();
+  const {
+    mutate: updateUserInfo,
+    isSuccess,
+    isLoading: isUpdatingUserInfo,
+  } = useUpdateUserInfo();
 
   useEffect(() => {
     if (shouldRedirect) {
@@ -27,16 +31,18 @@ export default function AgreeTerms(): JSX.Element {
   }, [shouldRedirect, router]);
 
   useEffect(() => {
-    if (!hasAcceptedTerms) return;
+    if (!hasAcceptedTerms || isUpdatingUserInfo) return;
+    if (isSuccess) {
+      return setShouldRedirect(true);
+    }
 
     agreeTos();
 
     async function agreeTos() {
       setIsLoading(true);
-      await updateUserInfo({ agreed_to_tos: true });
-      setShouldRedirect(true);
+      updateUserInfo({ agreed_to_tos: true });
     }
-  }, [hasAcceptedTerms]);
+  }, [hasAcceptedTerms, isUpdatingUserInfo, isSuccess, updateUserInfo]);
 
   function handleAcceptClick() {
     setHasAcceptedTerms(true);

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -55,7 +55,7 @@ const Data: FunctionComponent = () => {
     if (router.asPath === ROUTES.DATA) {
       router.push(ROUTES.DATA_SAMPLES);
     }
-  });
+  }, [router]);
 
   // this constant is inside the component so we can associate
   // each category with its respective variable.


### PR DESCRIPTION
### Description

Hi all!

I think the bug should be fixed in this PR 🙆‍♂️ 

@mmmmmmaya is right that we need to invalidate the userInfo query once we set `agreeTos` to `true`, otherwise React Query will return the cached response by default. SORRY FOR MISSING THAT 🤦 !

I made the following changes:

1. Add `useUpdateUserInfo()`, which is a tiny wrapper to use `useMutation` from `react-query`, so we can invalidate `userInfo` cache on success
2. `useProtectedRoute()` push route pushes inside `useEffect()`, since pushes are side effects and this helps preventing unintended route pushes if `useProtectedRoute()` is called by the parent component on re-render
3. Use `useUpdateUserInfo()` in `AgreeTerms` page to redirect only on `isSuccess`

More on React Query invalidation is available here:

https://react-query.tanstack.com/guides/invalidations-from-mutations

Thanks all!

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

1. Go to http://frontend.genepinet.local:8000/agreeTerms
2. Go to dev console network tab, and turn on `Preserve log`
2. Click on `agree`
2. Find and copy the CURL for `PUT userinfo` and change payload to `--data-raw '{"agreed_to_tos":false}' \` 
    <img width="1108" alt="Screen Shot 2021-08-27 at 11 22 12 AM" src="https://user-images.githubusercontent.com/6309723/131175334-8ad68aa2-57de-4a57-8c3b-c14a010af01d.png">
1. Now you can run the CURL in your terminal any time you want to reset the ``agreed_to_tos flag to false
2. Once it's false, refresh the ToS page and click agree again, it should now redirect as expected

