### PR TITLE
Maya/150460 status tags

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -19,12 +19,6 @@
     width: 100%;
     flex-direction: row;
     align-items: baseline;
-    // TODO (mlila): when refactoring to remove scss, combined this with
-    // TODO          name column cell styles in `StyledRowContent`
-
-    &:first-of-type {
-      flex: 2 0 40%;
-    }
 
     svg {
       fill: $black;

--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -11,7 +11,7 @@
 .header {
   display: flex;
   // (thuang): Offset for Chrome scrollbar width
-  padding-right: $space-l;
+  padding: 0 $space-l;
   border-bottom: 3px solid $gray-lightest !important;
 
   .headerMetaCell {
@@ -19,6 +19,12 @@
     width: 100%;
     flex-direction: row;
     align-items: baseline;
+    // TODO (mlila): when refactoring to remove scss, combined this with
+    // TODO          name column cell styles in `StyledRowContent`
+
+    &:first-of-type {
+      flex: 2 0 40%;
+    }
 
     svg {
       fill: $black;

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -241,9 +241,9 @@ export const DataTable: FunctionComponent<Props> = ({
   // render functions
   const headerRow = headers.map((header: Header, index) => {
     const headerJSX = headerRenderer({ header, index });
-    const align = header.align;
+    const { align, key, sortKey } = header;
     let sortIndicator: JSX.Element | null = null;
-    if (isEqual(header.sortKey, state.sortKey)) {
+    if (isEqual(sortKey, state.sortKey)) {
       sortIndicator = <SortArrowDownIcon />;
       if (state.ascending) {
         sortIndicator = <SortArrowUpIcon />;
@@ -251,11 +251,13 @@ export const DataTable: FunctionComponent<Props> = ({
     }
     return (
       <TableHeader
-        onClick={() => handleSortClick(header.sortKey)}
-        key={header.sortKey.join("-")}
+        onClick={() => handleSortClick(sortKey)}
+        key={sortKey.join("-")}
         className={style.headerMetaCell}
         data-test-id="header-cell"
         align={align}
+        // * Tree name column should be slightly wider than the rest to accommodate status tags
+        wide={key === "name"}
       >
         {headerJSX}
         {sortIndicator}

--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -87,14 +87,18 @@ export const HeaderCheckbox = styled(Checkbox)`
 
 export interface AlignProps extends Props {
   align?: string;
+  wide?: boolean;
 }
 
 export const TableHeader = styled("div")`
   ${(props: AlignProps) => {
-    const { align } = props;
+    const { align, wide } = props;
     const justify = align ?? "left";
 
     return `
+      &:first-of-type {
+        flex: ${wide ? "2 0 40%" : ""};
+      }
       justify-content: ${justify};
   `;
   }}

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -15,6 +15,12 @@ interface Lineage {
   version: unknown;
 }
 
+enum TREE_STATUS {
+  Completed = "COMPLETED",
+  Failed = "FAILED",
+  Started = "STARTED",
+}
+
 interface Sample extends BioinformaticsType {
   type: "Sample";
   privateId: string;
@@ -36,7 +42,7 @@ interface Tree extends BioinformaticsType {
   creationDate: string;
   startedDate: string;
   workflowId: string;
-  status: string;
+  status: TREE_STATUS;
   downloadLink?: string;
 }
 

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { StyledChip } from "./style";
+
+interface Props {
+  treeStatus: TREE_STATUS;
+}
+
+const STATUS_MAP = {
+  COMPLETED: "success",
+  FAILED: "error",
+  STARTED: "beta",
+};
+
+const PhyloTreeStatusTag = ({ treeStatus }: Props): JSX.Element => (
+  <StyledChip
+    isRounded
+    label={treeStatus}
+    size="small"
+    status={STATUS_MAP[treeStatus]}
+  />
+);
+
+export { PhyloTreeStatusTag };

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/index.tsx
@@ -1,11 +1,25 @@
 import React from "react";
+import { TREE_STATUS } from "src/common/constants/types";
 import { StyledChip } from "./style";
+
+// TODO (mlila): this should actually be exported from sds
+export type CHIP_STATUS =
+  | "success"
+  | "error"
+  | "warning"
+  | "info"
+  | "pending"
+  | "beta";
 
 interface Props {
   treeStatus: TREE_STATUS;
 }
 
-const STATUS_MAP = {
+interface MapType {
+  [key: string]: CHIP_STATUS;
+}
+
+const STATUS_MAP: MapType = {
   COMPLETED: "success",
   FAILED: "error",
   STARTED: "beta",
@@ -16,7 +30,7 @@ const PhyloTreeStatusTag = ({ treeStatus }: Props): JSX.Element => (
     isRounded
     label={treeStatus}
     size="small"
-    status={STATUS_MAP[treeStatus]}
+    status={STATUS_MAP[treeStatus] as CHIP_STATUS}
   />
 );
 

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/style.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { Chip, getSpacings } from "czifui";
+
+export const StyledChip = styled(Chip)`
+  ${(props) => {
+    const spacings = getSpacings(props);
+
+    return `
+      margin: 0 ${spacings?.xs}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/index.tsx
@@ -4,6 +4,7 @@ import { TREE_STATUS } from "src/common/constants/types";
 import TreeIcon from "src/common/icons/PhyloTree.svg";
 import { createTreeModalInfo } from "src/common/utils";
 import TreeVizModal from "../TreeVizModal";
+import { PhyloTreeStatusTag } from "./components/PhyloTreeStatusTag";
 import { CellWrapper, StyledOpenInNewIcon, StyledRowContent } from "./style";
 
 interface NameProps {
@@ -13,7 +14,8 @@ interface NameProps {
 
 const TreeTableNameCell = ({ value, item }: NameProps): JSX.Element => {
   const [open, setOpen] = useState(false);
-  const isDisabled = item?.status !== TREE_STATUS.Completed;
+  const status = item?.status;
+  const isDisabled = status !== TREE_STATUS.Completed;
 
   const handleClickOpen = () => {
     if (!isDisabled) setOpen(true);
@@ -43,6 +45,7 @@ const TreeTableNameCell = ({ value, item }: NameProps): JSX.Element => {
           <TreeIcon className={dataTableStyle.icon} />
           {value}
           <StyledOpenInNewIcon disabled={isDisabled} />
+          <PhyloTreeStatusTag treeStatus={status} />
         </CellWrapper>
       </StyledRowContent>
     </>

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { getColors, Props } from "czifui";
+import { getColors, getSpacings, Props } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import OpenInNewIcon from "src/common/icons/OpenInNew.svg";
 import { icon } from "../../../../common/components/library/data_table/style";
@@ -14,6 +14,14 @@ export const StyledOpenInNewIcon = styled(OpenInNewIcon, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${icon}
+  flex: 0 0 auto;
+
+  ${(props) => {
+    const spacings = getSpacings(props);
+    return `
+      margin: 0 0 0 ${spacings?.l}px;
+    `;
+  }}
 
   ${(props: ExtraProps) => {
     const { disabled } = props;
@@ -30,6 +38,8 @@ export const StyledOpenInNewIcon = styled(OpenInNewIcon, {
 export const StyledRowContent = styled(RowContent, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
+  flex: 2 0 40%;
+
   ${(props: ExtraProps) => {
     const { disabled } = props;
     const colors = getColors(props);

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -2,7 +2,10 @@ import styled from "@emotion/styled";
 import { getColors, getSpacings, Props } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import OpenInNewIcon from "src/common/icons/OpenInNew.svg";
-import { icon } from "../../../../common/components/library/data_table/style";
+import {
+  icon,
+  nameCell,
+} from "../../../../common/components/library/data_table/style";
 
 export interface ExtraProps extends Props {
   disabled?: boolean;

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -2,10 +2,7 @@ import styled from "@emotion/styled";
 import { getColors, getSpacings, Props } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import OpenInNewIcon from "src/common/icons/OpenInNew.svg";
-import {
-  icon,
-  nameCell,
-} from "../../../../common/components/library/data_table/style";
+import { icon } from "../../../../common/components/library/data_table/style";
 
 export interface ExtraProps extends Props {
   disabled?: boolean;


### PR DESCRIPTION
### Summary
- **What:** Add status tags for phylo trees
- **Ticket:** [[sc150460]](https://app.clubhouse.io/genepi/story/150460)
- **Env:** https://statustags-frontend.dev.genepi.czi.technology

### Testing
1. Open trees pages
1. Ensure each tree has a status tag next to it representing the status of the build
2. Three types available: Complete, failed, and started

### Demos
<img width="574" alt="Screen Shot 2021-09-22 at 2 25 34 PM" src="https://user-images.githubusercontent.com/7562933/134424209-d0774be1-4ea7-4b52-a47f-36da1de2c286.png">

### Checklist
- [x] I merged latest `feat/filtering`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)