### PR TITLE
strip leading and trailing whitespace

### DIFF
--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -311,12 +311,9 @@ def download_samples(ctx, sample_ids):
 def update_public_ids(ctx, group_id, private_to_public_id_mapping_fh):
     api_client = ctx.obj["api_client"]
 
-    def strip_lr_spaces(id: str) -> str:
-        return id.lstrip().rstrip()
-
     csvreader = csv.DictReader(private_to_public_id_mapping_fh)
     private_to_public = {
-        strip_lr_spaces(row["private_identifier"]): strip_lr_spaces(row["public_identifier"])
+        row["private_identifier"].strip(): row["public_identifier"].strip()
         for row in csvreader
     }
 

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -311,8 +311,14 @@ def download_samples(ctx, sample_ids):
 def update_public_ids(ctx, group_id, private_to_public_id_mapping_fh):
     api_client = ctx.obj["api_client"]
 
+    def strip_lr_spaces(id: str) -> str:
+        return id.lstrip().rstrip()
+
     csvreader = csv.DictReader(private_to_public_id_mapping_fh)
-    private_to_public = {row["private_identifier"]: row["public_identifier"] for row in csvreader}
+    private_to_public = {
+        strip_lr_spaces(row["private_identifier"]): strip_lr_spaces(row["public_identifier"])
+        for row in csvreader
+    }
 
     payload = {
         "group_id": group_id,


### PR DESCRIPTION
### Summary:
- **What:** strip off trailing and leading whitespaces from private and public ids, just because i can see this being an issue in the future
- **Ticket:** no ticket
- **Env:** no env

### Testing:
`python src/cli/aspencli.py --env local samples update_public_ids --group-id 1 --private-to-public-id-mapping ~/Downloads/test_rename_public_identifiers.csv`
[test_rename_public_identifiers.csv](https://github.com/chanzuckerberg/aspen/files/7238200/test_rename_public_identifiers.csv)



### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)