### PR TITLE
[sc137430] reorder columns

### DIFF
--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -10,24 +10,24 @@ export const SAMPLE_HEADERS: Header[] = [
     text: "Public ID",
   },
   {
-    key: "uploadDate",
-    sortKey: ["uploadDate"],
-    text: "Upload Date",
-  },
-  {
     key: "collectionDate",
     sortKey: ["collectionDate"],
     text: "Collection Date",
   },
   {
-    key: "collectionLocation",
-    sortKey: ["collectionLocation"],
-    text: "Collection Location",
-  },
-  {
     key: "lineage",
     sortKey: ["lineage", "lineage"],
     text: "Lineage",
+  },
+  {
+    key: "uploadDate",
+    sortKey: ["uploadDate"],
+    text: "Upload Date",
+  },
+  {
+    key: "collectionLocation",
+    sortKey: ["collectionLocation"],
+    text: "Collection Location",
   },
   {
     key: "gisaid",


### PR DESCRIPTION
### Summary
- **What:** reorder columns to be in a better order
- **Why:** I needed something easy to break up my search investigation
- **Ticket:** [[sc137430]](https://app.shortcut.com/genepi/story/137430)

### Demos
#### Before: 
![Screen Shot 2021-09-27 at 1 06 31 PM](https://user-images.githubusercontent.com/7562933/134977751-22d91d81-bab1-41e0-8a3a-571b0c1409ce.png)

#### After: 
![Screen Shot 2021-09-27 at 1 06 10 PM](https://user-images.githubusercontent.com/7562933/134977728-5791570b-dc3f-47ea-8b05-ba36fc8761b7.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)