### PR TITLE
[ch160837] filter state panel toggle

### DIFF
--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -213,10 +213,8 @@ const FilterPanel: FC<Props> = ({
     }
   };
 
-  if (!isOpen) return null;
-
   return (
-    <StyledFilterPanel>
+    <StyledFilterPanel isOpen={isOpen}>
       <CollectionDateFilter
         updateCollectionDateFilter={updateCollectionDateFilter}
       />

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -23,6 +23,7 @@ export interface DefaultMenuSelectOption {
 }
 
 interface Props {
+  isOpen: boolean;
   lineages: DefaultMenuSelectOption[];
   setActiveFilterCount: (count: number) => void;
   setDataFilterFunc: Dispatch<
@@ -122,6 +123,7 @@ const applyFilter = (data: TableItem[], dataFilter: FilterType) => {
 };
 
 const FilterPanel: FC<Props> = ({
+  isOpen,
   lineages,
   setActiveFilterCount,
   setDataFilterFunc,
@@ -210,6 +212,8 @@ const FilterPanel: FC<Props> = ({
       updateDataFilter("CZBFailedGenomeRecovery", { selected });
     }
   };
+
+  if (!isOpen) return null;
 
   return (
     <StyledFilterPanel>

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -3,10 +3,12 @@ import { Chip, getColors, getSpacings, InputDropdown } from "czifui";
 
 export const StyledFilterPanel = styled.div`
   ${(props) => {
+    const { isOpen } = props;
     const colors = getColors(props);
     const spacings = getSpacings(props);
     return `
       border-right: ${spacings?.xxxs}px ${colors?.gray[200]} solid;
+      display: ${isOpen ? "block" : "none"};
       padding: ${spacings?.xl}px;
       width: 240px;
     `;

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -1,8 +1,17 @@
 import styled from "@emotion/styled";
-import { Chip, getColors, getSpacings, InputDropdown } from "czifui";
+import { Chip, getColors, getSpacings, InputDropdown, Props } from "czifui";
 
-export const StyledFilterPanel = styled.div`
-  ${(props) => {
+export interface ExtraProps extends Props {
+  isOpen?: boolean;
+}
+
+// * Please keep this in sync with the props used in `ExtraProps`
+const doNotForwardProps = ["isOpen"];
+
+export const StyledFilterPanel = styled("div", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  ${(props: ExtraProps) => {
     const { isOpen } = props;
     const colors = getColors(props);
     const spacings = getSpacings(props);

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -186,10 +186,11 @@ const Data: FunctionComponent = () => {
         </Menu>
       </FlexContainer>
       <FlexContainer className={style.view}>
-        {viewName === "Samples" && shouldShowFilters && (
+        {viewName === "Samples" && (
           // TODO (mlila): replace with sds filterpanel once it's complete
           <FilterPanel
             lineages={lineages}
+            isOpen={shouldShowFilters}
             setActiveFilterCount={setActiveFilterCount}
             setDataFilterFunc={setDataFilterFunc}
           />


### PR DESCRIPTION
### Summary
- **What:** Don't remove filter state when toggling the filter panel
- **Why:** Preserve the work the user did to filter the samples
- **Ticket:** [[ch160837]](https://app.clubhouse.io/genepi/story/160837)
- **Env:** https://savefilterstate-frontend.dev.genepi.czi.technology

### Testing
1. Filter your samples
1. Choose some samples
2. Toggle filter panel
3. Verify the exact same set of samples are shown
4. Toggle panel again
5. Verify the same samples are still shown
6. Verify chips are still displayed under applied filters

### Demos
![after](https://user-images.githubusercontent.com/7562933/133350142-454c304f-ab19-45d9-8b81-c247757931a8.gif)

### Checklist
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)