### PR TITLE
[ch160824] exclude na dates

### DIFF
--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -97,6 +97,9 @@ const applyFilter = (data: TableItem[], dataFilter: FilterType) => {
     case TypeFilterType.Date:
       return filter(data, (d) => {
         const value = transform ? transform(d) : d;
+
+        if (!value) return false;
+
         const doesPassFilterCheckStart = !start || value >= start;
         const doesPassFilterCheckEnd = !end || value <= end;
 

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { DATE_REGEX } from "../DateField/constants";
 import { CollectionDateFilter } from "./components/CollectionDateFilter";
 import { GenomeRecoveryFilter } from "./components/GenomeRecoveryFilter";
 import { LineageFilter } from "./components/LineageFilter";
@@ -98,7 +99,7 @@ const applyFilter = (data: TableItem[], dataFilter: FilterType) => {
       return filter(data, (d) => {
         const value = transform ? transform(d) : d;
 
-        if (!value) return false;
+        if (!DATE_REGEX.test(value)) return false;
 
         const doesPassFilterCheckStart = !start || value >= start;
         const doesPassFilterCheckEnd = !end || value <= end;

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -96,6 +96,8 @@ const applyFilter = (data: TableItem[], dataFilter: FilterType) => {
 
   switch (type) {
     case TypeFilterType.Date:
+      if (!start && !end) return data;
+
       return filter(data, (d) => {
         const value = transform ? transform(d) : d;
 

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -213,10 +213,10 @@ const FilterPanel: FC<Props> = ({
 
   return (
     <StyledFilterPanel>
+      <UploadDateFilter updateUploadDateFilter={updateUploadDateFilter} />
       <CollectionDateFilter
         updateCollectionDateFilter={updateCollectionDateFilter}
       />
-      <UploadDateFilter updateUploadDateFilter={updateUploadDateFilter} />
       <LineageFilter
         options={lineages}
         updateLineageFilter={updateLineageFilter}


### PR DESCRIPTION
### Summary
- **What:**
  - Exclude N/A dates from filtered samples in the table
  - Also, fix the order of the filters in the side panel
- **Why:** if you're filtering for a specific range, you probably don't want to see things that have no date.
- **Ticket:** [[ch160824]](https://app.clubhouse.io/genepi/story/160824)
- **Env:** https://nadates-frontend.dev.genepi.czi.technology/data/samples

### Testing
1. Filter on `Upload date` for last 7 days
1. Verify no failed samples (N/A dates) appear

### Demos
![after](https://user-images.githubusercontent.com/7562933/133347016-6401d4f6-e7ca-4a88-a8c4-90937d379a14.gif)

### Checklist
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)