### PR TITLE
allow users to click through preparing modal if they want to

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -1,5 +1,5 @@
 import { LoadingIndicator } from "czifui";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { StyledDialog, StyledP, StyledTitle } from "./style";
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
   onClose(): void;
 }
 
-const TIME_MODAL_SHOWN = 8000; // 8 seconds
+const TIME_MODAL_SHOWN = 5000; // 5 seconds
 const USHER_URL =
   "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
 
@@ -18,32 +18,53 @@ const UsherPreparingModal = ({
   onClose,
 }: Props): JSX.Element => {
   const [hasOpenedUrl, setHasOpenedUrl] = useState<boolean>(false);
+  const [timer, setTimer] = useState<ReturnType<typeof setTimeout>>();
+
+  const openUsher = useCallback(() => {
+    if (!fastaUrl) return;
+
+    const link = document.createElement("a");
+    link.href = `${USHER_URL + fastaUrl}`;
+    link.target = "_blank";
+    link.rel = "noopener";
+    link.click();
+    link.remove();
+
+    onClose();
+    setTimer();
+    clearTimeout(timer);
+  }, [fastaUrl, onClose, timer]);
 
   useEffect(() => {
+    // The s3 link was cleared by the parent, so future renders of this component
+    // should know that any fasta link set in the future has not been opened yet.
     if (!fastaUrl) {
       setHasOpenedUrl(false);
       return;
     }
 
+    // only set a timer to open an usher link if this modal is open.
+    // otherwise, we risk opening a link when someone clicks "cancel"
+    // from the previous modal.
+    // Also, only open the link once :)
     if (isOpen && !hasOpenedUrl) {
       setHasOpenedUrl(true);
-      setTimeout(() => {
-        if (!fastaUrl) return;
 
-        const link = document.createElement("a");
-        link.href = `${USHER_URL + fastaUrl}`;
-        link.target = "_blank";
-        link.rel = "noopener";
-        link.click();
-        link.remove();
-
-        onClose();
+      const newTimer = setTimeout(() => {
+        openUsher();
       }, TIME_MODAL_SHOWN);
+
+      setTimer(newTimer);
     }
-  }, [fastaUrl, hasOpenedUrl, isOpen, onClose]);
+  }, [fastaUrl, hasOpenedUrl, isOpen, onClose, openUsher]);
 
   return (
-    <StyledDialog open={isOpen} maxWidth="xs">
+    <StyledDialog
+      open={isOpen}
+      maxWidth="xs"
+      onClose={openUsher}
+      disableEscapeKeyDown={false}
+    >
       <div>
         <LoadingIndicator sdsStyle="tag" />
       </div>

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -33,8 +33,8 @@ const UsherPreparingModal = ({
     link.remove();
 
     onClose();
-    setTimer(undefined);
     if (timer) clearTimeout(timer);
+    setTimer(undefined);
   }, [fastaUrl, onClose, timer]);
 
   useEffect(() => {

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -8,6 +8,8 @@ interface Props {
   onClose(): void;
 }
 
+type TimeoutType = ReturnType<typeof setTimeout> | undefined;
+
 const TIME_MODAL_SHOWN = 5000; // 5 seconds
 const USHER_URL =
   "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
@@ -18,7 +20,7 @@ const UsherPreparingModal = ({
   onClose,
 }: Props): JSX.Element => {
   const [hasOpenedUrl, setHasOpenedUrl] = useState<boolean>(false);
-  const [timer, setTimer] = useState<ReturnType<typeof setTimeout>>();
+  const [timer, setTimer] = useState<TimeoutType>();
 
   const openUsher = useCallback(() => {
     if (!fastaUrl) return;
@@ -31,8 +33,8 @@ const UsherPreparingModal = ({
     link.remove();
 
     onClose();
-    setTimer();
-    clearTimeout(timer);
+    setTimer(undefined);
+    if (timer) clearTimeout(timer);
   }, [fastaUrl, onClose, timer]);
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
- **What:** Allow the user to click the backdrop of the preparing modal in order to not wait 5 seconds to open their usher link.
- **Why:** The message may be useful for the first few times, but also blocks the user from getting to their data quickly
- **Env:** https://usherthree-frontend.dev.genepi.czi.technology?usher=true [pending]

### Testing
1. The modal should automatically open the link to usher and close itself after 5 seconds
1. If you click the back drop before 5 seconds are up, the link should open immediately

### Demos
![after](https://user-images.githubusercontent.com/7562933/137797163-ad982ec1-5bc3-48c9-81e3-9bed9232eb37.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)