### PR TITLE
Add slices to happy update/create.

### DIFF
--- a/.happy/config.json
+++ b/.happy/config.json
@@ -4,6 +4,30 @@
     "default_env": "rdev",
     "app": "aspen",
     "default_compose_env": ".env.ecr",
+    "slice_default_tag": "branch-trunk",
+    "slices": {
+      "frontend": {
+        "build_images": ["frontend"]
+      },
+      "backend": {
+        "build_images": ["backend"]
+      },
+      "fullstack": {
+        "build_images": ["frontend", "backend"]
+      },
+      "batch": {
+        "build_images": ["nextstrain", "pangolin", "gisaid"]
+      },
+      "nextstrain": {
+        "build_images": ["nextstrain"]
+      },
+      "pangolin": {
+        "build_images": ["pangolin"]
+      },
+      "gisaid": {
+        "build_images": ["gisaid"]
+      }
+    },
     "environments": {
         "rdev": {
             "aws_profile": "genepi-dev",

--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -5,6 +5,7 @@ module stack {
   happymeta_          = var.happymeta_
   happy_config_secret = var.happy_config_secret
   image_tag           = var.image_tag
+  image_tags          = jsondecode(var.image_tags)
   priority            = var.priority
   stack_name          = var.stack_name
   deployment_stage    = "prod"

--- a/.happy/terraform/envs/prod/variables.tf
+++ b/.happy/terraform/envs/prod/variables.tf
@@ -13,6 +13,12 @@ variable image_tag {
   description = "Please provide an image tag"
 }
 
+variable image_tags {
+  type        = string
+  description = "Override the default image tags (json-encoded map)"
+  default     = "{}"
+}
+
 variable priority {
   type        = number
   description = "Listener rule priority number within the given listener"

--- a/.happy/terraform/envs/rdev/main.tf
+++ b/.happy/terraform/envs/rdev/main.tf
@@ -5,6 +5,7 @@ module stack {
   happymeta_          = var.happymeta_
   happy_config_secret = var.happy_config_secret
   image_tag           = var.image_tag
+  image_tags          = jsondecode(var.image_tags)
   priority            = var.priority
   stack_name          = var.stack_name
   deployment_stage    = "rdev"

--- a/.happy/terraform/envs/rdev/variables.tf
+++ b/.happy/terraform/envs/rdev/variables.tf
@@ -13,6 +13,12 @@ variable image_tag {
   description = "Please provide an image tag"
 }
 
+variable image_tags {
+  type        = string
+  description = "Override the default image tags (json-encoded map)"
+  default     = "{}"
+}
+
 variable priority {
   type        = number
   description = "Listener rule priority number within the given listener"

--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -5,6 +5,7 @@ module stack {
   happymeta_          = var.happymeta_
   happy_config_secret = var.happy_config_secret
   image_tag           = var.image_tag
+  image_tags          = jsondecode(var.image_tags)
   priority            = var.priority
   stack_name          = var.stack_name
   deployment_stage    = "staging"

--- a/.happy/terraform/envs/staging/variables.tf
+++ b/.happy/terraform/envs/staging/variables.tf
@@ -13,6 +13,12 @@ variable image_tag {
   description = "Please provide an image tag"
 }
 
+variable image_tags {
+  type        = string
+  description = "Override the default image tags (json-encoded map)"
+  default     = "{}"
+}
+
 variable priority {
   type        = number
   description = "Listener rule priority number within the given listener"

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -8,7 +8,7 @@ locals {
 module nextstrain_scc_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-scc-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -38,7 +38,7 @@ module nextstrain_scc_contextual_sfn_config {
 module nextstrain_alameda_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-alameda-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -68,7 +68,7 @@ module nextstrain_alameda_contextual_sfn_config {
 module nextstrain_contra_costa_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-contra-costa-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -98,7 +98,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
 module nextstrain_fresno_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-fresno-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -128,7 +128,7 @@ module nextstrain_fresno_contextual_sfn_config {
 module nextstrain_humboldt_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-humboldt-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -158,7 +158,7 @@ module nextstrain_humboldt_contextual_sfn_config {
 module nextstrain_marin_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-marin-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -188,7 +188,7 @@ module nextstrain_marin_contextual_sfn_config {
 module nextstrain_monterey_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-monterey-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -218,7 +218,7 @@ module nextstrain_monterey_contextual_sfn_config {
 module nextstrain_orange_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-orange-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -248,7 +248,7 @@ module nextstrain_orange_contextual_sfn_config {
 module nextstrain_san_bernardino_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-bernardino-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -278,7 +278,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
 module nextstrain_del_norte_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-del-norte-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -308,7 +308,7 @@ module nextstrain_del_norte_contextual_sfn_config {
 module nextstrain_san_joaquin_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-joaquin-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -338,7 +338,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
 module nextstrain_san_luis_obispo_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-luis-obispo-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -368,7 +368,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
 module nextstrain_san_francisco_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-francisco-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -399,7 +399,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
 module nextstrain_tulare_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-tulare-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -429,7 +429,7 @@ module nextstrain_tulare_contextual_sfn_config {
 module nextstrain_tuolumne_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-tuolumne-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -459,7 +459,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
 module nextstrain_ventura_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-ventura-contextual-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = "${local.nextstrain_image}"
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -8,7 +8,7 @@ locals {
 module nextstrain_scc_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-scc-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -38,7 +38,7 @@ module nextstrain_scc_contextual_sfn_config {
 module nextstrain_alameda_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-alameda-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -68,7 +68,7 @@ module nextstrain_alameda_contextual_sfn_config {
 module nextstrain_contra_costa_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-contra-costa-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -98,7 +98,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
 module nextstrain_fresno_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-fresno-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -128,7 +128,7 @@ module nextstrain_fresno_contextual_sfn_config {
 module nextstrain_humboldt_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-humboldt-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -158,7 +158,7 @@ module nextstrain_humboldt_contextual_sfn_config {
 module nextstrain_marin_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-marin-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -188,7 +188,7 @@ module nextstrain_marin_contextual_sfn_config {
 module nextstrain_monterey_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-monterey-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -218,7 +218,7 @@ module nextstrain_monterey_contextual_sfn_config {
 module nextstrain_orange_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-orange-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -248,7 +248,7 @@ module nextstrain_orange_contextual_sfn_config {
 module nextstrain_san_bernardino_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-bernardino-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -278,7 +278,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
 module nextstrain_del_norte_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-del-norte-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -308,7 +308,7 @@ module nextstrain_del_norte_contextual_sfn_config {
 module nextstrain_san_joaquin_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-joaquin-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -338,7 +338,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
 module nextstrain_san_luis_obispo_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-luis-obispo-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -368,7 +368,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
 module nextstrain_san_francisco_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-san-francisco-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -399,7 +399,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
 module nextstrain_tulare_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-tulare-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -429,7 +429,7 @@ module nextstrain_tulare_contextual_sfn_config {
 module nextstrain_tuolumne_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-tuolumne-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"
@@ -459,7 +459,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
 module nextstrain_ventura_contextual_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-ventura-contextual-sfn"
-  image    = "${local.nextstrain_image}"
+  image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
   wdl_path = "workflows/nextstrain.wdl"

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -10,7 +10,6 @@ locals {
   alb_key = var.require_okta ? "private_albs" : "public_albs"
 
   custom_stack_name     = var.stack_name
-  image_tag             = var.image_tag
   priority              = var.priority
   deployment_stage      = var.deployment_stage
   remote_dev_prefix     = var.stack_prefix
@@ -33,17 +32,16 @@ locals {
   aspen_data_bucket     = local.secret["s3_buckets"]["aspen_data"]["name"]
 
   # Web images
-  frontend_image_repo   = local.secret["ecrs"]["frontend"]["url"]
-  backend_image_repo    = local.secret["ecrs"]["backend"]["url"]
+  frontend_image   = join(":", [local.secret["ecrs"]["frontend"]["url"], lookup(var.image_tags, "frontend", var.image_tag)])
+  backend_image    = join(":", [local.secret["ecrs"]["backend"]["url"], lookup(var.image_tags, "backend", var.image_tag)])
 
   # Workflow images
-  pangolin_image_repo   = local.secret["ecrs"]["pangolin"]["url"]
-  nextstrain_image_repo = local.secret["ecrs"]["nextstrain"]["url"]
-  gisaid_image_repo     = local.secret["ecrs"]["gisaid"]["url"]
-  covidhub_import_image_repo  = local.secret["ecrs"]["covidhub-import"]["url"]
+  pangolin_image   = join(":", [local.secret["ecrs"]["pangolin"]["url"], lookup(var.image_tags, "pangolin", var.image_tag)])
+  nextstrain_image = join(":", [local.secret["ecrs"]["nextstrain"]["url"], lookup(var.image_tags, "nextstrain", var.image_tag)])
+  gisaid_image     = join(":", [local.secret["ecrs"]["gisaid"]["url"], lookup(var.image_tags, "gisaid", var.image_tag)])
 
   # This is the wdl executor image, doesn't change on update.
-  swipe_image_repo     = local.secret["ecrs"]["swipe"]["url"]
+  swipe_image     = join(":", [local.secret["ecrs"]["swipe"]["url"], "rev-6"]) # TODO - we probably don't want to hardcode this
 
   batch_role_arn             = local.secret["batch_queues"]["aspen"]["role_arn"]
   ec2_queue_arn              = local.secret["batch_envs"]["aspen"]["envs"]["EC2"]["queue_arn"]
@@ -98,7 +96,7 @@ module frontend_service {
   custom_stack_name     = local.custom_stack_name
   app_name              = "frontend"
   vpc                   = local.vpc_id
-  image                 = "${local.frontend_image_repo}:${local.image_tag}"
+  image                 = local.frontend_image
   cluster               = local.cluster
   desired_count         = 2
   listener              = local.frontend_listener_arn
@@ -123,7 +121,7 @@ module backend_service {
   custom_stack_name     = local.custom_stack_name
   app_name              = "backend"
   vpc                   = local.vpc_id
-  image                 = "${local.backend_image_repo}:${local.image_tag}"
+  image                 = local.backend_image
   cluster               = local.cluster
   desired_count         = 2
   listener              = local.backend_listener_arn
@@ -161,7 +159,7 @@ module swipe_sfn {
 module gisaid_sfn_config {
   source   = "../sfn_config"
   app_name = "gisaid-sfn"
-  image    = "${local.gisaid_image_repo}:${local.image_tag}"
+  image    = local.gisaid_image
   vcpus    = 32
   memory   = 420000
   wdl_path = "workflows/gisaid.wdl"
@@ -184,7 +182,7 @@ module gisaid_sfn_config {
 module pangolin_sfn_config {
   source   = "../sfn_config"
   app_name = "pangolin-sfn"
-  image    = "${local.pangolin_image_repo}:${local.image_tag}"
+  image    = local.pangolin_image
   memory   = 120000
   wdl_path = "workflows/pangolin.wdl"
   custom_stack_name     = local.custom_stack_name
@@ -201,7 +199,7 @@ module pangolin_sfn_config {
 module pangolin_ondemand_sfn_config {
   source   = "../sfn_config"
   app_name = "pangolin-ondemand-sfn"
-  image    = "${local.pangolin_image_repo}:${local.image_tag}"
+  image    = local.pangolin_image
   memory   = 120000
   wdl_path = "workflows/pangolin-ondemand.wdl"
   custom_stack_name     = local.custom_stack_name
@@ -217,7 +215,7 @@ module pangolin_ondemand_sfn_config {
 module nextstrain_template_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = local.nextstrain_image
   vcpus    = 10
   memory   = 64000
   wdl_path = "workflows/nextstrain.wdl"
@@ -238,7 +236,7 @@ module nextstrain_template_sfn_config {
 module nextstrain_ondemand_template_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-ondemand-sfn"
-  image    = "${local.nextstrain_image_repo}:${local.image_tag}"
+  image    = local.nextstrain_image
   vcpus    = 10
   memory   = 64000
   wdl_path = "workflows/nextstrain-ondemand.wdl"
@@ -259,7 +257,7 @@ module nextstrain_ondemand_template_sfn_config {
 module migrate_db {
   source                = "../migration"
   stack_resource_prefix = local.stack_resource_prefix
-  image                 = "${local.backend_image_repo}:${local.image_tag}"
+  image                 = local.backend_image
   task_role_arn         = local.ecs_role_arn
   cmd                   = local.migration_cmd
   custom_stack_name     = local.custom_stack_name
@@ -272,7 +270,7 @@ module delete_db {
   count                 = var.delete_protected ? 0 : 1
   stack_resource_prefix = local.stack_resource_prefix
   source                = "../deletion"
-  image                 = "${local.backend_image_repo}:${local.image_tag}"
+  image                 = local.backend_image
   task_role_arn         = local.ecs_role_arn
   cmd                   = local.deletion_cmd
   custom_stack_name     = local.custom_stack_name
@@ -285,7 +283,7 @@ module swipe_batch {
   app_name              = "swipe"
   stack_resource_prefix = local.stack_resource_prefix
   batch_role_arn        = local.batch_role_arn
-  swipe_image            = "${local.swipe_image_repo}:rev-6" # FIXME rev shouldn't be hardcoded
+  swipe_image           = local.swipe_image
   custom_stack_name     = local.custom_stack_name
   remote_dev_prefix     = local.remote_dev_prefix
   deployment_stage      = local.deployment_stage

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -10,9 +10,15 @@ variable aws_role {
   default     = ""
 }
 
+variable image_tags {
+   type        = map(string)
+   description = "Override image tag for each docker image"
+   default     = {}
+}
+
 variable image_tag {
    type        = string
-  description = "Please provide an image tag"
+   description = "Please provide a default image tag"
 }
 
 variable priority {

--- a/docs/DEV_ENV.md
+++ b/docs/DEV_ENV.md
@@ -98,3 +98,22 @@ self-signed cert in for convenience.
 #### Configuring Pycharm with Docker Compose:
 
 Follow the instructions in [the wiki](https://czi.atlassian.net/wiki/spaces/SI/pages/1801100933/PyCharm+configuration+for+Happy+Path)
+
+
+#### Quickstart setup from scratch:
+
+* [Install docker](https://www.docker.com/products/docker-desktop)
+* [Install homebrew](https://docs.brew.sh/Installation)
+
+```
+brew install awscli jq
+brew tap chanzuckerberg/tap
+brew install aws-oidc
+mkdir -p ~/.aws  # Temp workaround for aws-oidc bug.
+touch ~/.aws/config  # Temp workaround for aws-oidc bug.
+aws-oidc configure --issuer-url https://czi-prod.okta.com --client-id aws-config --config-url https://aws-config-generation.staging.si.czi.technology # Just use the defaults
+git clone git@github.com:chanzuckerberg/aspen.git
+cd aspen
+/usr/bin/env/python3 -m pip install .happy/requirements.txt
+make local-init
+```

--- a/docs/REMOTE_DEV.md
+++ b/docs/REMOTE_DEV.md
@@ -33,6 +33,25 @@ If you forget which stacks you've created, just run `./scripts/happy list` at an
 
 If you need to reset your remote dev stack DB run `./scripts/happy migrate <your-stack-name> --reset`.
 
+### Slices
+If you're only working on a subset of the Aspen application, there's no need to build and push all docker images to test your changes in remote-dev. Both `happy create` and `happy update` commands support a `--slice` option that uses the latest `trunk` build of all docker images except the ones you're working on. For example, if you're only making changes to the frontend/backend images, you don't care to build & push the gisaid image. The following command will create an rdev with your changes reflected in only the `frontend` and `backend` images:
+
+```
+./scripts/happy create mynewrdev --slice fullstack
+```
+
+The currently supported slices are:
+
+| slice name  | images |
+| ----------- | ------ |
+| frontend | frontend |
+| backend | backend |
+| fullstack | frontend, backend |
+| batch | nextsttrain, pangolin, gisaid |
+| nextstrain | nextsttrain |
+| gisaid | gisaid |
+| pangolin | pangolin |
+
 ### Connecting to remote dev databases
 NOTE - You'll need to [install and configure blessclient](https://czi.atlassian.net/wiki/spaces/SI/pages/1779598774/Install+BlessClient) first!
 
@@ -57,7 +76,7 @@ Options:
 ### Remote Dev Database management
 There are two commands in the Aspen CLI that exist specifically to enable management of remote dev environments: `aspen-cli db --remote setup` and `aspen-cli db --remote drop`. The `setup` command is responsible for creating a new database in our Aurora database, and importing a db snapshot into the new database. The `drop` command drops a database when a remote dev stack is deleted.
 
-### GitHub Action Ingegration
+### GitHub Action Integration
 A new stack can also be deployed to remote development environment through GitHub Action integration. Pushing any branch prefixed with "rdev-" will trigger the GH Action workflow to create or update a dev stack, with the stack name equals the part of branch name following the prefix, e.g. pushing branch "rdev-my-dev-branch" will deploy the stack "my-dev-branch" in the remote dev enviroment. This is useful in situation where local connections is slow.
 
 ### Authentication

--- a/scripts/happy
+++ b/scripts/happy
@@ -100,7 +100,9 @@ class StackMeta:
         "instance": "happy/instance",
         "owner": "happy/meta/owner",
         "priority": "happy/meta/priority",
+        "slice": "happy/meta/slice",
         "imagetag": "happy/meta/imagetag",
+        "imagetags": "happy/meta/imagetags",
         "configsecret": "happy/meta/configsecret",
         "created": "happy/meta/created-at",
         "updated": "happy/meta/updated-at",
@@ -110,6 +112,7 @@ class StackMeta:
         "instance": "stack_name",
         "priority": "priority",
         "imagetag": "image_tag",
+        "imagetags": "image_tags",
         "configsecret": "happy_config_secret",
     }
 
@@ -149,7 +152,7 @@ class StackMeta:
     def parameters(self):
         return {v: self.meta[k] for k, v in self.parameter_map.items()}
 
-    def update(self, tag, stack_mgr):
+    def update(self, tag, stack_tags, stack_mgr):
         stacks = stack_mgr.stacks
 
         # Track timestamps for this stack
@@ -158,6 +161,7 @@ class StackMeta:
             self.created = now
 
         self.imagetag = tag
+        self.imagetags = stack_tags
         self.updated = now
 
         if not self.owner:
@@ -253,7 +257,10 @@ class Stack:
             sensitive=False,
         )
         for k, v in self.meta.parameters.items():
-            self.workspace.set_var(k, str(v), "", sensitive=False)
+            if k == "image_tags":
+                self.workspace.set_var(k, json.dumps(v), "", sensitive=False)
+            else:
+                self.workspace.set_var(k, str(v), "", sensitive=False)
         self.workspace.reset_cache()  # Resets known vars
 
         with config_tarball(self.stack_mgr.config.terraform_directory) as targz_file:
@@ -925,6 +932,21 @@ def logs(ctx, stack_name, service, since):
     orchestrator = ctx.obj["orchestrator"]
     orchestrator.logs(stack_name, service, since)
 
+def build_slice(ctx, slice_name, default_tag=None):
+    config = ctx.obj["config"]
+    if slice_name not in config.slices:
+        valid_slices = ", ".join(config["slices"].keys())
+        raise CliError(f"Slice {slice_name} is invalid - valid names: {valid_slices}")
+
+    build_images = config.slices[slice_name]["build_images"]
+    slice_tag = generate_tag(ctx)
+    ctx.invoke(push, images=build_images, tag=slice_tag)
+
+    if not default_tag:
+        default_tag = config.slice_default_tag
+    stacktags = {slice_img: slice_tag for slice_img in build_images}
+    return stacktags, default_tag
+
 
 @cli.command()
 @click.argument("stack_name")
@@ -932,8 +954,10 @@ def logs(ctx, stack_name, service, since):
 @click.option("--wait/--no-wait", is_flag=True, default=True, help="wait for this to complete")
 @click.option("--force", is_flag=True, default=False, help="Ignore already-exists errors")
 @click.option("--skip-check-tag", is_flag=True, default=False, help="Skip checking that the specified tag exists (requires --tag)")
+@click.option("--slice", "-s", "slice_name", help="If you only need to test a slice of the app, specify it here")
+@click.option("--slice-default-tag", help="For stacks using slices, override the default tag for any images that aren't being built & pushed by the slice")
 @click.pass_context
-def create(ctx, stack_name, tag, wait, force, skip_check_tag):
+def create(ctx, stack_name, tag, wait, force, skip_check_tag, slice_name, slice_default_tag):
     """Create a new stack with a given tag"""
     stackmgr = ctx.obj["stack_mgr"]
     if stack_name in stackmgr.stacks:
@@ -944,12 +968,16 @@ def create(ctx, stack_name, tag, wait, force, skip_check_tag):
     if tag and not skip_check_tag:
         check_images_exist(ctx, tag)
 
+    stacktags = {}
+    if slice_name:
+        stacktags, tag = build_slice(ctx, slice_name, slice_default_tag)
+
     stack_meta = StackMeta(ctx, stack_name)
     stack_meta.load({"happy/meta/configsecret": ctx.obj["config"].secret_arn})
     if not tag:
         tag = generate_tag(ctx)
         ctx.invoke(push, tag=tag)
-    stack_meta.update(tag, stackmgr)
+    stack_meta.update(tag, stacktags, stackmgr)
     print(f"creating {stack_name}")
 
     stack = stackmgr.add(stack_name)
@@ -990,7 +1018,9 @@ def config_tarball(source_dir):
 @click.option("--skip-migrations/--do-migrations", is_flag=True, default=False, help="Skip running migrations")
 @click.option("--skip-check-tag", is_flag=True, default=False, help="Skip checking that the specified tag exists (requires --tag)")
 @click.pass_context
-def update(ctx, stack_name, tag, wait, skip_migrations, skip_check_tag):
+@click.option("--slice", "-s", "slice_name", help="If you only need to test a slice of the app, specify it here")
+@click.option("--slice-default-tag", help="For stacks using slices, override the default tag for any images that aren't being built & pushed by the slice")
+def update(ctx, stack_name, tag, wait, skip_migrations, skip_check_tag, slice_name, slice_default_tag):
     """Update a dev stack tag version"""
     stackmgr = ctx.obj["stack_mgr"]
     try:
@@ -1001,6 +1031,11 @@ def update(ctx, stack_name, tag, wait, skip_migrations, skip_check_tag):
         check_images_exist(ctx, tag)
 
     print(f"updating {stack_name}")
+
+    stacktags = {}
+    if slice_name:
+        stacktags, tag = build_slice(ctx, slice_name, slice_default_tag)
+
     if not tag:
         tag = generate_tag(ctx)
         ctx.invoke(push, tag=tag)
@@ -1008,7 +1043,7 @@ def update(ctx, stack_name, tag, wait, skip_migrations, skip_check_tag):
     stack_meta = stack.meta
     # Reset the configsecret if it has changed
     stack_meta.load({"happy/meta/configsecret": ctx.obj["config"].secret_arn})
-    stack_meta.update(tag, stackmgr)
+    stack_meta.update(tag, stacktags, stackmgr)
     success = stack.apply(wait or not skip_migrations)
     if not success:
         raise CliError("Apply failed, skipping migrations")
@@ -1076,12 +1111,15 @@ def list_command(ctx):
     env = ctx.obj["config"].env
     stackmgr = ctx.obj["stack_mgr"]
     print(f"Listing stacks in environment '{env}'")
-    headings = ["Name", "Owner", "Tag", "Status", "URLs"]
+    headings = ["Name", "Owner", "Tags", "Status", "URLs"]
     tp = TablePrinter(headings)
     for name, info in stackmgr.stacks.items():
         url = info.outputs.get("frontend_url", "")
         status = info.status
-        tp.add_row([name, info.meta.owner, info.meta.imagetag, status, url])
+        tag = info.meta.imagetag
+        if info.meta.imagetags:
+            tag = ", ".join(set(info.meta.imagetags.values()) | {tag})
+        tp.add_row([name, info.meta.owner, tag, status, url])
     tp.print()
 
 

--- a/scripts/happy
+++ b/scripts/happy
@@ -110,6 +110,7 @@ class StackMeta:
 
     parameter_map = {
         "instance": "stack_name",
+        "slice": "slice",
         "priority": "priority",
         "imagetag": "image_tag",
         "imagetags": "image_tags",
@@ -152,7 +153,7 @@ class StackMeta:
     def parameters(self):
         return {v: self.meta[k] for k, v in self.parameter_map.items()}
 
-    def update(self, tag, stack_tags, stack_mgr):
+    def update(self, tag, stack_tags, slice_name, stack_mgr):
         stacks = stack_mgr.stacks
 
         # Track timestamps for this stack
@@ -163,6 +164,7 @@ class StackMeta:
         self.imagetag = tag
         self.imagetags = stack_tags
         self.updated = now
+        self.slice = slice_name
 
         if not self.owner:
             self.owner = resolve_owner(self.ctx)
@@ -977,7 +979,7 @@ def create(ctx, stack_name, tag, wait, force, skip_check_tag, slice_name, slice_
     if not tag:
         tag = generate_tag(ctx)
         ctx.invoke(push, tag=tag)
-    stack_meta.update(tag, stacktags, stackmgr)
+    stack_meta.update(tag, stacktags, slice_name, stackmgr)
     print(f"creating {stack_name}")
 
     stack = stackmgr.add(stack_name)
@@ -1043,7 +1045,7 @@ def update(ctx, stack_name, tag, wait, skip_migrations, skip_check_tag, slice_na
     stack_meta = stack.meta
     # Reset the configsecret if it has changed
     stack_meta.load({"happy/meta/configsecret": ctx.obj["config"].secret_arn})
-    stack_meta.update(tag, stacktags, stackmgr)
+    stack_meta.update(tag, stacktags, slice_name, stackmgr)
     success = stack.apply(wait or not skip_migrations)
     if not success:
         raise CliError("Apply failed, skipping migrations")


### PR DESCRIPTION
### Summary:
- **What:** This adds a `--slice` argument to the happy CLI that bypasses building/pushing images for applications that haven't been modified
- **Ticket:** [sc168694](https://app.shortcut.com/genepi/story/168694)
- **Env:** `https://webslice2-frontend.dev.genepi.czi.technology`

### Notes:
Sometimes an engineer will only modify one or two components in our overall application stack, and then be forced to build & push all images in our stack in order to be able to launch a remote dev environment. This can be very time- and bandwidth-consuming and is often totally unnecessary.

This PR defines a slice as a set of images associated with an alias (eg: the `fullstack` slice includes the `frontend` and `backend` docker images) in `.happy/config.json` that can be referenced by the Happy CLI when creating or updating a stack. To create or update an rdev stack that uses the `branch-trunk` tag for all images not listed as part of our slice:

```
$ ./scripts/happy create --slice frontend testuichange
or
$ ./scripts/happy update --slice fullstack testapichange
```

The default tag can also be overridden:
```
./scripts/happy create --slice batch --slice-default-tag sha-1234567 mystack
```

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)