### PR TITLE
Add "selected" column to metadata TSV downloads

### DIFF
--- a/src/backend/aspen/app/views/api_utils.py
+++ b/src/backend/aspen/app/views/api_utils.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm.query import Query
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, or_
 
-from aspen.database.models import DataType, Group, PhyloTree, Sample, User
+from aspen.database.models import DataType, Group, PhyloRun, PhyloTree, Sample, User
 
 
 def filter_usergroup_dict(

--- a/src/backend/aspen/app/views/api_utils.py
+++ b/src/backend/aspen/app/views/api_utils.py
@@ -183,7 +183,7 @@ def authz_sample_filters(query: Query, sample_ids: Set[str], user: User) -> Quer
 
 
 # TODO, this is incredibly similar to sample authz filters. Generalize these!
-def authz_phylo_tree_filters(query: Query, tree_ids: Set[str], user: User) -> Query:
+def authz_phylo_tree_filters(query: Query, tree_ids: Set[int], user: User) -> Query:
     # No filters for system admins
     if user.system_admin:
         query = query.filter(

--- a/src/backend/aspen/app/views/api_utils.py
+++ b/src/backend/aspen/app/views/api_utils.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm.query import Query
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, or_
 
-from aspen.database.models import DataType, Group, Sample, User
+from aspen.database.models import DataType, Group, PhyloTree, Sample, User
 
 
 def filter_usergroup_dict(

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -116,7 +116,7 @@ def _process_phylo_tree(db_session: Session, phylo_tree_id: int, user: User) -> 
         .join(PhyloRun)
         .options(joinedload(PhyloTree.constituent_samples))
     )
-    tree_query = authz_phylo_tree_filters(tree_query, [phylo_tree_id], user)
+    tree_query = authz_phylo_tree_filters(tree_query, {phylo_tree_id}, user)
     phylo_tree: PhyloTree
     try:
         phylo_tree = tree_query.one()

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -208,7 +208,7 @@ def phylo_tree(phylo_tree_id: int):
 
 
 def _extract_accessions(accessions_list: list, node: dict):
-    node_attributes = node["node_attrs"]
+    node_attributes = node.get("node_attrs", {})
     if "external_accession" in node_attributes:
         accessions_list.append(node_attributes["external_accession"]["value"])
     if "name" in node:

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -186,12 +186,12 @@ def _get_selected_samples(db_session, phylo_tree_id):
     )
 
     phylo_run = phylo_tree.producing_workflow
-    all_samples = set(phylo_run.gisaid_ids)
+    selected_samples = set(phylo_run.gisaid_ids)
     for uploaded_pathogen_genome in phylo_run.inputs:
         sample = uploaded_pathogen_genome.sample
-        all_samples.add(sample.public_identifier.replace("hCoV-19/", ""))
-        all_samples.add(sample.private_identifier)
-    return all_samples
+        selected_samples.add(sample.public_identifier.replace("hCoV-19/", ""))
+        selected_samples.add(sample.private_identifier)
+    return selected_samples
 
 
 @application.route("/api/phylo_tree/<int:phylo_tree_id>", methods=["GET"])

--- a/src/backend/aspen/app/views/tests/test_auspice_redirect.py
+++ b/src/backend/aspen/app/views/tests/test_auspice_redirect.py
@@ -1,6 +1,7 @@
 import json
 
 import requests
+from botocore.client import ClientError
 
 from aspen.database.models import CanSee, DataType
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
@@ -84,7 +85,11 @@ def test_auspice_redirect_view(session, app, client, mock_s3_resource, test_data
     session.commit()
 
     # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+    try:
+        mock_s3_resource.meta.client.head_bucket(Bucket=phylo_tree.s3_bucket)
+    except ClientError:
+        # The bucket does not exist or you have no access.
+        mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
 
     json_test_file = test_data_dir / "ncov_aspen.json"
     with json_test_file.open() as fh:
@@ -100,8 +105,8 @@ def test_auspice_redirect_view(session, app, client, mock_s3_resource, test_data
     res = client.get(f"/api/auspice/view/{phylo_tree.id}")
     res_presigned = res.json["url"]
 
-    # this is a little hacky, currently when calling a get request on moto generated presigned url it gets 404
-    # i think this is due to calling get not being within the moto test scope, so as a workaround i''m checking that
+    # this is a little hacky, currently when calling a get request on localstack generated presigned url it gets 404
+    # i think this is due to calling get not being within the localstack test scope, so as a workaround i''m checking that
     # the key and bucket names from the phylo tree entry are in the returned presigned url and that the response code from the view is 200
     assert res.status == "200 OK"
     assert app.aspen_config.EXTERNAL_AUSPICE_BUCKET in res_presigned

--- a/src/backend/aspen/app/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_rename.py
@@ -1,5 +1,7 @@
 import json
 
+from botocore.client import ClientError
+
 from aspen.app.views.phylo_trees import _process_phylo_tree
 from aspen.database.models import CanSee, DataType
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
@@ -65,8 +67,12 @@ def test_phylo_tree_rename(session, mock_s3_resource, test_data_dir):
         [local_sample, can_see_sample, wrong_can_see_sample, no_can_see_sample],
     )
 
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+    # Create the bucket if it doesn't exist in localstack.
+    try:
+        mock_s3_resource.meta.client.head_bucket(Bucket=phylo_tree.s3_bucket)
+    except ClientError:
+        # The bucket does not exist or you have no access.
+        mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
 
     json_test_file = test_data_dir / "ncov_aspen.json"
     with json_test_file.open() as fh:
@@ -118,8 +124,12 @@ def test_phylo_tree_rename_admin(session, mock_s3_resource, test_data_dir):
         [renamed_sample],
     )
 
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+    # Create the bucket if it doesn't exist in localstack.
+    try:
+        mock_s3_resource.meta.client.head_bucket(Bucket=phylo_tree.s3_bucket)
+    except ClientError:
+        # The bucket does not exist or you have no access.
+        mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
 
     json_test_file = test_data_dir / "ncov_aspen.json"
     with json_test_file.open() as fh:

--- a/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
@@ -2,6 +2,8 @@ import json
 import random
 from typing import Collection, List, Mapping, Sequence, Tuple, Union
 
+from botocore.client import ClientError
+
 from aspen.app.views.phylo_trees import PHYLO_TREE_KEY
 from aspen.database.models import (
     CanSee,
@@ -245,9 +247,13 @@ def test_phylo_tree_can_see(
     user: User = user_factory(viewer_group)
     _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
     phylo_tree = trees[0]  # we only have one
-    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+    # Create the bucket if it doesn't exist in localstack.
+    try:
+        mock_s3_resource.meta.client.head_bucket(Bucket=phylo_tree.s3_bucket)
+    except ClientError:
+        # The bucket does not exist or you have no access.
+        mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
 
     json_test_file = test_data_dir / "ncov_aspen.json"
     with json_test_file.open() as fh:
@@ -283,9 +289,13 @@ def test_phylo_tree_no_can_see(
     user: User = user_factory(viewer_group)
     _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
     phylo_tree = trees[0]  # we only have one
-    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+    # Create the bucket if it doesn't exist in localstack.
+    try:
+        mock_s3_resource.meta.client.head_bucket(Bucket=phylo_tree.s3_bucket)
+    except ClientError:
+        # The bucket does not exist or you have no access.
+        mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
 
     json_test_file = test_data_dir / "ncov_aspen.json"
     with json_test_file.open() as fh:
@@ -321,9 +331,13 @@ def test_phylo_tree_admin(
     user: User = user_factory(viewer_group, system_admin=True)
     _, _, trees, _ = make_all_test_data(owner_group, user, n_samples, n_trees)
 
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
     phylo_tree = trees[0]  # we only have one
-    mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
+    # Create the bucket if it doesn't exist in localstack.
+    try:
+        mock_s3_resource.meta.client.head_bucket(Bucket=phylo_tree.s3_bucket)
+    except ClientError:
+        # The bucket does not exist or you have no access.
+        mock_s3_resource.create_bucket(Bucket=phylo_tree.s3_bucket)
 
     json_test_file = test_data_dir / "ncov_aspen.json"
     with json_test_file.open() as fh:

--- a/src/backend/aspen/app/views/tests/test_tree_metadata_download.py
+++ b/src/backend/aspen/app/views/tests/test_tree_metadata_download.py
@@ -1,0 +1,162 @@
+from aspen.database.models import CanSee, DataType
+from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
+from aspen.test_infra.models.sample import sample_factory
+from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
+from aspen.test_infra.models.usergroup import group_factory, user_factory
+
+
+def create_phylotree_with_inputs(session, owner_group):
+    username = "owner"
+    user = user_factory(
+        owner_group, name=username, auth0_user_id=username, email=username
+    )
+    sample = sample_factory(
+        owner_group,
+        user,
+        public_identifier="public_identifier_1",
+        private_identifier="private_identifier_1",
+    )
+    input_entity = uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+
+    phylo_run = phylorun_factory(
+        owner_group, inputs=[input_entity], gisaid_ids=["public_identifier_2"]
+    )
+    phylo_tree = phylotree_factory(
+        phylo_run,
+        [sample],
+    )
+
+    session.add_all([phylo_tree])
+    session.commit()
+    return phylo_tree, phylo_run
+
+
+def create_phylotree(session):
+    owner_group = group_factory()
+    user = user_factory(owner_group)
+    sample = sample_factory(owner_group, user)
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+
+    phylo_tree = phylotree_factory(
+        phylorun_factory(owner_group),
+        [sample],
+    )
+
+    session.add_all([phylo_tree, owner_group, owner_group])
+    session.commit()
+    return user, phylo_tree
+
+
+def test_tree_metadata_download(
+    session,
+    app,
+    client,
+):
+    """
+    Test a regular sequence download for a sample submitted by the user's group
+    """
+    user, tree = create_phylotree(session)
+
+    with client.session_transaction() as sess:
+        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
+    res = client.get(f"/api/phylo_tree/sample_ids/{tree.id}")
+    expected_filename = f"{tree.id}_sample_ids.tsv"
+    expected_document = (
+        "Sample Identifier\tSelected\r\n"
+        "public_identifier_1	n\r\n"
+        "public_identifier_2	n\r\n"
+        "public_identifier_3	n\r\n"
+        "public_identifier_4	n\r\n"
+        "public_identifier_5	n\r\n"
+    )
+    file_contents = str(res.data, encoding="UTF-8")
+    assert file_contents == expected_document
+    assert res.status == "200 OK"
+    assert res.headers["Content-Type"] == "text/tsv"
+    assert (
+        res.headers["Content-Disposition"]
+        == f"attachment; filename={expected_filename}"
+    )
+
+
+def create_unique_user(group, username):
+    user = user_factory(group, name=username, auth0_user_id=username, email=username)
+    return user
+
+
+def test_private_id_matrix(
+    session,
+    app,
+    client,
+):
+    """
+    Test that we use public ids in the fasta file if the requester only has access to the samples
+    sequence data but not private ids
+    """
+    owner_group = group_factory(name="owner_group")
+    private_ids_group = group_factory(name="private_ids_group")
+    noaccess_group = group_factory(name="noaccess_group")
+    viewer_group = group_factory(name="viewer_group")
+    viewer_user = create_unique_user(viewer_group, "viewer")
+    private_ids_user = create_unique_user(private_ids_group, "private_ids")
+    noaccess_user = create_unique_user(noaccess_group, "noaccess")
+    phylo_tree, phylo_run = create_phylotree_with_inputs(session, owner_group)
+    # give the viewer group access to trees from the owner group
+    CanSee(
+        viewer_group=viewer_group,
+        owner_group=owner_group,
+        data_type=DataType.TREES,
+    )
+    # give the private ids group access to private ids from the owner group
+    CanSee(
+        viewer_group=private_ids_group,
+        owner_group=owner_group,
+        data_type=DataType.PRIVATE_IDENTIFIERS,
+    )
+    CanSee(
+        viewer_group=private_ids_group,
+        owner_group=owner_group,
+        data_type=DataType.TREES,
+    )
+    session.add_all([noaccess_user, viewer_user, private_ids_user, phylo_tree])
+    session.commit()
+
+    matrix = [
+        {
+            "user": noaccess_user,
+            "expected_status": "400 BAD REQUEST",
+            "expected_data": f'{{"error":"PhyloTree with id {phylo_tree.id} not viewable by user with id: {noaccess_user.id}"}}\n',
+        },
+        {
+            "user": viewer_user,
+            "expected_status": "200 OK",
+            "expected_data": (
+                "Sample Identifier\tSelected\r\n"
+                "public_identifier_1	y\r\n"
+                "public_identifier_2	y\r\n"
+                "public_identifier_3	n\r\n"
+                "public_identifier_4	n\r\n"
+                "public_identifier_5	n\r\n"
+            ),
+        },
+        {
+            "user": private_ids_user,
+            "expected_status": "200 OK",
+            "expected_data": (
+                "Sample Identifier\tSelected\r\n"
+                "private_identifier_1	y\r\n"
+                "public_identifier_2	y\r\n"
+                "public_identifier_3	n\r\n"
+                "public_identifier_4	n\r\n"
+                "public_identifier_5	n\r\n"
+            ),
+        },
+    ]
+    for case in matrix:
+        user = case["user"]
+        with client.session_transaction() as sess:
+            sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
+        res = client.get(f"/api/phylo_tree/sample_ids/{phylo_tree.id}")
+        assert res.status == case["expected_status"]
+        file_contents = str(res.data, encoding="UTF-8")
+        assert file_contents == case["expected_data"]

--- a/src/backend/aspen/app/views/tests/test_tree_metadata_download.py
+++ b/src/backend/aspen/app/views/tests/test_tree_metadata_download.py
@@ -63,11 +63,11 @@ def test_tree_metadata_download(
     expected_filename = f"{tree.id}_sample_ids.tsv"
     expected_document = (
         "Sample Identifier\tSelected\r\n"
-        "public_identifier_1	n\r\n"
-        "public_identifier_2	n\r\n"
-        "public_identifier_3	n\r\n"
-        "public_identifier_4	n\r\n"
-        "public_identifier_5	n\r\n"
+        "public_identifier_1	no\r\n"
+        "public_identifier_2	no\r\n"
+        "public_identifier_3	no\r\n"
+        "public_identifier_4	no\r\n"
+        "public_identifier_5	no\r\n"
     )
     file_contents = str(res.data, encoding="UTF-8")
     assert file_contents == expected_document
@@ -132,11 +132,11 @@ def test_private_id_matrix(
             "expected_status": "200 OK",
             "expected_data": (
                 "Sample Identifier\tSelected\r\n"
-                "public_identifier_1	y\r\n"
-                "public_identifier_2	y\r\n"
-                "public_identifier_3	n\r\n"
-                "public_identifier_4	n\r\n"
-                "public_identifier_5	n\r\n"
+                "public_identifier_1	yes\r\n"
+                "public_identifier_2	yes\r\n"
+                "public_identifier_3	no\r\n"
+                "public_identifier_4	no\r\n"
+                "public_identifier_5	no\r\n"
             ),
         },
         {
@@ -144,11 +144,11 @@ def test_private_id_matrix(
             "expected_status": "200 OK",
             "expected_data": (
                 "Sample Identifier\tSelected\r\n"
-                "private_identifier_1	y\r\n"
-                "public_identifier_2	y\r\n"
-                "public_identifier_3	n\r\n"
-                "public_identifier_4	n\r\n"
-                "public_identifier_5	n\r\n"
+                "private_identifier_1	yes\r\n"
+                "public_identifier_2	yes\r\n"
+                "public_identifier_3	no\r\n"
+                "public_identifier_4	no\r\n"
+                "public_identifier_5	no\r\n"
             ),
         },
     ]

--- a/src/backend/aspen/fileio/tsv_streamer.py
+++ b/src/backend/aspen/fileio/tsv_streamer.py
@@ -1,10 +1,7 @@
 import csv
-from io import StringIO
-from typing import Any, Callable, Iterable, Mapping, Optional, Set
+from typing import Any, Iterable, Mapping
 
-from flask import g, jsonify, request, Response, stream_with_context
-
-from aspen.database.connection import session_scope
+from flask import Response, stream_with_context
 
 
 class SimpleStringWriter:

--- a/src/backend/aspen/fileio/tsv_streamer.py
+++ b/src/backend/aspen/fileio/tsv_streamer.py
@@ -1,0 +1,64 @@
+import csv
+from io import StringIO
+from typing import Any, Callable, Iterable, Mapping, Optional, Set
+
+from flask import g, jsonify, request, Response, stream_with_context
+
+from aspen.database.connection import session_scope
+
+
+class SimpleStringWriter:
+    def __init__(self):
+        self.contents = []
+
+    def write(self, data):
+        self.contents.append(data)
+
+    def read(self):
+        for line in self.contents:
+            yield line
+        self.contents = []
+
+
+class TSVStreamer:
+    fields: Iterable[str] = []
+
+    def __init__(self, filename: str, data):
+        self.filename = filename
+        self.data = data
+
+    def get_response(self):
+        generator = self.stream()
+        resp = Response(generator, mimetype="application/binary")
+        resp.headers["Content-Disposition"] = f"attachment; filename={self.filename}"
+        resp.headers["Content-Type"] = "text/tsv"
+        return resp
+
+    def writerow(self):
+        raise NotImplementedError("Must override writerow")
+
+    @stream_with_context
+    def stream(self):
+        stringfh = SimpleStringWriter()
+        csvwriter = csv.DictWriter(stringfh, self.fields, delimiter="\t")
+        csvwriter.writeheader()
+        for item in self.data:
+            csvdata: Mapping[str, Any] = self.generate_row(item)
+            csvwriter.writerow(csvdata)
+            for res in stringfh.read():
+                yield res
+
+
+class MetadataTSVStreamer(TSVStreamer):
+    fields = ["Sample Identifier", "Selected"]
+
+    def __init__(self, filename: str, data: Iterable, selected: Iterable):
+        super().__init__(filename, data)
+        self.selected = selected
+
+    def generate_row(self, item):
+        data: Mapping[str, Any] = {
+            "Sample Identifier": item,
+            "Selected": "y" if item in self.selected else "n",
+        }
+        return data

--- a/src/backend/aspen/fileio/tsv_streamer.py
+++ b/src/backend/aspen/fileio/tsv_streamer.py
@@ -56,6 +56,6 @@ class MetadataTSVStreamer(TSVStreamer):
     def generate_row(self, item):
         data: Mapping[str, Any] = {
             "Sample Identifier": item,
-            "Selected": "y" if item in self.selected else "n",
+            "Selected": "yes" if item in self.selected else "no",
         }
         return data

--- a/src/backend/aspen/test_infra/aws.py
+++ b/src/backend/aspen/test_infra/aws.py
@@ -1,3 +1,5 @@
+import os
+
 import boto3
 import pytest
 from moto import mock_s3
@@ -6,5 +8,10 @@ from moto import mock_s3
 @pytest.fixture(scope="session")
 def mock_s3_resource():
     with mock_s3():
+        backup_boto_url = os.environ.get("BOTO_ENDPOINT_URL")
+        if backup_boto_url:
+            del os.environ["BOTO_ENDPOINT_URL"]
         s3_resource = boto3.resource("s3")
         yield s3_resource
+    if backup_boto_url:
+        os.environ["BOTO_ENDPOINT_URL"] = backup_boto_url

--- a/src/backend/aspen/test_infra/aws.py
+++ b/src/backend/aspen/test_infra/aws.py
@@ -2,16 +2,14 @@ import os
 
 import boto3
 import pytest
-from moto import mock_s3
 
 
 @pytest.fixture(scope="session")
 def mock_s3_resource():
-    with mock_s3():
-        backup_boto_url = os.environ.get("BOTO_ENDPOINT_URL")
-        if backup_boto_url:
-            del os.environ["BOTO_ENDPOINT_URL"]
-        s3_resource = boto3.resource("s3")
-        yield s3_resource
-    if backup_boto_url:
-        os.environ["BOTO_ENDPOINT_URL"] = backup_boto_url
+    # NOTE - this is using localstack instead of moto! Beware that state can persist between tests.
+    s3 = boto3.resource(
+        "s3",
+        endpoint_url=os.getenv("BOTO_ENDPOINT_URL") or None,
+        config=boto3.session.Config(signature_version="s3v4"),
+    )
+    yield s3

--- a/src/backend/aspen/test_infra/models/phylo_tree.py
+++ b/src/backend/aspen/test_infra/models/phylo_tree.py
@@ -1,7 +1,12 @@
 import datetime
-from typing import Mapping, Union
+from typing import Iterable, Mapping, Union
 
-from aspen.database.models import PhyloRun, PhyloTree, WorkflowStatusType
+from aspen.database.models import (
+    PhyloRun,
+    PhyloTree,
+    UploadedPathogenGenome,
+    WorkflowStatusType,
+)
 
 
 class _SentinelType:
@@ -18,6 +23,8 @@ def phylorun_factory(
     end_datetime: Union[datetime.datetime, _SentinelType] = _sentinel,
     software_versions: Union[Mapping[str, str], _SentinelType] = _sentinel,
     template_args: Mapping[str, str] = {},
+    inputs: Iterable[UploadedPathogenGenome] = [],
+    gisaid_ids: Iterable[str] = [],
 ):
     start_datetime = (
         start_datetime
@@ -39,6 +46,8 @@ def phylorun_factory(
         end_datetime=end_datetime,
         software_versions=software_versions,
         template_args=template_args,
+        gisaid_ids=gisaid_ids,
+        inputs=inputs,
     )
 
 

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -269,6 +269,18 @@ def get_userinfo(ctx):
     resp = api_client.get("/api/usergroup")
     print(resp.text)
 
+@cli.group()
+def phylo_trees():
+    pass
+
+@phylo_trees.command(name="get-sample-ids")
+@click.argument("tree_id")
+@click.pass_context
+def get_tree_sample_ids(ctx, tree_id):
+    api_client = ctx.obj["api_client"]
+    resp = api_client.get(f"/api/phylo_tree/sample_ids/{tree_id}")
+    print(resp.text)
+
 
 @cli.group()
 def samples():


### PR DESCRIPTION
### Description

This adds an additional "selected" column to metadata tsv downloads in order to improve visualization options in auspice. Only samples that are inputs to the phylo run workflow (translation: only selected samples in on-demand tree builds, or all county samples for nightly runs), or listed as gisaid accessions to be include will have a "yes" value in the selected column.

Note that this pr ALSO updates our test infrastructure to use localstack instead of moto in our tests. This has some drawbacks (s3 state can persist between test runs!) but makes our tests more consistent since all other AWS services our tests interact with (secrets manager, ssm, step functions) are calling localstack as well.

#### Issue
[ch155886](https://app.clubhouse.io/genepi/story/155886)

### Test plan

Unit tests are included and passing. I added a CLI command to download metadata files that works in local dev. I'll test this in staging as well once it's merged.
