### PR TITLE
Add Sentry integration to FastAPI

### DIFF
--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -29,7 +29,11 @@ def get_usergroup_query(session: AsyncSession, auth0_user_id: str) -> Query:
 async def setup_userinfo(
     session: AsyncSession, auth0_user_id: str
 ) -> Union[User, None]:
-    sentry_sdk.set_user({ "requested_user_id": auth0_user_id, })
+    sentry_sdk.set_user(
+        {
+            "requested_user_id": auth0_user_id,
+        }
+    )
     try:
         userquery = get_usergroup_query(session, auth0_user_id)
         userwait = await session.execute(userquery)

--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Union
 
+import sentry_sdk
 import sqlalchemy as sa
 from auth0.v3.exceptions import TokenValidationError
 from fastapi import Depends
@@ -28,22 +29,22 @@ def get_usergroup_query(session: AsyncSession, auth0_user_id: str) -> Query:
 async def setup_userinfo(
     session: AsyncSession, auth0_user_id: str
 ) -> Union[User, None]:
-    # sentry_sdk.set_user( { "requested_user_id": auth0_user_id, })
+    sentry_sdk.set_user({ "requested_user_id": auth0_user_id, })
     try:
         userquery = get_usergroup_query(session, auth0_user_id)
         userwait = await session.execute(userquery)
         user = userwait.unique().scalars().first()
     except NoResultFound:
-        # sentry_sdk.capture_message(
-        #     f"Requested auth0_user_id {auth0_user_id} not found in usergroup query."
-        # )
+        sentry_sdk.capture_message(
+            f"Requested auth0_user_id {auth0_user_id} not found in usergroup query."
+        )
         return None
-    # sentry_sdk.set_user(
-    #     {
-    #         "id": user.id,
-    #         "auth0_uid": user.auth0_auth0_user_id,
-    #     }
-    # )
+    sentry_sdk.set_user(
+        {
+            "id": user.id,
+            "auth0_uid": user.auth0_user_id,
+        }
+    )
     return user
 
 

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -1,6 +1,8 @@
 import os
 from typing import List
 
+import sentry_sdk
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from fastapi import Depends, FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
@@ -44,6 +46,13 @@ def get_app() -> FastAPI:
         allow_methods=["*"],
     )
     _app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
+
+    sentry_sdk.init(
+        dsn=settings.SENTRY_BACKEND_DSN,
+        environment=os.environ.get("DEPLOYMENT_STAGE"),
+        traces_sample_rate=1.0,
+    )
+    _app.add_middleware(SentryAsgiMiddleware)
 
     _app.include_router(
         users.router, prefix="/v2/users", dependencies=[Depends(get_auth_user)]

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -2,8 +2,8 @@ import os
 from typing import List
 
 import sentry_sdk
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from fastapi import Depends, FastAPI
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 from aspen.api.auth import get_auth_user

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -167,8 +167,6 @@ class Settings(BaseSettings):
     # sentry properties
     @cached_property
     def SENTRY_BACKEND_DSN(self) -> str:
-        if os.getenv("SENTRY_BACKEND_DSN"):
-            return os.environ["SENTRY_BACKEND_DSN"]
         try:
             return self.AWS_SECRET["SENTRY_BACKEND_DSN"]
         except KeyError:

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -166,11 +166,11 @@ class Settings(BaseSettings):
     ####################################################################################
     # sentry properties
     @cached_property
-    def SENTRY_URL(self) -> str:
-        if os.getenv("SENTRY_URL"):
-            return os.environ["SENTRY_URL"]
+    def SENTRY_BACKEND_DSN(self) -> str:
+        if os.getenv("SENTRY_BACKEND_DSN"):
+            return os.environ["SENTRY_BACKEND_DSN"]
         try:
-            return self.AWS_SECRET["SENTRY_URL"]
+            return self.AWS_SECRET["SENTRY_BACKEND_DSN"]
         except KeyError:
             return ""
 

--- a/src/backend/aspen/api/views/health.py
+++ b/src/backend/aspen/api/views/health.py
@@ -7,5 +7,4 @@ router = APIRouter()
 
 @router.get("/", response_model=healthschema)
 async def get_health() -> healthschema:
-    raise Exception("Testing Sentry")
     return healthschema.parse_obj({"healthy": True})

--- a/src/backend/aspen/api/views/health.py
+++ b/src/backend/aspen/api/views/health.py
@@ -7,4 +7,5 @@ router = APIRouter()
 
 @router.get("/", response_model=healthschema)
 async def get_health() -> healthschema:
+    raise Exception("Testing Sentry")
     return healthschema.parse_obj({"healthy": True})


### PR DESCRIPTION
### Summary:
- **What:** `Replicates our Sentry setup in FastAPI`
- **Ticket:** [sc161330](https://app.shortcut.com/genepi/story/161330)
- **Env:** `https://sentry-asgi-backend.dev.genepi.czi.technology/`

### Demos:

### Notes:
The key in our AWS secret store storing the Sentry DSN is changed from `SENTRY_URL` to `SENTRY_BACKEND_DSN` to avoid confusion with the `SENTRY_URL` environment variable that is referenced in `sentry-cli` documentation.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)