### PR TITLE
add fontCapsXxxs

### DIFF
--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -1,5 +1,12 @@
 import styled from "@emotion/styled";
-import { Chip, getColors, getSpacings, InputDropdown, Props, fontCapsXxxs } from "czifui";
+import {
+  Chip,
+  fontCapsXxxs,
+  getColors,
+  getSpacings,
+  InputDropdown,
+  Props,
+} from "czifui";
 
 export interface ExtraProps extends Props {
   isOpen?: boolean;

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Chip, getColors, getSpacings, InputDropdown, Props } from "czifui";
+import { Chip, getColors, getSpacings, InputDropdown, Props, fontCapsXxxs } from "czifui";
 
 export interface ExtraProps extends Props {
   isOpen?: boolean;
@@ -25,9 +25,9 @@ export const StyledFilterPanel = styled("div", {
 `;
 
 export const StyledInputDropdown = styled(InputDropdown)`
+  ${fontCapsXxxs}
   padding: 0;
   text-align: left;
-  text-transform: uppercase;
 `;
 
 export const StyledFilterWrapper = styled.div`


### PR DESCRIPTION
### Summary:
- **What:** small styling changes for dropdown filters (replace text-transform with `fontCapsXxxs`) to address janeece's feedback
 <img width="1063" alt="Screen Shot 2021-09-21 at 3 35 22 PM" src="https://user-images.githubusercontent.com/13052132/134256627-f470ced8-c362-4d1a-a522-b9621c357293.png">

- **Ticket:** no ticket
- **Env:** coming soon

### Demos:

### Notes:
@mmmmmmaya is going to look into adding an open state to the InputDropdown component, to properly apply the same stylings from the active state, which will fix the active state comment from above:


### Checklist:
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)