### PR TITLE
Group level unique ids

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -377,7 +377,7 @@ def create_sample():
 
     already_exists: Union[
         None, Mapping[str, list[str]]
-    ] = api_utils.check_duplicate_samples(request_data, g.db_session)
+    ] = api_utils.check_duplicate_samples(request_data, g.db_session, user.group_id)
     if already_exists:
         raise ex.BadRequestException(
             f"Error inserting data, private_identifiers {already_exists['existing_private_ids']} or public_identifiers: {already_exists['existing_public_ids']} already exist in our database, please remove these samples before proceeding with upload.",

--- a/src/backend/aspen/database/models/accessions.py
+++ b/src/backend/aspen/database/models/accessions.py
@@ -27,7 +27,6 @@ class GisaidAccession(Accession):
     """A single GISAID accession of a pathogen genome."""
 
     __tablename__ = "gisaid_accessions"
-    __table_args__ = (UniqueConstraint("public_identifier"),)
     __mapper_args__ = {"polymorphic_identity": EntityType.GISAID_REPOSITORY_SUBMISSION}
 
     entity_id = Column(Integer, ForeignKey(Entity.id), primary_key=True)

--- a/src/backend/aspen/database/models/sample.py
+++ b/src/backend/aspen/database/models/sample.py
@@ -97,9 +97,9 @@ class Sample(idbase, DictMixin):  # type: ignore
             "submitting_group_id",
             "public_identifier",
             # To avoid overlapping above unique index, explicitly set `name` here
-            name='uq_samples_submitting_group_id_public_identifier'
-            ),
-        )
+            name="uq_samples_submitting_group_id_public_identifier",
+        ),
+    )
 
     submitting_group_id = Column(
         Integer,

--- a/src/backend/aspen/database/models/sample.py
+++ b/src/backend/aspen/database/models/sample.py
@@ -90,7 +90,16 @@ class Sample(idbase, DictMixin):  # type: ignore
     """A physical sample.  Multiple sequences can be taken of each physical sample."""
 
     __tablename__ = "samples"
-    __table_args__ = (UniqueConstraint("submitting_group_id", "private_identifier"),)
+    __table_args__ = (
+        # Unique index uses default name format of `uq_samples_submitting_group_id`
+        UniqueConstraint("submitting_group_id", "private_identifier"),
+        UniqueConstraint(
+            "submitting_group_id",
+            "public_identifier",
+            # To avoid overlapping above unique index, explicitly set `name` here
+            name='uq_samples_submitting_group_id_public_identifier'
+            ),
+        )
 
     submitting_group_id = Column(
         Integer,
@@ -123,7 +132,6 @@ class Sample(idbase, DictMixin):  # type: ignore
     public_identifier = Column(
         String,
         nullable=False,
-        unique=True,
         comment="This is the public identifier we assign to this sample.",
     )
 

--- a/src/backend/database_migrations/versions/20211015_205900_uniqueness_of_ids_at_group_level_not_.py
+++ b/src/backend/database_migrations/versions/20211015_205900_uniqueness_of_ids_at_group_level_not_.py
@@ -1,0 +1,55 @@
+"""Uniqueness of IDs at group level, not global
+
+Create Date: 2021-10-15 20:59:01.637737
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20211015_205900"
+down_revision = "20211008_225815"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "uq_gisaid_accessions_public_identifier",
+        "gisaid_accessions",
+        schema="aspen",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_samples_public_identifier",
+        "samples",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_samples_submitting_group_id_public_identifier",
+        "samples",
+        ["submitting_group_id", "public_identifier"],
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "uq_samples_submitting_group_id_public_identifier",
+        "samples",
+        schema="aspen",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_samples_public_identifier",
+        "samples",
+        ["public_identifier"],
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        "uq_gisaid_accessions_public_identifier",
+        "gisaid_accessions",
+        ["public_identifier"],
+        schema="aspen",
+    )

--- a/src/backend/database_migrations/versions/20211015_205900_uniqueness_of_ids_at_group_level_not_.py
+++ b/src/backend/database_migrations/versions/20211015_205900_uniqueness_of_ids_at_group_level_not_.py
@@ -4,7 +4,6 @@ Create Date: 2021-10-15 20:59:01.637737
 
 """
 import enumtables  # noqa: F401
-import sqlalchemy as sa
 from alembic import op
 
 revision = "20211015_205900"


### PR DESCRIPTION
### Summary:
- **What:** Restricts uniqueness of Private/Public IDs to within the user-group "namespace"
- **Ticket:** [sc<166263>](https://app.shortcut.com/genepi/story/<166263>)
- **Env:** https://group-unique-ids-frontend.dev.genepi.czi.technology/

### Notes:
Motivation here is that two different groups should be able to use the same sample IDs without impacting the other.

- Changes Private ID (`private_identifier`) and Public ID (`public_identifier`) ingestion process to only checking against the user's group for duplicated IDs, rather than checking globally.
- Tweaks uniqueness constraint for `public_identifier` to be unique only in context of the group ID, not globally unique.
- Removes uniqueness entirely for EPI ISL Accession ID (`gisaid_accessions` table, `public_identifier` column [NB: this is (almost always) **not** the same as the samples `public_identifier`, they just use the same name with a teeny bit of possible overlap in meaning.])
  - There is a downside here. Preferably, we would have the EPI ISL Accession be unique within a group, like we do with Private/Public ID in samples. But because of how the accessions table works, that would be really hard, and we have an [upcoming ticket](https://app.shortcut.com/genepi/story/150108) that will re-work this entirely, so it seems like an acceptable compromise.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)