### PR TITLE
Maya/usher feedback

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -40,13 +40,12 @@ interface Props {
   failedSamples: string[];
   open: boolean;
   onClose: () => void;
-  onLinkCreateSuccess(url?: string): void;
+  onLinkCreateSuccess(url: string, treeType: string): void;
 }
 
-interface DropdownOptionProps {
+interface DropdownOptionProps extends DefaultMenuSelectOption {
   id: number;
   description: string;
-  name: string;
   value: string;
   priority: number;
 }
@@ -146,15 +145,17 @@ export const UsherPlacementModal = ({
     </div>
   );
 
-  const onOptionChange = (opt: DefaultMenuSelectOption | null) => {
+  const onOptionChange = (opt: DefaultMenuSelectOption | null): void => {
     if (!opt) {
       setDropdownLabel("");
       setTreeType("");
       return;
     }
 
-    setDropdownLabel(opt?.name);
-    setTreeType(opt?.value);
+    const { name, value } = opt as DropdownOptionProps;
+
+    setDropdownLabel(name);
+    setTreeType(value);
   };
 
   const ONE_SECOND = 1000;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -74,6 +74,7 @@ export const UsherPlacementModal = ({
   );
   const [isUsherDisabled, setUsherDisabled] = useState<boolean>(false);
   const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(false);
+  const [treeType, setTreeType] = useState<string>("");
 
   const defaultNumSamples = getDefaultNumSamplesPerSubtree(sampleIds?.length);
 
@@ -110,7 +111,7 @@ export const UsherPlacementModal = ({
     },
     onSuccess: (data: FastaResponseType) => {
       const url = data?.url;
-      if (url) onLinkCreateSuccess(data.url);
+      if (url) onLinkCreateSuccess(data.url, treeType);
     },
   });
 
@@ -148,10 +149,12 @@ export const UsherPlacementModal = ({
   const onOptionChange = (opt: DefaultMenuSelectOption | null) => {
     if (!opt) {
       setDropdownLabel("");
+      setTreeType("");
       return;
     }
 
     setDropdownLabel(opt?.name);
+    setTreeType(opt?.value);
   };
 
   const ONE_SECOND = 1000;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -12,9 +12,15 @@ interface Props {
 type TimeoutType = ReturnType<typeof setTimeout> | undefined;
 
 const TIME_MODAL_SHOWN = 5000; // 5 seconds
-const USHER_URL =
-  "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
-const USHER_TREE_TYPE_QUERY = "&phyloPlaceTree=";
+
+const generateUsherLink = (remoteFile, treeType) => {
+  const USHER_URL =
+    "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
+  const USHER_TREE_TYPE_QUERY = "&phyloPlaceTree=";
+  const encodedFileLink = encodeURIComponent(remoteFile);
+
+  return `${USHER_URL}${encodedFileLink}${USHER_TREE_TYPE_QUERY}${treeType}`;
+};
 
 const UsherPreparingModal = ({
   fastaUrl,
@@ -29,9 +35,7 @@ const UsherPreparingModal = ({
     if (!fastaUrl) return;
 
     const link = document.createElement("a");
-    link.href = `${USHER_URL}${encodeURIComponent(
-      fastaUrl
-    )}${USHER_TREE_TYPE_QUERY}${treeType}`;
+    link.href = generateUsherLink(fastaUrl, treeType);
     link.target = "_blank";
     link.rel = "noopener";
     link.click();

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -13,7 +13,7 @@ type TimeoutType = ReturnType<typeof setTimeout> | undefined;
 
 const TIME_MODAL_SHOWN = 5000; // 5 seconds
 
-const generateUsherLink = (remoteFile, treeType) => {
+const generateUsherLink = (remoteFile: string, treeType: string) => {
   const USHER_URL =
     "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
   const USHER_TREE_TYPE_QUERY = "&phyloPlaceTree=";

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPreparingModal/index.tsx
@@ -6,6 +6,7 @@ interface Props {
   fastaUrl: string;
   isOpen: boolean;
   onClose(): void;
+  treeType: string;
 }
 
 type TimeoutType = ReturnType<typeof setTimeout> | undefined;
@@ -13,11 +14,13 @@ type TimeoutType = ReturnType<typeof setTimeout> | undefined;
 const TIME_MODAL_SHOWN = 5000; // 5 seconds
 const USHER_URL =
   "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
+const USHER_TREE_TYPE_QUERY = "&phyloPlaceTree=";
 
 const UsherPreparingModal = ({
   fastaUrl,
   isOpen,
   onClose,
+  treeType,
 }: Props): JSX.Element => {
   const [hasOpenedUrl, setHasOpenedUrl] = useState<boolean>(false);
   const [timer, setTimer] = useState<TimeoutType>();
@@ -26,7 +29,9 @@ const UsherPreparingModal = ({
     if (!fastaUrl) return;
 
     const link = document.createElement("a");
-    link.href = `${USHER_URL + fastaUrl}`;
+    link.href = `${USHER_URL}${encodeURIComponent(
+      fastaUrl
+    )}${USHER_TREE_TYPE_QUERY}${treeType}`;
     link.target = "_blank";
     link.rel = "noopener";
     link.click();
@@ -35,7 +40,7 @@ const UsherPreparingModal = ({
     onClose();
     if (timer) clearTimeout(timer);
     setTimer(undefined);
-  }, [fastaUrl, onClose, timer]);
+  }, [fastaUrl, onClose, timer, treeType]);
 
   useEffect(() => {
     // The s3 link was cleared by the parent, so future renders of this component

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
@@ -18,6 +18,7 @@ const UsherTreeFlow = ({
   const [isConfirmOpen, setIsConfirmOpen] = useState<boolean>(false);
   const [isPreparingOpen, setIsPreparingOpen] = useState<boolean>(false);
   const [fastaUrl, setFastaUrl] = useState<string>("");
+  const [selectedTreeType, setSelectedTreeType] = useState<string>("");
 
   useEffect(() => {
     if (shouldStartUsherFlow) handlePlacementOpen();
@@ -29,12 +30,14 @@ const UsherTreeFlow = ({
 
   const handlePlacementClose = () => {
     setFastaUrl("");
+    setSelectedTreeType("");
     setIsPlacementOpen(false);
   };
 
-  const onLinkCreateSuccess = (url: string) => {
+  const onLinkCreateSuccess = (url: string, treeType: string) => {
     setFastaUrl(url);
     setIsConfirmOpen(true);
+    setSelectedTreeType(treeType);
   };
 
   const handleConfirmationClose = () => {
@@ -67,9 +70,10 @@ const UsherTreeFlow = ({
         onConfirm={handleConfirmationConfirm}
       />
       <UsherPreparingModal
+        fastaUrl={fastaUrl}
         isOpen={isPreparingOpen}
         onClose={handlePreparingClose}
-        fastaUrl={fastaUrl}
+        treeType={selectedTreeType}
       />
     </>
   );


### PR DESCRIPTION
### Summary
- **What:** Use the specified tree type when generating link to usher
- **Why:** So the user can decide the context they want to use
- **Env:** https://usherfive-frontend.dev.genepi.czi.technology?usher=true

### Testing
I am 99% sure this is correct. I generated two trees, one of each type. When I used the GISAID option, the page included some text that read `Nearest neighboring GISAID/public sequence ...`. When I used the type without GISAID, the same line of text read `Nearest neighboring public sequence ...`. Maybe there is someone on the team that can confirm the different options generate trees within the correct context 😬 

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)