### PR TITLE
Add patch utility to nextstrain container.

### DIFF
--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -14,6 +14,7 @@ RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sourc
 RUN apt-get -qq update && apt-get -qq -y install \
     jq \
     git \
+    patch \
     locales \
     zstd \
     && locale-gen en_US.UTF-8


### PR DESCRIPTION
### Description

Fix ondemand run errors due to missing patch utility

#### Issue
[ch<fill_in_issue_number>](https://app.clubhouse.io/genepi/story/<fill_in_issue_number>)

### Test plan

I ran `apt-get install patch` inside the container locally and was able to patch main_workflow.smk successfully
