### PR TITLE
Vincent-dan/curl option

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -172,7 +172,7 @@ module gisaid_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = module.swipe_sfn.step_function_arn
-  schedule_expressions  = contains(["prod", "staging"], local.deployment_stage) ? ["cron(0 20 ? * MON-FRI *)"] : []
+  schedule_expressions  = contains(["prod", "staging"], local.deployment_stage) ? ["cron(0 3 ? * MON-FRI *)"] : []
   event_role_arn        = local.event_role_arn
   extra_args            =  {
     aspen_config_secret_name = "${local.deployment_stage}/aspen-config"

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -91,7 +91,7 @@ task IngestGISAID {
     gisaid_username=$(echo "${gisaid_credentials}" | jq -r .username)
     gisaid_password=$(echo "${gisaid_credentials}" | jq -r .password)
 
-    curl "~{gisaid_ndjson_url}" --user "${gisaid_username}:${gisaid_password}" | \
+    curl "~{gisaid_ndjson_url}" --http1.1 --user "${gisaid_username}:${gisaid_password}" | \
         bunzip2 | \
         zstdmt > sequences.fasta.zst
 

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -91,7 +91,7 @@ task IngestGISAID {
     gisaid_username=$(echo "${gisaid_credentials}" | jq -r .username)
     gisaid_password=$(echo "${gisaid_credentials}" | jq -r .password)
 
-    curl "~{gisaid_ndjson_url}" --http1.1 --user "${gisaid_username}:${gisaid_password}" | \
+    curl "~{gisaid_ndjson_url}" --user "${gisaid_username}:${gisaid_password}" | \
         bunzip2 | \
         zstdmt > sequences.fasta.zst
 


### PR DESCRIPTION
### Summary:
- **What:** Add `curl` option to specify http protocol version and change the gisaid download to run at night. 

### Demos:
With the curl change:
![image](https://user-images.githubusercontent.com/20667188/138152623-0e1e8875-4a5a-4d13-adf4-2a3778a9cf9b.png)

### Notes:
- There is a [remaining ticket]((https://app.shortcut.com/genepi/story/168701/add-retries-to-gisaid-job#activity-169042)) to add retries. Let's give the current changes a few runs and go from there.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [NA] I tested in multiple browsers
- [NA] I added relevant unit tests
- [NA?] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)