### PR TITLE
Handle template args without a location field.

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -40,7 +40,7 @@ def generate_tree_name_from_template(phylo_run: PhyloRun) -> str:
     location = phylo_run.group.location  # safe default
     if isinstance(phylo_run.template_args, Mapping):
         template_args = phylo_run.template_args
-        location = template_args["location"]
+        location = template_args.get("location", location)
     return f"{location} Tree {format_date(phylo_run.start_datetime)}"
 
 


### PR DESCRIPTION
### Description

We have some entries in the phylo_runs table that don't contain a "location" key in their template args. This should prevent 500 errors from our backend when we try to return results for these rows

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

Spot-tested locally.
