### PR TITLE
Add sequencing date to Samples table

### DIFF
--- a/src/backend/aspen/app/views/api_utils.py
+++ b/src/backend/aspen/app/views/api_utils.py
@@ -33,7 +33,7 @@ def get_usergroup_query(session: Session, user_id: str) -> Query:
     )
 
 
-def format_date(dt: datetime.date, format="%Y-%m-%d") -> str:
+def format_date(dt: Optional[datetime.date], format="%Y-%m-%d") -> str:
     if dt is not None:
         return dt.strftime(format)
     else:

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -99,6 +99,7 @@ def _format_created_date(sample: Sample) -> str:
 
 
 def _format_sequencing_date(sample: Sample) -> str:
+    sequencing_date: Optional[datetime.date]
     try:
         # Using `get_uploaded_entity` may be unnecessary since it can also pull from
         # sequencing_reads_collection, but that model isn't used right now.

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -99,13 +99,15 @@ def _format_created_date(sample: Sample) -> str:
 
 
 def _format_sequencing_date(sample: Sample) -> str:
-    if sample.czb_failed_genome_recovery:
-        # Unclear from Product standpoint if there would have been a sequencing date?
-        return api_utils.format_date(None)
-    # Using `get_uploaded_entity` may be unnecessary since it conditionally pulls from
-    # sequencing_reads_collection as well, but that model isn't used right now.
-    sequenced_entity = sample.get_uploaded_entity()
-    return api_utils.format_date(sequenced_entity.sequencing_date)
+    try:
+        # Using `get_uploaded_entity` may be unnecessary since it can also pull from
+        # sequencing_reads_collection, but that model isn't used right now.
+        sequenced_entity = sample.get_uploaded_entity()
+        sequencing_date = sequenced_entity.sequencing_date
+    except ValueError:
+        # No underlying entity, so no sequencing to associate
+        sequencing_date = None
+    return api_utils.format_date(sequencing_date)
 
 
 def _format_gisaid_accession(

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -99,6 +99,9 @@ def _format_created_date(sample: Sample) -> str:
 
 
 def _format_sequencing_date(sample: Sample) -> str:
+    if sample.czb_failed_genome_recovery:
+        # Unclear from Product standpoint if there would have been a sequencing date?
+        return api_utils.format_date(None)
     # Using `get_uploaded_entity` may be unnecessary since it conditionally pulls from
     # sequencing_reads_collection as well, but that model isn't used right now.
     sequenced_entity = sample.get_uploaded_entity()

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -98,6 +98,13 @@ def _format_created_date(sample: Sample) -> str:
         return "not yet uploaded"
 
 
+def _format_sequencing_date(sample: Sample) -> str:
+    # Using `get_uploaded_entity` may be unnecessary since it conditionally pulls from
+    # sequencing_reads_collection as well, but that model isn't used right now.
+    sequenced_entity = sample.get_uploaded_entity()
+    return api_utils.format_date(sequenced_entity.sequencing_date)
+
+
 def _format_gisaid_accession(
     sample: Sample,
     entity_id_to_gisaid_accession_workflow_map: defaultdict[
@@ -305,6 +312,7 @@ def samples():
             "public_identifier": sample.public_identifier,
             "upload_date": _format_created_date(sample),
             "collection_date": api_utils.format_date(sample.collection_date),
+            "sequencing_date": _format_sequencing_date(sample),
             "collection_location": sample.location,
             "gisaid": _format_gisaid_accession(
                 sample, entity_id_to_gisaid_accession_workflow_map

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -200,8 +200,9 @@ def test_samples_view_gisaid_not_eligible(
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
                 "upload_date": api_utils.format_date(None),
-                # Unclear from Product standpoint what should happen with sequencing_date
-                # when failed genome recovery...
+                # In some cases, `sequencing_date` could actually still exist with a
+                # failed genome recovery, but for this test it's None because the sample
+                # has no underlying sequenced entity (no uploaded_pathogen_genome).
                 "sequencing_date": api_utils.format_date(None),
                 "lineage": {
                     "lineage": None,

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -54,6 +54,9 @@ def test_samples_view(
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
+                ),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
                     "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -106,6 +109,9 @@ def test_samples_view_gisaid_rejected(
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
+                ),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
                     "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -152,6 +158,9 @@ def test_samples_view_gisaid_no_info(
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
+                ),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
                     "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -191,6 +200,9 @@ def test_samples_view_gisaid_not_eligible(
                 "private_identifier": sample.private_identifier,
                 "public_identifier": sample.public_identifier,
                 "upload_date": api_utils.format_date(None),
+                # Unclear from Product standpoint what should happen with sequencing_date
+                # when failed genome recovery...
+                "sequencing_date": api_utils.format_date(None),
                 "lineage": {
                     "lineage": None,
                     "probability": None,
@@ -240,6 +252,9 @@ def test_samples_view_gisaid_submitted(
                 "public_identifier": sample.public_identifier,
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
+                ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
                 ),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
@@ -391,6 +406,9 @@ def test_samples_view_cansee_metadata(
             },
             "public_identifier": sample.public_identifier,
             "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
+            "sequencing_date": api_utils.format_date(
+                uploaded_pathogen_genome.sequencing_date
+            ),
             "lineage": {
                 "lineage": uploaded_pathogen_genome.pangolin_lineage,
                 "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -446,6 +464,9 @@ def test_samples_view_cansee_all(
             "private_identifier": sample.private_identifier,
             "public_identifier": sample.public_identifier,
             "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
+            "sequencing_date": api_utils.format_date(
+                uploaded_pathogen_genome.sequencing_date
+            ),
             "lineage": {
                 "lineage": uploaded_pathogen_genome.pangolin_lineage,
                 "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -510,6 +531,9 @@ def test_samples_failed_accession(
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
+                ),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
                     "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -573,6 +597,9 @@ def test_samples_multiple_accession(
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
                 ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
+                ),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
                     "probability": uploaded_pathogen_genome.pangolin_probability,
@@ -624,6 +651,9 @@ def test_samples_view_no_pangolin(
                 "public_identifier": sample.public_identifier,
                 "upload_date": api_utils.format_date(
                     uploaded_pathogen_genome.upload_date
+                ),
+                "sequencing_date": api_utils.format_date(
+                    uploaded_pathogen_genome.sequencing_date
                 ),
                 "lineage": {
                     "lineage": None,

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -98,6 +98,7 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
   ["private_identifier", "privateId"],
   ["public_identifier", "publicId"],
   ["upload_date", "uploadDate"],
+  ["sequencing_date", "sequencingDate"],
   ["czb_failed_genome_recovery", "CZBFailedGenomeRecovery"],
 ]);
 

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -28,6 +28,7 @@ interface Sample extends BioinformaticsType {
   uploadDate: string;
   collectionDate: string;
   collectionLocation: string;
+  sequencingDate: string;
   gisaid: GISAID;
   CZBFailedGenomeRecovery: boolean;
   lineage: Lineage;

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -112,6 +112,19 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
       </RowContent>
     );
   },
+
+  sequencingDate: ({
+    value,
+    header,
+  }): JSX.Element => {
+    let displayValue = value;
+    if (value === "N/A") {
+      displayValue = '-';
+    }
+    // defaultCellRenderer only uses `value` and `header` but its input type asks
+    // for more than that, so just forcing typescript to be cool.
+    return defaultCellRenderer({value: displayValue, header} as CustomTableRenderProps);
+  },
 };
 
 export const SampleRenderer = createTableCellRenderer(

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -113,17 +113,19 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     );
   },
 
-  sequencingDate: ({
-    value,
-    header,
-  }): JSX.Element => {
+  // Preferably, we would just use defaultCellRenderer for this column, but we want
+  // to intercept its value and change it out in some cases before rendering.
+  sequencingDate: ({ header, value }): JSX.Element => {
     let displayValue = value;
     if (value === "N/A") {
-      displayValue = '-';
+      displayValue = "-";
     }
     // defaultCellRenderer only uses `value` and `header` but its input type asks
     // for more than that, so just forcing typescript to be cool.
-    return defaultCellRenderer({value: displayValue, header} as CustomTableRenderProps);
+    return defaultCellRenderer({
+      header,
+      value: displayValue,
+    } as CustomTableRenderProps);
   },
 };
 

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -30,6 +30,11 @@ export const SAMPLE_HEADERS: Header[] = [
     text: "Collection Location",
   },
   {
+    key: "sequencingDate",
+    sortKey: ["sequencingDate"],
+    text: "Sequencing Date",
+  },
+  {
     key: "gisaid",
     sortKey: ["gisaid", "status"],
     text: "GISAID",


### PR DESCRIPTION
### Summary:
- **What:** Adds column of "Sequencing Date" to Samples table and corresponding info being sent from backend on call to the GET samples endpoint
- **Ticket:** [sc<148995>](https://app.shortcut.com/genepi/story/<148995>)
- **Env:** https://display-seq-date-frontend.dev.genepi.czi.technology [Note: when testing this, I'm not sure what groups actually have Sequencing Dates in their data? Both Fresno and Contra Costa counties in rdev DB don't seem to have any of seq date info in there. I think it's working as expected, it's just that it's not very interesting to look at with the users I've tried so far...]

### Demos:
![image](https://user-images.githubusercontent.com/89553795/138360087-f8869063-0a9f-4903-ba9f-b60be6a1b3e8.png)

---

Feels kinda crowded when on a thin browser window, but that's mostly pre-existing: this just exacerbates it by one more column's worth of squish.
![image](https://user-images.githubusercontent.com/89553795/138360180-cb88181c-d457-49b8-b49b-e9fbace87998.png)


### Notes:
- Some of the specific design call-outs in the ticket aren't here. There were width requirements in the design for the column, but I found it pretty challenging to work on the styling aspects because of how our tables are currently built in code.
- Similarly, the table still suffers from the column alignment issues it did previously. Certain long strings for Private ID or Public ID will cause their cell to grow larger than expected, which will then push the rest of the row out of alignment with the other rows.
    - Along those lines, I think the header row and the actual data rows aren't currently communicating width info to each other so they don't stay aligned when things get wonky because of the above. This also generally contributes to the column alignment issues, at least so far as the header row looks off from the below rows.

I discussed the above with Phoenix and Maya, and we generally think it would be worth it to refactor the tables throughout the FE. With that in mind, I'd like to tackle the refactoring instead of trying to fix the above in our current table implementation. And as part of the refactoring I'll work on handling the above.


### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- ~[ ] I have notified others of changes they need to make locally~ [none needed!]