### PR TITLE
add error 600 text

### DIFF
--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -57,5 +57,10 @@ export const StyledErrorMessage = styled.span`
   /* set max-width here so that there's space for both error messages to be present and be spaced appropriately */
   max-width: 159px;
   ${fontBodyXxxs}
-  color: red;
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      color: ${colors?.error[600]};
+    `;
+  }}
 `;


### PR DESCRIPTION
### Summary:
- **What:** add error600 instead of generic red to error message on date filters
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** added screenshot instead

### Screenshots:

<img width="317" alt="Screen Shot 2021-09-27 at 1 10 19 PM" src="https://user-images.githubusercontent.com/13052132/134978063-dc70de08-220e-4ea8-a99a-cc554ebe8fc6.png">

### Checklist:
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)