### PR TITLE
Do a better job of caching config properties.

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -1,7 +1,6 @@
 STYLE_CHECK_PYTHON_CODE_DIRECTORIES = .
 STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES = third-party
 TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES = aspen
-TYPE_CHECK_INDIVIDUAL_PYTHON_CODE_DIRECTORIES = database_migrations
 
 
 ### CHECK STYLE #############################################
@@ -16,15 +15,9 @@ black:
 isort:
 	isort --profile black --check $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES) 
 
-MYPY_TARGETS = $(foreach stylecheckdir, $(TYPE_CHECK_INDIVIDUAL_PYTHON_CODE_DIRECTORIES), mypy-$(stylecheckdir))
-
-mypy: mypy-base $(MYPY_TARGETS)
-
-mypy-base:
-	mypy --ignore-missing-imports $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
-
-$(MYPY_TARGETS): mypy-%: mypy-base
-	mypy --ignore-missing-imports $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES) $*
+mypy:
+	mypy --ignore-missing-imports aspen
+	mypy --ignore-missing-imports database_migrations
 
 
 ### RUN STYLE #############################################

--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.query import Query
 from starlette.requests import Request
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.config.config import settings
+from aspen.api.config.config import get_settings
 from aspen.api.deps import get_db
 from aspen.auth.device_auth import validate_auth_header
 from aspen.database.models import Group, User
@@ -46,6 +46,7 @@ async def setup_userinfo(user_id):
 
 
 async def get_auth_user(request: Request):
+    settings = get_settings()
     auth_header = request.headers.get("authorization")
     auth0_user_id = None
     if auth_header:

--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -10,8 +10,8 @@ from sqlalchemy.orm.query import Query
 from starlette.requests import Request
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.config.config import get_settings
 from aspen.api.deps import get_db
+from aspen.api.settings import get_settings
 from aspen.auth.device_auth import validate_auth_header
 from aspen.database.models import Group, User
 

--- a/src/backend/aspen/api/config/config.py
+++ b/src/backend/aspen/api/config/config.py
@@ -1,6 +1,6 @@
 import json
 import os
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Any, Mapping
 
 from boto3 import Session
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
 
     ####################################################################################
     # Stack name
-    @property
+    @cached_property
     def STACK_PREFIX(self) -> str:
         remote_prefix = os.environ.get("REMOTE_DEV_PREFIX")
         deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
@@ -29,13 +29,8 @@ class Settings(BaseSettings):
 
     ####################################################################################
     # AWS secrets
-    # TODO TODO TODO cache this
-    @property
+    @cached_property
     def AWS_SECRET(self) -> Mapping[str, Any]:
-        # this extra level of indirection
-        # (Auth0Config.AWS_SECRET -> Auth0Config._AWS_SECRET()) is because of
-        # https://github.com/python/mypy/issues/1362
-        # TODO cache this.
         session = Session(region_name=self.AWS_REGION)
 
         secret_name = os.environ.get("ASPEN_CONFIG_SECRET_NAME", "aspen-config")
@@ -52,25 +47,21 @@ class Settings(BaseSettings):
             secret = get_secret_value_response["SecretString"]
             return json.loads(secret)
 
-    @property
+    @cached_property
     def DEBUG(self) -> bool:
         return False
 
-    @property
-    def TESTING(self) -> bool:
-        return False
-
-    @property
+    @cached_property
     def SECRET_KEY(self) -> str:
         return self.AWS_SECRET["FLASK_SECRET"]
 
     ####################################################################################
     # auth0 properties
-    @property
+    @cached_property
     def AUTH0_CLIENT_ID(self) -> str:
         return self.AWS_SECRET["AUTH0_CLIENT_ID"]
 
-    @property
+    @cached_property
     def AUTH0_LOGOUT_URL(self) -> str:
         flask_env = os.environ.get("FLASK_ENV")
         if flask_env == "production":
@@ -78,55 +69,54 @@ class Settings(BaseSettings):
         else:
             return f"https://{self.AUTH0_DOMAIN}/Account/Logout"
 
-    @property
+    @cached_property
     def AUTH0_CALLBACK_URL(self) -> str:
         flask_env = os.environ.get("FLASK_ENV")
+        if flask_env != "production":
+            return "http://backend.genepinet.local:3000/v2/auth/callback"
         api_url = os.environ.get("API_URL")
         if not api_url:
             raise Exception("Missing API_URL in config!")
-        if flask_env == "production":
-            return f"{api_url}/v2/auth/callback"
-        else:
-            return "http://backend.genepinet.local:3000/v2/auth/callback"
+        return f"{api_url}/v2/auth/callback"
 
-    @property
+    @cached_property
     def AUTH0_CLIENT_SECRET(self) -> str:
         return self.AWS_SECRET["AUTH0_CLIENT_SECRET"]
 
-    @property
+    @cached_property
     def AUTH0_MANAGEMENT_CLIENT_ID(self) -> str:
         return self.AWS_SECRET["AUTH0_MANAGEMENT_CLIENT_ID"]
 
-    @property
+    @cached_property
     def AUTH0_MANAGEMENT_CLIENT_SECRET(self) -> str:
         return self.AWS_SECRET["AUTH0_MANAGEMENT_CLIENT_SECRET"]
 
-    @property
+    @cached_property
     def AUTH0_DOMAIN(self) -> str:
         return self.AWS_SECRET["AUTH0_DOMAIN"]
 
-    @property
+    @cached_property
     def AUTH0_BASE_URL(self) -> str:
         try:
             return self.AWS_SECRET["AUTH0_BASE_URL"]
         except KeyError:
             return f"https://{self.AUTH0_DOMAIN}"
 
-    @property
+    @cached_property
     def AUTH0_ACCESS_TOKEN_URL(self) -> str:
         try:
             return self.AWS_SECRET["AUTH0_ACCESS_TOKEN_URL"]
         except KeyError:
             return f"{self.AUTH0_BASE_URL}/oauth/token"
 
-    @property
+    @cached_property
     def AUTH0_AUTHORIZE_URL(self) -> str:
         try:
             return self.AWS_SECRET["AUTH0_AUTHORIZE_URL"]
         except KeyError:
             return f"{self.AUTH0_BASE_URL}/authorize"
 
-    @property
+    @cached_property
     def AUTH0_CLIENT_KWARGS(self) -> Mapping[str, Any]:
         try:
             return self.AWS_SECRET["AUTH0_CLIENT_KWARGS"]
@@ -135,7 +125,7 @@ class Settings(BaseSettings):
                 "scope": "openid profile email",
             }
 
-    @property
+    @cached_property
     def AUTH0_USERINFO_URL(self) -> str:
         try:
             return self.AWS_SECRET["AUTH0_USERINFO_URL"]
@@ -144,7 +134,7 @@ class Settings(BaseSettings):
 
     ####################################################################################
     # database properties
-    @property
+    @cached_property
     def DB_DSN(self) -> str:
         # Allow db uri to be overridden by env var.
         if os.getenv("DB_DSN"):
@@ -157,23 +147,23 @@ class Settings(BaseSettings):
         db_name = os.getenv("REMOTE_DEV_PREFIX") or "/aspen_db"
         return f"{self.DB_DRIVER}://{username}:{password}@{instance_address}{db_name}"
 
-    @property
+    @cached_property
     def DATABASE_READONLY_URI(self) -> str:
         raise NotImplementedError()
 
     ####################################################################################
     # s3 properties
-    @property
+    @cached_property
     def DB_BUCKET(self) -> str:
         return self.AWS_SECRET["S3_db_bucket"]
 
-    @property
+    @cached_property
     def EXTERNAL_AUSPICE_BUCKET(self) -> str:
         return self.AWS_SECRET["S3_external_auspice_bucket"]
 
     ####################################################################################
     # sentry properties
-    @property
+    @cached_property
     def SENTRY_URL(self) -> str:
         if os.getenv("SENTRY_URL"):
             return os.environ["SENTRY_URL"]
@@ -184,9 +174,8 @@ class Settings(BaseSettings):
 
     ####################################################################################
     # SSM Parameter properties
-    @lru_cache()
+    @lru_cache
     def _AWS_SSM_PARAMETER(self, parameter_suffix) -> Mapping[str, Any]:
-        # TODO cache this.
         session = Session(region_name=self.AWS_REGION)
 
         deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
@@ -205,45 +194,51 @@ class Settings(BaseSettings):
             parameter = get_parameter["Parameter"]["Value"]
             return json.loads(parameter)
 
-    @property
+    @cached_property
     def AWS_NEXTSTRAIN_SFN_PARAMETER(self) -> Mapping[str, Any]:
         return self._AWS_SSM_PARAMETER("nextstrain-ondemand-sfn")
 
     ####################################################################################
     # SFN runtime input properties
-    @property
+    @cached_property
     def NEXTSTRAIN_DOCKER_IMAGE_ID(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["Input"]["Run"]["docker_image_id"]
 
     ####################################################################################
     # SFN batch config properties
-    @property
+    @cached_property
     def NEXTSTRAIN_OUTPUT_PREFIX(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["OutputPrefix"]
 
-    @property
+    @cached_property
     def RUN_WDL_URI(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RUN_WDL_URI"]
 
-    @property
+    @cached_property
     def NEXTSTRAIN_EC2_MEMORY(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunEC2Memory"]
 
-    @property
+    @cached_property
     def NEXTSTRAIN_EC2_VCPU(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunEC2Vcpu"]
 
-    @property
+    @cached_property
     def NEXTSTRAIN_SPOT_MEMORY(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunSPOTMemory"]
 
-    @property
+    @cached_property
     def NEXTSTRAIN_SPOT_VCPU(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunSPOTVcpu"]
 
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+        keep_untouched = (
+            cached_property,
+        )  # https://github.com/samuelcolvin/pydantic/issues/1241
 
 
-settings = Settings()
+@lru_cache()
+def get_settings() -> Settings:
+    settings = Settings()
+    return settings

--- a/src/backend/aspen/api/deps.py
+++ b/src/backend/aspen/api/deps.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from aspen.api.config.config import get_settings
 from aspen.database.connection import init_async_db
 
 session_context_var: ContextVar[Optional[AsyncSession]] = ContextVar(
@@ -10,8 +11,9 @@ session_context_var: ContextVar[Optional[AsyncSession]] = ContextVar(
 )
 
 
-async def set_db(settings):
+async def set_db():
     """Store db session in the context var and reset it"""
+    settings = get_settings()
     db = init_async_db(settings.DB_DSN)
     session = db.make_session()
     token = session_context_var.set(session)

--- a/src/backend/aspen/api/deps.py
+++ b/src/backend/aspen/api/deps.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from aspen.api.config.config import get_settings
+from aspen.api.settings import get_settings
 from aspen.database.connection import init_async_db
 
 session_context_var: ContextVar[Optional[AsyncSession]] = ContextVar(

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -1,11 +1,10 @@
 import os
-from functools import partial
 
 from fastapi import Depends, FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 from aspen.api.auth import get_auth_user
-from aspen.api.config.config import settings
+from aspen.api.config.config import get_settings
 from aspen.api.deps import set_db
 from aspen.api.error.http_exceptions import AspenException, exception_handler
 from aspen.api.middleware.session import SessionMiddleware
@@ -27,12 +26,13 @@ def get_allowed_origins():
 
 
 def get_app() -> FastAPI:
+    settings = get_settings()
     _app = FastAPI(
         title=settings.SERVICE_NAME,
         debug=settings.DEBUG,
         openapi_url="/v2/openapi.json",
         docs_url="/v2/docs",
-        dependencies=[Depends(partial(set_db, settings))],
+        dependencies=[Depends(set_db)],
     )
 
     # Configure CORS

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -46,7 +46,6 @@ def get_app() -> FastAPI:
     )
     _app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 
-    # Warning - do not enable this route!
     _app.include_router(
         users.router, prefix="/v2/users", dependencies=[Depends(get_auth_user)]
     )

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -4,10 +4,10 @@ from fastapi import Depends, FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 from aspen.api.auth import get_auth_user
-from aspen.api.config.config import get_settings
 from aspen.api.deps import set_db
 from aspen.api.error.http_exceptions import AspenException, exception_handler
 from aspen.api.middleware.session import SessionMiddleware
+from aspen.api.settings import get_settings
 from aspen.api.views import auth, health, users
 
 

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -238,7 +238,7 @@ class Settings(BaseSettings):
         )  # https://github.com/samuelcolvin/pydantic/issues/1241
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> Settings:
     settings = Settings()
     return settings

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -9,7 +9,9 @@ from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
-    SERVICE_NAME: str = "FastApi"
+    """Pydantic Settings object - do not instantiate it directly, please use get_settings() as a dependency where possible"""
+
+    SERVICE_NAME: str = "Aspen"
 
     DB_DRIVER: str = "postgresql+asyncpg"
 

--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -3,24 +3,24 @@ from functools import lru_cache
 from urllib.parse import urlencode
 
 from authlib.integrations.base_client.errors import OAuthError
-from authlib.integrations.starlette_client import OAuth, StarletteOAuth2App
+from authlib.integrations.starlette_client import OAuth, StarletteRemoteApp
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 from starlette.requests import Request
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.config.config import get_settings, Settings
+from aspen.api.settings import get_settings, Settings
 
 # From the example here:
 # https://github.com/authlib/demo-oauth-client/tree/master/fastapi-google-login
 router = APIRouter()
 
 
-@lru_cache()
-def get_auth0_client() -> StarletteOAuth2App:
+@lru_cache
+def get_auth0_client() -> StarletteRemoteApp:
     # TODO - settings is an unhashable type, so we can't make it a Dependency
     # *and* use the lru_cache decorator on this getter. We should probably use
-    # fastapi's built-in dependency caching instead of lru_cache() here, but
+    # fastapi's built-in dependency caching instead of lru_cache here, but
     # it needs a little more thought first.
     # see: https://github.com/tiangolo/fastapi/issues/1985
     settings: Settings = get_settings()

--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -1,38 +1,53 @@
 import os
+from functools import lru_cache
 from urllib.parse import urlencode
 
 from authlib.integrations.base_client.errors import OAuthError
-from authlib.integrations.starlette_client import OAuth
-from fastapi import APIRouter
+from authlib.integrations.starlette_client import OAuth, StarletteOAuth2App
+from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 from starlette.requests import Request
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.config.config import settings
+from aspen.api.config.config import get_settings, Settings
 
 # From the example here:
 # https://github.com/authlib/demo-oauth-client/tree/master/fastapi-google-login
 router = APIRouter()
 
-oauth = OAuth()
-auth0 = oauth.register(
-    "auth0",
-    client_id=settings.AUTH0_CLIENT_ID,
-    client_secret=settings.AUTH0_CLIENT_SECRET,
-    api_base_url=settings.AUTH0_BASE_URL,
-    access_token_url=settings.AUTH0_ACCESS_TOKEN_URL,
-    authorize_url=settings.AUTH0_AUTHORIZE_URL,
-    client_kwargs=settings.AUTH0_CLIENT_KWARGS,
-)
+
+@lru_cache()
+def get_auth0_client() -> StarletteOAuth2App:
+    # TODO - settings is an unhashable type, so we can't make it a Dependency
+    # *and* use the lru_cache decorator on this getter. We should probably use
+    # fastapi's built-in dependency caching instead of lru_cache() here, but
+    # it needs a little more thought first.
+    # see: https://github.com/tiangolo/fastapi/issues/1985
+    settings: Settings = get_settings()
+    oauth = OAuth()
+    auth0 = oauth.register(
+        "auth0",
+        client_id=settings.AUTH0_CLIENT_ID,
+        client_secret=settings.AUTH0_CLIENT_SECRET,
+        api_base_url=settings.AUTH0_BASE_URL,
+        access_token_url=settings.AUTH0_ACCESS_TOKEN_URL,
+        authorize_url=settings.AUTH0_AUTHORIZE_URL,
+        client_kwargs=settings.AUTH0_CLIENT_KWARGS,
+    )
+    return auth0
 
 
 @router.get("/login")
-async def login(request: Request):
+async def login(
+    request: Request,
+    auth0=Depends(get_auth0_client),
+    settings: Settings = Depends(get_settings),
+):
     return await auth0.authorize_redirect(request, settings.AUTH0_CALLBACK_URL)
 
 
 @router.get("/callback")
-async def auth(request: Request):
+async def auth(request: Request, auth0=Depends(get_auth0_client)):
     try:
         token = await auth0.authorize_access_token(request)
     except OAuthError:
@@ -56,7 +71,7 @@ async def auth(request: Request):
 
 
 @router.get("/logout")
-async def logout(request: Request):
+async def logout(request: Request, settings: Settings = Depends(get_settings)):
     # Clear session stored data
     request.session.pop("jwt_payload", None)
     request.session.pop("profile", None)


### PR DESCRIPTION
### Summary:
- **What:** Cache apiv2 config settings
- **Ticket:** [sc161319](https://app.shortcut.com/genepi/story/161319)

### Notes:
I'd previously left a bunch of TODO's in the code for where we were handling settings poorly and not caching computed values as well as we should. This PR improves on that by:
- Explicitly caching ~all computed settings
- Not instantiating the Settings() module multiple times
- Using FastAPI's dependency injection system to manage the application configs in some cases. I think we can take this further, but I'm still getting used to it. 

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)