### PR TITLE
date filter error message fix

### DIFF
--- a/src/frontend/src/components/DateField/index.tsx
+++ b/src/frontend/src/components/DateField/index.tsx
@@ -44,7 +44,7 @@ export default function DateField({
       onBlur={handleBlur}
       value={value}
       error={Boolean(errorMessage)}
-      helperText={helperText || errorMessage}
+      helperText={helperText}
     />
   );
 }

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -14,8 +14,10 @@ import {
   StyledInputDropdown,
 } from "../../style";
 import {
+  ErrorMessageHolder,
   StyledButton,
   StyledDateRange,
+  StyledErrorMessage,
   StyledManualDate,
   StyledText,
 } from "./style";
@@ -96,7 +98,10 @@ export const DateFilter: FC<Props> = ({
 
   // formik `isValid` actually gets set after `isValidating` goes back to false
   // So we have to check both to avoid visual flicker in Apply button.
-  const { values, setFieldValue, isValid, isValidating } = formik;
+  const { values, setFieldValue, isValid, isValidating, errors } = formik;
+
+  const errorMessageFieldKeyStart = errors[fieldKeyStart];
+  const errorMessageFieldKeyEnd = errors[fieldKeyEnd];
 
   // Use this over directly using `updateDateFilter` prop so we track filter changes.
   const setDatesFromRange = (start: DateType, end: DateType) => {
@@ -159,6 +164,18 @@ export const DateFilter: FC<Props> = ({
             <StyledText>to</StyledText>
             <DateField fieldKey={fieldKeyEnd} formik={formik} />
           </StyledDateRange>
+          <ErrorMessageHolder>
+            {errorMessageFieldKeyStart ? (
+              <StyledErrorMessage>{errors[fieldKeyStart]}</StyledErrorMessage>
+            ) : (
+              <StyledErrorMessage />
+            )}
+            {errorMessageFieldKeyEnd ? (
+              <StyledErrorMessage>{errors[fieldKeyEnd]}</StyledErrorMessage>
+            ) : (
+              <StyledErrorMessage />
+            )}
+          </ErrorMessageHolder>
           {(values[fieldKeyStart] || values[fieldKeyEnd]) && (
             <StyledButton
               color="primary"

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -59,8 +59,3 @@ export const StyledErrorMessage = styled.span`
   ${fontBodyXxxs}
   color: red;
 `;
-
-export const StyledErrorButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-`;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import {
   Button,
   fontBodyXs,
+  fontBodyXxxs,
   getColors,
   getFontWeights,
   getSpacings,
@@ -45,4 +46,21 @@ export const StyledButton = styled(Button)`
       margin-top: ${spacings?.xs}px;
     `;
   }}
+`;
+
+export const ErrorMessageHolder = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const StyledErrorMessage = styled.span`
+  /* set max-width here so that there's space for both error messages to be present and be spaced appropriately */
+  max-width: 159px;
+  ${fontBodyXxxs}
+  color: red;
+`;
+
+export const StyledErrorButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
 `;


### PR DESCRIPTION
### Summary:
- **What:** addressing this feedback:
 - [x] [Should Have] - When error message appears for incorrect date format, can we have the inputs remain aligned to the top? 
![Filtering-error alignement](https://user-images.githubusercontent.com/63013360/133694812-9e50a420-e3ac-4b2e-9f51-ca80e68f0d60.png)

- **Ticket:** no ticket
- **Env:** https://more-stylings-frontend.dev.genepi.czi.technology/data/samples

### Screenshots:

<img width="316" alt="Screen Shot 2021-09-22 at 2 40 15 PM" src="https://user-images.githubusercontent.com/13052132/134425905-194c1a7e-db38-45aa-a2b3-9632b488fdf0.png">
<img width="349" alt="Screen Shot 2021-09-22 at 2 40 09 PM" src="https://user-images.githubusercontent.com/13052132/134425907-4e385943-d444-48a3-89dd-8d627add70a4.png">
<img width="327" alt="Screen Shot 2021-09-22 at 2 40 24 PM" src="https://user-images.githubusercontent.com/13052132/134425902-a73432e2-ff96-43b7-8599-d1adb2e556d3.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)