### PR TITLE
Re-enable 2x/week deploys at 9am.

### DIFF
--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -2,10 +2,8 @@ name: Scheduled Prod Deploy
 
 on:
   schedule:
-    # Weekly Mondays & Thursdays @ 15:00 UTC (8am PST)
-    # - cron: '0 15 * * 1,4'
-    # Weekly Mondays 15:00 UTC (8am PST)
-    - cron: '0 15 * * 1'
+     Weekly Mondays & Thursdays @ 16:00 UTC (9am PST)
+     - cron: '0 16 * * 1,4'
 
 env:
   DOCKER_BUILDKIT: 1


### PR DESCRIPTION
### Summary:
- **What:** We'd temporarily disabled Thursday deploys while investigating a problem with gisaid jobs. This re-enables the Thursday deploy *and* moves deploys forward an hour to 9am when I think more of the team is available to deal with any issues that may come up during deploys.


### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)