### PR TITLE
Return failed and completed trees from API call

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -94,7 +94,7 @@ def phylo_trees():
             "completed_date": format_datetime(phylo_run.end_datetime),
             "status": phylo_run.workflow_status.value,
             "workflow_id": phylo_run.workflow_id,
-            "pathogen_genome_count": 0  # TODO: do we still need this?
+            "pathogen_genome_count": 0,  # TODO: do we still need this?
         }
         results.append(result)
 

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -11,7 +11,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import aliased, joinedload, Session
 
 from aspen.app.app import application, requires_auth
-from aspen.app.views.api_utils import format_datetime
+from aspen.app.views.api_utils import format_datetime, format_date
 from aspen.database.models import (
     DataType,
     PhyloRun,
@@ -39,6 +39,12 @@ def humanize_tree_name(s3_key: str):
     return title_case
 
 
+def generate_tree_name_from_template(phylo_run: PhyloRun) -> str:
+    template_data = json.loads(phylo_run.template_args)
+    if template_data['run_name']:
+        return template_data['run_name']
+    return f"{phylo_run.group.name} Tree {format_date(phylo_run.start_datetime)}"
+
 @application.route("/api/phylo_trees", methods=["GET"])
 @requires_auth
 def phylo_trees():
@@ -54,7 +60,6 @@ def phylo_trees():
             phylo_run_alias,
         )
         .options(
-            joinedload(phylo_run_alias.outputs),
             joinedload(phylo_run_alias.outputs.of_type(PhyloTree)),
         )
         .filter(
@@ -64,30 +69,32 @@ def phylo_trees():
                 phylo_run_alias.group_id.in_(cansee_owner_group_ids),
             )
         )
-        .filter(phylo_run_alias.workflow_status == WorkflowStatusType.COMPLETED)
     )
 
     # filter for only information we need in sample table view
     results: MutableSequence[Mapping[str, Any]] = list()
     for phylo_run in phylo_runs:
-        phylo_tree: PhyloTree
+        phylo_tree: Optional[PhyloTree] = None
+        result: Mapping[str, Any] = {}
         for output in phylo_run.outputs:
             if isinstance(output, PhyloTree):
                 phylo_tree = output
-                break
-        else:
-            raise RecoverableError(
-                f"phylo run (workflow id={phylo_run.workflow_id}) does not have a"
-                " phylo tree output."
-            )
-        results.append(
-            {
-                "phylo_tree_id": phylo_tree.entity_id,
-                "name": humanize_tree_name(phylo_tree.s3_key),
-                "pathogen_genome_count": 0,  # Leaving this field in place temporarily for reverse-compatibility
-                "completed_date": format_datetime(phylo_run.end_datetime),
-            }
-        )
+                result = result | {
+                        "phylo_tree_id": phylo_tree.entity_id,
+                        "name": phylo_tree.name or humanize_tree_name(phylo_tree.s3_key),
+                    }
+        if not phylo_tree:
+            result = result | {
+                    "phylo_tree_id": None,
+                    "name": phylo_run.name or generate_tree_name_from_template(phylo_run),
+                }
+        result = result | {
+                    "started_date": format_datetime(phylo_run.start_datetime),
+                    "completed_date": format_datetime(phylo_run.end_datetime),
+                    "status": phylo_run.workflow_status.value,
+                    "workflow_id": phylo_run.workflow_id,
+                }
+        results.append(result)
 
     return jsonify({PHYLO_TREE_KEY: results})
 

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -42,7 +42,7 @@ def humanize_tree_name(s3_key: str):
 
 
 def generate_tree_name_from_template(phylo_run: PhyloRun) -> str:
-    template_args = json.loads(phylo_run.template_args)  # type: ignore
+    template_args = phylo_run.template_args
     return f"{template_args['location']} Tree {format_date(phylo_run.start_datetime)}"
 
 

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -94,6 +94,7 @@ def phylo_trees():
             "completed_date": format_datetime(phylo_run.end_datetime),
             "status": phylo_run.workflow_status.value,
             "workflow_id": phylo_run.workflow_id,
+            "pathogen_genome_count": 0  # TODO: do we still need this?
         }
         results.append(result)
 

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -11,7 +11,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import aliased, joinedload, Session
 
 from aspen.app.app import application, requires_auth
-from aspen.app.views.api_utils import format_datetime, format_date
+from aspen.app.views.api_utils import format_date, format_datetime
 from aspen.database.models import (
     DataType,
     PhyloRun,
@@ -41,9 +41,10 @@ def humanize_tree_name(s3_key: str):
 
 def generate_tree_name_from_template(phylo_run: PhyloRun) -> str:
     template_data = json.loads(phylo_run.template_args)
-    if template_data['run_name']:
-        return template_data['run_name']
+    if template_data["run_name"]:
+        return template_data["run_name"]
     return f"{phylo_run.group.name} Tree {format_date(phylo_run.start_datetime)}"
+
 
 @application.route("/api/phylo_trees", methods=["GET"])
 @requires_auth
@@ -80,20 +81,20 @@ def phylo_trees():
             if isinstance(output, PhyloTree):
                 phylo_tree = output
                 result = result | {
-                        "phylo_tree_id": phylo_tree.entity_id,
-                        "name": phylo_tree.name or humanize_tree_name(phylo_tree.s3_key),
-                    }
+                    "phylo_tree_id": phylo_tree.entity_id,
+                    "name": phylo_tree.name or humanize_tree_name(phylo_tree.s3_key),
+                }
         if not phylo_tree:
             result = result | {
-                    "phylo_tree_id": None,
-                    "name": phylo_run.name or generate_tree_name_from_template(phylo_run),
-                }
+                "phylo_tree_id": None,
+                "name": phylo_run.name or generate_tree_name_from_template(phylo_run),
+            }
         result = result | {
-                    "started_date": format_datetime(phylo_run.start_datetime),
-                    "completed_date": format_datetime(phylo_run.end_datetime),
-                    "status": phylo_run.workflow_status.value,
-                    "workflow_id": phylo_run.workflow_id,
-                }
+            "started_date": format_datetime(phylo_run.start_datetime),
+            "completed_date": format_datetime(phylo_run.end_datetime),
+            "status": phylo_run.workflow_status.value,
+            "workflow_id": phylo_run.workflow_id,
+        }
         results.append(result)
 
     return jsonify({PHYLO_TREE_KEY: results})

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -2,7 +2,16 @@ import json
 import os
 import re
 import uuid
-from typing import Any, Callable, Iterable, Mapping, MutableSequence, Set, Union
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    MutableSequence,
+    Optional,
+    Set,
+    Union,
+)
 
 import boto3
 import sqlalchemy
@@ -12,15 +21,8 @@ from sqlalchemy.orm import aliased, joinedload, Session
 
 from aspen.app.app import application, requires_auth
 from aspen.app.views.api_utils import format_date, format_datetime
-from aspen.database.models import (
-    DataType,
-    PhyloRun,
-    PhyloTree,
-    Sample,
-    WorkflowStatusType,
-)
+from aspen.database.models import DataType, PhyloRun, PhyloTree, Sample
 from aspen.database.models.usergroup import User
-from aspen.error.recoverable import RecoverableError
 from aspen.phylo_tree.identifiers import rename_nodes_on_tree
 
 PHYLO_TREE_KEY = "phylo_trees"
@@ -40,10 +42,8 @@ def humanize_tree_name(s3_key: str):
 
 
 def generate_tree_name_from_template(phylo_run: PhyloRun) -> str:
-    template_data = json.loads(phylo_run.template_args)
-    if template_data["run_name"]:
-        return template_data["run_name"]
-    return f"{phylo_run.group.name} Tree {format_date(phylo_run.start_datetime)}"
+    template_args = json.loads(phylo_run.template_args)  # type: ignore
+    return f"{template_args['location']} Tree {format_date(phylo_run.start_datetime)}"
 
 
 @application.route("/api/phylo_trees", methods=["GET"])

--- a/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
@@ -8,9 +8,11 @@ from aspen.database.models import (
     DataType,
     Group,
     PhyloTree,
+    PhyloRun,
     Sample,
     UploadedPathogenGenome,
     User,
+    WorkflowStatusType,
 )
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
@@ -52,6 +54,14 @@ def make_trees(
         for ix in range(n_trees)
     ]
 
+def make_runs_with_no_trees(group: Group) -> Collection[PhyloRun]:
+    # Make an in-progress run and a failed run.
+    other_statuses = [WorkflowStatusType.STARTED, WorkflowStatusType.FAILED]
+    template_args = {
+        "division": group.division,
+        "location": group.location,
+    }
+    return [phylorun_factory(group, workflow_status=status, template_args=template_args) for status in other_statuses]
 
 def make_all_test_data(
     group: Group, user: User, n_samples: int, n_trees: int
@@ -61,7 +71,8 @@ def make_all_test_data(
         UploadedPathogenGenome
     ] = make_uploaded_pathogen_genomes(samples)
     trees: Sequence[PhyloTree] = make_trees(group, samples, n_trees)
-    return samples, uploaded_pathogen_genomes, trees
+    treeless_runs: Collection[PhyloRun] = make_runs_with_no_trees(group)
+    return samples, uploaded_pathogen_genomes, trees, treeless_runs
 
 
 def check_results(client, user: User, trees: Collection[PhyloTree]):
@@ -91,13 +102,42 @@ def test_phylo_tree_view(
 ):
     group: Group = group_factory()
     user: User = user_factory(group)
-    _, _, trees = make_all_test_data(group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(group, user, n_samples, n_trees)
 
     session.add(group)
     session.commit()
 
     check_results(client, user, trees)
 
+def test_in_progress_and_failed_trees(
+    session,
+    app,
+    client,
+    n_samples=5,
+    n_trees=3,
+):
+    group: Group = group_factory()
+    user: User = user_factory(group)
+    _, _, _, treeless_runs = make_all_test_data(group, user, n_samples, n_trees)
+
+    session.add(group)
+    session.commit()
+
+    with client.session_transaction() as sess:
+        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
+    results: Mapping[str, List[Mapping[str, Union[str, int]]]] = json.loads(
+        client.get("/api/phylo_trees").get_data(as_text=True)
+    )
+
+    results_trees = results[PHYLO_TREE_KEY]
+    results_incomplete_trees = [tree for tree in results_trees if tree["status"] != WorkflowStatusType.COMPLETED.value]
+    assert len(results_incomplete_trees) == len(treeless_runs)
+    for incomplete in results_incomplete_trees:
+        assert incomplete["phylo_tree_id"] is None
+        assert incomplete["name"] is not None
+    assert len([tree for tree in results_incomplete_trees if tree["status"] == WorkflowStatusType.STARTED.value]) == 1
+    assert len([tree for tree in results_incomplete_trees if tree["status"] == WorkflowStatusType.FAILED.value]) == 1
+    
 
 def test_phylo_trees_can_see(
     session,
@@ -109,7 +149,7 @@ def test_phylo_trees_can_see(
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("CADPH")
     user: User = user_factory(viewer_group)
-    _, _, trees = make_all_test_data(owner_group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
     CanSee(viewer_group=viewer_group, owner_group=owner_group, data_type=DataType.TREES)
     session.add_all((owner_group, viewer_group))
@@ -128,7 +168,7 @@ def test_phylo_trees_no_can_see(
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("CADPH")
     user: User = user_factory(viewer_group)
-    _, _, trees = make_all_test_data(owner_group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
     session.add_all((owner_group, viewer_group))
     session.commit()
@@ -150,7 +190,7 @@ def test_phylo_trees_admin(
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("admin")
     user: User = user_factory(viewer_group, system_admin=True)
-    _, _, trees = make_all_test_data(owner_group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
     session.add_all((owner_group, viewer_group))
     session.commit()
@@ -170,7 +210,7 @@ def test_phylo_tree_can_see(
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("CADPH")
     user: User = user_factory(viewer_group)
-    _, _, trees = make_all_test_data(owner_group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
     # We need to create the bucket since this is all in Moto's 'virtual' AWS account
     phylo_tree = trees[0]  # we only have one
@@ -208,7 +248,7 @@ def test_phylo_tree_no_can_see(
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("CADPH")
     user: User = user_factory(viewer_group)
-    _, _, trees = make_all_test_data(owner_group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
     # We need to create the bucket since this is all in Moto's 'virtual' AWS account
     phylo_tree = trees[0]  # we only have one
@@ -246,7 +286,7 @@ def test_phylo_tree_admin(
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("admin")
     user: User = user_factory(viewer_group, system_admin=True)
-    _, _, trees = make_all_test_data(owner_group, user, n_samples, n_trees)
+    _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
     # We need to create the bucket since this is all in Moto's 'virtual' AWS account
     phylo_tree = trees[0]  # we only have one

--- a/src/backend/aspen/test_infra/models/phylo_tree.py
+++ b/src/backend/aspen/test_infra/models/phylo_tree.py
@@ -17,6 +17,7 @@ def phylorun_factory(
     start_datetime: Union[datetime.datetime, _SentinelType] = _sentinel,
     end_datetime: Union[datetime.datetime, _SentinelType] = _sentinel,
     software_versions: Union[Mapping[str, str], _SentinelType] = _sentinel,
+    template_args: Mapping[str, str] = {},
 ):
     start_datetime = (
         start_datetime
@@ -37,6 +38,7 @@ def phylorun_factory(
         start_datetime=start_datetime,
         end_datetime=end_datetime,
         software_versions=software_versions,
+        template_args=template_args,
     )
 
 

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -108,6 +108,8 @@ const TREE_MAP = new Map<string, keyof Tree>([
   ["phylo_tree_id", "id"],
   ["pathogen_genome_count", "pathogenGenomeCount"],
   ["completed_date", "creationDate"],
+  ["started_date", "startedDate"],
+  ["workflow_id", "workflowId"],
 ]);
 export const fetchTrees = (): Promise<TreeResponse> =>
   apiResponse<TreeResponse>(["phylo_trees"], [TREE_MAP], API.PHYLO_TREES);

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -30,10 +30,13 @@ interface Sample extends BioinformaticsType {
 
 interface Tree extends BioinformaticsType {
   type: "Tree";
-  id: number;
+  id?: number;
   name: string;
   pathogenGenomeCount: number;
   creationDate: string;
+  startedDate: string;
+  workflowId: string;
+  status: string;
   downloadLink?: string;
 }
 

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
@@ -21,7 +21,9 @@ const TreeTableNameCell = ({ value, item }: NameProps): JSX.Element => {
     setOpen(false);
   };
 
-  const treeId = item.id;
+  // TODO: Create a pathway to handle Trees with no id, for trees
+  // that are in progress or failed
+  const treeId = item.id as number;
 
   return (
     <>

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -43,7 +43,9 @@ const Data: FunctionComponent = () => {
 
       const apiSamples = sampleResponse["samples"];
       // TODO: Support in-progress and failed trees
-      const apiTrees = treeResponse["phylo_trees"].filter(tree => tree.status === "COMPLETED");
+      const apiTrees = treeResponse["phylo_trees"].filter(
+        (tree) => tree.status === "COMPLETED"
+      );
 
       setSamples(apiSamples);
       setTrees(apiTrees);

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -42,7 +42,8 @@ const Data: FunctionComponent = () => {
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];
-      const apiTrees = treeResponse["phylo_trees"];
+      // TODO: Support in-progress and failed trees
+      const apiTrees = treeResponse["phylo_trees"].filter(tree => tree.status === "COMPLETED");
 
       setSamples(apiSamples);
       setTrees(apiTrees);


### PR DESCRIPTION
### Description

Adds `started_date`, `status`, and `workflow_id` to the `/api/phylo_trees` response. Also returns all trees regardless of completion.

Adds a small bit of frontend code to filter out trees that don't have status `COMPLETED`, so they don't show up in the tree table just yet.

#### Issue
[ch150143](https://app.clubhouse.io/genepi/story/150143)

### Test plan

Tests to be updated
