### PR TITLE
use wget opposed to curl, add retries

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -70,6 +70,7 @@ task IngestGISAID {
     start_time=$(date +%s)
     build_id=$(date +%Y%m%d-%H%M)
 
+
     aws configure set region ~{aws_region}
 
     export ASPEN_CONFIG_SECRET_NAME=~{aspen_config_secret_name}
@@ -227,6 +228,10 @@ task AlignGISAID {
     # fetch aspen config
     aspen_config="$(aws secretsmanager get-secret-value --secret-id ~{aspen_config_secret_name} --query SecretString --output text)"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$aspen_config")"
+
+    # echo important output locations for easier debugging
+    echo ASPEN S3 BUCKET $aspen_s3_db_bucket
+    echo BUILD ID $build_id
 
     # get the bucket/key from the object id
     processed_gisaid_location=$(python3 /usr/src/app/aspen/workflows/align_gisaid/lookup_processed_gisaid_object.py --processed-gisaid-object-id "~{processed_gisaid_object_id}")

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -231,10 +231,6 @@ task AlignGISAID {
     aspen_config="$(aws secretsmanager get-secret-value --secret-id ~{aspen_config_secret_name} --query SecretString --output text)"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$aspen_config")"
 
-    # echo important output locations for easier debugging
-    echo ASPEN S3 BUCKET $aspen_s3_db_bucket
-    echo BUILD ID $build_id
-
     # get the bucket/key from the object id
     processed_gisaid_location=$(python3 /usr/src/app/aspen/workflows/align_gisaid/lookup_processed_gisaid_object.py --processed-gisaid-object-id "~{processed_gisaid_object_id}")
     processed_gisaid_s3_bucket=$(echo "${processed_gisaid_location}" | jq -r .bucket)

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -93,7 +93,8 @@ task IngestGISAID {
     gisaid_password=$(echo "${gisaid_credentials}" | jq -r .password)
 
     wget "~{gisaid_ndjson_url}" --user "${gisaid_username}" --password "${gisaid_password}" --continue --tries=2 -O gisaid_dump.fasta.bz2
-    bunzip2 gisaid_dump.fasta.bz2 | zstdmt > sequences.fasta.zst
+    bunzip2 gisaid_dump.fasta.bz2 
+    zstdmt gisaid_dump.fasta -o sequences.fasta.zst
 
     aws s3 cp sequences.fasta.zst "s3://${aspen_s3_db_bucket}/${sequences_key}"
 

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -95,6 +95,7 @@ task IngestGISAID {
     wget "~{gisaid_ndjson_url}" --user "${gisaid_username}" --password "${gisaid_password}" --continue --tries=2 -O gisaid_dump.fasta.bz2
     bunzip2 gisaid_dump.fasta.bz2 
     zstdmt gisaid_dump.fasta -o sequences.fasta.zst
+    rm gisaid_dump.fasta
 
     aws s3 cp sequences.fasta.zst "s3://${aspen_s3_db_bucket}/${sequences_key}"
 

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -91,9 +91,8 @@ task IngestGISAID {
     gisaid_username=$(echo "${gisaid_credentials}" | jq -r .username)
     gisaid_password=$(echo "${gisaid_credentials}" | jq -r .password)
 
-    curl "~{gisaid_ndjson_url}" --user "${gisaid_username}:${gisaid_password}" | \
-        bunzip2 | \
-        zstdmt > sequences.fasta.zst
+    wget "~{gisaid_ndjson_url}" --user "${gisaid_username}" --password "${gisaid_password}" --continue --tries=2 -O gisaid_dump.fasta.bz2
+    bunzip2 gisaid_dump.fasta.bz2 | zstdmt > sequences.fasta.zst
 
     aws s3 cp sequences.fasta.zst "s3://${aspen_s3_db_bucket}/${sequences_key}"
 


### PR DESCRIPTION
### Summary:
- **What:** converting curl to wget ([which supports download retries opposed to curl](https://daniel.haxx.se/docs/curl-vs-wget.html)), also adding in retries for gisaid download. 
- **Ticket:** [sc168701](https://app.shortcut.com/genepi/story/168701)
- **Env:** `<rdev link>`

### Demos:
pipeline completed successfully in rdev ✅ 

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)