### PR TITLE
strip off time from createdDate

### DIFF
--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -13,6 +13,7 @@ import TreeTableDownloadMenu from "src/components/TreeTableDownloadMenu";
 import { Lineage, LineageTooltip } from "./components/LineageTooltip";
 import TreeTableNameCell from "./components/TreeTableNameCell";
 import { TreeTypeTooltip } from "./components/TreeTypeTooltip";
+import style from "./index.module.scss";
 import {
   GISAIDCell,
   PrivacyIcon,
@@ -134,6 +135,16 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     );
   },
   name: TreeTableNameCell,
+  startedDate: ({ value, header }): JSX.Element => {
+    const dateNoTime = value.split(" ")[0];
+    return (
+      <RowContent header={header}>
+        <div className={style.cell} data-test-id={`row-${header.key}`}>
+          {dateNoTime}
+        </div>
+      </RowContent>
+    );
+  },
   treeType: ({ value, header }: CustomTableRenderProps): JSX.Element => (
     <TreeTypeTooltip value={value as string}>
       <UnderlinedRowContent header={header}>


### PR DESCRIPTION
### Summary:
- **What:** remove time from startedDate (display CreationDate) column until we add in date conversion based on user's timezone
- **Ticket:** no ticket
- **Env:** added screenshot instead

### Screenshot:
<img width="1370" alt="Screen Shot 2021-09-28 at 8 41 31 AM" src="https://user-images.githubusercontent.com/13052132/135120201-0a50a836-d714-4cf2-b851-b62b43fca8ed.png">


### Checklist:
- [x] I merged latest `self-serve-tree-v1`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)