### PR TITLE
Maya/161303 161299 tooltips

### DIFF
--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Checkbox, getColors, getSpacings, Props } from "czifui";
+import { Checkbox, fontHeaderXs, getColors, getSpacings, Props } from "czifui";
 
 export const TableRow = styled.div`
   display: flex;
@@ -25,6 +25,7 @@ const doNotForwardProps = ["header"];
 export const RowContent = styled("div", {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
+  ${fontHeaderXs}
   display: flex;
   align-items: center;
   width: 100%;

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -14,13 +14,13 @@ import TreeTableNameCell from "./components/TreeTableNameCell";
 import { TreeTypeTooltip } from "./components/TreeTypeTooltip";
 import {
   GISAIDCell,
-  LineageCell,
-  LineageRowContent,
   PrivacyIcon,
   PrivateIdValueWrapper,
   SampleIconWrapper,
   StyledChip,
   Subtext,
+  UnderlinedCell,
+  UnderlinedRowContent,
 } from "./style";
 
 const LABEL_STATUS: Record<
@@ -53,13 +53,13 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   lineage: ({ value }): JSX.Element => {
     const hasLineage = Boolean(value.version);
 
-    const Component = hasLineage ? LineageRowContent : RowContent;
+    const Component = hasLineage ? UnderlinedRowContent : RowContent;
 
     const Content = (
       <Component>
-        <LineageCell className={dataTableStyle.cell}>
+        <UnderlinedCell className={dataTableStyle.cell}>
           {value.lineage || "Not Yet Processed"}
-        </LineageCell>
+        </UnderlinedCell>
       </Component>
     );
 
@@ -133,9 +133,11 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   name: TreeTableNameCell,
   treeType: ({ value, header }: CustomTableRenderProps): JSX.Element => (
     <TreeTypeTooltip value={value as string}>
-      <RowContent header={header}>
-        <div data-test-id={`row-${header.key}`}>{value}</div>
-      </RowContent>
+      <UnderlinedRowContent header={header}>
+        <UnderlinedCell data-test-id={`row-${header.key}`}>
+          {value}
+        </UnderlinedCell>
+      </UnderlinedRowContent>
     </TreeTypeTooltip>
   ),
 };

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -74,15 +74,15 @@ export const TREE_HEADERS: Header[] = [
     text: "Tree Name",
   },
   {
+    key: "creationDate",
+    sortKey: ["creationDate"],
+    text: "Creation Date",
+  },
+  {
     align: "center",
     key: "treeType",
     sortKey: ["treeType"],
     text: "Tree Type",
-  },
-  {
-    key: "creationDate",
-    sortKey: ["creationDate"],
-    text: "Creation Date",
   },
   {
     key: "downloadLink",

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -74,6 +74,7 @@ export const TREE_HEADERS: Header[] = [
     text: "Tree Name",
   },
   {
+    align: "center",
     key: "creationDate",
     sortKey: ["creationDate"],
     text: "Creation Date",

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -20,13 +20,13 @@ export const Subtext = styled.div`
   }}
 `;
 
-export const LineageCell = styled.div`
-  /* Created for LineageRowContent to target */
+export const UnderlinedCell = styled.div`
+  /* Created for UnderlinedRowContent to target */
 `;
 
-export const LineageRowContent = styled(RowContent)`
+export const UnderlinedRowContent = styled(RowContent)`
   &:hover {
-    ${LineageCell} {
+    ${UnderlinedCell} {
       ${(props) => {
         const colors = getColors(props);
 


### PR DESCRIPTION
### Summary:
- **What:** follow up style feedback for tree table tooltip changes
  - Move tree column to the right
  - Underline tree type on hover
  - Center creation date col
  - bold tree type table content
- **Ticket:**
  - [[sc161299]](https://app.shortcut.com/genepi/story/161299)
  - [[sc161303]](https://app.shortcut.com/genepi/story/161303)
- **Env:** https://tooltips-frontend.dev.genepi.czi.technology

### Demos
![Screen Shot 2021-09-22 at 11 45 39 AM](https://user-images.githubusercontent.com/7562933/134403425-28a86459-7f00-4fb1-a56b-81da657b25a7.png)

### Checklist
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)