### PR TITLE
update toast for tree creation 

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -153,7 +153,6 @@ const DataSubview: FunctionComponent<Props> = ({
     useState<boolean>(false);
   const [hasCreateTreeStarted, setCreateTreeStarted] = useState<boolean>(false);
   const [didCreateTreeFailed, setCreateTreeFailed] = useState<boolean>(false);
-
   const handleDownloadClickOpen = () => {
     setDownloadModalOpen(true);
   };
@@ -417,8 +416,8 @@ const DataSubview: FunctionComponent<Props> = ({
                     lightText={
                       <CreateTreeModalDiv>
                         Your tree is being created. It may take up to 12 hours
-                        to process. You will be able find your new tree on the
-                        Phylogenetic Trees page when it is ready.
+                        to process To check your tree’s status, visit the
+                        Phylogenetic Tree page.
                         <NextLink href={ROUTES.PHYLO_TREES} passHref>
                           <a href="passRef">
                             <StyledButton

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -416,7 +416,7 @@ const DataSubview: FunctionComponent<Props> = ({
                     lightText={
                       <CreateTreeModalDiv>
                         Your tree is being created. It may take up to 12 hours
-                        to process To check your tree’s status, visit the
+                        to process. To check your tree’s status, visit the
                         Phylogenetic Tree page.
                         <NextLink href={ROUTES.PHYLO_TREES} passHref>
                           <a href="passRef">


### PR DESCRIPTION
### Summary:
- **What:** updating the tree creation info toast now that we have tree statuses!
- **Ticket:** [sc161212](https://app.shortcut.com/genepi/story/161212)
- **Env:** https://more-stylings-frontend.dev.genepi.czi.technology

### Screenshots:
<img width="426" alt="Screen Shot 2021-09-23 at 11 31 03 AM" src="https://user-images.githubusercontent.com/13052132/134564539-7bb01a4b-0f3f-4a95-9179-9920bffc616f.png">

### Checklist:
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)