### PR TITLE
[ch163990] Maya/invalidate tree cache

### DIFF
--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -102,7 +102,7 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
 export const fetchSamples = (): Promise<SampleResponse> =>
   apiResponse<SampleResponse>(["samples"], [SAMPLE_MAP], API.SAMPLES);
 
-interface TreeResponse extends APIResponse {
+export interface TreeResponse extends APIResponse {
   phylo_trees: Tree[];
 }
 const TREE_MAP = new Map<string, keyof Tree>([

--- a/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/createTreeModal/index.tsx
@@ -3,8 +3,7 @@ import RadioGroup from "@material-ui/core/RadioGroup";
 import CloseIcon from "@material-ui/icons/Close";
 import { Alert, Link } from "czifui";
 import React, { SyntheticEvent, useEffect, useState } from "react";
-import { useMutation } from "react-query";
-import { createTree } from "src/common/queries/trees";
+import { useCreateTree } from "src/common/queries/trees";
 import { Header, StyledIconButton } from "../DownloadModal/style";
 import {
   RadioLabelNonContextualized,
@@ -93,7 +92,7 @@ export const CreateTreeModal = ({
     }
   }, [treeName, treeType]);
 
-  const mutation = useMutation(createTree, {
+  const mutation = useCreateTree({
     onError: () => {
       handleCreateTreeFailed();
       handleClose();

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -153,6 +153,7 @@ const DataSubview: FunctionComponent<Props> = ({
     useState<boolean>(false);
   const [hasCreateTreeStarted, setCreateTreeStarted] = useState<boolean>(false);
   const [didCreateTreeFailed, setCreateTreeFailed] = useState<boolean>(false);
+  const [searchQuery, setSearchQuery] = useState<string>("");
   const handleDownloadClickOpen = () => {
     setDownloadModalOpen(true);
   };
@@ -178,6 +179,10 @@ const DataSubview: FunctionComponent<Props> = ({
     setMetadataSelected(false);
     setFastaSelected(false);
   };
+
+  useEffect(() => {
+    searcher(searchQuery);
+  }, [data]);
 
   useEffect(() => {
     // Only show checkboxes on the sample datatable
@@ -233,12 +238,17 @@ const DataSubview: FunctionComponent<Props> = ({
     }, 12000);
   }, [hasCreateTreeStarted]);
 
-  // search functions
-  const searcher = (
+  const onChange = (
     _event: React.ChangeEvent<HTMLInputElement>,
     fieldInput: InputOnChangeData
   ) => {
     const query = fieldInput.value;
+    searcher(query);
+    setSearchQuery(query);
+  };
+
+  // search functions
+  const searcher = (query: string): void => {
     if (data === undefined) {
       return;
     } else if (query.length === 0) {
@@ -349,7 +359,7 @@ const DataSubview: FunctionComponent<Props> = ({
                 icon="search"
                 placeholder="Search"
                 loading={state.searching}
-                onChange={searcher}
+                onChange={onChange}
                 data-test-id="search"
               />
             </div>

--- a/src/frontend/src/common/queries/entities.ts
+++ b/src/frontend/src/common/queries/entities.ts
@@ -1,3 +1,4 @@
 export enum ENTITIES {
+  TREE_INFO = "TREE_INFO",
   USER_INFO = "USER_INFO",
 }

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -5,8 +5,9 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { Menu } from "semantic-ui-react";
-import { fetchSamples, fetchTrees } from "src/common/api";
+import { fetchSamples } from "src/common/api";
 import { useProtectedRoute } from "src/common/queries/auth";
+import { useTreeInfo } from "src/common/queries/trees";
 import { FilterPanel } from "src/components/FilterPanel";
 import { DataSubview } from "../../common/components";
 import { EMPTY_OBJECT } from "../../common/constants/empty";
@@ -29,7 +30,6 @@ const Data: FunctionComponent = () => {
   useProtectedRoute();
 
   const [samples, setSamples] = useState<Sample[] | undefined>();
-  const [trees, setTrees] = useState<Tree[] | undefined>();
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [shouldShowFilters, setShouldShowFilters] = useState<boolean>(true);
   const [dataFilterFunc, setDataFilterFunc] = useState<any>();
@@ -37,22 +37,17 @@ const Data: FunctionComponent = () => {
 
   const router = useRouter();
 
+  const treeResponse = useTreeInfo();
+  const trees = treeResponse?.data?.["phylo_trees"] ?? [];
+
   useEffect(() => {
     const setBioinformaticsData = async () => {
       setIsDataLoading(true);
-
-      const [sampleResponse, treeResponse] = await Promise.all([
-        fetchSamples(),
-        fetchTrees(),
-      ]);
-
+      const [sampleResponse] = await Promise.all([fetchSamples()]);
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];
-      const apiTrees = treeResponse["phylo_trees"];
-
       setSamples(apiSamples);
-      setTrees(apiTrees);
     };
 
     setBioinformaticsData();

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -43,7 +43,7 @@ const Data: FunctionComponent = () => {
   useEffect(() => {
     const setBioinformaticsData = async () => {
       setIsDataLoading(true);
-      const [sampleResponse] = await Promise.all([fetchSamples()]);
+      const sampleResponse = await fetchSamples();
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -30,6 +30,7 @@ const Data: FunctionComponent = () => {
   useProtectedRoute();
 
   const [samples, setSamples] = useState<Sample[] | undefined>();
+  const [trees, setTrees] = useState<Tree[] | undefined>();
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [shouldShowFilters, setShouldShowFilters] = useState<boolean>(true);
   const [dataFilterFunc, setDataFilterFunc] = useState<any>();
@@ -38,20 +39,24 @@ const Data: FunctionComponent = () => {
   const router = useRouter();
 
   const treeResponse = useTreeInfo();
-  const trees = treeResponse?.data?.["phylo_trees"] ?? [];
+  const { data, isLoading } = treeResponse;
 
   useEffect(() => {
     const setBioinformaticsData = async () => {
       setIsDataLoading(true);
+      if (isLoading) return;
       const sampleResponse = await fetchSamples();
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];
+      const apiTrees = data?.phylo_trees;
+
       setSamples(apiSamples);
+      setTrees(apiTrees);
     };
 
     setBioinformaticsData();
-  }, []);
+  }, [isLoading, data]);
 
   useEffect(() => {
     if (router.asPath === ROUTES.DATA) {


### PR DESCRIPTION
### Summary
- **What:** Invalidate FE cache when new tree created
- **Why:** So when users click the link to the trees page after creating a new tree, their tree is actually shown
- **Ticket:** [[sc-163990]](https://app.shortcut.com/genepi/story/163990)
- **Env:** https://phylotreecache-frontend.dev.genepi.czi.technology/data/phylogenetic_trees
- **Discussion:** https://czi-sci.slack.com/archives/C02F8V4LMNJ/p1632518947052000

### Testing
1. loading trees page directly doesnt yield a blank table
2. creating a new tree from samples page, then click “View my trees” link in toast message tkes you to the tree page AND your new tree is shown.
3. creating a new tree from samples page, then click “phylogenetic trees” tab in nav bar takes you to the tree page AND your new tree is shown.

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/134994814-9f987028-1230-4209-90cd-690f14e90407.gif)

#### After: 
(if the cache is refreshed after the page change occurs)
![after2](https://user-images.githubusercontent.com/7562933/134994775-9127636f-40d6-4145-a414-ca10f6b9696c.gif)

(if the cache is refreshed before the page change occurs)
![after](https://user-images.githubusercontent.com/7562933/134994768-6934e3a5-1e81-4299-a4db-c7260871408a.gif)

### Notes
- I created a [ticket](https://app.shortcut.com/genepi/story/164215/refactor-data-subview) to refactor the data subview component. It's starting to be responsible for too many things, and there are a lot of low hanging fruit for making this component easier to understand. 

### Checklist
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)