### PR TITLE
Fix gisaid pipeline.

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -250,6 +250,7 @@ task AlignGISAID {
     (cd /ncov; snakemake --printshellcmds results/aligned.fasta --profile my_profiles/align_gisaid 1>&2)
 
     mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/align.txt .
+    cp /ncov/data/metadata.tsv .  # Support wdl output paths.
 
     zstdmt /ncov/results/aligned.fasta
 
@@ -277,7 +278,6 @@ task AlignGISAID {
             --gisaid-s3-bucket "${aspen_s3_db_bucket}"                              \
             --gisaid-sequences-s3-key "${sequences_key}"                            \
             --gisaid-metadata-s3-key "${metadata_key}" > entity_id
-    cp /ncov/data/metadata.tsv metatdata.tsv  # Support wdl output paths.
     >>>
 
     output {


### PR DESCRIPTION
### Description

Our gisaid pipeline has been failing due to a missing metadata.tsv file. This just updates the handling of that file to match how we're handling other WDL outputs. 

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

I uploaded this to staging and executed it. The job was successful.
