### PR TITLE
Convert the ondemand phylo tree endpoint to fastapi

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -30,7 +30,7 @@ run-isort:
 	isort --profile black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES) 
 
 run-autoflake:
-	autoflake -v -i --remove-all-unused-imports --remove-unused-variables -r $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
+	autoflake -v -i --ignore-init-module-imports --remove-all-unused-imports --remove-unused-variables -r $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
 
 
 ### TESTING #############################################

--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -37,7 +37,7 @@ async def setup_userinfo(
     try:
         userquery = get_usergroup_query(session, auth0_user_id)
         userwait = await session.execute(userquery)
-        user = userwait.unique().scalars().first()
+        user = userwait.unique().scalars().one()
     except NoResultFound:
         sentry_sdk.capture_message(
             f"Requested auth0_user_id {auth0_user_id} not found in usergroup query."

--- a/src/backend/aspen/api/conftest.py
+++ b/src/backend/aspen/api/conftest.py
@@ -10,8 +10,8 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aspen.api.auth import get_auth_user, setup_userinfo
-from aspen.api.error import http_exceptions as ex
 from aspen.api.deps import get_db
+from aspen.api.error import http_exceptions as ex
 from aspen.api.main import get_app
 from aspen.database import connection as aspen_connection
 from aspen.database import schema

--- a/src/backend/aspen/api/conftest.py
+++ b/src/backend/aspen/api/conftest.py
@@ -10,6 +10,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aspen.api.auth import get_auth_user, setup_userinfo
+from aspen.api.error import http_exceptions as ex
 from aspen.api.deps import get_db
 from aspen.api.main import get_app
 from aspen.database import connection as aspen_connection
@@ -102,7 +103,7 @@ async def override_get_auth_user(
 ) -> None:
     found_auth_user = await setup_userinfo(session, request.headers.get("user_id"))
     if not found_auth_user:
-        raise Exception("invalid user")
+        raise ex.UnauthorizedException("invalid user")
     request.state.auth_user = found_auth_user
 
 

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -10,7 +10,7 @@ from aspen.api.auth import get_auth_user
 from aspen.api.error.http_exceptions import AspenException, exception_handler
 from aspen.api.middleware.session import SessionMiddleware
 from aspen.api.settings import get_settings
-from aspen.api.views import auth, health, users
+from aspen.api.views import auth, health, users, phylo_runs
 
 
 def get_allowed_origins() -> List[str]:
@@ -59,6 +59,7 @@ def get_app() -> FastAPI:
     )
     _app.include_router(health.router, prefix="/v2/health")
     _app.include_router(auth.router, prefix="/v2/auth")
+    _app.include_router(phylo_runs.router, prefix="/v2/phylo_runs", dependencies=[Depends(get_auth_user)])
 
     _app.add_exception_handler(
         AspenException,

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -10,7 +10,7 @@ from aspen.api.auth import get_auth_user
 from aspen.api.error.http_exceptions import AspenException, exception_handler
 from aspen.api.middleware.session import SessionMiddleware
 from aspen.api.settings import get_settings
-from aspen.api.views import auth, health, users, phylo_runs
+from aspen.api.views import auth, health, phylo_runs, users
 
 
 def get_allowed_origins() -> List[str]:
@@ -59,7 +59,11 @@ def get_app() -> FastAPI:
     )
     _app.include_router(health.router, prefix="/v2/health")
     _app.include_router(auth.router, prefix="/v2/auth")
-    _app.include_router(phylo_runs.router, prefix="/v2/phylo_runs", dependencies=[Depends(get_auth_user)])
+    _app.include_router(
+        phylo_runs.router,
+        prefix="/v2/phylo_runs",
+        dependencies=[Depends(get_auth_user)],
+    )
 
     _app.add_exception_handler(
         AspenException,

--- a/src/backend/aspen/api/schemas/base.py
+++ b/src/backend/aspen/api/schemas/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel
 
@@ -7,11 +7,12 @@ class BaseRequest(BaseModel):
     pass
 
 
-def convert_datetime_to_iso_8601_with_z_suffix(dt: datetime) -> str:
-    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+def convert_datetime_to_iso_8601(dt: datetime) -> str:
+    dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat(timespec="seconds")
 
 
 class BaseResponse(BaseModel):
     class Config:
         orm_mode = True
-        json_encoders = {datetime: convert_datetime_to_iso_8601_with_z_suffix}
+        json_encoders = {datetime: convert_datetime_to_iso_8601}

--- a/src/backend/aspen/api/schemas/base.py
+++ b/src/backend/aspen/api/schemas/base.py
@@ -1,6 +1,9 @@
 from pydantic import BaseModel
 
 
-class Base(BaseModel):
+class BaseRequest(BaseModel):
+    pass
+
+class BaseResponse(BaseModel):
     class Config:
         orm_mode = True

--- a/src/backend/aspen/api/schemas/base.py
+++ b/src/backend/aspen/api/schemas/base.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class BaseRequest(BaseModel):
     pass
 
+
 class BaseResponse(BaseModel):
     class Config:
         orm_mode = True

--- a/src/backend/aspen/api/schemas/base.py
+++ b/src/backend/aspen/api/schemas/base.py
@@ -8,7 +8,8 @@ class BaseRequest(BaseModel):
 
 
 def convert_datetime_to_iso_8601(dt: datetime) -> str:
-    dt = dt.replace(tzinfo=timezone.utc)
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt.isoformat(timespec="seconds")
 
 

--- a/src/backend/aspen/api/schemas/base.py
+++ b/src/backend/aspen/api/schemas/base.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -5,6 +7,11 @@ class BaseRequest(BaseModel):
     pass
 
 
+def convert_datetime_to_iso_8601_with_z_suffix(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 class BaseResponse(BaseModel):
     class Config:
         orm_mode = True
+        json_encoders = {datetime: convert_datetime_to_iso_8601_with_z_suffix}

--- a/src/backend/aspen/api/schemas/health.py
+++ b/src/backend/aspen/api/schemas/health.py
@@ -1,5 +1,5 @@
-from aspen.api.schemas.base import Base
+from aspen.api.schemas.base import BaseResponse
 
 
-class Health(Base):
+class Health(BaseResponse):
     healthy: bool = False

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List
+from typing import List, Union
 
 from pydantic import constr, StrictStr, validator
 
@@ -14,7 +14,8 @@ PHYLO_TREE_TYPES = {
 
 
 class PhyloRunRequestSchema(BaseRequest):
-    name: constr(min_length=1, max_length=128, strict=True)
+    # mpypy + pydantic is a work in progress: https://github.com/samuelcolvin/pydantic/issues/156
+    name: constr(min_length=1, max_length=128, strict=True)  # type: ignore
     samples: List[StrictStr]
     tree_type: StrictStr
 
@@ -39,7 +40,7 @@ class PhyloRunResponseSchema(BaseResponse):
 
     id: int
     start_datetime: datetime.datetime
-    end_datetime: datetime.datetime = None
+    end_datetime: Union[datetime.datetime, None] = None
     workflow_status: WorkflowStatusType  # TODO maybe we can keep SqlAlchemy out of this
     group: GroupResponseSchema
     template_file_path: StrictStr

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -1,12 +1,10 @@
-from aspen.api.schemas.base import BaseRequest, BaseResponse
 import datetime
-
-from pydantic import BaseModel, ValidationError, validator, constr, StrictStr
 from typing import List
-from aspen.database.models import (
-    WorkflowStatusType, 
-    TreeType,
-)
+
+from pydantic import constr, StrictStr, validator
+
+from aspen.api.schemas.base import BaseRequest, BaseResponse
+from aspen.database.models import TreeType, WorkflowStatusType
 
 # What kinds of ondemand nextstrain builds do we support?
 PHYLO_TREE_TYPES = {
@@ -14,12 +12,13 @@ PHYLO_TREE_TYPES = {
     TreeType.TARGETED.value: "targeted.yaml",
 }
 
+
 class PhyloRunRequestSchema(BaseRequest):
     name: constr(min_length=1, max_length=128, strict=True)
     samples: List[StrictStr]
     tree_type: StrictStr
 
-    @validator('tree_type')
+    @validator("tree_type")
     def tree_type_must_be_supported(cls, value):
         uppercase_tree_type = value.upper()
         assert PHYLO_TREE_TYPES.get(uppercase_tree_type)
@@ -29,12 +28,15 @@ class PhyloRunRequestSchema(BaseRequest):
 class GroupResponseSchema(BaseResponse):
     class Config:
         orm_mode = True
+
     id: int
     name: StrictStr
+
 
 class PhyloRunResponseSchema(BaseResponse):
     class Config:
         orm_mode = True
+
     id: int
     start_datetime: datetime.datetime
     end_datetime: datetime.datetime = None

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -1,7 +1,7 @@
 from aspen.api.schemas.base import BaseRequest, BaseResponse
 import datetime
 
-from pydantic import BaseModel, ValidationError, validator, constr
+from pydantic import BaseModel, ValidationError, validator, constr, StrictStr
 from typing import List
 from aspen.database.models import (
     WorkflowStatusType, 
@@ -15,9 +15,9 @@ PHYLO_TREE_TYPES = {
 }
 
 class PhyloRunRequestSchema(BaseRequest):
-    name: constr(min_length=1, max_length=128)
-    samples: List[str]
-    tree_type: str
+    name: constr(min_length=1, max_length=128, strict=True)
+    samples: List[StrictStr]
+    tree_type: StrictStr
 
     @validator('tree_type')
     def tree_type_must_be_supported(cls, value):
@@ -30,7 +30,7 @@ class GroupResponseSchema(BaseResponse):
     class Config:
         orm_mode = True
     id: int
-    name: str
+    name: StrictStr
 
 class PhyloRunResponseSchema(BaseResponse):
     class Config:
@@ -40,5 +40,5 @@ class PhyloRunResponseSchema(BaseResponse):
     end_datetime: datetime.datetime = None
     workflow_status: WorkflowStatusType  # TODO maybe we can keep SqlAlchemy out of this
     group: GroupResponseSchema
-    template_file_path: str
+    template_file_path: StrictStr
     template_args: dict

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -1,0 +1,44 @@
+from aspen.api.schemas.base import BaseRequest, BaseResponse
+import datetime
+
+from pydantic import BaseModel, ValidationError, validator, constr
+from typing import List
+from aspen.database.models import (
+    WorkflowStatusType, 
+    TreeType,
+)
+
+# What kinds of ondemand nextstrain builds do we support?
+PHYLO_TREE_TYPES = {
+    TreeType.NON_CONTEXTUALIZED.value: "non_contextualized.yaml",
+    TreeType.TARGETED.value: "targeted.yaml",
+}
+
+class PhyloRunRequestSchema(BaseRequest):
+    name: constr(min_length=1, max_length=128)
+    samples: List[str]
+    tree_type: str
+
+    @validator('tree_type')
+    def tree_type_must_be_supported(cls, value):
+        uppercase_tree_type = value.upper()
+        assert PHYLO_TREE_TYPES.get(uppercase_tree_type)
+        return uppercase_tree_type
+
+
+class GroupResponseSchema(BaseResponse):
+    class Config:
+        orm_mode = True
+    id: int
+    name: str
+
+class PhyloRunResponseSchema(BaseResponse):
+    class Config:
+        orm_mode = True
+    id: int
+    start_datetime: datetime.datetime
+    end_datetime: datetime.datetime = None
+    workflow_status: WorkflowStatusType  # TODO maybe we can keep SqlAlchemy out of this
+    group: GroupResponseSchema
+    template_file_path: str
+    template_args: dict

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -14,7 +14,7 @@ PHYLO_TREE_TYPES = {
 
 
 class PhyloRunRequestSchema(BaseRequest):
-    # mpypy + pydantic is a work in progress: https://github.com/samuelcolvin/pydantic/issues/156
+    # mypy + pydantic is a work in progress: https://github.com/samuelcolvin/pydantic/issues/156
     name: constr(min_length=1, max_length=128, strict=True)  # type: ignore
     samples: List[StrictStr]
     tree_type: StrictStr

--- a/src/backend/aspen/api/schemas/users.py
+++ b/src/backend/aspen/api/schemas/users.py
@@ -1,14 +1,8 @@
+from aspen.api.schemas.base import BaseResponse
 from typing import List
 
-from pydantic import BaseModel
 
-
-class Base(BaseModel):
-    class Config:
-        orm_mode = True
-
-
-class UserBase(Base):
+class UserBase(BaseResponse):
     agreed_to_tos: bool = False
 
 
@@ -16,5 +10,5 @@ class User(UserBase):
     pass
 
 
-class Users(Base):
+class Users(BaseResponse):
     items: List[User]

--- a/src/backend/aspen/api/schemas/users.py
+++ b/src/backend/aspen/api/schemas/users.py
@@ -1,5 +1,6 @@
-from aspen.api.schemas.base import BaseResponse
 from typing import List
+
+from aspen.api.schemas.base import BaseResponse
 
 
 class UserBase(BaseResponse):

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -202,33 +202,33 @@ class Settings(BaseSettings):
     # SFN runtime input properties
     @cached_property
     def NEXTSTRAIN_DOCKER_IMAGE_ID(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["Input"]["Run"]["docker_image_id"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["Input"]["Run"]["docker_image_id"]
 
     ####################################################################################
     # SFN batch config properties
     @cached_property
     def NEXTSTRAIN_OUTPUT_PREFIX(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["OutputPrefix"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["OutputPrefix"]
 
     @cached_property
     def RUN_WDL_URI(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RUN_WDL_URI"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["RUN_WDL_URI"]
 
     @cached_property
     def NEXTSTRAIN_EC2_MEMORY(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunEC2Memory"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["RunEC2Memory"]
 
     @cached_property
     def NEXTSTRAIN_EC2_VCPU(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunEC2Vcpu"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["RunEC2Vcpu"]
 
     @cached_property
     def NEXTSTRAIN_SPOT_MEMORY(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunSPOTMemory"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["RunSPOTMemory"]
 
     @cached_property
     def NEXTSTRAIN_SPOT_VCPU(self) -> str:
-        return self.AWS_NEXTSTRAIN_SFN_PARAMETER["RunSPOTVcpu"]
+        return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["RunSPOTVcpu"]
 
     class Config:
         env_file = ".env"

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -174,7 +174,7 @@ class Settings(BaseSettings):
 
     ####################################################################################
     # SSM Parameter properties
-    @lru_cache
+    # @lru_cache
     def _AWS_SSM_PARAMETER(self, parameter_suffix: str) -> Mapping[str, Any]:
         session = Session(region_name=self.AWS_REGION)
 
@@ -195,7 +195,7 @@ class Settings(BaseSettings):
             return json.loads(parameter)
 
     @cached_property
-    def AWS_NEXTSTRAIN_SFN_PARAMETER(self) -> Mapping[str, Any]:
+    def AWS_NEXTSTRAIN_SFN_PARAMETERS(self) -> Mapping[str, Any]:
         return self._AWS_SSM_PARAMETER("nextstrain-ondemand-sfn")
 
     ####################################################################################

--- a/src/backend/aspen/api/utils/__init__.py
+++ b/src/backend/aspen/api/utils/__init__.py
@@ -1,0 +1,1 @@
+from aspen.api.utils.get_matching_gisaid_ids import get_matching_gisaid_ids

--- a/src/backend/aspen/api/utils/__init__.py
+++ b/src/backend/aspen/api/utils/__init__.py
@@ -1,1 +1,0 @@
-from aspen.api.utils.get_matching_gisaid_ids import get_matching_gisaid_ids

--- a/src/backend/aspen/api/utils/__init__.py
+++ b/src/backend/aspen/api/utils/__init__.py
@@ -1,0 +1,3 @@
+from aspen.api.utils.get_matching_gisaid_ids import (  # noqa: F401
+    get_matching_gisaid_ids,
+)

--- a/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
+++ b/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
@@ -32,7 +32,7 @@ async def get_matching_gisaid_ids(sample_ids: Iterable[str], session: AsyncSessi
         GisaidMetadata.strain.in_(stripped_mapping.keys())
     )
     gisaid_matches: Iterable[GisaidMetadata] = await session.execute(gisaid_matches_query)
-    for gisaid_match in gisaid_matches:
+    for gisaid_match in gisaid_matches.scalars():
         # add back in originally submitted identifier (unstripped)
         gisaid_ids.add(stripped_mapping[gisaid_match.strain])
 

--- a/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
+++ b/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
@@ -31,13 +31,13 @@ async def get_matching_gisaid_ids(
     # first create a mapping of ids that were stripped (so we can return unstripped id later)
     stripped_mapping: Mapping[str, str] = {s.strip("hCoV-19/"): s for s in sample_ids}
 
-    gisaid_matches_query = sa.select(GisaidMetadata).filter(
+    gisaid_matches_query = sa.select(GisaidMetadata).filter(  # type: ignore
         GisaidMetadata.strain.in_(stripped_mapping.keys())
     )
-    gisaid_matches: Iterable[GisaidMetadata] = await session.execute(
-        gisaid_matches_query
-    )
-    for gisaid_match in gisaid_matches.scalars():
+    gisaid_matches: Iterable[GisaidMetadata] = (
+        await session.execute(gisaid_matches_query)
+    ).scalars()
+    for gisaid_match in gisaid_matches:
         # add back in originally submitted identifier (unstripped)
         gisaid_ids.add(stripped_mapping[gisaid_match.strain])
 

--- a/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
+++ b/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
@@ -1,0 +1,39 @@
+from aspen.database.models import GisaidMetadata
+from typing import Iterable, Mapping, Set
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import sqlalchemy as sa
+
+async def get_matching_gisaid_ids(sample_ids: Iterable[str], session: AsyncSession) -> Set[str]:
+    """
+    Check if a list of identifiers exist as gisaid strain names,
+    strip identifier (hCoV-19/) before proceeding with check against GisaidMetadata table
+
+    Parameters:
+        sample_ids Iterable[str]: A list of identifiers (usually submitted by a user)
+                                  that need to be checked if they exist as gisaid identifiers ( as strain names)
+        session (Session): An open sql alchemy session
+
+    Returns:
+            gisaid_ids (Set[str]): Set of idenitifiers that matched against GisaidMetadata table as strain names
+
+    """
+
+    gisaid_ids = set()
+
+    # we need to strip off hCoV-19/ before checking against gisaid strain name
+    # (Gisaid data is prepped by Nextstrain which strips off this prefix)
+
+    # first create a mapping of ids that were stripped (so we can return unstripped id later)
+    stripped_mapping: Mapping[str, str] = {s.strip("hCoV-19/"): s for s in sample_ids}
+
+    gisaid_matches_query = sa.select(GisaidMetadata).filter(
+        GisaidMetadata.strain.in_(stripped_mapping.keys())
+    )
+    gisaid_matches: Iterable[GisaidMetadata] = await session.execute(gisaid_matches_query)
+    for gisaid_match in gisaid_matches:
+        # add back in originally submitted identifier (unstripped)
+        gisaid_ids.add(stripped_mapping[gisaid_match.strain])
+
+    return gisaid_ids

--- a/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
+++ b/src/backend/aspen/api/utils/get_matching_gisaid_ids.py
@@ -1,11 +1,14 @@
-from aspen.database.models import GisaidMetadata
 from typing import Iterable, Mapping, Set
-from fastapi import Depends
-from sqlalchemy.ext.asyncio import AsyncSession
 
 import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
 
-async def get_matching_gisaid_ids(sample_ids: Iterable[str], session: AsyncSession) -> Set[str]:
+from aspen.database.models import GisaidMetadata
+
+
+async def get_matching_gisaid_ids(
+    sample_ids: Iterable[str], session: AsyncSession
+) -> Set[str]:
     """
     Check if a list of identifiers exist as gisaid strain names,
     strip identifier (hCoV-19/) before proceeding with check against GisaidMetadata table
@@ -31,7 +34,9 @@ async def get_matching_gisaid_ids(sample_ids: Iterable[str], session: AsyncSessi
     gisaid_matches_query = sa.select(GisaidMetadata).filter(
         GisaidMetadata.strain.in_(stripped_mapping.keys())
     )
-    gisaid_matches: Iterable[GisaidMetadata] = await session.execute(gisaid_matches_query)
+    gisaid_matches: Iterable[GisaidMetadata] = await session.execute(
+        gisaid_matches_query
+    )
     for gisaid_match in gisaid_matches.scalars():
         # add back in originally submitted identifier (unstripped)
         gisaid_ids.add(stripped_mapping[gisaid_match.strain])

--- a/src/backend/aspen/api/views/health.py
+++ b/src/backend/aspen/api/views/health.py
@@ -7,4 +7,4 @@ router = APIRouter()
 
 @router.get("/", response_model=healthschema)
 async def get_health() -> healthschema:
-    return healthschema.parse_obj({"healthy": True})
+    return healthschema.parse_obj({"healthy": False})

--- a/src/backend/aspen/api/views/health.py
+++ b/src/backend/aspen/api/views/health.py
@@ -7,4 +7,4 @@ router = APIRouter()
 
 @router.get("/", response_model=healthschema)
 async def get_health() -> healthschema:
-    return healthschema.parse_obj({"healthy": False})
+    return healthschema.parse_obj({"healthy": True})

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import os
 import re
-from typing import Iterable, MutableSequence
+from typing import MutableSequence
 
 import sentry_sdk
 import sqlalchemy as sa
@@ -61,7 +61,7 @@ async def kick_off_phylo_run(
     # all_samples: Iterable[Sample] = db.query(Sample).options(
     #     joinedload(Sample.uploaded_pathogen_genome, innerjoin=True),
     # )
-    all_samples_query: Iterable[Sample] = sa.select(Sample).options(
+    all_samples_query = sa.select(Sample).options(  # type: ignore
         joinedload(Sample.uploaded_pathogen_genome, innerjoin=True),
     )
 
@@ -102,11 +102,11 @@ async def kick_off_phylo_run(
         raise ex.BadRequestException("No sequences selected for run")
 
     # 4B - AlignedGisaidDump
-    aligned_gisaid_dump_query = (
-        sa.select(AlignedGisaidDump)
-        .join(AlignedGisaidDump.producing_workflow)
-        .order_by(Workflow.end_datetime.desc())
-        .limit(1)
+    aligned_gisaid_dump_query = (  # type: ignore
+        sa.select(AlignedGisaidDump)  # type: ignore
+        .join(AlignedGisaidDump.producing_workflow)  # type: ignore
+        .order_by(Workflow.end_datetime.desc())  # type: ignore
+        .limit(1)  # type: ignore
     )
     aligned_gisaid_dump = await db.execute(aligned_gisaid_dump_query)
     try:
@@ -181,7 +181,7 @@ async def kick_off_phylo_run(
     execution_name = f"{group.prefix}-ondemand-nextstrain-{str(start_datetime)}"
     execution_name = re.sub(r"[^0-9a-zA-Z-]", r"-", execution_name)
 
-    result = client.start_execution(
+    client.start_execution(
         stateMachineArn=sfn_params["StateMachineArn"],
         name=execution_name,
         input=json.dumps(sfn_input_json),

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -38,7 +38,6 @@ PHYLO_TREE_TYPES = {
     TreeType.TARGETED.value: "targeted.yaml",
 }
 
-# route
 router = APIRouter()
 
 

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -19,7 +19,6 @@ from aspen.api.settings import get_settings
 from aspen.api.utils import get_matching_gisaid_ids
 from aspen.app.views.api_utils import (
     authz_sample_filters,
-    get_matching_gisaid_ids,
     get_missing_and_found_sample_ids,
 )
 from aspen.database.models import (

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -1,0 +1,85 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
+
+import sqlalchemy as sa
+from sqlalchemy.orm import joinedload
+
+from aspen.api.deps import get_db
+from aspen.api.schemas.users import User as userschema
+from aspen.database.models.usergroup import User
+from aspen.database.models.sample import Sample
+from aspen.database.models import TreeType
+
+from aspen.app.views.api_utils import (
+    authz_sample_filters,
+    get_matching_gisaid_ids,
+    get_missing_and_found_sample_ids,
+)
+
+from typing import Iterable
+
+import logging
+logging.basicConfig()
+logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+
+# schema
+from pydantic import BaseModel, ValidationError, validator, constr
+from typing import List
+
+# What kinds of ondemand nextstrain builds do we support?
+PHYLO_TREE_TYPES = {
+    TreeType.NON_CONTEXTUALIZED.value: "non_contextualized.yaml",
+    TreeType.TARGETED.value: "targeted.yaml",
+}
+
+class PhyloRunRequestSchema(BaseModel):
+    name: constr(min_length=1, max_length=128)
+    samples: List[str]
+    tree_type: str
+
+    @validator('tree_type')
+    def tree_type_must_be_supported(cls, value):
+        assert PHYLO_TREE_TYPES.get(value.upper())
+        return value
+
+class PhyloRunResponseSchema(BaseModel):
+    samples: str
+
+# route
+router = APIRouter()
+
+@router.post("/")
+async def kick_off_phylo_run(phylo_run_request: PhyloRunRequestSchema, request: Request, db: AsyncSession = Depends(get_db)) -> PhyloRunResponseSchema:
+    user = request.state.auth_user
+    # Note - sample run will be associated with users's primary group.
+    #    (do we want admins to be able to start runs on behalf of other dph's ?)
+    group = user.group
+
+    # validation happens in input schema
+
+    sample_ids = phylo_run_request.samples
+    
+    # Step 2 - prepare big sample query per the old db cli
+    # all_samples: Iterable[Sample] = db.query(Sample).options(
+    #     joinedload(Sample.uploaded_pathogen_genome, innerjoin=True),
+    # )
+    all_samples_query: Iterable[Sample] = sa.select(Sample).options(joinedload(Sample.uploaded_pathogen_genome, innerjoin=True),)
+
+    # Step 3 - Enforce AuthZ (check if user has permission to see private identifiers and scope down the search for matching ID's to groups that the user has read access to.)
+    # user_visible_samples = authz_sample_filters(all_samples, sample_ids, user)
+    user_visible_sample_query = authz_sample_filters(all_samples_query, sample_ids, user)
+    print(user_visible_sample_query)
+    user_visible_samples = await db.execute(user_visible_sample_query)
+    user_visible_samples = user_visible_samples.unique().scalars()
+    for sample in user_visible_samples:
+        print(sample.public_identifier)
+
+    # Are there any sample ID's that don't match sample table public and private identifiers
+    missing_sample_ids, found_sample_ids = get_missing_and_found_sample_ids(
+        sample_ids, user_visible_samples
+    )
+
+
+
+    return PhyloRunResponseSchema.parse_obj({ "samples": str(found_sample_ids) })

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -15,7 +15,11 @@ from starlette.requests import Request
 
 from aspen.api.deps import get_db
 from aspen.api.error import http_exceptions as ex
-from aspen.api.schemas.phylo_runs import PhyloRunRequestSchema, PhyloRunResponseSchema
+from aspen.api.schemas.phylo_runs import (
+    PHYLO_TREE_TYPES,
+    PhyloRunRequestSchema,
+    PhyloRunResponseSchema,
+)
 from aspen.api.settings import get_settings
 from aspen.api.utils import get_matching_gisaid_ids
 from aspen.app.views.api_utils import (
@@ -31,12 +35,6 @@ from aspen.database.models import (
     Workflow,
     WorkflowStatusType,
 )
-
-# What kinds of ondemand nextstrain builds do we support?
-PHYLO_TREE_TYPES = {
-    TreeType.NON_CONTEXTUALIZED.value: "non_contextualized.yaml",
-    TreeType.TARGETED.value: "targeted.yaml",
-}
 
 router = APIRouter()
 

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -38,6 +38,7 @@ from aspen.app.views.api_utils import (
 )
 
 from aspen.api.utils import get_matching_gisaid_ids
+from aspen.api.schemas.phylo_runs import PhyloRunRequestSchema, PhyloRunResponseSchema
 
 from typing import Iterable, MutableSequence
 
@@ -45,43 +46,11 @@ import logging
 logging.basicConfig()
 logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
-# schema
-from pydantic import BaseModel, ValidationError, validator, constr
-from typing import List
-
 # What kinds of ondemand nextstrain builds do we support?
 PHYLO_TREE_TYPES = {
     TreeType.NON_CONTEXTUALIZED.value: "non_contextualized.yaml",
     TreeType.TARGETED.value: "targeted.yaml",
 }
-
-class GroupResponseSchema(BaseModel):
-    class Config:
-        orm_mode = True
-    id: int
-    name: str
-
-class PhyloRunRequestSchema(BaseModel):
-    name: constr(min_length=1, max_length=128)
-    samples: List[str]
-    tree_type: str
-
-    @validator('tree_type')
-    def tree_type_must_be_supported(cls, value):
-        uppercase_tree_type = value.upper()
-        assert PHYLO_TREE_TYPES.get(uppercase_tree_type)
-        return uppercase_tree_type
-
-class PhyloRunResponseSchema(BaseModel):
-    class Config:
-        orm_mode = True
-    id: int
-    start_datetime: datetime.datetime
-    end_datetime: datetime.datetime = None
-    workflow_status: WorkflowStatusType
-    group: GroupResponseSchema
-    template_file_path: str
-    template_args: dict
 
 # route
 router = APIRouter()

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -42,10 +42,6 @@ from aspen.api.schemas.phylo_runs import PhyloRunRequestSchema, PhyloRunResponse
 
 from typing import Iterable, MutableSequence
 
-import logging
-logging.basicConfig()
-logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
-
 # What kinds of ondemand nextstrain builds do we support?
 PHYLO_TREE_TYPES = {
     TreeType.NON_CONTEXTUALIZED.value: "non_contextualized.yaml",

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -1,15 +1,35 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
+import datetime
+
+from boto3 import Session
+
+import sentry_sdk
+import re
+import json
 
 import sqlalchemy as sa
 from sqlalchemy.orm import joinedload
 
 from aspen.api.deps import get_db
 from aspen.api.schemas.users import User as userschema
-from aspen.database.models.usergroup import User
-from aspen.database.models.sample import Sample
-from aspen.database.models import TreeType
+
+from aspen.api.settings import get_settings
+import os
+
+from aspen.database.models import (
+    User,
+    Sample,
+    PathogenGenome,
+    TreeType,
+    AlignedGisaidDump,
+    Workflow,
+    PhyloRun,
+    WorkflowStatusType
+)
+
+from aspen.api.error import http_exceptions as ex
 
 from aspen.app.views.api_utils import (
     authz_sample_filters,
@@ -17,7 +37,9 @@ from aspen.app.views.api_utils import (
     get_missing_and_found_sample_ids,
 )
 
-from typing import Iterable
+from aspen.api.utils import get_matching_gisaid_ids
+
+from typing import Iterable, MutableSequence
 
 import logging
 logging.basicConfig()
@@ -33,6 +55,12 @@ PHYLO_TREE_TYPES = {
     TreeType.TARGETED.value: "targeted.yaml",
 }
 
+class GroupResponseSchema(BaseModel):
+    class Config:
+        orm_mode = True
+    id: int
+    name: str
+
 class PhyloRunRequestSchema(BaseModel):
     name: constr(min_length=1, max_length=128)
     samples: List[str]
@@ -40,11 +68,20 @@ class PhyloRunRequestSchema(BaseModel):
 
     @validator('tree_type')
     def tree_type_must_be_supported(cls, value):
-        assert PHYLO_TREE_TYPES.get(value.upper())
-        return value
+        uppercase_tree_type = value.upper()
+        assert PHYLO_TREE_TYPES.get(uppercase_tree_type)
+        return uppercase_tree_type
 
 class PhyloRunResponseSchema(BaseModel):
-    samples: str
+    class Config:
+        orm_mode = True
+    id: int
+    start_datetime: datetime.datetime
+    end_datetime: datetime.datetime = None
+    workflow_status: WorkflowStatusType
+    group: GroupResponseSchema
+    template_file_path: str
+    template_args: dict
 
 # route
 router = APIRouter()
@@ -69,17 +106,122 @@ async def kick_off_phylo_run(phylo_run_request: PhyloRunRequestSchema, request: 
     # Step 3 - Enforce AuthZ (check if user has permission to see private identifiers and scope down the search for matching ID's to groups that the user has read access to.)
     # user_visible_samples = authz_sample_filters(all_samples, sample_ids, user)
     user_visible_sample_query = authz_sample_filters(all_samples_query, sample_ids, user)
-    print(user_visible_sample_query)
     user_visible_samples = await db.execute(user_visible_sample_query)
-    user_visible_samples = user_visible_samples.unique().scalars()
-    for sample in user_visible_samples:
-        print(sample.public_identifier)
+    user_visible_samples = user_visible_samples.unique().scalars().all()
 
     # Are there any sample ID's that don't match sample table public and private identifiers
     missing_sample_ids, found_sample_ids = get_missing_and_found_sample_ids(
         sample_ids, user_visible_samples
     )
 
+    # See if these missing_sample_ids match any Gisaid IDs
+    gisaid_ids = await get_matching_gisaid_ids(missing_sample_ids, db)
+
+    # Do we have any samples that are not aspen private or public identifiers or gisaid identifiers?
+    missing_sample_ids = missing_sample_ids - gisaid_ids
+
+    # Throw an error if we have any sample ID's that didn't match county samples OR gisaid samples.
+    if missing_sample_ids:
+        sentry_sdk.capture_message(
+            f"User requested invalid samples ({missing_sample_ids})"
+        )
+        raise ex.BadRequestException("missing ids", {"ids": list(missing_sample_ids)})
+
+    # Step 4 - Create a phylo run & associated input rows in the DB
+    # 4A - collect the sample sequences
+    pathogen_genomes: MutableSequence[PathogenGenome] = list()
+    for sample in user_visible_samples:
+        pathogen_genomes.append(sample.uploaded_pathogen_genome)
+    if len(pathogen_genomes) == 0:
+        sentry_sdk.capture_message(
+            f"No sequences selected for run from {sample_ids}.", "error"
+        )
+        raise ex.BadRequestException("No sequences selected for run")
+
+    # 4B - AlignedGisaidDump
+    aligned_gisaid_dump_query = (
+        sa.select(AlignedGisaidDump)
+        .join(AlignedGisaidDump.producing_workflow)
+        .order_by(Workflow.end_datetime.desc())
+        .limit(1)
+    )
+    aligned_gisaid_dump = await db.execute(aligned_gisaid_dump_query)
+    aligned_gisaid_dump = aligned_gisaid_dump.scalars().first()
+    if not aligned_gisaid_dump:
+        sentry_sdk.capture_message(
+            "No Aligned Gisaid Dump found! Cannot create PhyloRun!", "fatal"
+        )
+        raise ex.ServerException("No gisaid dump for run")
+
+    # 4C build our PhyloRun object
+    template_path_prefix = (
+        "/usr/src/app/aspen/workflows/nextstrain_run/builds_templates"
+    )
+    builds_template_file = (
+        f"{template_path_prefix}/{PHYLO_TREE_TYPES[phylo_run_request.tree_type]}"
+    )
+    builds_template_args = {
+        "division": group.division,
+        "location": group.location,
+    }
+    start_datetime = datetime.datetime.now()
+
+    workflow: PhyloRun = PhyloRun(
+        start_datetime=start_datetime,
+        workflow_status=WorkflowStatusType.STARTED,
+        software_versions={},
+        group=group,
+        template_file_path=builds_template_file,
+        template_args=builds_template_args,
+        name=phylo_run_request.name,
+        gisaid_ids=list(gisaid_ids),
+        tree_type=TreeType(phylo_run_request.tree_type),
+    )
+    workflow.inputs = list(pathogen_genomes)
+    workflow.inputs.append(aligned_gisaid_dump)
+
+    db.add(workflow)
+    await db.commit()
+
+    # Step 5 - Kick off the phylo run job.
+    aws_region = os.environ.get("AWS_REGION")
+    settings = get_settings()
+    sfn_params = settings.AWS_NEXTSTRAIN_SFN_PARAMETERS
+    sfn_input_json = {
+        "Input": {
+            "Run": {
+                "aspen_config_secret_name": os.environ.get(
+                    "ASPEN_CONFIG_SECRET_NAME", "aspen-config"
+                ),
+                "aws_region": aws_region,
+                "docker_image_id": sfn_params["Input"]["Run"]["docker_image_id"],
+                "remote_dev_prefix": os.getenv("REMOTE_DEV_PREFIX"),
+                "s3_filestem": f"{group.location}/{phylo_run_request.tree_type.capitalize()}",
+                "workflow_id": workflow.id,
+            },
+        },
+        "OutputPrefix": f"{sfn_params['OutputPrefix']}/{workflow.id}",
+        "RUN_WDL_URI": sfn_params["RUN_WDL_URI"],
+        "RunEC2Memory": sfn_params["RunEC2Memory"],
+        "RunEC2Vcpu": sfn_params["RunEC2Vcpu"],
+        "RunSPOTMemory": sfn_params["RunSPOTMemory"],
+        "RunSPOTVcpu": sfn_params["RunSPOTVcpu"],
+    }
+
+    session = Session(region_name=aws_region)
+    client = session.client(
+        service_name="stepfunctions",
+        endpoint_url=os.getenv("BOTO_ENDPOINT_URL") or None,
+    )
+
+    execution_name = f"{group.prefix}-ondemand-nextstrain-{str(start_datetime)}"
+    execution_name = re.sub(r"[^0-9a-zA-Z-]", r"-", execution_name)
+
+    result = client.start_execution(
+        stateMachineArn=sfn_params["StateMachineArn"],
+        name=execution_name,
+        input=json.dumps(sfn_input_json),
+    )
 
 
-    return PhyloRunResponseSchema.parse_obj({ "samples": str(found_sample_ids) })
+    return PhyloRunResponseSchema.from_orm(workflow)

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -57,9 +57,6 @@ async def kick_off_phylo_run(
     sample_ids = phylo_run_request.samples
 
     # Step 2 - prepare big sample query per the old db cli
-    # all_samples: Iterable[Sample] = db.query(Sample).options(
-    #     joinedload(Sample.uploaded_pathogen_genome, innerjoin=True),
-    # )
     all_samples_query = sa.select(Sample).options(  # type: ignore
         joinedload(Sample.uploaded_pathogen_genome, innerjoin=True),
     )

--- a/src/backend/aspen/api/views/tests/test_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_runs.py
@@ -1,0 +1,223 @@
+from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
+from aspen.test_infra.models.sample import sample_factory
+from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
+from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.workflow import aligned_gisaid_dump_factory
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+# Example:
+# async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -> None:
+async def test_create_phylo_run(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test phylo tree creation, local-only samples.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+    gisaid_dump = aligned_gisaid_dump_factory()
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {
+        "name": "test phylorun",
+        "tree_type": "targeted",
+        "samples": [sample.public_identifier],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 200
+    response = res.json()
+    template_args = response["template_args"]
+    assert template_args["division"] == group.division
+    assert template_args["location"] == group.location
+    assert "targeted.yaml" in response["template_file_path"]
+    assert response["workflow_status"] == "STARTED"
+    assert response["group"]["name"] == group.name
+    assert "id" in response
+
+
+async def test_create_phylo_run_with_gisaid_ids(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test phylo tree creation that includes a reference to a GISAID sequence.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    gisaid_dump = aligned_gisaid_dump_factory()
+    gisaid_sample = gisaid_metadata_factory()
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    async_session.add(gisaid_sample)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {
+        "name": "test phylorun",
+        "tree_type": "non_contextualized",
+        "samples": [sample.public_identifier, gisaid_sample.strain],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 200
+    response = res.json()
+    template_args = response["template_args"]
+    assert template_args["division"] == group.division
+    assert template_args["location"] == group.location
+    assert "non_contextualized.yaml" in response["template_file_path"]
+    assert response["workflow_status"] == "STARTED"
+    assert response["group"]["name"] == group.name
+    assert "id" in response
+
+
+async def test_create_invalid_phylo_run_name(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test a phylo tree run request with a bad tree name.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+    gisaid_dump = aligned_gisaid_dump_factory()
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {
+        "name": 3.1415926535,
+        "tree_type": "targeted",
+        "samples": [sample.public_identifier],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 422
+
+
+async def test_create_invalid_phylo_run_tree_type(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test a phylo tree run request with a bad tree type.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+    gisaid_dump = aligned_gisaid_dump_factory()
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {
+        "name": "test phylorun",
+        "tree_type": "global",
+        "samples": [sample.public_identifier],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 422
+
+
+async def test_create_invalid_phylo_run_bad_sample_id(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test a phylo tree run request with a bad sample id.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+    gisaid_dump = aligned_gisaid_dump_factory()
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {
+        "name": "test phylorun",
+        "tree_type": "non_contextualized",
+        "samples": [sample.public_identifier, "bad_sample_identifier"],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 400
+
+
+async def test_create_invalid_phylo_run_sample_cannot_see(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test a phylo tree run request with a sample a group should not have access to.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+
+    group2 = group_factory(name="The Other Group")
+    user2 = user_factory(
+        group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
+    )
+    sample2 = sample_factory(group2, user2, public_identifier="USA/OTHER/123456")
+
+    gisaid_dump = aligned_gisaid_dump_factory()
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(group)
+    async_session.add(group2)
+    async_session.add(gisaid_dump)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {
+        "name": "test phylorun",
+        "tree_type": "non_contextualized",
+        "samples": [sample.public_identifier, sample2.public_identifier],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 400
+
+
+async def test_create_phylo_run_unauthorized_access_redirect(
+        async_session: AsyncSession,
+        http_client: AsyncClient,
+):
+    """
+    Test a request from an outside, unauthorized source.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+
+    gisaid_dump = aligned_gisaid_dump_factory()
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    await async_session.commit()
+
+    auth_headers = {}
+    data = {
+        "name": "test phylorun",
+        "tree_type": "non_contextualized",
+        "samples": [sample.public_identifier],
+    }
+    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    assert res.status_code == 401

--- a/src/backend/aspen/api/views/tests/test_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_runs.py
@@ -12,8 +12,6 @@ from aspen.test_infra.models.workflow import aligned_gisaid_dump_factory
 pytestmark = pytest.mark.asyncio
 
 
-# Example:
-# async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -> None:
 async def test_create_phylo_run(
     async_session: AsyncSession,
     http_client: AsyncClient,
@@ -213,11 +211,10 @@ async def test_create_phylo_run_unauthorized_access_redirect(
     async_session.add(gisaid_dump)
     await async_session.commit()
 
-    auth_headers = {}
     data = {
         "name": "test phylorun",
         "tree_type": "non_contextualized",
         "samples": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post("/v2/phylo_runs/", json=data)
     assert res.status_code == 401

--- a/src/backend/aspen/api/views/tests/test_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_runs.py
@@ -1,12 +1,12 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
 from aspen.test_infra.models.usergroup import group_factory, user_factory
 from aspen.test_infra.models.workflow import aligned_gisaid_dump_factory
-
-import pytest
-from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -15,8 +15,8 @@ pytestmark = pytest.mark.asyncio
 # Example:
 # async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -> None:
 async def test_create_phylo_run(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test phylo tree creation, local-only samples.
@@ -49,8 +49,8 @@ async def test_create_phylo_run(
 
 
 async def test_create_phylo_run_with_gisaid_ids(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test phylo tree creation that includes a reference to a GISAID sequence.
@@ -85,8 +85,8 @@ async def test_create_phylo_run_with_gisaid_ids(
 
 
 async def test_create_invalid_phylo_run_name(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test a phylo tree run request with a bad tree name.
@@ -111,8 +111,8 @@ async def test_create_invalid_phylo_run_name(
 
 
 async def test_create_invalid_phylo_run_tree_type(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test a phylo tree run request with a bad tree type.
@@ -137,8 +137,8 @@ async def test_create_invalid_phylo_run_tree_type(
 
 
 async def test_create_invalid_phylo_run_bad_sample_id(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test a phylo tree run request with a bad sample id.
@@ -163,8 +163,8 @@ async def test_create_invalid_phylo_run_bad_sample_id(
 
 
 async def test_create_invalid_phylo_run_sample_cannot_see(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test a phylo tree run request with a sample a group should not have access to.
@@ -197,8 +197,8 @@ async def test_create_invalid_phylo_run_sample_cannot_see(
 
 
 async def test_create_phylo_run_unauthorized_access_redirect(
-        async_session: AsyncSession,
-        http_client: AsyncClient,
+    async_session: AsyncSession,
+    http_client: AsyncClient,
 ):
     """
     Test a request from an outside, unauthorized source.

--- a/src/backend/aspen/uvicorn_worker.py
+++ b/src/backend/aspen/uvicorn_worker.py
@@ -9,6 +9,11 @@ from typing import Any
 from uvicorn.workers import UvicornWorker
 
 
+# This file is here to make sure our application automatically reloads when
+# the python files it's serving have changed. This is *supposed* to be handled
+# automatically by gunicorn, but there's a bug in the interaction between
+# gunicorn (our web process manager) and uvicorn (our application server) that
+# we're working around for now.
 # Code from https://github.com/encode/uvicorn/pull/1193/files
 class ReloaderThread(threading.Thread):
     def __init__(self, worker: "AspenUvicornWorker", sleep_interval: float = 1.0):

--- a/src/backend/aspen/uvicorn_worker.py
+++ b/src/backend/aspen/uvicorn_worker.py
@@ -1,0 +1,38 @@
+import asyncio
+import os
+import signal
+import sys
+import threading
+import time
+from typing import Any
+
+from uvicorn.workers import UvicornWorker
+
+
+# Code from https://github.com/encode/uvicorn/pull/1193/files
+class ReloaderThread(threading.Thread):
+    def __init__(self, worker: "AspenUvicornWorker", sleep_interval: float = 1.0):
+        super().__init__()
+        self.setDaemon(True)
+        self._worker = worker
+        self._interval = sleep_interval
+
+    def run(self) -> None:
+        while True:
+            if not self._worker.alive:
+                os.kill(os.getpid(), signal.SIGINT)
+            time.sleep(self._interval)
+
+
+class AspenUvicornWorker(UvicornWorker):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._reloader_thread = ReloaderThread(self)
+
+    def run(self) -> None:
+        if self.cfg.reload:
+            self._reloader_thread.start()
+
+        if sys.version_info >= (3, 7):
+            return asyncio.run(self._serve())
+        return asyncio.get_event_loop().run_until_complete(self._serve())

--- a/src/backend/etc/supervisord.conf
+++ b/src/backend/etc/supervisord.conf
@@ -45,7 +45,7 @@ startretries = 9999
 
 [program:fastapi]
 directory=/usr/src/app
-command=gunicorn --reload -k uvicorn.workers.UvicornWorker -c /usr/src/app/aspen/api/gunicorn_conf.py aspen.api.main:app
+command=gunicorn --reload -k aspen.uvicorn_worker.AspenUvicornWorker -c /usr/src/app/aspen/api/gunicorn_conf.py aspen.api.main:app
 environment=PYTHONUNBUFFERED=1
 stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes=0

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -357,5 +357,20 @@ def start_phylo_run(ctx, name, tree_type, sample_ids, show_headers):
         print(resp.headers)
     print(resp.text)
 
+@phylo_run.command(name="startv2")
+@click.option("-n","--name", required=True, type=str)
+@click.option("-t","--type", "tree_type", required=True, type=click.Choice(["OVERVIEW", "TARGETED", "NON_CONTEXTUALIZED"], case_sensitive=False))
+@click.option("-h", "--show-headers", is_flag=True)
+@click.argument("sample_ids", nargs=-1)
+@click.pass_context
+def start_phylo_run_v2(ctx, name, tree_type, sample_ids, show_headers):
+    api_client = ctx.obj["api_client"]
+    payload = { "name": name, "tree_type": tree_type, "samples": sample_ids }
+    resp = api_client.post("/v2/phylo_runs/", json=payload)
+    if show_headers:
+        print(resp.headers)
+    print(resp.text)
+    print(resp)
+
 if __name__ == "__main__":
     cli()

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -9,7 +9,7 @@ export enum API {
   PHYLO_TREES = "/api/phylo_trees",
   SAMPLES_CREATE = "/api/samples/create",
   SAMPLES_FASTA_DOWNLOAD = "/api/sequences",
-  CREATE_TREE = "/api/phylo_runs",
+  CREATE_TREE = "/v2/phylo_runs/",
   GET_FASTA_URL = "/api/sequences/getfastaurl",
   USHER_TREE_OPTIONS = "/api/usher/tree_options",
 }


### PR DESCRIPTION
### Summary:
- **What:** Convert the ondemand phylo tree endpoint to fastapi
- **Ticket:** [sc161319](https://app.shortcut.com/genepi/story/161319)
- **Env:** https://phylov2-frontend.dev.genepi.czi.technology/

### Notes:
This converts our first endpoint from flask to fastapi.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)