### PR TITLE
Date Filtering fixes

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -5411,9 +5411,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "czifui": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/czifui/-/czifui-0.0.53.tgz",
-      "integrity": "sha512-RJtyIbwqqnFj9e8JTKboOIUREY1HM6JYE/QDbqNWsrIUmLg+VxnmSqPZcQlPhD/GDrjZPHvnWvrXLQ0lP7wUkQ=="
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/czifui/-/czifui-0.0.55.tgz",
+      "integrity": "sha512-E7BB8gI3FOgwhksbcKnyWe2URgjFKF89E9JQbhfs6m0GemC0Rpp0hdDyKinTnpoS/5qSExLJKehV4arhLCvm2w=="
     },
     "damerau-levenshtein": {
       "version": "1.0.7",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/parser": "^4.5.0",
     "babel-eslint": "^10.1.0",
     "classnames": "^2.2.6",
-    "czifui": "^0.0.53",
+    "czifui": "^0.0.55",
     "deep-equal": "^2.0.5",
     "deepmerge": "^4.2.2",
     "eslint": "^7.11.0",

--- a/src/frontend/src/components/DateField/index.tsx
+++ b/src/frontend/src/components/DateField/index.tsx
@@ -44,7 +44,7 @@ export default function DateField({
       onBlur={handleBlur}
       value={value}
       error={Boolean(errorMessage)}
-      helperText={helperText || errorMessage}
+      helperText={helperText}
     />
   );
 }

--- a/src/frontend/src/components/FilterPanel/components/CollectionDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/CollectionDateFilter/index.tsx
@@ -1,6 +1,30 @@
 import React, { FC } from "react";
 import { FormattedDateType } from "src/components/DateField";
-import { DateFilter } from "../DateFilter";
+import { DateFilter, DateMenuOption } from "../DateFilter";
+
+const MENU_OPTIONS_COLLECTION_DATE: DateMenuOption[] = [
+  {
+    name: "Last 7 Days",
+    numDaysStartOffset: 7,
+  },
+  {
+    name: "Last 30 Days",
+    numDaysStartOffset: 30,
+  },
+  // Average month has ~30.4 days, so that's why the non-round numbers
+  {
+    name: "Last 3 Months",
+    numDaysStartOffset: 91,
+  },
+  {
+    name: "Last 6 Months",
+    numDaysStartOffset: 182,
+  },
+  {
+    name: "Last Year",
+    numDaysStartOffset: 365,
+  },
+];
 
 interface Props {
   updateCollectionDateFilter: (
@@ -16,6 +40,7 @@ const CollectionDateFilter: FC<Props> = ({ updateCollectionDateFilter }) => {
       fieldKeyStart="collectionDateStart"
       inputLabel="Collection Date"
       updateDateFilter={updateCollectionDateFilter}
+      menuOptions={MENU_OPTIONS_COLLECTION_DATE}
     />
   );
 };

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -14,8 +14,10 @@ import {
   StyledInputDropdown,
 } from "../../style";
 import {
+  ErrorMessageHolder,
   StyledButton,
   StyledDateRange,
+  StyledErrorMessage,
   StyledManualDate,
   StyledText,
 } from "./style";
@@ -96,7 +98,10 @@ export const DateFilter: FC<Props> = ({
 
   // formik `isValid` actually gets set after `isValidating` goes back to false
   // So we have to check both to avoid visual flicker in Apply button.
-  const { values, setFieldValue, isValid, isValidating } = formik;
+  const { values, setFieldValue, isValid, isValidating, errors } = formik;
+
+  const errorMessageFieldKeyStart = errors[fieldKeyStart];
+  const errorMessageFieldKeyEnd = errors[fieldKeyEnd];
 
   // Use this over directly using `updateDateFilter` prop so we track filter changes.
   const setDatesFromRange = (start: DateType, end: DateType) => {
@@ -159,6 +164,18 @@ export const DateFilter: FC<Props> = ({
             <StyledText>to</StyledText>
             <DateField fieldKey={fieldKeyEnd} formik={formik} />
           </StyledDateRange>
+          <ErrorMessageHolder>
+            {errorMessageFieldKeyStart ? (
+              <StyledErrorMessage>{errors[fieldKeyStart]}</StyledErrorMessage>
+            ) : (
+              <StyledErrorMessage />
+            )}
+            {errorMessageFieldKeyEnd ? (
+              <StyledErrorMessage>{errors[fieldKeyEnd]}</StyledErrorMessage>
+            ) : (
+              <StyledErrorMessage />
+            )}
+          </ErrorMessageHolder>
           {(values[fieldKeyStart] || values[fieldKeyEnd]) && (
             <StyledButton
               color="primary"

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuItem } from "czifui";
 import { useFormik } from "formik";
-import { noop, isEmpty } from "lodash";
+import { isEmpty, noop } from "lodash";
 import React, { FC, useEffect, useState } from "react";
 import DateField, { FormattedDateType } from "src/components/DateField";
 import {
@@ -26,7 +26,7 @@ export interface DateMenuOption {
   name: string; // Must be UNIQUE because we assume can be used as key/id
   // For both `numDays...` it's relative to now() when option is chosen.
   // Assume start is guaranteed, but end cap is not.
-  numDaysEndOffset?: number;  // How far back end of date interval is
+  numDaysEndOffset?: number; // How far back end of date interval is
   numDaysStartOffset: number; // How far back start of date interval is
 }
 
@@ -50,9 +50,10 @@ const DateFilter: FC<Props> = ({
   const [endDate, setEndDate] = useState<FormattedDateType>();
   // Are fields valid and user should be allowed to hit the "Apply" button?
   // Related to some async form validation weirdness. See `validateForm` call below.
-  const [areFieldsValid, setAreFieldsValid] = useState<Boolean>(false);
+  const [areFieldsValid, setAreFieldsValid] = useState<boolean>(false);
   // What menu option is chosen. If none chosen, `null`.
-  const [selectedDateMenuOption, setSelectedDateMenuOption] = useState<DateMenuOption | null>(null);
+  const [selectedDateMenuOption, setSelectedDateMenuOption] =
+    useState<DateMenuOption | null>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
 
   const validationSchema = yup.object({
@@ -174,15 +175,9 @@ const DateFilter: FC<Props> = ({
       >
         <StyledManualDate>
           <StyledDateRange>
-            <DateField
-              fieldKey={fieldKeyStart}
-              formik={formik}
-            />
+            <DateField fieldKey={fieldKeyStart} formik={formik} />
             <StyledText>to</StyledText>
-            <DateField
-              fieldKey={fieldKeyEnd}
-              formik={formik}
-            />
+            <DateField fieldKey={fieldKeyEnd} formik={formik} />
           </StyledDateRange>
           {(values[fieldKeyStart] || values[fieldKeyEnd]) && (
             <StyledButton
@@ -202,7 +197,10 @@ const DateFilter: FC<Props> = ({
           <MenuItem
             key={dateOption.name}
             onClick={() => setDatesFromMenuOption(dateOption)}
-            selected={Boolean(selectedDateMenuOption && selectedDateMenuOption.name === dateOption.name)}
+            selected={Boolean(
+              selectedDateMenuOption &&
+                selectedDateMenuOption.name === dateOption.name
+            )}
           >
             {dateOption.name}
           </MenuItem>
@@ -238,7 +236,9 @@ function DateChip({
   // Might be worth extracting date message to a common helper func elsewhere?
   let dateIntervalLabel = `${startDate || "Prior"} to ${endDate || "Today"}`;
   // If a date menu option was selected, just use its specific name instead
-  if (selectedDateMenuOption) { dateIntervalLabel = selectedDateMenuOption.name; }
+  if (selectedDateMenuOption) {
+    dateIntervalLabel = selectedDateMenuOption.name;
+  }
   return (
     <StyledChip
       size="medium"

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -109,7 +109,12 @@ const DateFilter: FC<Props> = ({
         setAreFieldsValid(false);
       }
     });
-  }, [validateForm, values]);
+  }, [
+    validateForm,
+    values,
+    fieldKeyEnd, // Shouldn't change, but makes linter happy and JIC
+    fieldKeyStart, // Shouldn't change, but makes linter happy and JIC
+  ]);
 
   const formatDate = (d: DateType) => {
     if (d === undefined) return d;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import {
   Button,
   fontBodyXs,
+  fontBodyXxxs,
   getColors,
   getFontWeights,
   getSpacings,
@@ -45,4 +46,16 @@ export const StyledButton = styled(Button)`
       margin-top: ${spacings?.xs}px;
     `;
   }}
+`;
+
+export const ErrorMessageHolder = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const StyledErrorMessage = styled.span`
+  /* set max-width here so that there's space for both error messages to be present and be spaced appropriately */
+  max-width: 159px;
+  ${fontBodyXxxs}
+  color: red;
 `;

--- a/src/frontend/src/components/FilterPanel/components/GenomeRecoveryFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/GenomeRecoveryFilter/index.tsx
@@ -1,5 +1,6 @@
-import { ComplexFilter, DefaultMenuSelectOption, ComplexFilterValue } from "czifui";
+import { ComplexFilterValue, DefaultMenuSelectOption } from "czifui";
 import React from "react";
+import { StyledComplexFilter } from "../../style";
 
 interface Props {
   updateGenomeRecoveryFilter: (selected?: string) => void;
@@ -14,10 +15,16 @@ const GENOME_RECOVERY_OPTIONS = [
   },
 ];
 
-// Because czifui ComplexFilter expects callback that handles both single
-// and multi case at same time, we sidestep type issue with this.
+// HACK Because czifui ComplexFilter expects callback that handles both
+// single and multi case at same time, we sidestep type issue with this.
 type CallbackTypeWorkaround = (options: ComplexFilterValue) => void;
 
+// TODO -- With czifui 0.0.55, the `InputDropdownComponent` was exposed so it
+// can be directly styled and passed in as we do with others.
+// This should be swapped over so it matches the approach we do elsewhere.
+// (vince) To tweak the internal style of dropdown in ComplexFilter, need to
+// create a specialized set of props to insert CSS via raw `style` put into
+// underlying HTML tag. Was done when we were on czifui 0.0.53.
 const PROPS_FOR_INPUT_DROPDOWN = {
   sdsStyle: "minimal", // Would be defaulted, but must set everything now.
   // This `style` gets directly put in as HTML style and interpolated to CSS.
@@ -30,20 +37,12 @@ const PROPS_FOR_INPUT_DROPDOWN = {
 const GenomeRecoveryFilter = ({
   updateGenomeRecoveryFilter,
 }: Props): JSX.Element => {
-
   const onChange = (selectedOption: DefaultMenuSelectOption | null) => {
     updateGenomeRecoveryFilter(selectedOption?.name);
   };
 
-  // TODO (mlila): replace with sds complex filter when complete
-  // (vince): For the most part, will be a simple drop-in replacement, but there
-  // are some styling difficulties right now. See notes in LineageFilter about
-  // czifui 0.0.55, but also, even with that version I think it won't work
-  // immediately because of the `Wrapper` component in how ComplexFilter is
-  // implemented locking it to 150px width. Whenever we make the change over,
-  // expect to need to figure that out as part of it.
   return (
-    <ComplexFilter
+    <StyledComplexFilter
       label="Genome Recovery"
       options={GENOME_RECOVERY_OPTIONS}
       onChange={onChange as CallbackTypeWorkaround}

--- a/src/frontend/src/components/FilterPanel/components/GenomeRecoveryFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/GenomeRecoveryFilter/index.tsx
@@ -1,12 +1,5 @@
-import Popper from "@material-ui/core/Popper";
-import { MenuSelect } from "czifui";
-import React, { useEffect, useState } from "react";
-import { DefaultMenuSelectOption } from "../../index";
-import {
-  StyledChip,
-  StyledFilterWrapper,
-  StyledInputDropdown,
-} from "../../style";
+import { ComplexFilter, DefaultMenuSelectOption, ComplexFilterValue } from "czifui";
+import React from "react";
 
 interface Props {
   updateGenomeRecoveryFilter: (selected?: string) => void;
@@ -21,40 +14,25 @@ const GENOME_RECOVERY_OPTIONS = [
   },
 ];
 
+// Because czifui ComplexFilter expects callback that handles both single
+// and multi case at same time, we sidestep type issue with this.
+type CallbackTypeWorkaround = (options: ComplexFilterValue) => void;
+
+const PROPS_FOR_INPUT_DROPDOWN = {
+  sdsStyle: "minimal", // Would be defaulted, but must set everything now.
+  // This `style` gets directly put in as HTML style and interpolated to CSS.
+  style: {
+    padding: "0",
+    textTransform: "uppercase",
+  },
+} as const;
+
 const GenomeRecoveryFilter = ({
   updateGenomeRecoveryFilter,
 }: Props): JSX.Element => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [value, setValue] = useState<DefaultMenuSelectOption | null>();
 
-  useEffect(() => {
-    updateGenomeRecoveryFilter(value?.name);
-  }, [updateGenomeRecoveryFilter, value]);
-
-  const open = Boolean(anchorEl);
-  const id = "genome-recovery";
-
-  const handleClose = () => {
-    if (anchorEl) {
-      anchorEl.focus();
-    }
-
-    setAnchorEl(null);
-  };
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleChange = (
-    _: React.ChangeEvent<unknown>,
-    newValue: DefaultMenuSelectOption | null
-  ) => {
-    setValue(newValue as DefaultMenuSelectOption);
-  };
-
-  const handleDelete = () => {
-    setValue(null);
+  const onChange = (selectedOption: DefaultMenuSelectOption | null) => {
+    updateGenomeRecoveryFilter(selectedOption?.name);
   };
 
   // TODO (mlila): replace with sds complex filter when complete
@@ -65,39 +43,13 @@ const GenomeRecoveryFilter = ({
   // implemented locking it to 150px width. Whenever we make the change over,
   // expect to need to figure that out as part of it.
   return (
-    <>
-      <StyledFilterWrapper>
-        <StyledInputDropdown
-          sdsStyle="minimal"
-          label="Genome Recovery"
-          onClick={handleClick}
-        />
-        <Chips value={value} onDelete={handleDelete} />
-      </StyledFilterWrapper>
-      <Popper id={id} open={open} anchorEl={anchorEl}>
-        <MenuSelect
-          open
-          onClose={handleClose}
-          value={value}
-          onChange={handleChange}
-          options={GENOME_RECOVERY_OPTIONS}
-        />
-      </Popper>
-    </>
+    <ComplexFilter
+      label="Genome Recovery"
+      options={GENOME_RECOVERY_OPTIONS}
+      onChange={onChange as CallbackTypeWorkaround}
+      InputDropdownProps={PROPS_FOR_INPUT_DROPDOWN}
+    />
   );
-};
-
-interface ChipsProps {
-  value?: DefaultMenuSelectOption | null;
-  onDelete: () => void;
-}
-
-// TODO (mlila): replace with sds tag when it's complete
-const Chips = ({ value, onDelete }: ChipsProps): JSX.Element | null => {
-  if (!value) return null;
-  const { name } = value as never;
-
-  return <StyledChip size="medium" label={name} onDelete={onDelete} />;
 };
 
 export { GenomeRecoveryFilter };

--- a/src/frontend/src/components/FilterPanel/components/GenomeRecoveryFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/GenomeRecoveryFilter/index.tsx
@@ -12,6 +12,15 @@ interface Props {
   updateGenomeRecoveryFilter: (selected?: string) => void;
 }
 
+const GENOME_RECOVERY_OPTIONS = [
+  {
+    name: "Complete",
+  },
+  {
+    name: "Failed",
+  },
+];
+
 const GenomeRecoveryFilter = ({
   updateGenomeRecoveryFilter,
 }: Props): JSX.Element => {
@@ -24,14 +33,6 @@ const GenomeRecoveryFilter = ({
 
   const open = Boolean(anchorEl);
   const id = "genome-recovery";
-  const OPTIONS = [
-    {
-      name: "Complete",
-    },
-    {
-      name: "Failed",
-    },
-  ];
 
   const handleClose = () => {
     if (anchorEl) {
@@ -57,6 +58,12 @@ const GenomeRecoveryFilter = ({
   };
 
   // TODO (mlila): replace with sds complex filter when complete
+  // (vince): For the most part, will be a simple drop-in replacement, but there
+  // are some styling difficulties right now. See notes in LineageFilter about
+  // czifui 0.0.55, but also, even with that version I think it won't work
+  // immediately because of the `Wrapper` component in how ComplexFilter is
+  // implemented locking it to 150px width. Whenever we make the change over,
+  // expect to need to figure that out as part of it.
   return (
     <>
       <StyledFilterWrapper>
@@ -73,7 +80,7 @@ const GenomeRecoveryFilter = ({
           onClose={handleClose}
           value={value}
           onChange={handleChange}
-          options={OPTIONS}
+          options={GENOME_RECOVERY_OPTIONS}
         />
       </Popper>
     </>

--- a/src/frontend/src/components/FilterPanel/components/LineageFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/LineageFilter/index.tsx
@@ -21,7 +21,7 @@ const getOptionSelected = (
   return option.name === value.name;
 };
 // ComplexFilter doesn't directly do the check, it's done by its child MenuSelect
-const optionCheckingMenuSelectProps = {
+const MenuSelectProps = {
   getOptionSelected,
 };
 
@@ -57,7 +57,7 @@ const LineageFilter = (props: Props): JSX.Element => {
       label="Lineage"
       options={options}
       onChange={setValue}
-      MenuSelectProps={optionCheckingMenuSelectProps}
+      MenuSelectProps={MenuSelectProps}
       multiple
       search
       InputDropdownProps={PROPS_FOR_INPUT_DROPDOWN}

--- a/src/frontend/src/components/FilterPanel/components/LineageFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/LineageFilter/index.tsx
@@ -1,9 +1,6 @@
-import {
-  ComplexFilter,
-  ComplexFilterValue,
-  DefaultMenuSelectOption,
-} from "czifui";
+import { ComplexFilterValue, DefaultMenuSelectOption } from "czifui";
 import React, { useEffect, useState } from "react";
+import { StyledComplexFilter } from "../../style";
 
 interface Props {
   options: DefaultMenuSelectOption[];
@@ -38,11 +35,11 @@ const LineageFilter = (props: Props): JSX.Element => {
   }, [updateLineageFilter, value]);
 
   // TODO -- With czifui 0.0.55, the `InputDropdownComponent` was exposed so it
-  // can be directly styled and passed in as we do with others. Once we've upgraded
-  // to 0.0.55+, this should be swapped over so it matches the approach we do elsewhere.
+  // can be directly styled and passed in as we do with others.
+  // This should be swapped over so it matches the approach we do elsewhere.
   // (vince) To tweak the internal style of dropdown in ComplexFilter, need to
   // create a specialized set of props to insert CSS via raw `style` put into
-  // underlying HTML tag. [As of czifui 0.0.53. See above for newer.]
+  // underlying HTML tag. Was done when we were on czifui 0.0.53.
   const PROPS_FOR_INPUT_DROPDOWN = {
     sdsStyle: "minimal", // Would be defaulted, but must set everything now.
     // This `style` gets directly put in as HTML style and interpolated to CSS.
@@ -53,7 +50,7 @@ const LineageFilter = (props: Props): JSX.Element => {
   } as const;
 
   return (
-    <ComplexFilter
+    <StyledComplexFilter
       label="Lineage"
       options={options}
       onChange={setValue}

--- a/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
@@ -1,6 +1,25 @@
 import React, { FC } from "react";
 import { FormattedDateType } from "src/components/DateField";
-import { DateFilter } from "../DateFilter";
+import { DateFilter, DateMenuOption } from "../DateFilter";
+
+
+const MENU_OPTIONS_UPLOAD_DATE: DateMenuOption[] = [
+  {
+    name: "Today",
+    numDaysStartOffset: 0,
+  },
+  {
+    name: "Yesterday",
+    numDaysStartOffset: 1,
+    numDaysEndOffset: 1
+  },
+  {
+    name: "Last 7 Days",
+    numDaysStartOffset: 7
+  },
+];
+
+
 interface Props {
   updateUploadDateFilter: (
     start: FormattedDateType,
@@ -15,6 +34,7 @@ const UploadDateFilter: FC<Props> = ({ updateUploadDateFilter }) => {
       fieldKeyStart="uploadDateStart"
       inputLabel="Upload Date"
       updateDateFilter={updateUploadDateFilter}
+      menuOptions={MENU_OPTIONS_UPLOAD_DATE}
     />
   );
 };

--- a/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
@@ -2,7 +2,6 @@ import React, { FC } from "react";
 import { FormattedDateType } from "src/components/DateField";
 import { DateFilter, DateMenuOption } from "../DateFilter";
 
-
 const MENU_OPTIONS_UPLOAD_DATE: DateMenuOption[] = [
   {
     name: "Today",
@@ -10,15 +9,14 @@ const MENU_OPTIONS_UPLOAD_DATE: DateMenuOption[] = [
   },
   {
     name: "Yesterday",
+    numDaysEndOffset: 1,
     numDaysStartOffset: 1,
-    numDaysEndOffset: 1
   },
   {
     name: "Last 7 Days",
-    numDaysStartOffset: 7
+    numDaysStartOffset: 7,
   },
 ];
-
 
 interface Props {
   updateUploadDateFilter: (

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import {
   Chip,
+  ComplexFilter,
   fontCapsXxxs,
   getColors,
   getSpacings,
@@ -55,6 +56,17 @@ export const StyledChip = styled(Chip)`
     const spacings = getSpacings(props);
     return `
       margin: ${spacings?.xxs}px ${spacings?.xxs}px 0 0;
+    `;
+  }}
+`;
+
+export const StyledComplexFilter = styled(ComplexFilter)`
+  ${(props) => {
+    const spacings = getSpacings(props);
+    return `
+      margin: ${spacings?.l}px 0;
+      width: 200px;
+      }
     `;
   }}
 `;


### PR DESCRIPTION
### Summary:
- **What:** Fix Date Filtering to handle menu options more like specifications. Also covers a note from Janeece in feat/filtering PR regarding Genome Recovery filter.
- **Tickets:** [sc<161475>](https://app.shortcut.com/genepi/story/<161475>), [sc<161482>](https://app.shortcut.com/genepi/story/<161482>)
- **Env:**  https://filter-fixups-frontend.dev.genepi.czi.technology

### Demos:
![image](https://user-images.githubusercontent.com/89553795/134263393-9c115711-0313-47af-80be-ca12296e615e.png)
Upload Date now has its own menu options instead of matching Creation Date's options.

---

![image](https://user-images.githubusercontent.com/89553795/134263450-4fdffcdf-134f-4c7b-9cd3-1f2ddb0d5682.png)
Bad date format prevents user "Apply"ing the filter. Need to fix filter.

---

![image](https://user-images.githubusercontent.com/89553795/134263581-2048a413-49b0-4f9a-88d9-a24aac2a7659.png)
Selecting a menu option clears out field filters, they remain blank until a user types into them again. Menu option that is selected is highlighted.

---

![image](https://user-images.githubusercontent.com/89553795/134263645-6d687538-7b6c-447b-b967-5640ac3fa35b.png)
Selected Genome Recovery filter shows "selected" state (bold).

---

### Notes:

### Checklist:
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)