### PR TITLE
add pango lineage to Aspen metadata and allow filtering

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -278,6 +278,7 @@ def write_sequences_files(session, pathogen_genomes, sequences_fh, metadata_fh):
             "originating_lab": sample.sample_collected_by,
             "submitting_lab": sample.submitting_group.name,
             "authors": ", ".join(sample.authors),
+            "pango_lineage": sample.uploaded_pathogen_genome.pangolin_lineage,
         }
 
         metadata_csv_fh.writerow(aspen_metadata_row)

--- a/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
+++ b/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
@@ -84,7 +84,8 @@
     "host",
     "submitting_lab",
     "originating_lab",
-    "author"
+    "author",
+    "pango_lineage"
   ],
   "panels": [
     "tree",


### PR DESCRIPTION
Thanks to Phoenix who actually wrote the edit!

### Summary:
- **What:** Currently samples from Aspen do not show Pango lineages on trees b/c we don't export that column from database. This PR added it in, and enable filtering by lineages on the tree. 

There is a caveat that our Pangolin version (daily update) usually do not match GISAID version (current versino is 9-16), and samples from GISAID carries their own lineage calls from GISAID. In the long term, if we want do to this totally correct, we should rerun Pangolin on the GISAID data using our own Pangolin installation. Alternatively in theory Nextstrain can run Pangolin on the fly but it's not straightforward to install Pangolin except Conda, but neither our docker nor Nextstrain base docker uses Conda....

### Demos:
Before:
![image](https://user-images.githubusercontent.com/20667188/135169923-cd9097c6-efa6-41b1-b140-6762b24df742.png)

After:
![image](https://user-images.githubusercontent.com/20667188/135292720-0d21163c-12a9-4653-bcc5-2c03503014cd.png)


### Notes:
I passed py-lint test!!!!

### Checklist:
- [ v] I merged latest `<base branch>`
- [ v] I manually verified the change
- [ v] I added labels to my PR
- [ v] I tested in multiple browsers
- [ NA] I added relevant unit tests
- [ NA] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)