### PR TITLE
[sc161296] disable view download failed

### DIFF
--- a/src/frontend/src/common/constants/types.ts
+++ b/src/frontend/src/common/constants/types.ts
@@ -2,3 +2,9 @@ export enum VIEWNAME {
   SAMPLES = "Samples",
   TREES = "Phylogenetic Trees",
 }
+
+export enum TREE_STATUS {
+  Completed = "COMPLETED",
+  Failed = "FAILED",
+  Started = "STARTED",
+}

--- a/src/frontend/src/components/TreeTableDownloadMenu/index.tsx
+++ b/src/frontend/src/components/TreeTableDownloadMenu/index.tsx
@@ -7,11 +7,13 @@ import style from "./index.module.scss";
 interface TreeTableDownloadMenuProps {
   jsonLink: string;
   accessionsLink: string;
+  shouldAllowDownload: boolean;
 }
 
 const TreeTableDownloadMenu = ({
   jsonLink,
   accessionsLink,
+  shouldAllowDownload,
 }: TreeTableDownloadMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
 
@@ -39,9 +41,11 @@ const TreeTableDownloadMenu = ({
         onClose={handleClose}
         getContentAnchorEl={null}
       >
-        <a href={jsonLink} target="_blank" rel="noopener">
-          <MenuItem onClick={handleClose}>{"Tree file (.json)"}</MenuItem>
-        </a>
+        {shouldAllowDownload && (
+          <a href={jsonLink} target="_blank" rel="noopener">
+            <MenuItem onClick={handleClose}>{"Tree file (.json)"}</MenuItem>
+          </a>
+        )}
         <a href={accessionsLink} target="_blank" rel="noopener">
           <MenuItem onClick={handleClose}>{"Private IDs (.tsv)"}</MenuItem>
         </a>

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { defaultCellRenderer } from "src/common/components/library/data_table";
 import dataTableStyle from "src/common/components/library/data_table/index.module.scss";
 import { RowContent } from "src/common/components/library/data_table/style";
+import { TREE_STATUS } from "src/common/constants/types";
 import SampleIcon from "src/common/icons/Sample.svg";
 import { createTableCellRenderer, stringGuard } from "src/common/utils";
 import TreeTableDownloadMenu from "src/components/TreeTableDownloadMenu";
@@ -120,11 +121,13 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   downloadLink: ({ value, item }): JSX.Element => {
     const jsonDownloadLink = stringGuard(value);
     const tsvDownloadLink = stringGuard(item["accessionsLink"]);
+    const shouldAllowDownload = item?.status === TREE_STATUS.Completed;
     return (
       <RowContent>
         <TreeTableDownloadMenu
           jsonLink={jsonDownloadLink}
           accessionsLink={tsvDownloadLink}
+          shouldAllowDownload={shouldAllowDownload}
         />
       </RowContent>
     );

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import dataTableStyle from "src/common/components/library/data_table/index.module.scss";
+import { TREE_STATUS } from "src/common/constants/types";
 import TreeIcon from "src/common/icons/PhyloTree.svg";
 import { createTreeModalInfo } from "src/common/utils";
 import TreeVizModal from "../TreeVizModal";
@@ -12,9 +13,10 @@ interface NameProps {
 
 const TreeTableNameCell = ({ value, item }: NameProps): JSX.Element => {
   const [open, setOpen] = useState(false);
+  const isDisabled = item?.status !== TREE_STATUS.Completed;
 
   const handleClickOpen = () => {
-    setOpen(true);
+    if (!isDisabled) setOpen(true);
   };
 
   const handleClose = () => {
@@ -35,11 +37,12 @@ const TreeTableNameCell = ({ value, item }: NameProps): JSX.Element => {
       <StyledRowContent
         className={dataTableStyle.cell}
         onClick={handleClickOpen}
+        disabled={isDisabled}
       >
         <CellWrapper data-test-id="tree-name-cell">
           <TreeIcon className={dataTableStyle.icon} />
           {value}
-          <StyledOpenInNewIcon />
+          <StyledOpenInNewIcon disabled={isDisabled} />
         </CellWrapper>
       </StyledRowContent>
     </>

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -1,39 +1,57 @@
 import styled from "@emotion/styled";
-import { getColors } from "czifui";
+import { getColors, Props } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import OpenInNewIcon from "src/common/icons/OpenInNew.svg";
 import { icon } from "../../../../common/components/library/data_table/style";
 
-export const StyledOpenInNewIcon = styled(OpenInNewIcon)`
+export interface ExtraProps extends Props {
+  disabled?: boolean;
+}
+
+const doNotForwardProps = ["disabled"];
+
+export const StyledOpenInNewIcon = styled(OpenInNewIcon, {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
   ${icon}
+
+  ${(props: ExtraProps) => {
+    const { disabled } = props;
+    const colors = getColors(props);
+
+    if (disabled) {
+      return `
+        fill: ${colors?.gray[200]};
+      `;
+    }
+  }}
 `;
 
-export const StyledRowContent = styled(RowContent)`
-  cursor: pointer;
+export const StyledRowContent = styled(RowContent, {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  ${(props: ExtraProps) => {
+    const { disabled } = props;
+    const colors = getColors(props);
 
-  :hover {
-    ${StyledOpenInNewIcon} {
-      ${(props) => {
-        const colors = getColors(props);
+    if (disabled) return;
 
-        return `
+    return `
+      cursor: pointer;
+
+      :hover {
+        ${StyledOpenInNewIcon} {
           fill: ${colors?.primary[400]};
-        `;
-      }}
-    }
-  }
+        }
+      }
 
-  :active {
-    ${StyledOpenInNewIcon} {
-      ${(props) => {
-        const colors = getColors(props);
-
-        return `
+      :active {
+        ${StyledOpenInNewIcon} {
           fill: ${colors?.primary[600]};
-        `;
-      }}
-    }
-  }
+        }
+      }
+    `;
+  }}
 `;
 
 export const CellWrapper = styled.div`


### PR DESCRIPTION
### Summary:
- **What:** Disable json download and auspice link when tree build not complete or failed
- **Ticket:** [sc161296](https://app.shortcut.com/genepi/story/161296)
- **Env:** https://disableauspice-frontend.dev.genepi.czi.technology/data/phylogenetic_trees

### Demos
![Screen Shot 2021-09-20 at 5 36 09 PM](https://user-images.githubusercontent.com/7562933/134095281-d61aaf1a-2383-44d4-9104-7946e61e8ee3.png)

### Checklist:
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)