### PR TITLE
reset state on create tree modal close and on mutation fail/success

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
@@ -57,7 +57,6 @@ export const CreateTreeModal = ({
   handleCreateTreeFailed,
   handleSetCreateTreeStarted,
 }: Props): JSX.Element => {
-
   const [treeName, setTreeName] = useState<string>("");
   const [isTreeNameTooLong, setTreeNameTooLong] = useState<boolean>(false);
   const [isTreeBuildDisabled, setTreeBuildDisabled] = useState<boolean>(false);

--- a/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
@@ -57,12 +57,24 @@ export const CreateTreeModal = ({
   handleCreateTreeFailed,
   handleSetCreateTreeStarted,
 }: Props): JSX.Element => {
+
   const [treeName, setTreeName] = useState<string>("");
   const [isTreeNameTooLong, setTreeNameTooLong] = useState<boolean>(false);
   const [isTreeBuildDisabled, setTreeBuildDisabled] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<TreeType>("TARGETED");
   const [areInstructionsShown, setInstructionsShown] = useState<boolean>(false);
   useState<boolean>(false);
+
+  const clearState = function () {
+    setTreeName("");
+    setTreeType("TARGETED");
+    setInstructionsShown(false);
+  };
+
+  const handleClose = function () {
+    clearState();
+    onClose();
+  };
 
   useEffect(() => {
     const treeNameLength = treeName.length;
@@ -83,16 +95,12 @@ export const CreateTreeModal = ({
 
   const mutation = useMutation(createTree, {
     onError: () => {
-      setTreeName("");
-      setTreeType("TARGETED");
       handleCreateTreeFailed();
-      onClose();
+      handleClose();
     },
     onSuccess: () => {
-      setTreeName("");
-      setTreeType("TARGETED");
-      onClose();
       handleSetCreateTreeStarted();
+      handleClose();
     },
   });
 
@@ -123,12 +131,12 @@ export const CreateTreeModal = ({
       disableBackdropClick
       disableEscapeKeyDown
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       fullWidth={true}
       maxWidth={"sm"}
     >
       <StyledDialogTitle>
-        <StyledIconButton onClick={onClose}>
+        <StyledIconButton onClick={handleClose}>
           <CloseIcon />
         </StyledIconButton>
         <Header>Create New Phylogenetic Tree</Header>


### PR DESCRIPTION
### Description
reset state on mutation success/fail and when closing create tree modal

#### Issue
[ch160828](https://app.clubhouse.io/genepi/story/160828)

### Test plan

rdev here: https://close-info-modal-frontend.dev.genepi.czi.technology/data/samples
