### PR TITLE
little bit of state clean up

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -28,12 +28,6 @@ import {
 interface Props {
   sampleIds: string[];
   failedSamples: any[];
-  isMetadataSelected: boolean;
-  setMetadataSelected: (prevState: boolean) => void;
-  isFastaSelected: boolean;
-  setFastaSelected: (prevState: boolean) => void;
-  isFastaDisabled: boolean;
-  setFastaDisabled: (prevState: boolean) => void;
   tsvData: [string[], string[][]] | undefined;
   open: boolean;
   onClose: () => void;
@@ -43,12 +37,6 @@ interface Props {
 const DownloadModal = ({
   sampleIds,
   failedSamples,
-  isMetadataSelected,
-  setMetadataSelected,
-  isFastaSelected,
-  setFastaSelected,
-  isFastaDisabled,
-  setFastaDisabled,
   tsvData,
   open,
   onClose,
@@ -68,6 +56,10 @@ const DownloadModal = ({
   const [tsvHeaders, setTsvHeaders] = useState<string[]>([]);
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const tooltipRef = useCallback((node) => setAnchorEl(node), []);
+
+  const [isFastaDisabled, setFastaDisabled] = useState<boolean>(false);
+  const [isFastaSelected, setFastaSelected] = useState<boolean>(false);
+  const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
 
   useEffect(() => {
     if (tsvData) {
@@ -93,6 +85,12 @@ const DownloadModal = ({
     setFastaSelected(!isFastaSelected);
   };
 
+  const handleCloseModal = () => {
+    setFastaSelected(false);
+    setMetadataSelected(false);
+    onClose();
+  };
+
   const mutation = useMutation(downloadSamplesFasta, {
     onError: () => {
       setDownloadFailed(true);
@@ -103,7 +101,7 @@ const DownloadModal = ({
       link.download = fastaDownloadName;
       link.click();
       link.remove();
-      onClose();
+      handleCloseModal();
     },
   });
 
@@ -123,10 +121,10 @@ const DownloadModal = ({
       disableBackdropClick
       disableEscapeKeyDown
       open={open}
-      onClose={onClose}
+      onClose={handleCloseModal}
     >
       <DialogTitle>
-        <StyledIconButton onClick={onClose}>
+        <StyledIconButton onClick={handleCloseModal}>
           <CloseIcon />
         </StyledIconButton>
         <Header>Select Download</Header>
@@ -239,7 +237,7 @@ const DownloadModal = ({
             variant="contained"
             isRounded
             disabled={false}
-            onClick={onClose}
+            onClick={handleCloseModal}
           >
             {getDownloadButtonText()}
           </StyledButton>

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -147,17 +147,15 @@ const DataSubview: FunctionComponent<Props> = ({
   const [isCreateTreeDisabled, setCreateTreeDisabled] = useState<boolean>(true);
   const [failedSamples, setFailedSamples] = useState<any[]>([]);
   const [downloadFailed, setDownloadFailed] = useState<boolean>(false);
-  const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
-  const [isFastaSelected, setFastaSelected] = useState<boolean>(false);
-  const [isFastaDisabled, setFastaDisabled] = useState<boolean>(false);
   const [isNSCreateTreeModalOpen, setIsNSCreateTreeModalOpen] =
     useState<boolean>(false);
   const [hasCreateTreeStarted, setCreateTreeStarted] = useState<boolean>(false);
   const [didCreateTreeFailed, setCreateTreeFailed] = useState<boolean>(false);
   const [isUsherConfirmOpen, setIsUsherConfirmOpen] = useState<boolean>(false);
-  const [searchQuery, setSearchQuery] = useState<string>("");
   const [isUsherPreparingOpen, setIsUsherPreparingOpen] =
     useState<boolean>(false);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+
   const handleDownloadClickOpen = () => {
     setDownloadModalOpen(true);
   };
@@ -180,8 +178,6 @@ const DataSubview: FunctionComponent<Props> = ({
 
   const handleDownloadClose = () => {
     setDownloadModalOpen(false);
-    setMetadataSelected(false);
-    setFastaSelected(false);
   };
 
   useEffect(() => {
@@ -312,12 +308,6 @@ const DataSubview: FunctionComponent<Props> = ({
               sampleIds={checkedSamples}
               failedSamples={failedSamples}
               setDownloadFailed={setDownloadFailed}
-              isMetadataSelected={isMetadataSelected}
-              setMetadataSelected={setMetadataSelected}
-              isFastaSelected={isFastaSelected}
-              setFastaSelected={setFastaSelected}
-              isFastaDisabled={isFastaDisabled}
-              setFastaDisabled={setFastaDisabled}
               tsvData={tsvDataMap(
                 checkedSamples,
                 tableData,


### PR DESCRIPTION
### Summary
- **What:** A little bit of state clean up for data subview. 
- **Why:** I noticed some of the state being maintained by this component was actually state for the download modal. I chose to move it into DownloadModal to make the component more self contained and easier to understand. It also works as part of the data subview clean up.
- **Ticket:** [[sc-164215]](https://app.shortcut.com/genepi/story/164215)
- **Env:** https://mrclean-frontend.dev.genepi.czi.technology

### Testing
Basically check that the download modal functionality hasn't changed at all

### Demos
Should be no visual or functional changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)