### PR TITLE
Temporarily skip Thurs deploy.

### DIFF
--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -3,7 +3,9 @@ name: Scheduled Prod Deploy
 on:
   schedule:
     # Weekly Mondays & Thursdays @ 15:00 UTC (8am PST)
-    - cron: '0 15 * * 1,4'
+    # - cron: '0 15 * * 1,4'
+    # Weekly Mondays 15:00 UTC (8am PST)
+    - cron: '0 15 * * 1'
 
 env:
   DOCKER_BUILDKIT: 1


### PR DESCRIPTION
### Summary:
- **What:** Take Thurs off the auto-deploy schedule temporarily.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)