### PR TITLE
Phylo runs >12h old without a phylo tree are marked as failed.

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -16,6 +16,7 @@ from aspen.app.views.api_utils import (
     format_date,
     format_datetime,
 )
+from datetime import timedelta, datetime
 from aspen.database.models import (
     DataType,
     PhyloRun,
@@ -105,6 +106,8 @@ def phylo_trees():
                 "phylo_tree_id": None,
                 "name": phylo_run.name or generate_tree_name_from_template(phylo_run),
             }
+            if phylo_run.start_datetime and phylo_run.start_datetime < (datetime.now() - timedelta(hours=12)):
+                result["status"] = "FAILED"
         results.append(result)
 
     return jsonify({PHYLO_TREE_KEY: results})

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import uuid
+from datetime import datetime, timedelta
 from typing import Any, Callable, Iterable, Mapping, MutableSequence, Optional, Set
 
 import boto3
@@ -16,7 +17,6 @@ from aspen.app.views.api_utils import (
     format_date,
     format_datetime,
 )
-from datetime import timedelta, datetime
 from aspen.database.models import (
     DataType,
     PhyloRun,
@@ -106,7 +106,9 @@ def phylo_trees():
                 "phylo_tree_id": None,
                 "name": phylo_run.name or generate_tree_name_from_template(phylo_run),
             }
-            if phylo_run.start_datetime and phylo_run.start_datetime < (datetime.now() - timedelta(hours=12)):
+            if phylo_run.start_datetime and phylo_run.start_datetime < (
+                datetime.now() - timedelta(hours=12)
+            ):
                 result["status"] = "FAILED"
         results.append(result)
 


### PR DESCRIPTION
### Summary:
- **What:** Any phylo runs started >12h ago that don't have a phylo tree will have a FAILED status
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)