### PR TITLE
Fix state management for settings & oauth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
     ports:
       - "3000:3000"
     environment:
+      - API_URL=http://backend.genepinet.localdev:3000
+      - FLASK_ENV=development
       - PYTHONUNBUFFERED=1
       - RESTART_ON_FAILURE=yes
       - BOTO_ENDPOINT_URL=http://localstack.genepinet.localdev:4566

--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -12,8 +12,8 @@ from sqlalchemy.orm.query import Query
 from starlette.requests import Request
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.deps import get_db
-from aspen.api.settings import get_settings
+from aspen.api.deps import get_db, get_settings
+from aspen.api.settings import Settings
 from aspen.auth.device_auth import validate_auth_header
 from aspen.database.models import Group, User
 
@@ -53,9 +53,10 @@ async def setup_userinfo(
 
 
 async def get_auth_user(
-    request: Request, session: AsyncSession = Depends(get_db)
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
 ) -> User:
-    settings = get_settings()
     auth_header = request.headers.get("authorization")
     auth0_user_id = None
     if auth_header:

--- a/src/backend/aspen/api/deps.py
+++ b/src/backend/aspen/api/deps.py
@@ -14,7 +14,9 @@ def get_auth0_client(request: Request):
 
 
 def get_settings(request: Request):
-    # This parameter is added to the app when we instantiate it.
+    # We stashed our settings object in app.state when we loaded the app, and every
+    # request object has that app attached at request.app, so this dependency is just
+    # returning the settings object we created at startup.
     settings = request.app.state.aspen_settings
     return settings
 

--- a/src/backend/aspen/api/deps.py
+++ b/src/backend/aspen/api/deps.py
@@ -1,15 +1,28 @@
 from typing import AsyncGenerator
 
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
-from aspen.api.settings import get_settings
+from aspen.api.settings import Settings
 from aspen.database.connection import init_async_db
 
 
-async def get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
+def get_auth0_client(request: Request):
+    # This parameter is added to the app when we instantiate it.
+    return request.app.state.auth0_client
+
+
+def get_settings(request: Request):
+    # This parameter is added to the app when we instantiate it.
+    settings = request.app.state.aspen_settings
+    return settings
+
+
+async def get_db(
+    request: Request, settings: Settings = Depends(get_settings)
+) -> AsyncGenerator[AsyncSession, None]:
     """Store db session in the context var and reset it"""
-    settings = get_settings()
     db = init_async_db(settings.DB_DSN)
     session = db.make_session()
     try:

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -2,6 +2,7 @@ import os
 from typing import List
 
 import sentry_sdk
+from authlib.integrations.starlette_client import OAuth
 from fastapi import Depends, FastAPI
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from starlette.middleware.cors import CORSMiddleware
@@ -9,7 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from aspen.api.auth import get_auth_user
 from aspen.api.error.http_exceptions import AspenException, exception_handler
 from aspen.api.middleware.session import SessionMiddleware
-from aspen.api.settings import get_settings
+from aspen.api.settings import Settings
 from aspen.api.views import auth, health, phylo_runs, users
 
 
@@ -28,13 +29,29 @@ def get_allowed_origins() -> List[str]:
 
 
 def get_app() -> FastAPI:
-    settings = get_settings()
+    settings = Settings()
     _app = FastAPI(
         title=settings.SERVICE_NAME,
         debug=settings.DEBUG,
         openapi_url="/v2/openapi.json",
         docs_url="/v2/docs",
     )
+
+    # Add a global settings object to the app that we can use as a dependency
+    _app.state.aspen_settings = settings
+
+    # Add a global oauth client to the app that we can use as a dependency
+    oauth = OAuth()
+    auth0 = oauth.register(
+        "auth0",
+        client_id=settings.AUTH0_CLIENT_ID,
+        client_secret=settings.AUTH0_CLIENT_SECRET,
+        api_base_url=settings.AUTH0_BASE_URL,
+        access_token_url=settings.AUTH0_ACCESS_TOKEN_URL,
+        authorize_url=settings.AUTH0_AUTHORIZE_URL,
+        client_kwargs=settings.AUTH0_CLIENT_KWARGS,
+    )
+    _app.state.auth0_client = auth0
 
     # Configure CORS
     _app.add_middleware(
@@ -45,7 +62,7 @@ def get_app() -> FastAPI:
         max_age=600,
         allow_methods=["*"],
     )
-    _app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
+    _app.add_middleware(SessionMiddleware, secret_key=settings.FLASK_SECRET)
 
     sentry_sdk.init(
         dsn=settings.SENTRY_BACKEND_DSN,

--- a/src/backend/aspen/api/settings.py
+++ b/src/backend/aspen/api/settings.py
@@ -1,71 +1,113 @@
 import json
 import os
-from functools import cached_property, lru_cache
-from typing import Any, Mapping
+from functools import cached_property
+from typing import Any, Dict
 
 from boto3 import Session
 from botocore.exceptions import ClientError
 from pydantic import BaseSettings
 
 
+def aws_secret_settings(settings) -> Dict[str, Any]:
+    session = Session(region_name=os.environ["AWS_REGION"])
+    secret_name = os.environ.get("ASPEN_CONFIG_SECRET_NAME", "aspen-config")
+    client = session.client(
+        service_name="secretsmanager",
+        endpoint_url=os.environ.get("BOTO_ENDPOINT_URL"),
+    )
+    try:
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    except ClientError as e:
+        raise e
+    else:
+        secret = get_secret_value_response["SecretString"]
+    response: Dict = {}
+    secrets = json.loads(secret)
+    keys = settings.__config__.aws_secret_keys
+    response = {key: secrets[key] for key in keys if secrets.get(key)}
+    remap_keys = settings.__config__.aws_secrets_remap
+    response.update(
+        {val: secrets[key] for key, val in remap_keys.items() if secrets.get(key)}
+    )
+    return response
+
+
+def aws_ssm_settings(settings) -> Dict[str, Any]:
+    session = Session(region_name=os.environ["AWS_REGION"])
+
+    dev_prefix = os.environ.get("REMOTE_DEV_PREFIX")
+    deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
+    stack_prefix = dev_prefix if dev_prefix else f"/{deployment_stage}stack"
+
+    parameters = settings.__config__.aws_ssm_params
+
+    client = session.client(
+        service_name="ssm", endpoint_url=os.environ.get("BOTO_ENDPOINT_URL")
+    )
+
+    response: Dict[str, Any] = {}
+    for param, key_name in parameters.items():
+        parameter_path = f"/aspen/{deployment_stage}{stack_prefix}/{param}"
+        try:
+            get_parameter = client.get_parameter(Name=parameter_path)
+        except ClientError as e:
+            raise e
+        else:
+            param_value = get_parameter["Parameter"]["Value"]
+        response[key_name] = json.loads(param_value)
+    return response
+
+
 class Settings(BaseSettings):
     """Pydantic Settings object - do not instantiate it directly, please use get_settings() as a dependency where possible"""
 
+    # Hardcoded vars"
     SERVICE_NAME: str = "Aspen"
-
     DB_DRIVER: str = "postgresql+asyncpg"
-
     DB_POOL_SIZE: int = 5
     DB_MAX_OVERFLOW: int = 0
     DB_ECHO: bool = False
+    DEBUG: bool = True
+
+    # Env vars usually read from env vars
     AWS_REGION: str
+    FLASK_ENV: str
+    API_URL: str
+    REMOTE_DEV_PREFIX: str = ""
+    DEPLOYMENT_STAGE: str = ""
+
+    # Env vars usually pulled from AWS Secrets Manager
+    SENTRY_BACKEND_DSN: str = ""
+    EXTERNAL_AUSPICE_BUCKET: str
+    DB_BUCKET: str = ""
+    DB_rw_username: str
+    DB_rw_password: str
+    DB_address: str
+    AUTH0_USERINFO_URL: str = "userinfo"
+    FLASK_SECRET: str
+    AUTH0_CLIENT_ID: str
+    AUTH0_CLIENT_SECRET: str
+    AUTH0_MANAGEMENT_CLIENT_ID: str = ""
+    AUTH0_MANAGEMENT_CLIENT_SECRET: str = ""
+    AUTH0_DOMAIN: str
+    AUTH0_CLIENT_KWARGS: Dict[str, Any] = {
+        "scope": "openid profile email",
+    }
+
+    # These are same-name'd keys in an AWS secret, so they get remapped when
+    # we load the secrets, and then we use getter methods to handle special cases.
+    SECRET_AUTH0_AUTHORIZE_URL: str
+    SECRET_AUTH0_BASE_URL: str
+    SECRET_AUTH0_ACCESS_TOKEN_URL: str
+
+    # Env vars usually pulled from AWS SSM Parameters
+    AWS_NEXTSTRAIN_SFN_PARAMETERS: Dict
 
     ####################################################################################
     # Stack name
     @cached_property
-    def STACK_PREFIX(self) -> str:
-        remote_prefix = os.environ.get("REMOTE_DEV_PREFIX")
-        deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
-        stack_name = remote_prefix if remote_prefix else f"/{deployment_stage}stack"
-        return stack_name
-
-    ####################################################################################
-    # AWS secrets
-    @cached_property
-    def AWS_SECRET(self) -> Mapping[str, Any]:
-        session = Session(region_name=self.AWS_REGION)
-
-        secret_name = os.environ.get("ASPEN_CONFIG_SECRET_NAME", "aspen-config")
-        client = session.client(
-            service_name="secretsmanager",
-            endpoint_url=os.environ.get("BOTO_ENDPOINT_URL"),
-        )
-
-        try:
-            get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-        except ClientError as e:
-            raise e
-        else:
-            secret = get_secret_value_response["SecretString"]
-            return json.loads(secret)
-
-    @cached_property
-    def DEBUG(self) -> bool:
-        return False
-
-    @cached_property
-    def SECRET_KEY(self) -> str:
-        return self.AWS_SECRET["FLASK_SECRET"]
-
-    ####################################################################################
-    # auth0 properties
-    @cached_property
-    def AUTH0_CLIENT_ID(self) -> str:
-        return self.AWS_SECRET["AUTH0_CLIENT_ID"]
-
-    @cached_property
     def AUTH0_LOGOUT_URL(self) -> str:
-        flask_env = os.environ.get("FLASK_ENV")
+        flask_env = self.FLASK_ENV
         if flask_env == "production":
             return f"{self.AUTH0_BASE_URL}/v2/logout"
         else:
@@ -73,66 +115,29 @@ class Settings(BaseSettings):
 
     @cached_property
     def AUTH0_CALLBACK_URL(self) -> str:
-        flask_env = os.environ.get("FLASK_ENV")
-        if flask_env != "production":
-            return "http://backend.genepinet.localdev:3000/v2/auth/callback"
-        api_url = os.environ.get("API_URL")
-        if not api_url:
-            raise Exception("Missing API_URL in config!")
+        api_url = self.API_URL
         return f"{api_url}/v2/auth/callback"
-
-    @cached_property
-    def AUTH0_CLIENT_SECRET(self) -> str:
-        return self.AWS_SECRET["AUTH0_CLIENT_SECRET"]
-
-    @cached_property
-    def AUTH0_MANAGEMENT_CLIENT_ID(self) -> str:
-        return self.AWS_SECRET["AUTH0_MANAGEMENT_CLIENT_ID"]
-
-    @cached_property
-    def AUTH0_MANAGEMENT_CLIENT_SECRET(self) -> str:
-        return self.AWS_SECRET["AUTH0_MANAGEMENT_CLIENT_SECRET"]
-
-    @cached_property
-    def AUTH0_DOMAIN(self) -> str:
-        return self.AWS_SECRET["AUTH0_DOMAIN"]
 
     @cached_property
     def AUTH0_BASE_URL(self) -> str:
         try:
-            return self.AWS_SECRET["AUTH0_BASE_URL"]
+            return self.SECRET_AUTH0_BASE_URL
         except KeyError:
             return f"https://{self.AUTH0_DOMAIN}"
 
     @cached_property
     def AUTH0_ACCESS_TOKEN_URL(self) -> str:
         try:
-            return self.AWS_SECRET["AUTH0_ACCESS_TOKEN_URL"]
+            return self.SECRET_AUTH0_ACCESS_TOKEN_URL
         except KeyError:
             return f"{self.AUTH0_BASE_URL}/oauth/token"
 
     @cached_property
     def AUTH0_AUTHORIZE_URL(self) -> str:
         try:
-            return self.AWS_SECRET["AUTH0_AUTHORIZE_URL"]
+            return self.SECRET_AUTH0_AUTHORIZE_URL
         except KeyError:
             return f"{self.AUTH0_BASE_URL}/authorize"
-
-    @cached_property
-    def AUTH0_CLIENT_KWARGS(self) -> Mapping[str, Any]:
-        try:
-            return self.AWS_SECRET["AUTH0_CLIENT_KWARGS"]
-        except KeyError:
-            return {
-                "scope": "openid profile email",
-            }
-
-    @cached_property
-    def AUTH0_USERINFO_URL(self) -> str:
-        try:
-            return self.AWS_SECRET["AUTH0_USERINFO_URL"]
-        except KeyError:
-            return "userinfo"
 
     ####################################################################################
     # database properties
@@ -143,10 +148,10 @@ class Settings(BaseSettings):
             return os.environ["DB_DSN"]
         if os.getenv("DB_URI"):
             return os.environ["DB_URI"]
-        username = self.AWS_SECRET["DB_rw_username"]
-        password = self.AWS_SECRET["DB_rw_password"]
-        instance_address = self.AWS_SECRET["DB_address"]
-        db_name = os.getenv("REMOTE_DEV_PREFIX") or "/aspen_db"
+        username = self.DB_rw_username
+        password = self.DB_rw_password
+        instance_address = self.DB_address
+        db_name = self.REMOTE_DEV_PREFIX or "/aspen_db"
         return f"{self.DB_DRIVER}://{username}:{password}@{instance_address}{db_name}"
 
     @cached_property
@@ -154,58 +159,11 @@ class Settings(BaseSettings):
         raise NotImplementedError()
 
     ####################################################################################
-    # s3 properties
-    @cached_property
-    def DB_BUCKET(self) -> str:
-        return self.AWS_SECRET["S3_db_bucket"]
-
-    @cached_property
-    def EXTERNAL_AUSPICE_BUCKET(self) -> str:
-        return self.AWS_SECRET["S3_external_auspice_bucket"]
-
-    ####################################################################################
-    # sentry properties
-    @cached_property
-    def SENTRY_BACKEND_DSN(self) -> str:
-        try:
-            return self.AWS_SECRET["SENTRY_BACKEND_DSN"]
-        except KeyError:
-            return ""
-
-    ####################################################################################
-    # SSM Parameter properties
-    # @lru_cache
-    def _AWS_SSM_PARAMETER(self, parameter_suffix: str) -> Mapping[str, Any]:
-        session = Session(region_name=self.AWS_REGION)
-
-        deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
-        parameter_name = (
-            f"/aspen/{deployment_stage}{self.STACK_PREFIX}/{parameter_suffix}"
-        )
-        client = session.client(
-            service_name="ssm", endpoint_url=os.environ.get("BOTO_ENDPOINT_URL")
-        )
-
-        try:
-            get_parameter = client.get_parameter(Name=parameter_name)
-        except ClientError as e:
-            raise e
-        else:
-            parameter = get_parameter["Parameter"]["Value"]
-            return json.loads(parameter)
-
-    @cached_property
-    def AWS_NEXTSTRAIN_SFN_PARAMETERS(self) -> Mapping[str, Any]:
-        return self._AWS_SSM_PARAMETER("nextstrain-ondemand-sfn")
-
-    ####################################################################################
-    # SFN runtime input properties
+    # SFN batch config properties
     @cached_property
     def NEXTSTRAIN_DOCKER_IMAGE_ID(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["Input"]["Run"]["docker_image_id"]
 
-    ####################################################################################
-    # SFN batch config properties
     @cached_property
     def NEXTSTRAIN_OUTPUT_PREFIX(self) -> str:
         return self.AWS_NEXTSTRAIN_SFN_PARAMETERS["OutputPrefix"]
@@ -236,9 +194,40 @@ class Settings(BaseSettings):
         keep_untouched = (
             cached_property,
         )  # https://github.com/samuelcolvin/pydantic/issues/1241
+        aws_secrets_remap = {
+            "S3_db_bucket": "DB_BUCKET",
+            "S3_external_auspice_bucket": "EXTERNAL_AUSPICE_BUCKET",
+            "AUTH0_BASE_URL": "SECRET_AUTH0_BASE_URL",
+            "AUTH0_ACCESS_TOKEN_URL": "SECRET_AUTH0_ACCESS_TOKEN_URL",
+            "AUTH0_AUTHORIZE_URL": "SECRET_AUTH0_AUTHORIZE_URL",
+        }
+        aws_secret_keys = [
+            "SENTRY_BACKEND_DSN",
+            "DB_rw_username",
+            "DB_rw_password",
+            "DB_address",
+            "AUTH0_USERINFO_URL",
+            "FLASK_SECRET",
+            "AUTH0_CLIENT_ID",
+            "AUTH0_CLIENT_SECRET",
+            "AUTH0_MANAGEMENT_CLIENT_ID",
+            "AUTH0_MANAGEMENT_CLIENT_SECRET",
+            "AUTH0_DOMAIN",
+            "AUTH0_CLIENT_KWARGS",
+        ]
+        aws_ssm_params = {"nextstrain-ondemand-sfn": "AWS_NEXTSTRAIN_SFN_PARAMETERS"}
 
-
-@lru_cache
-def get_settings() -> Settings:
-    settings = Settings()
-    return settings
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings,
+            env_settings,
+            file_secret_settings,
+        ):
+            return (
+                init_settings,
+                env_settings,
+                file_secret_settings,
+                aws_secret_settings,
+                aws_ssm_settings,
+            )

--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -1,41 +1,20 @@
 import os
-from functools import lru_cache
 from urllib.parse import urlencode
 
 from authlib.integrations.base_client.errors import OAuthError
-from authlib.integrations.starlette_client import OAuth, StarletteRemoteApp
+from authlib.integrations.starlette_client import StarletteRemoteApp
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 from starlette.requests import Request
 from starlette.responses import Response
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.settings import get_settings, Settings
+from aspen.api.deps import get_auth0_client, get_settings
+from aspen.api.settings import Settings
 
 # From the example here:
 # https://github.com/authlib/demo-oauth-client/tree/master/fastapi-google-login
 router = APIRouter()
-
-
-@lru_cache
-def get_auth0_client() -> StarletteRemoteApp:
-    # TODO - settings is an unhashable type, so we can't make it a Dependency
-    # *and* use the lru_cache decorator on this getter. We should probably use
-    # fastapi's built-in dependency caching instead of lru_cache here, but
-    # it needs a little more thought first.
-    # see: https://github.com/tiangolo/fastapi/issues/1985
-    settings: Settings = get_settings()
-    oauth = OAuth()
-    auth0 = oauth.register(
-        "auth0",
-        client_id=settings.AUTH0_CLIENT_ID,
-        client_secret=settings.AUTH0_CLIENT_SECRET,
-        api_base_url=settings.AUTH0_BASE_URL,
-        access_token_url=settings.AUTH0_ACCESS_TOKEN_URL,
-        authorize_url=settings.AUTH0_AUTHORIZE_URL,
-        client_kwargs=settings.AUTH0_CLIENT_KWARGS,
-    )
-    return auth0
 
 
 @router.get("/login")

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -13,14 +13,14 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from starlette.requests import Request
 
-from aspen.api.deps import get_db
+from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.phylo_runs import (
     PHYLO_TREE_TYPES,
     PhyloRunRequestSchema,
     PhyloRunResponseSchema,
 )
-from aspen.api.settings import get_settings
+from aspen.api.settings import Settings
 from aspen.api.utils import get_matching_gisaid_ids
 from aspen.app.views.api_utils import (
     authz_sample_filters,
@@ -44,6 +44,7 @@ async def kick_off_phylo_run(
     phylo_run_request: PhyloRunRequestSchema,
     request: Request,
     db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
 ) -> PhyloRunResponseSchema:
     user = request.state.auth_user
     # Note - sample run will be associated with users's primary group.
@@ -143,7 +144,6 @@ async def kick_off_phylo_run(
 
     # Step 5 - Kick off the phylo run job.
     aws_region = os.environ.get("AWS_REGION")
-    settings = get_settings()
     sfn_params = settings.AWS_NEXTSTRAIN_SFN_PARAMETERS
     sfn_input_json = {
         "Input": {


### PR DESCRIPTION
### Summary:
- **What:** This PR creates settings & oauth client objects once on application startup and then reuses them throughout the app

### Migration Notes:
Once pulling down this change, it's necessary to run `make local-start` to update env vars for the local dev backend.

### Notes:
This PR uses [pydantic's settings sources](https://pydantic-docs.helpmanual.io/usage/settings/#customise-settings-sources) to load AWS secrets & parameters when a Settings object is instantiated, and uses Fastapi's app.state semi-global parameter to keep track of a single Settings object, and a single OAuth client object for the lifetime of the application. This enables us to use the oauth/settings getters as dependencies properly without relying on complicated caching schemes.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)