### PR TITLE
Phoenix/fix sample count button

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -260,7 +260,7 @@ const DataSubview: FunctionComponent<Props> = ({
     if (viewName === VIEWNAME.SAMPLES && tableData !== undefined) {
       downloadButton = (
         <DownloadWrapper>
-          <StyledChip isRounded size="large" label={checkedSamples.length} status="info" />
+          <StyledChip isRounded label={checkedSamples.length} status="info" />
           <StyledDiv>Selected </StyledDiv>
           <Divider />
           <IconButton

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -260,7 +260,7 @@ const DataSubview: FunctionComponent<Props> = ({
     if (viewName === VIEWNAME.SAMPLES && tableData !== undefined) {
       downloadButton = (
         <DownloadWrapper>
-          <StyledChip size="medium" label={checkedSamples.length} />
+          <StyledChip isRounded size="large" label={checkedSamples.length} status="info" />
           <StyledDiv>Selected </StyledDiv>
           <Divider />
           <IconButton

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -264,6 +264,7 @@ const DataSubview: FunctionComponent<Props> = ({
             size="medium"
             label={checkedSamples.length}
             status="info"
+            isRounded={true}
           />
           <StyledDiv>Selected </StyledDiv>
           <Divider />

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -260,12 +260,7 @@ const DataSubview: FunctionComponent<Props> = ({
     if (viewName === VIEWNAME.SAMPLES && tableData !== undefined) {
       downloadButton = (
         <DownloadWrapper>
-          <StyledChip
-            size="medium"
-            label={checkedSamples.length}
-            status="info"
-            isRounded={true}
-          />
+          <StyledChip size="medium" label={checkedSamples.length} />
           <StyledDiv>Selected </StyledDiv>
           <Divider />
           <IconButton

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
+import { Chip } from "@material-ui/core";
 import {
   Alert,
   Button,
-  Chip,
   fontBodyXs,
   fontHeaderXs,
   getColors,
@@ -40,12 +40,14 @@ export const Divider = styled.div`
 `;
 
 export const StyledChip = styled(Chip)`
+  border-radius: 25px;
   ${(props) => {
     const colors = getColors(props);
     const fontWeights = getFontWeights(props);
     return `
       background-color: ${colors?.gray[200]};
       font-weight: ${fontWeights?.semibold};
+      color: ${colors?.primary[500]};  
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
-import { Chip } from "@material-ui/core";
 import {
   Alert,
   Button,
+  Chip,
   fontBodyXs,
   fontHeaderXs,
   getColors,
@@ -40,14 +40,12 @@ export const Divider = styled.div`
 `;
 
 export const StyledChip = styled(Chip)`
-  border-radius: 25px;
   ${(props) => {
     const colors = getColors(props);
     const fontWeights = getFontWeights(props);
     return `
       background-color: ${colors?.gray[200]};
       font-weight: ${fontWeights?.semibold};
-      color: ${colors?.primary[500]};  
     `;
   }}
 `;


### PR DESCRIPTION
### Description
czifui's chip component has changed a bit, material ui's chip component seems to work better for sample counter (need to add less stylings to have it fit the design)


#### Issue
no issue

### Test plan

locally and [rdev](https://chip-fix-frontend.dev.genepi.czi.technology/data/samples)
to check out what it looked like using czifui component check [here](https://featfiltering-frontend.dev.genepi.czi.technology/): 