### PR TITLE
disable download when tree status is incomplete or failed

### DIFF
--- a/src/frontend/src/components/TreeTableDownloadMenu/index.tsx
+++ b/src/frontend/src/components/TreeTableDownloadMenu/index.tsx
@@ -31,6 +31,7 @@ const TreeTableDownloadMenu = ({
         onClick={handleClick}
         className={style.button}
         endIcon={<ExpandMore />}
+        disabled={!shouldAllowDownload}
       >
         Download
       </Button>
@@ -41,11 +42,9 @@ const TreeTableDownloadMenu = ({
         onClose={handleClose}
         getContentAnchorEl={null}
       >
-        {shouldAllowDownload && (
-          <a href={jsonLink} target="_blank" rel="noopener">
-            <MenuItem onClick={handleClose}>{"Tree file (.json)"}</MenuItem>
-          </a>
-        )}
+        <a href={jsonLink} target="_blank" rel="noopener">
+          <MenuItem onClick={handleClose}>{"Tree file (.json)"}</MenuItem>
+        </a>
         <a href={accessionsLink} target="_blank" rel="noopener">
           <MenuItem onClick={handleClose}>{"Private IDs (.tsv)"}</MenuItem>
         </a>


### PR DESCRIPTION
### Summary:
- **What:** Disable all downloads from tree page when tree status is not complete

### Demos
![Screen Shot 2021-09-23 at 11 56 47 AM](https://user-images.githubusercontent.com/7562933/134567589-85e8171e-8733-4ca0-b956-0e10d2f2ae07.png)

### Checklist:
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)