### PR TITLE
Mark old PhyloRun workflows as failed in DB

### DIFF
--- a/src/backend/database_migrations/versions/20211001_110738_mark_old_phylo_runs_as_failed.py
+++ b/src/backend/database_migrations/versions/20211001_110738_mark_old_phylo_runs_as_failed.py
@@ -3,11 +3,11 @@
 Create Date: 2021-10-01 11:07:38.260898
 
 """
+import datetime
+
 import enumtables  # noqa: F401
 import sqlalchemy as sa
 from alembic import op
-
-import datetime
 
 # revision identifiers, used by Alembic.
 revision = "20211001_110738"
@@ -24,7 +24,9 @@ def upgrade():
     mark_failed_sql = sa.sql.text(
         "UPDATE aspen.workflows SET workflow_status = 'FAILED', end_datetime = :now WHERE workflow_type = 'PHYLO_RUN' AND workflow_status = 'STARTED' AND start_datetime <= :cutoff"
     )
-    params = { "now": now, "cutoff": forty_eight_hours_ago }
+    params = {"now": now, "cutoff": forty_eight_hours_ago}
+
+    conn = op.get_bind()
     conn.execute(mark_failed_sql, params)
 
 

--- a/src/backend/database_migrations/versions/20211001_110738_mark_old_phylo_runs_as_failed.py
+++ b/src/backend/database_migrations/versions/20211001_110738_mark_old_phylo_runs_as_failed.py
@@ -1,0 +1,32 @@
+"""Mark old Phylo Runs as failed
+
+Create Date: 2021-10-01 11:07:38.260898
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+import datetime
+
+# revision identifiers, used by Alembic.
+revision = "20211001_110738"
+down_revision = "20210928_203749"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    now = datetime.datetime.now()
+    forty_eight_hours = datetime.timedelta(hours=48)
+    forty_eight_hours_ago = now - forty_eight_hours
+
+    mark_failed_sql = sa.sql.text(
+        "UPDATE aspen.workflows SET workflow_status = 'FAILED', end_datetime = :now WHERE workflow_type = 'PHYLO_RUN' AND workflow_status = 'STARTED' AND start_datetime <= :cutoff"
+    )
+    params = { "now": now, "cutoff": forty_eight_hours_ago }
+    conn.execute(mark_failed_sql, params)
+
+
+def downgrade():
+    pass

--- a/src/backend/database_migrations/versions/20211001_110738_mark_old_phylo_runs_as_failed.py
+++ b/src/backend/database_migrations/versions/20211001_110738_mark_old_phylo_runs_as_failed.py
@@ -24,7 +24,7 @@ def upgrade():
     mark_failed_sql = sa.sql.text(
         "UPDATE aspen.workflows SET workflow_status = 'FAILED', end_datetime = :now WHERE workflow_type = 'PHYLO_RUN' AND workflow_status = 'STARTED' AND start_datetime <= :cutoff"
     )
-    params = {"now": now, "cutoff": forty_eight_hours_ago}
+    params = {"now": now.isoformat(), "cutoff": forty_eight_hours_ago.isoformat()}
 
     conn = op.get_bind()
     conn.execute(mark_failed_sql, params)


### PR DESCRIPTION
### Summary:
- **What:** A migration that marks `PHYLO_RUN` `workflows` older than 48 hours as failed.
- **Ticket:** [sc164300](https://app.shortcut.com/genepi/story/164300)
- **Env:** `<rdev link>`

### Demos:

### Notes:
"48 hours" means 48 hours old at the time the migration is run. The `end_datetime` is set to the time the migration is run.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)