### PR TITLE
Install vim and nano in frontend & backend docker images.

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -4,7 +4,7 @@ ENV FLASK_APP=aspen.main
 EXPOSE 3000
 
 # Utility
-RUN apt-get update && apt-get install -y vim procps wget make jq
+RUN apt-get update && apt-get install -y vim procps wget make jq nano
 
 # Orchestration. Supervisor is heavyweight but afaik nothing else supports sane child reaping and signal forwarding.
 RUN pip install --no-cache-dir supervisor

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y make wget \
   libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
   libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 \
-  lsb-release xdg-utils \
+  lsb-release xdg-utils nano vim procps \
   && rm -rf /var/lib/apt/lists/*
 COPY package*.json ./
 USER node


### PR DESCRIPTION
### Summary:
- **What:** Make sure vim & nano are installed in our frontend & backend docker images to help with debugging
- **Ticket:** [sc166774](https://app.shortcut.com/genepi/story/166774)
- **Env:** `https://editor-frontend.dev.genepi.czi.technology`

### Demos:
Try getting a shell and using an editor in the frontend or backend service containers:
`./scripts/happy shell editor backend`
`./scripts/happy shell editor frontend`

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)