### PR TITLE
Endpoint and data for UShER options

### DIFF
--- a/src/backend/aspen/app/serializers.py
+++ b/src/backend/aspen/app/serializers.py
@@ -38,3 +38,10 @@ class PhyloRunResponseSchema(Schema):
     group = fields.Nested(GroupResponseSchema, only=("id", "name"))
     template_file_path = fields.String()
     template_args = fields.Nested(GroupResponseSchema, only=("division", "location"))
+
+
+class UsherOptionResponseSchema(Schema):
+    id = fields.Int()
+    description = fields.String()
+    value = fields.String()
+    priority = fields.Int()

--- a/src/backend/aspen/app/views/usher.py
+++ b/src/backend/aspen/app/views/usher.py
@@ -1,6 +1,8 @@
 """Views for handling anything related to UShER"""
-from typing import Iterable, Sequence, Mapping, Any
+from typing import Any, Iterable, Mapping, Sequence
+
 from flask import g, jsonify
+
 from aspen.app.app import application, requires_auth
 from aspen.database.models.usher import UsherOption
 
@@ -9,11 +11,14 @@ from aspen.database.models.usher import UsherOption
 @requires_auth
 def get_usher_tree_options():
     """DOCME"""
-    print('this works, wacky')
-
-    usher_options: Iterable[UsherOption] = g.db_session.query(UsherOption).order_by(
-        # Lowest priority is most important, lessens as priority ascends
-        UsherOption.priority.asc()).all()
+    usher_options: Iterable[UsherOption] = (
+        g.db_session.query(UsherOption)
+        .order_by(
+            # Lowest priority is most important, lessens as priority ascends
+            UsherOption.priority.asc()
+        )
+        .all()
+    )
 
     serializable_options: Sequence[Mapping[str, Any]]
     serializable_options = [option.to_dict() for option in usher_options]

--- a/src/backend/aspen/app/views/usher.py
+++ b/src/backend/aspen/app/views/usher.py
@@ -1,0 +1,20 @@
+"""Views for handling anything related to UShER"""
+from typing import Iterable, Sequence, Mapping, Any
+from flask import g, jsonify
+from aspen.app.app import application, requires_auth
+from aspen.database.models.usher import UsherOption
+
+
+@application.route("/api/usher/tree_options", methods=["GET"])
+@requires_auth
+def get_usher_tree_options():
+    """DOCME"""
+    print('this works, wacky')
+
+    usher_options: Iterable[UsherOption] = g.db_session.query(UsherOption).order_by(
+        # Lowest priority is most important, lessens as priority ascends
+        UsherOption.priority.asc()).all()
+
+    serializable_options: Sequence[Mapping[str, Any]]
+    serializable_options = [option.to_dict() for option in usher_options]
+    return jsonify({"usher_options": serializable_options})

--- a/src/backend/aspen/app/views/usher.py
+++ b/src/backend/aspen/app/views/usher.py
@@ -10,7 +10,12 @@ from aspen.database.models.usher import UsherOption
 @application.route("/api/usher/tree_options", methods=["GET"])
 @requires_auth
 def get_usher_tree_options():
-    """DOCME"""
+    """Gets all options user can pick from when creating tree via UShER.
+
+    Transparent view of all info on each option in database.
+    Returned in order of priority. First in options list is highest priority,
+    which is what should be the default selection and first offered option.
+    """
     usher_options: Iterable[UsherOption] = (
         g.db_session.query(UsherOption)
         .order_by(

--- a/src/backend/aspen/app/views/usher.py
+++ b/src/backend/aspen/app/views/usher.py
@@ -1,9 +1,10 @@
 """Views for handling anything related to UShER"""
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Iterable
 
 from flask import g, jsonify
 
 from aspen.app.app import application, requires_auth
+from aspen.app.serializers import UsherOptionResponseSchema
 from aspen.database.models.usher import UsherOption
 
 
@@ -25,6 +26,5 @@ def get_usher_tree_options():
         .all()
     )
 
-    serializable_options: Sequence[Mapping[str, Any]]
-    serializable_options = [option.to_dict() for option in usher_options]
-    return jsonify({"usher_options": serializable_options})
+    options_schema = UsherOptionResponseSchema(many=True)
+    return jsonify({"usher_options": options_schema.dump(usher_options)})

--- a/src/backend/aspen/database/models/__init__.py
+++ b/src/backend/aspen/database/models/__init__.py
@@ -39,6 +39,7 @@ from aspen.database.models.sequences import (  # noqa: F401
     UploadedPathogenGenome,
 )
 from aspen.database.models.usergroup import Group, User  # noqa: F401
+from aspen.database.models.usher import UsherOption  # noqa: F401
 from aspen.database.models.workflow import (  # noqa: F401
     Workflow,
     WorkflowInputs,

--- a/src/backend/aspen/database/models/usher.py
+++ b/src/backend/aspen/database/models/usher.py
@@ -6,12 +6,13 @@ from aspen.database.models.mixins import DictMixin
 
 
 class UsherOption(idbase, DictMixin):  # type: ignore
-    """DOCME"""
+    """A possible tree creation option when using UShER."""
 
     __tablename__ = "usher_options"
 
     description = Column(String, unique=True, nullable=False)
     value = Column(String, unique=True, nullable=False)
+    # `priority` is order we display options to user. LOWEST number is max priority.
     priority = Column(Integer, unique=True)
 
     def __repr__(self):

--- a/src/backend/aspen/database/models/usher.py
+++ b/src/backend/aspen/database/models/usher.py
@@ -1,0 +1,18 @@
+"""Models for handling anything related to UShER"""
+from sqlalchemy import Column, Integer, String
+
+from aspen.database.models.base import idbase
+from aspen.database.models.mixins import DictMixin
+
+
+class UsherOption(idbase, DictMixin):  # type: ignore
+    """DOCME"""
+
+    __tablename__ = "usher_options"
+
+    description = Column(String, unique=True, nullable=False)
+    value = Column(String, unique=True, nullable=False)
+    priority = Column(Integer, unique=True)
+
+    def __repr__(self):
+        return f"UsherOption <{self.value}>"

--- a/src/backend/aspen/main.py
+++ b/src/backend/aspen/main.py
@@ -8,3 +8,4 @@ from aspen.app.views.phylo_runs import start_phylo_run  # noqa: F401
 from aspen.app.views.phylo_trees import auspice_view, phylo_trees  # noqa: F401
 from aspen.app.views.sample import samples  # noqa: F401
 from aspen.app.views.usergroup import usergroup  # noqa: F401
+from aspen.app.views.usher import get_usher_tree_options # noqa: F401

--- a/src/backend/aspen/main.py
+++ b/src/backend/aspen/main.py
@@ -8,4 +8,4 @@ from aspen.app.views.phylo_runs import start_phylo_run  # noqa: F401
 from aspen.app.views.phylo_trees import auspice_view, phylo_trees  # noqa: F401
 from aspen.app.views.sample import samples  # noqa: F401
 from aspen.app.views.usergroup import usergroup  # noqa: F401
-from aspen.app.views.usher import get_usher_tree_options # noqa: F401
+from aspen.app.views.usher import get_usher_tree_options  # noqa: F401

--- a/src/backend/database_migrations/versions/20211008_225815_add_usher_options.py
+++ b/src/backend/database_migrations/versions/20211008_225815_add_usher_options.py
@@ -1,0 +1,48 @@
+"""Add UShER options
+
+Create Date: 2021-10-08 22:58:16.389306
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20211008_225815"
+down_revision = "20211001_110738"
+branch_labels = None
+depends_on = None
+
+
+# Options we have as of creation of this migration
+CURRENT_USHER_OPTIONS = [
+    {
+        "description": "High-coverage samples from GISAID, GenBank, COG-UK and CNCB",
+        "value": "hgPhyloPlaceData/wuhCor1/public.plusGisaid.latest.masked.pb",
+        "priority": 1,
+    },
+    {
+        "description": "High-coverage samples from GenBank, COG-UK and CNCB",
+        "value": "hgPhyloPlaceData/wuhCor1/public-latest.all.masked.pb",
+        "priority": 2,
+    },
+]
+
+
+def upgrade():
+    usher_options_table = op.create_table(
+        "usher_options",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("value", sa.String(), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_usher_options")),
+        sa.UniqueConstraint("description", name=op.f("uq_usher_options_description")),
+        sa.UniqueConstraint("priority", name=op.f("uq_usher_options_priority")),
+        sa.UniqueConstraint("value", name=op.f("uq_usher_options_value")),
+        schema="aspen",
+    )
+
+    op.bulk_insert(usher_options_table, CURRENT_USHER_OPTIONS)
+
+
+def downgrade():
+    op.drop_table("usher_options", schema="aspen")


### PR DESCRIPTION
### Summary:
- **What:** Migration plus data population for providing UShER options, along with API endpoint to pull them
- **Ticket:** [sc<161393>](https://app.shortcut.com/genepi/story/<161393>), [sc<161377>](https://app.shortcut.com/genepi/story/<161377>)
- **Env:** No rdev

### Demos:
![image](https://user-images.githubusercontent.com/89553795/136863582-3c5d7889-559e-40b7-b72a-dc0360bb7cd7.png)

### Notes:
Getting the options requires auth

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)