### PR TITLE
Maya/filter styles

### DIFF
--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -24,6 +24,7 @@ export interface DefaultMenuSelectOption {
 
 interface Props {
   lineages: DefaultMenuSelectOption[];
+  setActiveFilterCount: (count: number) => void;
   setDataFilterFunc: Dispatch<
     SetStateAction<(data: TableItem[]) => TableItem[]>
   >;
@@ -120,7 +121,11 @@ const applyFilter = (data: TableItem[], dataFilter: FilterType) => {
   }
 };
 
-const FilterPanel: FC<Props> = ({ lineages, setDataFilterFunc }) => {
+const FilterPanel: FC<Props> = ({
+  lineages,
+  setActiveFilterCount,
+  setDataFilterFunc,
+}) => {
   const [dataFilters, setDataFilters] = useState<FiltersType>(DATA_FILTER_INIT);
 
   useEffect(() => {
@@ -139,6 +144,26 @@ const FilterPanel: FC<Props> = ({ lineages, setDataFilterFunc }) => {
 
     setDataFilterFunc(wrappedFilterFunc);
   }, [dataFilters, setDataFilterFunc]);
+
+  useEffect(() => {
+    const activeFilters = filter(dataFilters, (f) => {
+      const { params, type } = f;
+      let hasDefinedParam = false;
+
+      forEach(Object.keys(params), (k) => {
+        const isActive =
+          type === TypeFilterType.Multiple ? params[k].length > 0 : params[k];
+
+        if (isActive) {
+          hasDefinedParam = true;
+        }
+      });
+
+      return hasDefinedParam;
+    });
+
+    setActiveFilterCount(activeFilters.length);
+  }, [dataFilters, setActiveFilterCount]);
 
   const updateDataFilter = (filterKey: string, params: FilterParamsType) => {
     const { transform, type } = dataFilters[filterKey];

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -150,9 +150,13 @@ const FilterPanel: FC<Props> = ({
       const { params, type } = f;
       let hasDefinedParam = false;
 
-      forEach(Object.keys(params), (k) => {
+      type keyType = keyof FilterParamsType;
+      const keys = Object.keys(params) as keyType[];
+
+      forEach(keys, (k) => {
+        const param = params[k];
         const isActive =
-          type === TypeFilterType.Multiple ? params[k].length > 0 : params[k];
+          param && type === TypeFilterType.Multiple ? param.length > 0 : param;
 
         if (isActive) {
           hasDefinedParam = true;

--- a/src/frontend/src/views/Data/components/FilterPanelToggle/index.tsx
+++ b/src/frontend/src/views/Data/components/FilterPanelToggle/index.tsx
@@ -3,14 +3,18 @@ import { IconButtonBubble } from "src/common/styles/support/style";
 import { StyledDiv, StyledIconFilters } from "./style";
 
 interface Props {
+  activeFilterCount: number;
   onClick: () => void;
 }
 
-export const FilterPanelToggle: FC<Props> = ({ onClick }): JSX.Element => {
+export const FilterPanelToggle: FC<Props> = ({
+  activeFilterCount,
+  onClick,
+}): JSX.Element => {
   return (
     <StyledDiv>
       <IconButtonBubble onClick={onClick}>
-        <StyledIconFilters />
+        <StyledIconFilters /> {activeFilterCount}
       </IconButtonBubble>
     </StyledDiv>
   );

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -33,6 +33,7 @@ const Data: FunctionComponent = () => {
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [shouldShowFilters, setShouldShowFilters] = useState<boolean>(true);
   const [dataFilterFunc, setDataFilterFunc] = useState<any>();
+  const [activeFilterCount, setActiveFilterCount] = useState<number>(0);
 
   const router = useRouter();
 
@@ -172,6 +173,7 @@ const Data: FunctionComponent = () => {
         data-test-id="data-menu-items"
       >
         <FilterPanelToggle
+          activeFilterCount={activeFilterCount}
           onClick={() => {
             setShouldShowFilters(!shouldShowFilters);
           }}
@@ -185,6 +187,7 @@ const Data: FunctionComponent = () => {
           // TODO (mlila): replace with sds filterpanel once it's complete
           <FilterPanel
             lineages={lineages}
+            setActiveFilterCount={setActiveFilterCount}
             setDataFilterFunc={setDataFilterFunc}
           />
         )}


### PR DESCRIPTION
### Summary
- **What:** Add a very basic filter count tag to the filter panel toggle button
- **Why:** So users can see at a glance how many active filters they have

### Testing
1. Check tag count starts at 0
2. Add a filter
1. Check the tag count increases for every filter you add
2. check tag count decreases for each tag you take away
3. date tags should be active even if only start or end date defined.

### Demos
#### Before: 
![Screen Shot 2021-09-01 at 7 41 27 AM](https://user-images.githubusercontent.com/7562933/131691855-844bd20d-4196-4416-85c9-2a1b9492252b.png)

#### After: 
![Screen Shot 2021-09-01 at 7 41 02 AM](https://user-images.githubusercontent.com/7562933/131691869-70f3b33c-96ce-4ae0-9009-ef200f956e21.png)

### Notes
This tag will require styling. This PR is for logic only.

### Checklist
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)