### PR TITLE
Samples table checkbox alignment

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -8,10 +8,49 @@
   flex-direction: column;
 }
 
+// NOTE see associated `headerWithCheckbox` just below
 .header {
   display: flex;
-  // (thuang): Offset for Chrome scrollbar width
   padding: 0 $space-l;
+  border-bottom: 3px solid $gray-lightest !important;
+
+  .headerMetaCell {
+    display: flex;
+    width: 100%;
+    flex-direction: row;
+    align-items: baseline;
+
+    svg {
+      fill: $black;
+      width: $icon-xs;
+    }
+  }
+
+  .headerCell {
+    padding-bottom: $space-m;
+  }
+
+  .headerCellContent {
+    @include font-header-s;
+
+    color: $gray-dark;
+    margin-right: $space-xxs;
+
+    &:hover {
+      color: $black;
+      cursor: default;
+    }
+  }
+}
+
+// HACK (vince) Checkboxes in header require different padding, but because of all the
+// other child classes, we can't just change the top level header styling and not affect
+// classes downstream. So this is a copy-paste of above, but purely to target padding.
+// I don't like it either. But long-term we're moving away to Emotion `styled`, so I
+// think this is sane in the short-term.
+.headerWithCheckbox {
+  display: flex;
+  padding: 0; // Needed for checkbox in header to keep alignment with checkboxes in rows
   border-bottom: 3px solid $gray-lightest !important;
 
   .headerMetaCell {

--- a/src/frontend/src/common/components/library/data_table/index.module.scss
+++ b/src/frontend/src/common/components/library/data_table/index.module.scss
@@ -43,43 +43,12 @@
   }
 }
 
-// HACK (vince) Checkboxes in header require different padding, but because of all the
-// other child classes, we can't just change the top level header styling and not affect
-// classes downstream. So this is a copy-paste of above, but purely to target padding.
-// I don't like it either. But long-term we're moving away to Emotion `styled`, so I
-// think this is sane in the short-term.
-.headerWithCheckbox {
-  display: flex;
-  padding: 0; // Needed for checkbox in header to keep alignment with checkboxes in rows
-  border-bottom: 3px solid $gray-lightest !important;
-
-  .headerMetaCell {
-    display: flex;
-    width: 100%;
-    flex-direction: row;
-    align-items: baseline;
-
-    svg {
-      fill: $black;
-      width: $icon-xs;
-    }
-  }
-
-  .headerCell {
-    padding-bottom: $space-m;
-  }
-
-  .headerCellContent {
-    @include font-header-s;
-
-    color: $gray-dark;
-    margin-right: $space-xxs;
-
-    &:hover {
-      color: $black;
-      cursor: default;
-    }
-  }
+// Checkboxes in a header need to match alignment of row checkboxes below, so
+// we override padding. Headers with checkboxes should use above `.header` class
+// AND this class together. Because it comes second, it overrides, but everything
+// else continues to work as usual.
+.headerWithCheckbox{
+  padding: 0;
 }
 
 .cell {

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { get, isEqual } from "lodash/fp";
 import React, {
   Fragment,
@@ -334,13 +335,10 @@ export const DataTable: FunctionComponent<Props> = ({
       );
     }
 
-    // All headers use the base style.header
-    let headerStyleClass = style.header;
-    if (showCheckboxes) {
-      // However, if header needs to show checkbox, we add additional style
-      // to override certain aspects of header. See style file for more.
-      headerStyleClass = headerStyleClass + " " + style.headerWithCheckbox;
-    }
+    const headerStyleClass = classNames(
+      style.header, // All headers use this class
+      { [style.headerWithCheckbox]: showCheckboxes } // If checkbox, addl class to tweak it
+    );
 
     return (
       <div className={style.container}>

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -336,7 +336,10 @@ export const DataTable: FunctionComponent<Props> = ({
 
     return (
       <div className={style.container}>
-        <div className={style.header} data-test-id="header-row">
+        <div
+          className={showCheckboxes ? style.headerWithCheckbox : style.header}
+          data-test-id="header-row"
+        >
           {showCheckboxes && headerCheckbox()}
           {headerRow}
         </div>

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -334,12 +334,17 @@ export const DataTable: FunctionComponent<Props> = ({
       );
     }
 
+    // All headers use the base style.header
+    let headerStyleClass = style.header;
+    if (showCheckboxes) {
+      // However, if header needs to show checkbox, we add additional style
+      // to override certain aspects of header. See style file for more.
+      headerStyleClass = headerStyleClass + " " + style.headerWithCheckbox;
+    }
+
     return (
       <div className={style.container}>
-        <div
-          className={showCheckboxes ? style.headerWithCheckbox : style.header}
-          data-test-id="header-row"
-        >
+        <div className={headerStyleClass} data-test-id="header-row">
           {showCheckboxes && headerCheckbox()}
           {headerRow}
         </div>


### PR DESCRIPTION
### Summary:
- **What:** Fix checkbox alignment
- **Ticket:** No ticket, from comments in Google Doc
- **Env:** No rdev, just see photos below


### Demos:

Fixes checkbox issue on Samples page
![image](https://user-images.githubusercontent.com/89553795/134603621-77f83d8c-2b9f-4ba8-8b68-82c40dd1e617.png)



No impact on Trees page, spacing is same as before PR
![image](https://user-images.githubusercontent.com/89553795/134603639-a99ff4b0-8f1b-4e8f-911b-c96d86b71588.png)


### Notes:
I looked a little bit into getting the alignment for the row content (eg, collection date in the row being offset from its header), but I think that might be quite a bit more challenging. I'm not really sure how the alignment is currently happening, and I don't know if the header talks to the rows at all in terms of spacing and alignment right now. Not sure how to approach.
