### PR TITLE
add setTreeNameTooLong to clearState

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
@@ -68,6 +68,7 @@ export const CreateTreeModal = ({
     setTreeName("");
     setTreeType("TARGETED");
     setInstructionsShown(false);
+    setTreeNameTooLong(false);
   };
 
   const handleClose = function () {


### PR DESCRIPTION
### Summary:
- **What:** the `tree name is too long` error should be cleared when user exits the modal
- **Ticket:** no ticket, feedback from demo today
- **Env:** https://more-stylings-frontend.dev.genepi.czi.technology

### Checklist:
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)