### PR TITLE
replacing creationDate with StartedDate

### DIFF
--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -79,7 +79,7 @@ export const TREE_HEADERS: Header[] = [
     sortKey: ["startedDate"],
     // using startedDate instead of creationDate,
     // startedDate is populated for all phylorun statuses, creationDate only applies to completed trees
-    text: "Creation Date", 
+    text: "Creation Date",
   },
   {
     align: "center",

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -75,9 +75,11 @@ export const TREE_HEADERS: Header[] = [
   },
   {
     align: "center",
-    key: "creationDate",
-    sortKey: ["creationDate"],
-    text: "Creation Date",
+    key: "startedDate",
+    sortKey: ["startedDate"],
+    // using startedDate instead of creationDate,
+    // startedDate is populated for all phylorun statuses, creationDate only applies to completed trees
+    text: "Creation Date", 
   },
   {
     align: "center",

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -80,7 +80,7 @@ const Data: FunctionComponent = () => {
     },
     {
       data: trees,
-      defaultSortKey: ["creationDate"],
+      defaultSortKey: ["startedDate"],
       headerRenderer: TreeHeader,
       headers: TREE_HEADERS,
       isDataLoading,


### PR DESCRIPTION
### Summary:
- **What:** creationDate column in tree table view should use startedDate instead so that all trees regardless of status have an associated date field
- **Ticket:** no ticket
- **Env:** coming soon

### Checklist:
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)