### PR TITLE
Danphoenixjess/upgrade gisaid workflow

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -1,4 +1,4 @@
-version 1.1
+version 1.2
 
 workflow LoadGISAID {
     input {
@@ -238,28 +238,23 @@ task AlignGISAID {
     start_time=$(date +%s)
     build_id=$(date +%Y%m%d-%H%M)
 
-    # Not to pin to a specific git hash. May want to remove the version in the Dockerfile later.
-    rm -r /ncov  # remove the version already in docker
     git clone --depth 1 git://github.com/nextstrain/ncov /ncov
     ncov_git_rev=$(git -C /ncov rev-parse HEAD)
 
     # fetch the gisaid dataset
     aws s3 cp --no-progress "s3://${processed_gisaid_s3_bucket}/${processed_gisaid_sequences_s3_key}" - | zstdmt -d > /ncov/data/sequences.fasta
     aws s3 cp --no-progress "s3://${processed_gisaid_s3_bucket}/${processed_gisaid_metadata_s3_key}" /ncov/data/metadata.tsv
-
-    # prepare the builds and config yaml
-    git clone --depth 1 git://github.com/danrlu/test3 /test3  # provide updated builds.yaml and config.yaml for testing
     mkdir /ncov/my_profiles/align_gisaid/
-    cp /test3/{builds.yaml,config.yaml} /ncov/my_profiles/align_gisaid/
-    (cd /ncov; snakemake --printshellcmds results/filtered_gisaid.fasta.xz --profile my_profiles/align_gisaid || aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/" --recursive)  # how to export out log if run fails?
+    cp /usr/src/app/aspen/workflows/align_gisaid/{builds.yaml,config.yaml} /ncov/my_profiles/align_gisaid/
+    (cd /ncov; snakemake --printshellcmds results/filtered_gisaid.fasta.xz --profile my_profiles/align_gisaid || aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/" --recursive)  
 
-    mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/align_gisaid.txt .
+    mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/filtered_gisaid.txt .
     unxz -k /ncov/results/sanitized_metadata_gisaid.tsv.xz  # make an unzipped version for ImportGISAID. The zipped version goes to S3
     mv /ncov/results/sanitized_metadata_gisaid.tsv metadata.tsv  # this is for wdl to pipe into ImportGISAID.
 
     # upload the files to S3
     sequences_key="aligned_gisaid_dump/${build_id}/filtered_gisaid.fasta.xz"
-    metadata_key="aligned_gisaid_dump/${build_id}/sanitized_metadata_gisaid.tsv.xz"    # we need to remember to change these file names in downstream
+    metadata_key="aligned_gisaid_dump/${build_id}/sanitized_metadata_gisaid.tsv.xz"
     aws s3 cp /ncov/results/filtered_gisaid.fasta.xz "s3://${aspen_s3_db_bucket}/${sequences_key}"
     aws s3 cp /ncov/results/sanitized_metadata_gisaid.tsv.xz "s3://${aspen_s3_db_bucket}/${metadata_key}"
 
@@ -285,8 +280,8 @@ task AlignGISAID {
 
     output {
         Array[File] snakemake_logs = glob("*.snakemake.log")
-	File gisaid_metadata = "metadata.tsv"
-        File align_log = "align_gisaid.txt"
+        File gisaid_metadata = "metadata.tsv"
+        File align_log = "filtered_gisaid.txt"
         String entity_id = read_string("entity_id")
     }
 

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -238,27 +238,30 @@ task AlignGISAID {
     start_time=$(date +%s)
     build_id=$(date +%Y%m%d-%H%M)
 
-    # We're pinning to a specific git hash in the Dockerfile so we're not cloning this here.
-    # git clone --depth 1 git://github.com/nextstrain/ncov /ncov
+    # Not to pin to a specific git hash. May want to remove the version in the Dockerfile later.
+    rm -r /ncov  # remove the version already in docker
+    git clone --depth 1 git://github.com/nextstrain/ncov /ncov
     ncov_git_rev=$(git -C /ncov rev-parse HEAD)
 
     # fetch the gisaid dataset
     aws s3 cp --no-progress "s3://${processed_gisaid_s3_bucket}/${processed_gisaid_sequences_s3_key}" - | zstdmt -d > /ncov/data/sequences.fasta
     aws s3 cp --no-progress "s3://${processed_gisaid_s3_bucket}/${processed_gisaid_metadata_s3_key}" /ncov/data/metadata.tsv
+
+    # prepare the builds and config yaml
+    git clone --depth 1 git://github.com/danrlu/test3 /test3  # provide updated builds.yaml and config.yaml for testing
     mkdir /ncov/my_profiles/align_gisaid/
-    cp /usr/src/app/aspen/workflows/align_gisaid/{builds.yaml,config.yaml} /ncov/my_profiles/align_gisaid/
-    (cd /ncov; snakemake --printshellcmds results/aligned.fasta --profile my_profiles/align_gisaid 1>&2)
+    cp /test3/{builds.yaml,config.yaml} /ncov/my_profiles/align_gisaid/
+    (cd /ncov; snakemake --printshellcmds results/filtered_gisaid.fasta.xz --profile my_profiles/align_gisaid || aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/" --recursive)  # how to export out log if run fails?
 
-    mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/align.txt .
-    cp /ncov/data/metadata.tsv .  # Support wdl output paths.
-
-    zstdmt /ncov/results/aligned.fasta
+    mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/align_gisaid.txt .
+    unxz -k /ncov/results/sanitized_metadata_gisaid.tsv.xz  # make an unzipped version for ImportGISAID. The zipped version goes to S3
+    mv /ncov/results/sanitized_metadata_gisaid.tsv metadata.tsv  # this is for wdl to pipe into ImportGISAID.
 
     # upload the files to S3
-    sequences_key="aligned_gisaid_dump/${build_id}/sequences.fasta.zst"
-    metadata_key="aligned_gisaid_dump/${build_id}/metadata.tsv"
-    aws s3 cp /ncov/results/aligned.fasta.zst "s3://${aspen_s3_db_bucket}/${sequences_key}"
-    aws s3 cp /ncov/data/metadata.tsv "s3://${aspen_s3_db_bucket}/${metadata_key}"
+    sequences_key="aligned_gisaid_dump/${build_id}/filtered_gisaid.fasta.xz"
+    metadata_key="aligned_gisaid_dump/${build_id}/sanitized_metadata_gisaid.tsv.xz"    # we need to remember to change these file names in downstream
+    aws s3 cp /ncov/results/filtered_gisaid.fasta.xz "s3://${aspen_s3_db_bucket}/${sequences_key}"
+    aws s3 cp /ncov/results/sanitized_metadata_gisaid.tsv.xz "s3://${aspen_s3_db_bucket}/${metadata_key}"
 
     # These are set by the Dockerfile and the Happy CLI
     aspen_workflow_rev=$COMMIT_SHA
@@ -283,7 +286,7 @@ task AlignGISAID {
     output {
         Array[File] snakemake_logs = glob("*.snakemake.log")
 	File gisaid_metadata = "metadata.tsv"
-        File align_log = "align.txt"
+        File align_log = "align_gisaid.txt"
         String entity_id = read_string("entity_id")
     }
 

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -1,4 +1,4 @@
-version 1.2
+version 1.1
 
 workflow LoadGISAID {
     input {

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -75,7 +75,7 @@ task nextstrain_workflow {
     mkdir -p ncov/my_profiles/aspen ncov/results
     (cd ncov &&
      git init &&
-     git fetch --depth 1 git://github.com/nextstrain/ncov.git 30435fb9ec8de2f045167fb90adfec12f123e80a &&
+     git fetch --depth 1 git://github.com/nextstrain/ncov.git &&
      git checkout FETCH_HEAD
     )
     ncov_git_rev=$(cd ncov && git rev-parse HEAD)
@@ -95,8 +95,8 @@ task nextstrain_workflow {
     aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .metadata_key)
 
     # fetch the gisaid dataset
-    aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" - | zstdmt -d | xz -2 > ncov/results/aligned_gisaid.fasta.xz
-    aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" ncov/data/metadata_gisaid.tsv
+    aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" ncov/results/
+    aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" ncov/results/
 
     >&2 echo "You should exec into the docker container and run \"snakemake --printshellcmds auspice/ncov_aspen.json --profile my_profiles/aspen/  --resources=mem_mb=312320\" in the ncov subdirectory"
     >&2 echo "When you are done with the docker container, run \"touch /done\"."

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -53,13 +53,6 @@ RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetr
 
 RUN pip3 install nextstrain-cli csv-diff s3fs[boto3] aiobotocore[awscli,boto3] envdir fsspec pandas arrow
 
-RUN mkdir /ncov && \
-    cd /ncov && \
-    git init && \
-    git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 3e9ad400593b24cf94d24cdb56366f339f5a165b && \
-    git reset --hard FETCH_HEAD
-
 # Poetry: install app
 WORKDIR /usr/src/app
 COPY pyproject.toml poetry.lock environment.yaml ./

--- a/src/backend/aspen/workflows/align_gisaid/builds.yaml
+++ b/src/backend/aspen/workflows/align_gisaid/builds.yaml
@@ -1,1 +1,6 @@
+inputs:
+  - name: "gisaid"
+    metadata: "data/metadata.tsv"
+    sequences: "data/sequences.fasta"
+
 use_nextalign: true

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -26,7 +26,7 @@ aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$aspen_config")"
 mkdir -p ncov/my_profiles/aspen ncov/results
 (cd ncov &&
  git init &&
- git fetch --depth 1 git://github.com/nextstrain/ncov.git 30435fb9ec8de2f045167fb90adfec12f123e80a &&
+ git fetch --depth 1 git://github.com/nextstrain/ncov.git &&
  git checkout FETCH_HEAD
 )
 ncov_git_rev=$(cd ncov && git rev-parse HEAD)
@@ -57,8 +57,8 @@ aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .seq
 aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .metadata_key)
 
 # fetch the gisaid dataset
-aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" - | zstdmt -d | xz -2 > ncov/results/aligned_gisaid.fasta.xz
-aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" ncov/data/metadata_gisaid.tsv
+aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" ncov/results/
+aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" ncov/results/
 
 (cd ncov && snakemake --printshellcmds auspice/ncov_aspen.json --profile my_profiles/aspen/ --resources=mem_mb=312320) || aws s3 cp ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/phylo_run/${build_date}/${S3_FILESTEM}/${WORKFLOW_ID}/logs/" --recursive
 

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -41,7 +41,7 @@ echo "${workflow_id}" >| "/tmp/workflow_id"
 mkdir -p ncov/my_profiles/aspen ncov/results
 (cd ncov &&
  git init &&
- git fetch --depth 1 git://github.com/nextstrain/ncov.git 30435fb9ec8de2f045167fb90adfec12f123e80a &&
+ git fetch --depth 1 git://github.com/nextstrain/ncov.git &&
  git checkout FETCH_HEAD
 )
 ncov_git_rev=$(cd ncov && git rev-parse HEAD)
@@ -63,8 +63,8 @@ aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .seq
 aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .metadata_key)
 
 # fetch the gisaid dataset
-aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" - | zstdmt -d | xz -2 > ncov/results/aligned_gisaid.fasta.xz
-aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" ncov/data/metadata_gisaid.tsv
+aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" ncov/results/
+aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" ncov/results/
 
 (cd ncov && snakemake --printshellcmds auspice/ncov_aspen.json --profile my_profiles/aspen/ --resources=mem_mb=312320) || aws s3 cp ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/phylo_run/${build_id}/" --recursive
 


### PR DESCRIPTION
### Summary:
These changes aim to: 

- Make the daily GISAID job (in `gisaid.wdl`) run 2 additional steps to mask and filter all GISAID data, and use the output as starting point for downstream tree build (in `nextstrain-dbg.wdl`,  `run_nextstrain_ondemand.sh` and `run_nextstrain_scheduled.sh`). This cut our longest tree build (overview tree) from 7.5hr to 5hr. 

- Remove `ncov` in the GISAID docker (`Dockerfile.gisaid`) and only have it cloned in `gisaid.wdl` to make version management more straightforward. I searched around to make sure it's not used elsewhere but I couldn't test the impact of this change.

- `builds.yaml` is updated to include what is required by the newer `ncov` than the pinned `ncov` in GISAID docker.

- Unpin `ncov` in tree runs (in `nextstrain-dbg.wdl`,  `run_nextstrain_ondemand.sh` and `run_nextstrain_scheduled.sh`). They were pinned when `ncov` had a bug upstream. All tests were done with the current newest `ncov` versions and they seem to work fine.

### Tests:
Phoenix tested the `gisaid.wdl` and I tested the `nextstrain-dbg.wdl` on `danrlu/improve_gisaid` branch, which are [the first 2 files here](https://github.com/chanzuckerberg/aspen/compare/d76256f..6d3d041) when compared against the current branch.

### Demos:
![image](https://user-images.githubusercontent.com/20667188/137820006-e7bae967-94c2-4b43-86e3-4f71a3d57629.png)

### Notes:
[This](https://github.com/nextstrain/ncov/blob/master/.github/workflows/preprocess-gisaid.yml) is the set up Nextstrain uses to preprocess their GISAID data, for reference in case we want to cut back on our memory.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)