### PR TITLE
Add autoflake to `make backend-run-style`

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -30,7 +30,7 @@ run-isort:
 	isort --profile black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES) 
 
 run-autoflake:
-	autoflake -i --remove-all-unused-imports --remove-unused-variables -r $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
+	autoflake -v -i --remove-all-unused-imports --remove-unused-variables -r $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
 
 
 ### TESTING #############################################

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -21,13 +21,16 @@ mypy:
 
 
 ### RUN STYLE #############################################
-run-style: run-black run-isort
+run-style: run-autoflake run-black run-isort
 
 run-black:
 	black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --exclude $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES)
 
 run-isort:
 	isort --profile black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES) 
+
+run-autoflake:
+	autoflake -i --remove-all-unused-imports --remove-unused-variables -r $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
 
 
 ### TESTING #############################################

--- a/src/backend/poetry.lock
+++ b/src/backend/poetry.lock
@@ -123,6 +123,17 @@ cryptography = "*"
 client = ["requests"]
 
 [[package]]
+name = "autoflake"
+version = "1.4"
+description = "Removes unused imports and unused variables"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyflakes = ">=1.1.0"
+
+[[package]]
 name = "awscli"
 version = "1.20.23"
 description = "Universal Command Line Environment for AWS."
@@ -867,7 +878,7 @@ email = ["email-validator (>=1.0.3)"]
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -881,7 +892,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pyjwt"
-version = "2.2.0"
+version = "2.3.0"
 description = "JSON Web Token implementation in Python"
 category = "main"
 optional = false
@@ -1451,7 +1462,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ae14dae18e994c69273835502867c003f614a0b9adf6db5f309d909539f79d6d"
+content-hash = "dade04790386d80aa27d318e2886d239ebfd77a9f31476fa1afaa3564f30dd71"
 
 [metadata.files]
 alembic = [
@@ -1500,6 +1511,9 @@ auth0-python = [
 authlib = [
     {file = "Authlib-0.15.4-py2.py3-none-any.whl", hash = "sha256:d9fe5edb59801b16583faa86f88d798d99d952979b9616d5c735b9170b41ae2c"},
     {file = "Authlib-0.15.4.tar.gz", hash = "sha256:37df3a2554bc6fe0da3cc6848c44fac2ae40634a7f8fc72543947f4330b26464"},
+]
+autoflake = [
+    {file = "autoflake-1.4.tar.gz", hash = "sha256:61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea"},
 ]
 awscli = [
     {file = "awscli-1.20.23-py3-none-any.whl", hash = "sha256:0437bcba0819d97662b9462d7d842ad786dd9a1b3ca05464adad88006f229db7"},
@@ -1998,8 +2012,8 @@ pygments = [
     {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
 pyjwt = [
-    {file = "PyJWT-2.2.0-py3-none-any.whl", hash = "sha256:b0ed5824c8ecc5362e540c65dc6247567db130c4226670bf7699aec92fb4dae1"},
-    {file = "PyJWT-2.2.0.tar.gz", hash = "sha256:a0b9a3b4e5ca5517cac9f1a6e9cd30bf1aa80be74fcdf4e28eded582ecfcfbae"},
+    {file = "PyJWT-2.3.0-py3-none-any.whl", hash = "sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f"},
+    {file = "PyJWT-2.3.0.tar.gz", hash = "sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -50,6 +50,7 @@ uvicorn = {extras = ["standard"], version = "^0.15.0"}
 gunicorn = "^20.1.0"
 httpx = "^0.19.0"
 pytest-asyncio = "^0.15.1"
+autoflake = "^1.4"
 
 [tool.poetry.dev-dependencies]
 alembic = "^1.7.3"


### PR DESCRIPTION
### Summary:
- **What:** This updates `make backend-run-style` to clean up unused imports & variables. This is handy because `make backend-check-style` which is part of our CI pipeline checks for these errors and we don't otherwise have a way to automatically clean them up
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)