### PR TITLE
Change SENTRY_URL setting to SENTRY_BACKEND_DSN

### DIFF
--- a/src/backend/aspen/app/app.py
+++ b/src/backend/aspen/app/app.py
@@ -34,7 +34,7 @@ deployment = os.getenv("DEPLOYMENT_STAGE")
 # We should be able to allow this in all environments and only alert on prod.
 # Init as early as possible to catch more
 sentry_sdk.init(
-    dsn=aspen_config.SENTRY_URL,
+    dsn=aspen_config.SENTRY_BACKEND_DSN,
     integrations=[FlaskIntegration()],
     environment=deployment,
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/src/backend/aspen/config/config.py
+++ b/src/backend/aspen/config/config.py
@@ -238,11 +238,9 @@ class Config(object):
     ####################################################################################
     # sentry properties
     @property
-    def SENTRY_URL(self) -> str:
-        if os.getenv("SENTRY_URL"):
-            return os.environ["SENTRY_URL"]
+    def SENTRY_BACKEND_DSN(self) -> str:
         try:
-            return self.AWS_SECRET["SENTRY_URL"]
+            return self.AWS_SECRET["SENTRY_BACKEND_DSN"]
         except KeyError:
             return ""
 


### PR DESCRIPTION
### Summary:
- **What:** Changes the Flask setting that retrieves the Sentry backend dsn from our AWS secret store from `SENTRY_URL` to `SENTRY_BACKEND_DSN`. It turns out `SENTRY_URL` is a reserved environment variable for the `sentry-cli` command tool. This doesn't change how anything works, but keeps our implementation friendly with the docs and compatible with Sentry on the frontend if we add it in the future.
- **Ticket:** [sc161330](https://app.shortcut.com/genepi/story/161330)
- **Env:** `<rdev link>`

### Demos:

### Notes:
The check for an environment variable was leftover from a previous attempt to make Sentry play nice with localdev; it was never returning anything useful anyways, so it is removed.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)