### PR TITLE
Missing comment breaking YAML parse for schedule

### DIFF
--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -2,7 +2,7 @@ name: Scheduled Prod Deploy
 
 on:
   schedule:
-     Weekly Mondays & Thursdays @ 16:00 UTC (9am PST)
+    # Weekly Mondays & Thursdays @ 16:00 UTC (9am PST)
      - cron: '0 16 * * 1,4'
 
 env:


### PR DESCRIPTION
I kept getting notifications from GitHub about a workflow breaking, looks like it was the uncommented line in YAML breaking parsing.