### PR TITLE
styles

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -31,7 +31,6 @@ import {
   TextFieldAlert,
   Title,
   TreeNameInfoWrapper,
-  TreeNameSection,
   TreeNameTooLongAlert,
   TreeTypeSection,
 } from "./style";
@@ -141,7 +140,7 @@ export const CreateNSTreeModal = ({
       <StyledDialogContent>
         <Content data-test-id="modal-content">
           <form onSubmit={handleSubmit}>
-            <TreeNameSection>
+            <div>
               <TreeNameInfoWrapper>
                 <FieldTitle>Tree Name</FieldTitle>
                 <StyledInstructionsButton
@@ -180,7 +179,7 @@ export const CreateNSTreeModal = ({
                   </TextFieldAlert>
                 </TreeNameTooLongAlert>
               )}
-            </TreeNameSection>
+            </div>
             <TreeTypeSection>
               <TreeNameInfoWrapper>
                 <FieldTitle>Tree Type: </FieldTitle>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -141,15 +141,6 @@ export const StyledRadio = styled(Radio)`
   }}
 `;
 
-export const TreeNameSection = styled.div`
-  ${(props) => {
-    const spacings = getSpacings(props);
-    return `
-      margin-top: ${spacings?.s}px;
-    `;
-  }}
-`;
-
 export const TreeTypeSection = styled.div`
   ${(props) => {
     const spacings = getSpacings(props);

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -11,7 +11,6 @@ import { pluralize } from "src/common/utils/strUtils";
 import {
   Content,
   StyledDialogTitle,
-  StyledInfoOutlinedIcon,
   StyledTooltip,
   Title,
   TreeNameInfoWrapper,
@@ -25,6 +24,7 @@ import {
   StyledDialog,
   StyledDialogContent,
   StyledFieldTitleText,
+  StyledInfoIcon,
   StyledInputDropdown,
   StyledList,
   StyledListItem,
@@ -189,7 +189,7 @@ export const UsherPlacementModal = ({
             title={MAIN_USHER_TOOLTIP_TEXT}
             placement="top"
           >
-            <StyledInfoOutlinedIcon />
+            <StyledInfoIcon />
           </StyledTooltip>
         </FlexWrapper>
         <Title>
@@ -237,7 +237,7 @@ export const UsherPlacementModal = ({
                   title={PHYLOGENETIC_TREE_VERSION_TOOLTIP_TEXT}
                   placement="top"
                 >
-                  <StyledInfoOutlinedIcon />
+                  <StyledInfoIcon />
                 </StyledTooltip>
               </StyledFieldTitleText>
               <Dropdown
@@ -258,7 +258,7 @@ export const UsherPlacementModal = ({
                   title={SAMPLES_PER_SUBTREE_TOOLTIP_TEXT}
                   placement="top"
                 >
-                  <StyledInfoOutlinedIcon />
+                  <StyledInfoIcon />
                 </StyledTooltip>
               </StyledFieldTitleText>
               <StyledTextField

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -71,6 +71,7 @@ export const UsherPlacementModal = ({
   const [dropdownOptions, setDropdownOptions] = useState<DropdownOptionProps[]>(
     []
   );
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isUsherDisabled, setUsherDisabled] = useState<boolean>(false);
   const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(false);
 
@@ -100,16 +101,19 @@ export const UsherPlacementModal = ({
 
   useEffect(() => {
     const hasValidSamplesSelected = sampleIds?.length > failedSamples?.length;
-    setUsherDisabled(!hasValidSamplesSelected);
-  }, [sampleIds, failedSamples]);
+    const shouldDisable = !hasValidSamplesSelected || isLoading;
+    setUsherDisabled(shouldDisable);
+  }, [sampleIds, failedSamples, isLoading]);
 
   const fastaFetch = useFastaFetch({
     onError: () => {
+      setIsLoading(false);
       onClose();
     },
     onSuccess: (data: FastaResponseType) => {
       const url = data?.url;
       if (url) onLinkCreateSuccess(data.url);
+      setIsLoading(false);
     },
   });
 
@@ -117,6 +121,7 @@ export const UsherPlacementModal = ({
     evt.preventDefault();
     sampleIds = sampleIds.filter((id) => !failedSamples.includes(id));
     fastaFetch.mutate({ sampleIds });
+    setIsLoading(true);
   };
 
   const MAIN_USHER_TOOLTIP_TEXT = (
@@ -280,7 +285,7 @@ export const UsherPlacementModal = ({
               type="submit"
               value="Submit"
             >
-              Create Placement
+              {isLoading ? "Loading ..." : "Create Placement"}
             </StyledButton>
           </form>
         </Content>

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -1,4 +1,3 @@
-import CloseIcon from "@material-ui/icons/Close";
 import { DefaultMenuSelectOption, Dropdown, InputDropdown } from "czifui";
 import { debounce, forEach } from "lodash";
 import React, { SyntheticEvent, useEffect, useState } from "react";
@@ -12,20 +11,20 @@ import {
 import { pluralize } from "src/common/utils/strUtils";
 import {
   Content,
-  StyledDialogContent,
   StyledDialogTitle,
   StyledInfoOutlinedIcon,
   StyledTooltip,
   Title,
   TreeNameInfoWrapper,
-  TreeNameSection,
 } from "../../../CreateNSTreeModal/style";
-import { Header, StyledIconButton } from "../../../DownloadModal/style";
+import { Header } from "../../../DownloadModal/style";
 import { FailedSampleAlert } from "../../../FailedSampleAlert";
 import {
   FlexWrapper,
   StyledButton,
+  StyledCloseIcon,
   StyledDialog,
+  StyledDialogContent,
   StyledFieldTitleText,
   StyledInputDropdown,
   StyledList,
@@ -173,9 +172,7 @@ export const UsherPlacementModal = ({
       maxWidth={"sm"}
     >
       <StyledDialogTitle>
-        <StyledIconButton onClick={onClose}>
-          <CloseIcon />
-        </StyledIconButton>
+        <StyledCloseIcon onClick={onClose} />
         <FlexWrapper>
           <Header>Run Phylogenetic Placement with UShER</Header>
           <StyledTooltip
@@ -194,7 +191,7 @@ export const UsherPlacementModal = ({
       <StyledDialogContent>
         <Content data-test-id="modal-content">
           <form onSubmit={handleSubmit}>
-            <TreeNameSection>
+            <div>
               <TreeNameInfoWrapper>
                 <StyledSectionHeader>Use UShER for: </StyledSectionHeader>
               </TreeNameInfoWrapper>
@@ -224,10 +221,8 @@ export const UsherPlacementModal = ({
                 </StyledListItem>
               </StyledList>
               <StyledSectionHeader>Settings</StyledSectionHeader>
-              <FlexWrapper>
-                <StyledFieldTitleText>
-                  Place Samples onto Phylogenetic Tree Version:
-                </StyledFieldTitleText>
+              <StyledFieldTitleText>
+                <span>Place Samples onto Phylogenetic Tree Version:</span>
                 <StyledTooltip
                   arrow
                   leaveDelay={200}
@@ -236,7 +231,7 @@ export const UsherPlacementModal = ({
                 >
                   <StyledInfoOutlinedIcon />
                 </StyledTooltip>
-              </FlexWrapper>
+              </StyledFieldTitleText>
               <Dropdown
                 label={dropdownLabel}
                 onChange={onOptionChange}
@@ -246,10 +241,10 @@ export const UsherPlacementModal = ({
                 InputDropdownProps={{ sdsStyle: "square" }}
                 options={dropdownOptions}
               />
-              <FlexWrapper>
-                <StyledFieldTitleText>
+              <StyledFieldTitleText>
+                <span>
                   Number of samples per subtree showing sample placement:
-                </StyledFieldTitleText>
+                </span>
                 <StyledTooltip
                   arrow
                   title={SAMPLES_PER_SUBTREE_TOOLTIP_TEXT}
@@ -257,7 +252,7 @@ export const UsherPlacementModal = ({
                 >
                   <StyledInfoOutlinedIcon />
                 </StyledTooltip>
-              </FlexWrapper>
+              </StyledFieldTitleText>
               <StyledTextField
                 id="outlined-basic"
                 variant="outlined"
@@ -273,7 +268,7 @@ export const UsherPlacementModal = ({
                 </FlexWrapper>
               )}
               <FailedSampleAlert numFailedSamples={failedSamples?.length} />
-            </TreeNameSection>
+            </div>
             <StyledButton
               color="primary"
               variant="contained"

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { Dialog } from "@material-ui/core";
 import TextField from "@material-ui/core/TextField";
+import CloseIcon from "@material-ui/icons/Close";
 import {
   Button,
   fontBodyXs,
@@ -13,18 +14,35 @@ import {
   List,
   ListItem,
 } from "czifui";
+import { StyledDialogContent as DialogContent } from "../../../CreateNSTreeModal/style";
 import { StyledWarningIcon as WarningIcon } from "../../../FailedSampleAlert/style";
 
 const INPUT_HEIGHT = "34px";
 
+export const StyledDialogContent = styled(DialogContent)`
+  ${(props) => {
+    const spacings = getSpacings(props);
+    return `
+      padding-bottom: ${spacings?.xxl}px;
+    `;
+  }}
+`;
+
 export const StyledListItem = styled(ListItem)`
-  ${fontBodyXs}
+  &.MuiListItem-root {
+    ${fontBodyXs}
+  }
+
   ${(props) => {
     const colors = getColors(props);
     const spacings = getSpacings(props);
     return `
       color: ${colors?.gray[500]};
       margin-bottom: ${spacings?.xs}px;
+
+      &:last-of-type {
+        margin-bottom: 0;
+      }
     `;
   }}
 `;
@@ -44,7 +62,7 @@ export const StyledSectionHeader = styled.div`
     const spacings = getSpacings(props);
     return `
       color: black;
-      margin-bottom: ${spacings?.xxs}px;
+      margin-bottom: ${spacings?.m}px;
     `;
   }}
 `;
@@ -52,14 +70,22 @@ export const StyledSectionHeader = styled.div`
 export const StyledFieldTitleText = styled.div`
   ${fontHeaderXs}
   color: black;
+  display: flex;
+  align-items: center;
+
+  ${(props) => {
+    const spacings = getSpacings(props);
+    return `
+      margin-bottom: ${spacings?.xs}px;
+    `;
+  }}
 `;
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
     const spacings = getSpacings(props);
     return `
-      margin-bottom: ${spacings?.xxs}px;
-      margin-top: ${spacings?.xs}px;
+      margin-bottom: ${spacings?.xl}px;
       width: 150px;
 
       .MuiInputBase-root {
@@ -101,11 +127,8 @@ export const StyledWarningIcon = styled(WarningIcon)`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpacings(props);
     const colors = getColors(props);
     return `
-      margin-top: ${spacings?.xl}px;
-      margin-bottom: ${spacings?.l}px;
       &:active {
         background-color: ${colors?.gray[400]};
       }
@@ -118,8 +141,7 @@ export const StyledInputDropdown = styled(InputDropdown)`
     const spacings = getSpacings(props);
 
     return `
-      margin-bottom: ${spacings?.xl}px;
-      margin-top: ${spacings?.xxs}px;
+      margin-bottom: ${spacings?.l}px;
       width: 100%;
       height: ${INPUT_HEIGHT};
     `;
@@ -131,4 +153,20 @@ export const StyledDialog = styled(Dialog)`
   + [role="tooltip"] {
     z-index: 1400;
   }
+`;
+
+export const StyledCloseIcon = styled(CloseIcon)`
+  position: absolute;
+  cursor: pointer;
+
+  ${(props) => {
+    const colors = getColors(props);
+    const spacings = getSpacings(props);
+
+    return `
+      color: ${colors?.gray[400]};
+      right: ${spacings?.xl}px;
+      top: ${spacings?.xl}px;
+    `;
+  }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -14,7 +14,10 @@ import {
   List,
   ListItem,
 } from "czifui";
-import { StyledDialogContent as DialogContent } from "../../../CreateNSTreeModal/style";
+import {
+  StyledDialogContent as DialogContent,
+  StyledInfoOutlinedIcon as InfoIcon,
+} from "../../../CreateNSTreeModal/style";
 import { StyledWarningIcon as WarningIcon } from "../../../FailedSampleAlert/style";
 
 const INPUT_HEIGHT = "34px";
@@ -169,4 +172,8 @@ export const StyledCloseIcon = styled(CloseIcon)`
       top: ${spacings?.xl}px;
     `;
   }}
+`;
+
+export const StyledInfoIcon = styled(InfoIcon)`
+  margin-top: 3px;
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -1,5 +1,5 @@
 import { LoadingIndicator } from "czifui";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { StyledDialog, StyledP, StyledTitle } from "./style";
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
   onClose(): void;
 }
 
-const TIME_MODAL_SHOWN = 8000; // 8 seconds
+const TIME_MODAL_SHOWN = 5000; // 5 seconds
 const USHER_URL =
   "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
 
@@ -18,32 +18,53 @@ const UsherPreparingModal = ({
   onClose,
 }: Props): JSX.Element => {
   const [hasOpenedUrl, setHasOpenedUrl] = useState<boolean>(false);
+  const [timer, setTimer] = useState<ReturnType<typeof setTimeout>>();
+
+  const openUsher = useCallback(() => {
+    if (!fastaUrl) return;
+
+    const link = document.createElement("a");
+    link.href = `${USHER_URL + fastaUrl}`;
+    link.target = "_blank";
+    link.rel = "noopener";
+    link.click();
+    link.remove();
+
+    onClose();
+    setTimer();
+    clearTimeout(timer);
+  }, [fastaUrl, onClose, timer]);
 
   useEffect(() => {
+    // The s3 link was cleared by the parent, so future renders of this component
+    // should know that any fasta link set in the future has not been opened yet.
     if (!fastaUrl) {
       setHasOpenedUrl(false);
       return;
     }
 
+    // only set a timer to open an usher link if this modal is open.
+    // otherwise, we risk opening a link when someone clicks "cancel"
+    // from the previous modal.
+    // Also, only open the link once :)
     if (isOpen && !hasOpenedUrl) {
       setHasOpenedUrl(true);
-      setTimeout(() => {
-        if (!fastaUrl) return;
 
-        const link = document.createElement("a");
-        link.href = `${USHER_URL + fastaUrl}`;
-        link.target = "_blank";
-        link.rel = "noopener";
-        link.click();
-        link.remove();
-
-        onClose();
+      const newTimer = setTimeout(() => {
+        openUsher();
       }, TIME_MODAL_SHOWN);
+
+      setTimer(newTimer);
     }
-  }, [fastaUrl, hasOpenedUrl, isOpen, onClose]);
+  }, [fastaUrl, hasOpenedUrl, isOpen, onClose, openUsher]);
 
   return (
-    <StyledDialog open={isOpen} maxWidth="xs">
+    <StyledDialog
+      open={isOpen}
+      maxWidth="xs"
+      onClose={openUsher}
+      disableEscapeKeyDown={false}
+    >
       <div>
         <LoadingIndicator sdsStyle="tag" />
       </div>

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -8,6 +8,8 @@ interface Props {
   onClose(): void;
 }
 
+type TimeoutType = ReturnType<typeof setTimeout> | undefined;
+
 const TIME_MODAL_SHOWN = 5000; // 5 seconds
 const USHER_URL =
   "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
@@ -18,7 +20,7 @@ const UsherPreparingModal = ({
   onClose,
 }: Props): JSX.Element => {
   const [hasOpenedUrl, setHasOpenedUrl] = useState<boolean>(false);
-  const [timer, setTimer] = useState<ReturnType<typeof setTimeout>>();
+  const [timer, setTimer] = useState<TimeoutType>();
 
   const openUsher = useCallback(() => {
     if (!fastaUrl) return;
@@ -31,8 +33,8 @@ const UsherPreparingModal = ({
     link.remove();
 
     onClose();
-    setTimer();
-    clearTimeout(timer);
+    setTimer(undefined);
+    if (timer) clearTimeout(timer);
   }, [fastaUrl, onClose, timer]);
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
- **What:** Update styling for some usher stuff
- **Env:** https://usherthree-frontend.dev.genepi.czi.technology?usher=true

### Demos
#### Before: 
![Screen Shot 2021-10-18 at 9 56 13 AM](https://user-images.githubusercontent.com/7562933/137792280-42ebcb7c-9cab-438c-a7cd-a562560609c4.png)

#### After: 
![Screen Shot 2021-10-18 at 9 56 34 AM](https://user-images.githubusercontent.com/7562933/137792272-57b300ad-4baf-4b47-9953-fbd0caa13026.png)

### Notes
The dropdown input has the incorrect styles for basically all states. This needs to be updated in SDS and then we can pull the changes in. I don't think this should be a release blocker, though, and I am going to work on this today,

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)