### PR TITLE
sds getSpacings >>> getSpaces

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -104,7 +104,7 @@ Aspen customizes the default `czifui` theme, in order to have its unique brand i
 For example, throughout the code base, you will find patterns such as the following:
 
 ```ts
-import { fontBodyM, getColors, getSpacings } from "czifui";
+import { fontBodyM, getColors, getSpaces } from "czifui";
 
 export const Foo = styled.div`
   // This is the design system's font body medium mixin we import from czifui
@@ -118,13 +118,13 @@ export const Foo = styled.div`
   ${(props) => {
     // getColors() is a selector that picks out colors from the theme object
     const colors = getColors(props);
-    // getSpacings() is a selector that picks out spacings from the theme object
-    const spacings = getSpacings(props);
+    // getSpaces() is a selector that picks out spaces from the theme object
+    const spaces = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[500]};
-      padding-bottom: ${spacings?.m}px;
-      margin-bottom: ${spacings?.xxl}px;
+      padding-bottom: ${spaces?.m}px;
+      margin-bottom: ${spaces?.xxl}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/Dialog/components/DialogActions/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogActions/style.ts
@@ -16,13 +16,13 @@ export const StyledDialogActions = styled(DialogActions, {
   justify-content: flex-start;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: 0 ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xxl}px;
+      padding: 0 ${spaces?.xxl}px ${spaces?.xxl}px ${spaces?.xxl}px;
 
       &.MuiDialogActions-spacing > :not(:first-child) {
-        margin-left: ${spacings?.m}px;
+        margin-left: ${spaces?.m}px;
       }
     `;
   }}

--- a/src/frontend/src/common/components/library/Dialog/components/DialogActions/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogActions/style.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { DialogActions } from "@material-ui/core";
-import { getSpacings, Props } from "czifui";
+import { getSpaces, Props } from "czifui";
 import { narrow } from "../common";
 
 export interface ExtraProps extends Props {
@@ -16,7 +16,7 @@ export const StyledDialogActions = styled(DialogActions, {
   justify-content: flex-start;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: 0 ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xxl}px;

--- a/src/frontend/src/common/components/library/Dialog/components/DialogContent/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogContent/style.ts
@@ -14,10 +14,10 @@ export const StyledDialogContent = styled(DialogContent, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: 0 ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px;
+      padding: 0 ${spaces?.xxl}px ${spaces?.xl}px ${spaces?.xxl}px;
     `;
   }}
 

--- a/src/frontend/src/common/components/library/Dialog/components/DialogContent/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogContent/style.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { DialogContent } from "@material-ui/core";
-import { getSpacings, Props } from "czifui";
+import { getSpaces, Props } from "czifui";
 import { narrow } from "../common";
 
 export interface ExtraProps extends Props {
@@ -14,7 +14,7 @@ export const StyledDialogContent = styled(DialogContent, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: 0 ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px;

--- a/src/frontend/src/common/components/library/Dialog/components/DialogTitle/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogTitle/style.ts
@@ -14,10 +14,10 @@ export const StyledDialogTitle = styled(DialogTitle, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: ExtraProps) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px;
+      padding: ${spaces?.xxl}px ${spaces?.xxl}px ${spaces?.xl}px ${spaces?.xxl}px;
     `;
   }}
 
@@ -25,12 +25,12 @@ export const StyledDialogTitle = styled(DialogTitle, {
 
   ${(props) => {
     const { narrow } = props;
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     if (!narrow) return "";
 
     return `
-      padding-bottom: ${spacings?.s}px;
+      padding-bottom: ${spaces?.s}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/Dialog/components/DialogTitle/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogTitle/style.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { DialogTitle } from "@material-ui/core";
-import { getSpacings, Props } from "czifui";
+import { getSpaces, Props } from "czifui";
 import { narrow } from "../common";
 
 export interface ExtraProps extends Props {
@@ -14,7 +14,7 @@ export const StyledDialogTitle = styled(DialogTitle, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: ExtraProps) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px;
@@ -25,7 +25,7 @@ export const StyledDialogTitle = styled(DialogTitle, {
 
   ${(props) => {
     const { narrow } = props;
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     if (!narrow) return "";
 

--- a/src/frontend/src/common/components/library/data_subview/components/AfterModalAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/AfterModalAlert/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Alert, Button, fontBodyXs, getFontWeights, getSpacings } from "czifui";
+import { Alert, Button, fontBodyXs, getFontWeights, getSpaces } from "czifui";
 
 export const StyledAlert = styled(Alert)`
   position: absolute;
@@ -30,7 +30,7 @@ export const DismissButton = styled(Button)`
     background-color: transparent;
   }
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const fontWeights = getFontWeights(props);
     return `
       font-weight: ${fontWeights?.semibold};

--- a/src/frontend/src/common/components/library/data_subview/components/AfterModalAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/AfterModalAlert/style.ts
@@ -30,11 +30,11 @@ export const DismissButton = styled(Button)`
     background-color: transparent;
   }
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const fontWeights = getFontWeights(props);
     return `
       font-weight: ${fontWeights?.semibold};
-      margin-top: ${spacings?.xl}px;
+      margin-top: ${spaces?.xl}px;
       margin-left: 0px;
       padding-left: 0px;
     `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/style.ts
@@ -6,14 +6,14 @@ import {
   fontHeaderXs,
   getColors,
   getFontWeights,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 import IconCheckSmall from "src/common/icons/IconCheckSmall.svg";
 import IconCloseSmall from "src/common/icons/IconCloseSmall.svg";
 
 export const Label = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xxxs}px;
     `;
@@ -24,7 +24,7 @@ export const LabelMain = styled.span`
   ${fontHeaderXs}
   color: black;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.l}px;
       margin-right: ${spacings?.xxs}px;
@@ -37,7 +37,7 @@ export const LabelLight = styled.span`
   ${fontHeaderXs}
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       font-weight: ${fontWeights?.regular};
@@ -56,7 +56,7 @@ export const StyledListItem = styled(ListItem)`
   padding: 0px;
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       font-weight: ${fontWeights?.regular};
       padding-bottom: ${spacings?.xxxs}px;
@@ -71,7 +71,7 @@ export const SmallText = styled.span`
 export const StyledListItemIcon = styled(ListItemIcon)`
   min-width: 24px;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.s}px;
     `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/style.ts
@@ -13,9 +13,9 @@ import IconCloseSmall from "src/common/icons/IconCloseSmall.svg";
 
 export const Label = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xxxs}px;
+      margin-bottom: ${spaces?.xxxs}px;
     `;
   }}
 `;
@@ -24,11 +24,11 @@ export const LabelMain = styled.span`
   ${fontHeaderXs}
   color: black;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.l}px;
-      margin-right: ${spacings?.xxs}px;
-      margin-bottom: ${spacings?.xxxs}px;
+      margin-top: ${spaces?.l}px;
+      margin-right: ${spaces?.xxs}px;
+      margin-bottom: ${spaces?.xxxs}px;
     `;
   }}
 `;
@@ -37,13 +37,13 @@ export const LabelLight = styled.span`
   ${fontHeaderXs}
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
       font-weight: ${fontWeights?.regular};
-      margin-top: ${spacings?.l}px;
-      margin-right: ${spacings?.m}px;
-      margin-bottom: ${spacings?.xxxs}px;
+      margin-top: ${spaces?.l}px;
+      margin-right: ${spaces?.m}px;
+      margin-bottom: ${spaces?.xxxs}px;
       color: ${colors?.gray[500]};
     `;
   }}
@@ -56,10 +56,10 @@ export const StyledListItem = styled(ListItem)`
   padding: 0px;
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       font-weight: ${fontWeights?.regular};
-      padding-bottom: ${spacings?.xxxs}px;
+      padding-bottom: ${spaces?.xxxs}px;
     `;
   }}
 `;
@@ -71,9 +71,9 @@ export const SmallText = styled.span`
 export const StyledListItemIcon = styled(ListItemIcon)`
   min-width: 24px;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.s}px;
+      margin-top: ${spaces?.s}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -35,19 +35,19 @@ export const Title = styled.span`
   ${fontBodyS}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
-      margin-bottom: ${spacings?.l}px;
+      margin-bottom: ${spaces?.l}px;
     `;
   }}
 `;
 
 export const StyledDialogTitle = styled(DialogTitle)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding-bottom: ${spacings?.l}px;
+      padding-bottom: ${spaces?.l}px;
     `;
   }}
 `;
@@ -56,9 +56,9 @@ export const StyledTextField = styled(TextField)`
   color: black;
   padding: 0px;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding-bottom: ${spacings?.s}px;
+      padding-bottom: ${spaces?.s}px;
     `;
   }}
 `;
@@ -67,9 +67,9 @@ export const FieldTitle = styled.div`
   ${fontHeaderXs}
   color: black;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xxs}px;
+      margin-bottom: ${spaces?.xxs}px;
     `;
   }}
 `;
@@ -78,10 +78,10 @@ export const StyledInstructions = styled(Instructions)`
   border-radius: 4px;
   color: black;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xs}px;
-      padding: ${spacings?.l}px;
+      margin-bottom: ${spaces?.xs}px;
+      padding: ${spaces?.l}px;
     `;
   }}
 `;
@@ -91,10 +91,10 @@ export const InstructionsSemiBold = styled.span`
   ${fontBodyXs}
   ${(props: Props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       font-weight: ${fontWeights?.semibold};
-      margin-bottom: ${spacings?.xxxs};
+      margin-bottom: ${spaces?.xxxs};
     `;
   }}
 `;
@@ -108,11 +108,11 @@ export const StyledInstructionsButton = styled(Button)`
   ${fontCapsXxxs}
   padding-left: 0px;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      margin-left: ${spacings?.m}px;
-      padding-top: ${spacings?.xxs}px;
+      margin-left: ${spaces?.m}px;
+      padding-top: ${spaces?.xxs}px;
       &:hover {
         background-color: transparent;
         color: ${colors?.primary[500]};
@@ -127,9 +127,9 @@ export const StyledRadio = styled(Radio)`
   width: 20px;
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-right: ${spacings?.s}px;
+      margin-right: ${spaces?.s}px;
       color: ${colors?.gray[400]};
       &.Mui-checked {
         color: ${colors?.primary[500]};
@@ -143,10 +143,10 @@ export const StyledRadio = styled(Radio)`
 
 export const TreeTypeSection = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.s}px;
-      margin-bottom: ${spacings?.s}px;
+      margin-top: ${spaces?.s}px;
+      margin-bottom: ${spaces?.s}px;
     `;
   }}
 `;
@@ -161,10 +161,10 @@ export const TreeNameTooLongAlert = styled.div`
   display: flex;
   align-items: center;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.xxxs}px;
-      margin-bottom: ${spacings?.xl}px;
+      margin-top: ${spaces?.xxxs}px;
+      margin-bottom: ${spaces?.xl}px;
     `;
   }}
 `;
@@ -173,20 +173,20 @@ export const CreateTreeInfo = styled.div`
   ${fontBodyXxs}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: ${colors?.gray[400]};
-      margin-top: ${spacings?.l}px;
+      margin-top: ${spaces?.l}px;
     `;
   }}
 `;
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      margin-top: ${spacings?.xxl}px;
+      margin-top: ${spaces?.xxl}px;
       &:active {
         background-color: ${colors?.gray[400]};
       }
@@ -196,9 +196,9 @@ export const StyledButton = styled(Button)`
 
 export const StyledTooltip = styled(Tooltip)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-left: ${spacings?.xxs}px;
+      margin-left: ${spaces?.xxs}px;
     `;
   }}
 `;
@@ -231,10 +231,10 @@ export const StyledErrorOutlinedIcon = styled(ErrorOutlineIcon)`
   ${(props) => {
     const colors = getColors(props);
     const iconSizes = getIconSizes(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: ${colors?.error[400]};
-      margin-right: ${spacings?.xs}px;
+      margin-right: ${spaces?.xs}px;
       height: ${iconSizes?.s.height}px;
       width: ${iconSizes?.s.width}px;
     `;
@@ -249,15 +249,15 @@ export const StyledFormControlLabel = styled(FormControlLabel)`
   margin-right: 0px;
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const checked = props.checked;
     return `
       &:hover {
         background-color: ${colors?.gray[100]};
       }
       background-color: ${checked ? colors?.gray[100] : "transparent"};
-      margin-bottom: ${spacings?.s}px;
-      padding: ${spacings?.l}px;
+      margin-bottom: ${spaces?.s}px;
+      padding: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -15,7 +15,7 @@ import {
   getColors,
   getFontWeights,
   getIconSizes,
-  getSpacings,
+  getSpaces,
   Props,
   Tooltip,
 } from "czifui";
@@ -35,7 +35,7 @@ export const Title = styled.span`
   ${fontBodyS}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
       margin-bottom: ${spacings?.l}px;
@@ -45,7 +45,7 @@ export const Title = styled.span`
 
 export const StyledDialogTitle = styled(DialogTitle)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding-bottom: ${spacings?.l}px;
     `;
@@ -56,7 +56,7 @@ export const StyledTextField = styled(TextField)`
   color: black;
   padding: 0px;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding-bottom: ${spacings?.s}px;
     `;
@@ -67,7 +67,7 @@ export const FieldTitle = styled.div`
   ${fontHeaderXs}
   color: black;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xxs}px;
     `;
@@ -78,7 +78,7 @@ export const StyledInstructions = styled(Instructions)`
   border-radius: 4px;
   color: black;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xs}px;
       padding: ${spacings?.l}px;
@@ -91,7 +91,7 @@ export const InstructionsSemiBold = styled.span`
   ${fontBodyXs}
   ${(props: Props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       font-weight: ${fontWeights?.semibold};
       margin-bottom: ${spacings?.xxxs};
@@ -108,7 +108,7 @@ export const StyledInstructionsButton = styled(Button)`
   ${fontCapsXxxs}
   padding-left: 0px;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       margin-left: ${spacings?.m}px;
@@ -127,7 +127,7 @@ export const StyledRadio = styled(Radio)`
   width: 20px;
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-right: ${spacings?.s}px;
       color: ${colors?.gray[400]};
@@ -143,7 +143,7 @@ export const StyledRadio = styled(Radio)`
 
 export const TreeTypeSection = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.s}px;
       margin-bottom: ${spacings?.s}px;
@@ -161,7 +161,7 @@ export const TreeNameTooLongAlert = styled.div`
   display: flex;
   align-items: center;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.xxxs}px;
       margin-bottom: ${spacings?.xl}px;
@@ -173,7 +173,7 @@ export const CreateTreeInfo = styled.div`
   ${fontBodyXxs}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: ${colors?.gray[400]};
       margin-top: ${spacings?.l}px;
@@ -183,7 +183,7 @@ export const CreateTreeInfo = styled.div`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       margin-top: ${spacings?.xxl}px;
@@ -196,7 +196,7 @@ export const StyledButton = styled(Button)`
 
 export const StyledTooltip = styled(Tooltip)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-left: ${spacings?.xxs}px;
     `;
@@ -231,7 +231,7 @@ export const StyledErrorOutlinedIcon = styled(ErrorOutlineIcon)`
   ${(props) => {
     const colors = getColors(props);
     const iconSizes = getIconSizes(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: ${colors?.error[400]};
       margin-right: ${spacings?.xs}px;
@@ -249,7 +249,7 @@ export const StyledFormControlLabel = styled(FormControlLabel)`
   margin-right: 0px;
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const checked = props.checked;
     return `
       &:hover {

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
@@ -10,7 +10,7 @@ import {
   fontHeaderXl,
   getColors,
   getFontWeights,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 
 export const Header = styled.div`
@@ -31,7 +31,7 @@ export const Title = styled.span`
   ${fontBodyM}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
       margin-bottom: ${spacings?.l}px;
@@ -44,7 +44,7 @@ export const CheckBoxInfo = styled.div`
   position: inline-block;
   float: left;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.l}px;
       margin-bottom: ${spacings?.l}px;
@@ -72,7 +72,7 @@ export const CheckBoxWrapper = styled.div`
   width: 500px;
   border-radius: 5px;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       margin-bottom: ${spacings?.xxs}px;
@@ -97,7 +97,7 @@ export const DownloadType = styled.div`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.xxl}px;
     `;
@@ -116,7 +116,7 @@ export const StyledIconButton = styled(IconButton)`
     background-color: transparent;
   }
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding-bottom: ${spacings?.l}px;
     `;

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
@@ -31,10 +31,10 @@ export const Title = styled.span`
   ${fontBodyM}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
-      margin-bottom: ${spacings?.l}px;
+      margin-bottom: ${spaces?.l}px;
     `;
   }}
 `;
@@ -44,10 +44,10 @@ export const CheckBoxInfo = styled.div`
   position: inline-block;
   float: left;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.l}px;
-      margin-bottom: ${spacings?.l}px;
+      margin-top: ${spaces?.l}px;
+      margin-bottom: ${spaces?.l}px;
     `;
   }}
 `;
@@ -72,10 +72,10 @@ export const CheckBoxWrapper = styled.div`
   width: 500px;
   border-radius: 5px;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      margin-bottom: ${spacings?.xxs}px;
+      margin-bottom: ${spaces?.xxs}px;
       &:hover {
         background-color: ${colors?.gray[100]};
       }
@@ -97,9 +97,9 @@ export const DownloadType = styled.div`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.xxl}px;
+      margin-top: ${spaces?.xxl}px;
     `;
   }}
 `;
@@ -116,9 +116,9 @@ export const StyledIconButton = styled(IconButton)`
     background-color: transparent;
   }
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding-bottom: ${spacings?.l}px;
+      padding-bottom: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
@@ -1,11 +1,6 @@
 import styled from "@emotion/styled";
 import ErrorOutlineOutlinedIcon from "@material-ui/icons/ErrorOutlineOutlined";
-import {
-  fontBodyXxxs,
-  getFontWeights,
-  getIconSizes,
-  getSpacings,
-} from "czifui";
+import { fontBodyXxxs, getFontWeights, getIconSizes, getSpaces } from "czifui";
 
 const AlertInstructionsCommon = `
   ${fontBodyXxxs}
@@ -29,7 +24,7 @@ export const AlertInstructionsNotSemiBold = styled.span`
 export const StyledWarningIcon = styled(ErrorOutlineOutlinedIcon)`
   ${(props) => {
     const iconSizes = getIconSizes(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       height: ${iconSizes?.s.height}px;
       width: ${iconSizes?.s.width}px;

--- a/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
@@ -24,11 +24,11 @@ export const AlertInstructionsNotSemiBold = styled.span`
 export const StyledWarningIcon = styled(ErrorOutlineOutlinedIcon)`
   ${(props) => {
     const iconSizes = getIconSizes(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       height: ${iconSizes?.s.height}px;
       width: ${iconSizes?.s.width}px;
-      margin-top: ${spacings?.xxs}px;
+      margin-top: ${spaces?.xxs}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/IconButton/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/IconButton/style.ts
@@ -4,9 +4,9 @@ import { getSpaces } from "czifui";
 export const StyledSpan = styled.span`
   display: flex;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-left: ${spacings?.m}px;
+      margin-left: ${spaces?.m}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/IconButton/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/IconButton/style.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
-import { getSpacings } from "czifui";
+import { getSpaces } from "czifui";
 
 export const StyledSpan = styled.span`
   display: flex;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-left: ${spacings?.m}px;
     `;

--- a/src/frontend/src/common/components/library/data_subview/components/RedirectConfirmationModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/RedirectConfirmationModal/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontHeaderXl, getColors, getSpacings } from "czifui";
+import { fontHeaderXl, getColors, getSpaces } from "czifui";
 import { P } from "src/common/styles/support/style";
 
 export const StyledHeader = styled.div`
@@ -10,7 +10,7 @@ export const StyledImg = styled("img")`
   height: 45px;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.l}px;

--- a/src/frontend/src/common/components/library/data_subview/components/RedirectConfirmationModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/RedirectConfirmationModal/style.ts
@@ -10,10 +10,10 @@ export const StyledImg = styled("img")`
   height: 45px;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.l}px;
+      margin-bottom: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/TreeCreateHelpLink/styles.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/TreeCreateHelpLink/styles.ts
@@ -5,10 +5,10 @@ import { NewTabLink } from "../../../NewTabLink";
 export const StyledDiv = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-left: ${spacings?.l}px;
+      margin-left: ${spaces?.l}px;
 
       &:hover {
         path {
@@ -34,11 +34,11 @@ export const StyledSpan = styled.span`
   ${fontBodyXs}
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       font-weight: ${fontWeights?.semibold};
-      margin: 0 ${spacings?.xxs}px;
+      margin: 0 ${spaces?.xxs}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/TreeCreateHelpLink/styles.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/TreeCreateHelpLink/styles.ts
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
-import { fontBodyXs, getColors, getFontWeights, getSpacings } from "czifui";
+import { fontBodyXs, getColors, getFontWeights, getSpaces } from "czifui";
 import { NewTabLink } from "../../../NewTabLink";
 
 export const StyledDiv = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-left: ${spacings?.l}px;
@@ -34,7 +34,7 @@ export const StyledSpan = styled.span`
   ${fontBodyXs}
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       font-weight: ${fontWeights?.semibold};

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -8,7 +8,7 @@ import {
   fontHeaderM,
   fontHeaderXs,
   getColors,
-  getSpacings,
+  getSpaces,
   InputDropdown,
   List,
   ListItem,
@@ -23,7 +23,7 @@ const INPUT_HEIGHT = "34px";
 
 export const StyledDialogContent = styled(DialogContent)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding-bottom: ${spacings?.xxl}px;
     `;
@@ -37,7 +37,7 @@ export const StyledListItem = styled(ListItem)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
       margin-bottom: ${spacings?.xs}px;
@@ -51,7 +51,7 @@ export const StyledListItem = styled(ListItem)`
 
 export const StyledList = styled(List)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xl}px;
     `;
@@ -61,7 +61,7 @@ export const StyledList = styled(List)`
 export const StyledSectionHeader = styled.div`
   ${fontHeaderM}
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: black;
       margin-bottom: ${spacings?.m}px;
@@ -76,7 +76,7 @@ export const StyledFieldTitleText = styled.div`
   align-items: center;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xs}px;
     `;
@@ -85,7 +85,7 @@ export const StyledFieldTitleText = styled.div`
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xl}px;
       width: 150px;
@@ -107,7 +107,7 @@ export const StyledSuggestionText = styled.div`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       color: ${colors?.warning[600]};
@@ -140,7 +140,7 @@ export const StyledButton = styled(Button)`
 
 export const StyledInputDropdown = styled(InputDropdown)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.l}px;
@@ -156,7 +156,7 @@ export const StyledCloseIcon = styled(CloseIcon)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       color: ${colors?.gray[400]};

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -23,9 +23,9 @@ const INPUT_HEIGHT = "34px";
 
 export const StyledDialogContent = styled(DialogContent)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding-bottom: ${spacings?.xxl}px;
+      padding-bottom: ${spaces?.xxl}px;
     `;
   }}
 `;
@@ -37,10 +37,10 @@ export const StyledListItem = styled(ListItem)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
-      margin-bottom: ${spacings?.xs}px;
+      margin-bottom: ${spaces?.xs}px;
 
       &:last-of-type {
         margin-bottom: 0;
@@ -51,9 +51,9 @@ export const StyledListItem = styled(ListItem)`
 
 export const StyledList = styled(List)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xl}px;
+      margin-bottom: ${spaces?.xl}px;
     `;
   }}
 `;
@@ -61,10 +61,10 @@ export const StyledList = styled(List)`
 export const StyledSectionHeader = styled.div`
   ${fontHeaderM}
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: black;
-      margin-bottom: ${spacings?.m}px;
+      margin-bottom: ${spaces?.m}px;
     `;
   }}
 `;
@@ -76,18 +76,18 @@ export const StyledFieldTitleText = styled.div`
   align-items: center;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xs}px;
+      margin-bottom: ${spaces?.xs}px;
     `;
   }}
 `;
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xl}px;
+      margin-bottom: ${spaces?.xl}px;
       width: 150px;
 
       .MuiInputBase-root {
@@ -107,11 +107,11 @@ export const StyledSuggestionText = styled.div`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       color: ${colors?.warning[600]};
-      margin-left: ${spacings?.s}px;
+      margin-left: ${spaces?.s}px;
     `;
   }}
 `;
@@ -140,10 +140,10 @@ export const StyledButton = styled(Button)`
 
 export const StyledInputDropdown = styled(InputDropdown)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.l}px;
+      margin-bottom: ${spaces?.l}px;
       width: 100%;
       height: ${INPUT_HEIGHT};
     `;
@@ -156,12 +156,12 @@ export const StyledCloseIcon = styled(CloseIcon)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       color: ${colors?.gray[400]};
-      right: ${spacings?.xl}px;
-      top: ${spacings?.xl}px;
+      right: ${spaces?.xl}px;
+      top: ${spaces?.xl}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -6,7 +6,7 @@ import {
   fontHeaderXs,
   getColors,
   getFontWeights,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import DownloadImage from "src/common/icons/IconDownload.svg";
@@ -14,7 +14,7 @@ import DownloadImage from "src/common/icons/IconDownload.svg";
 export const StyledDiv = styled.div`
   ${fontHeaderXs}
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const fontWeights = getFontWeights(props);
     return `
     margin-left: ${spacings?.m}px;
@@ -28,7 +28,7 @@ export const Divider = styled.div`
   height: 28px;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
     margin-left: ${spacings?.xl}px;
@@ -44,7 +44,7 @@ export const StyledButton = styled(Button)`
     background-color: transparent;
   }
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const fontWeights = getFontWeights(props);
     return `
       font-weight: ${fontWeights?.semibold};

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -14,10 +14,10 @@ import DownloadImage from "src/common/icons/IconDownload.svg";
 export const StyledDiv = styled.div`
   ${fontHeaderXs}
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const fontWeights = getFontWeights(props);
     return `
-    margin-left: ${spacings?.m}px;
+    margin-left: ${spaces?.m}px;
     font-weight: ${fontWeights?.semibold};
     color: black;
     `;
@@ -28,10 +28,10 @@ export const Divider = styled.div`
   height: 28px;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-    margin-left: ${spacings?.xl}px;
+    margin-left: ${spaces?.xl}px;
     border-right: 1px solid ${colors?.gray[500]};
     `;
   }}
@@ -44,11 +44,11 @@ export const StyledButton = styled(Button)`
     background-color: transparent;
   }
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const fontWeights = getFontWeights(props);
     return `
       font-weight: ${fontWeights?.semibold};
-      margin-top: ${spacings?.xs}px;
+      margin-top: ${spaces?.xs}px;
       margin-left: 0px;
       padding-left: 0px;
     `;

--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -33,22 +33,22 @@ export const RowContent = styled("div", {
   ${(props: ExtraProps) => {
     const { header } = props;
     const align = header?.align ?? "left";
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       justify-content: ${align};
-      padding: ${spacings?.l}px 0;
-      margin-right: ${spacings?.m}px;
+      padding: ${spaces?.l}px 0;
+      margin-right: ${spaces?.m}px;
   `;
   }}
 `;
 
 export const icon = (props: Props): string => {
   const colors = getColors(props);
-  const spacings = getSpaces(props);
+  const spaces = getSpaces(props);
 
   return `
-    margin: 0 ${spacings?.l}px;
+    margin: 0 ${spaces?.l}px;
     fill: ${colors?.gray[500]};
   `;
 };
@@ -72,13 +72,13 @@ export const HeaderCheckbox = styled(Checkbox)`
     }
   }
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-      padding-right: ${spacings?.l}px;
-      padding-left: ${spacings?.m}px;
-      padding-bottom: ${spacings?.l}px;
+      padding-right: ${spaces?.l}px;
+      padding-left: ${spaces?.m}px;
+      padding-bottom: ${spaces?.l}px;
       &.MuiCheckbox-indeterminate {
         color: ${colors?.primary[500]};
       }

--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Checkbox, fontHeaderXs, getColors, getSpacings, Props } from "czifui";
+import { Checkbox, fontHeaderXs, getColors, getSpaces, Props } from "czifui";
 
 export const TableRow = styled.div`
   display: flex;
@@ -33,7 +33,7 @@ export const RowContent = styled("div", {
   ${(props: ExtraProps) => {
     const { header } = props;
     const align = header?.align ?? "left";
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       justify-content: ${align};
@@ -45,7 +45,7 @@ export const RowContent = styled("div", {
 
 export const icon = (props: Props): string => {
   const colors = getColors(props);
-  const spacings = getSpacings(props);
+  const spacings = getSpaces(props);
 
   return `
     margin: 0 ${spacings?.l}px;
@@ -72,7 +72,7 @@ export const HeaderCheckbox = styled(Checkbox)`
     }
   }
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
 
     return `

--- a/src/frontend/src/common/styles/support/style.ts
+++ b/src/frontend/src/common/styles/support/style.ts
@@ -82,11 +82,11 @@ export const IconButtonBubble = styled(Button)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       fill: ${colors?.gray[300]};
-      margin: ${spacings?.xxxs}px;
-      padding: ${spacings?.xs}px;
+      margin: ${spaces?.xxxs}px;
+      padding: ${spaces?.xs}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/styles/support/style.ts
+++ b/src/frontend/src/common/styles/support/style.ts
@@ -8,7 +8,7 @@ import {
   fontHeaderXxl,
   getColors,
   getFontWeights,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 
 export const NarrowContainer = styled.div`
@@ -82,7 +82,7 @@ export const IconButtonBubble = styled(Button)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       fill: ${colors?.gray[300]};
       margin: ${spacings?.xxxs}px;

--- a/src/frontend/src/components/AcknowledgePolicyChanges/style.ts
+++ b/src/frontend/src/components/AcknowledgePolicyChanges/style.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import CloseIcon from "@material-ui/icons/Close";
-import { fontBodyS, getColors, getIconSizes, getSpacings } from "czifui";
+import { fontBodyS, getColors, getIconSizes, getSpaces } from "czifui";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import IconInfo from "src/common/icons/IconInfo.svg";
 
@@ -14,7 +14,7 @@ export const Container = styled.div`
   align-items: center;
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       background-color: ${colors?.primary[400]};
       padding: ${spacings?.s}px ${spacings?.l}px;
@@ -27,7 +27,7 @@ export const StyledIconInfo = styled(IconInfo)`
   vertical-align: middle;
   ${(props) => {
     const iconSizes = getIconSizes(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       width: ${iconSizes?.l.width}px;
       height: ${iconSizes?.l.height}px;
@@ -72,7 +72,7 @@ export const StyledCloseIcon = styled(CloseIcon)`
   ${(props) => {
     const colors = getColors(props);
     const iconSizes = getIconSizes(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       width: ${iconSizes?.l.width}px;
       height: ${iconSizes?.l.height}px;

--- a/src/frontend/src/components/AcknowledgePolicyChanges/style.ts
+++ b/src/frontend/src/components/AcknowledgePolicyChanges/style.ts
@@ -14,10 +14,10 @@ export const Container = styled.div`
   align-items: center;
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       background-color: ${colors?.primary[400]};
-      padding: ${spacings?.s}px ${spacings?.l}px;
+      padding: ${spaces?.s}px ${spaces?.l}px;
     `;
   }}
 `;
@@ -27,11 +27,11 @@ export const StyledIconInfo = styled(IconInfo)`
   vertical-align: middle;
   ${(props) => {
     const iconSizes = getIconSizes(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       width: ${iconSizes?.l.width}px;
       height: ${iconSizes?.l.height}px;
-      margin-right: ${spacings?.m}px;
+      margin-right: ${spaces?.m}px;
     `;
   }}
 `;
@@ -72,11 +72,11 @@ export const StyledCloseIcon = styled(CloseIcon)`
   ${(props) => {
     const colors = getColors(props);
     const iconSizes = getIconSizes(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       width: ${iconSizes?.l.width}px;
       height: ${iconSizes?.l.height}px;
-      margin-left: ${spacings?.m}px;
+      margin-left: ${spaces?.m}px;
       &:hover {
         color: ${colors?.primary[300]};
         cursor: pointer;

--- a/src/frontend/src/components/Circle.ts
+++ b/src/frontend/src/components/Circle.ts
@@ -14,12 +14,12 @@ export const Circle = styled.div`
   ${(props) => {
     const colors = getColors(props);
     const corners = getCorners(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       background-color: ${colors?.primary[400]};
       border-radius: ${corners?.l}px;
-      margin-bottom: ${spacings?.xs}px;
+      margin-bottom: ${spaces?.xs}px;
     `;
   }}
 `;

--- a/src/frontend/src/components/Circle.ts
+++ b/src/frontend/src/components/Circle.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { getColors, getCorners, getSpacings } from "czifui";
+import { getColors, getCorners, getSpaces } from "czifui";
 
 export const Circle = styled.div`
   display: flex;
@@ -14,7 +14,7 @@ export const Circle = styled.div`
   ${(props) => {
     const colors = getColors(props);
     const corners = getCorners(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       background-color: ${colors?.primary[400]};

--- a/src/frontend/src/components/ConfirmDialog/style.ts
+++ b/src/frontend/src/components/ConfirmDialog/style.ts
@@ -12,10 +12,10 @@ export const Title = styled.div`
   ${fontHeaderL}
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.xxxs}px;
+      margin-bottom: ${spaces?.xxxs}px;
     `;
   }}
 `;
@@ -30,11 +30,11 @@ export const StyledFooter = styled.div`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
-      padding: 0 ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xxl}px;
-      margin: -${(spacings?.s || 0) + (spacings?.xl || 0)}px 0 0 0;
+      padding: 0 ${spaces?.xxl}px ${spaces?.xxl}px ${spaces?.xxl}px;
+      margin: -${(spaces?.s || 0) + (spaces?.xl || 0)}px 0 0 0;
     `;
   }}
 `;

--- a/src/frontend/src/components/ConfirmDialog/style.ts
+++ b/src/frontend/src/components/ConfirmDialog/style.ts
@@ -4,7 +4,7 @@ import {
   fontBodyXxs,
   fontHeaderL,
   getColors,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 import { narrow } from "src/common/components/library/Dialog/components/common";
 
@@ -12,7 +12,7 @@ export const Title = styled.div`
   ${fontHeaderL}
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.xxxs}px;
@@ -30,7 +30,7 @@ export const StyledFooter = styled.div`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       color: ${colors?.gray[500]};
       padding: 0 ${spacings?.xxl}px ${spacings?.xxl}px ${spacings?.xxl}px;

--- a/src/frontend/src/components/DateField/style.ts
+++ b/src/frontend/src/components/DateField/style.ts
@@ -4,10 +4,10 @@ import { getSpaces } from "czifui";
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      width: ${(spacings?.l || 0) + 120}px;
+      width: ${(spaces?.l || 0) + 120}px;
       margin: 0;
     `;
   }}

--- a/src/frontend/src/components/DateField/style.ts
+++ b/src/frontend/src/components/DateField/style.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 import TextField from "@material-ui/core/TextField";
-import { getSpacings } from "czifui";
+import { getSpaces } from "czifui";
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       width: ${(spacings?.l || 0) + 120}px;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -5,7 +5,7 @@ import {
   fontBodyXxxs,
   getColors,
   getFontWeights,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 
 export const StyledDateRange = styled.div`
@@ -16,7 +16,7 @@ export const StyledDateRange = styled.div`
 export const StyledManualDate = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       border-bottom: 1px solid ${colors?.gray[200]};
       padding-bottom: ${(spacings?.xxs ?? 0) + (spacings?.m ?? 0)}px;
@@ -31,7 +31,7 @@ export const StyledText = styled.span`
   ${fontBodyXs}
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       font-weight: ${fontWeights?.semibold};
       margin: 0 ${spacings?.xs}px;
@@ -41,7 +41,7 @@ export const StyledText = styled.span`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-top: ${spacings?.xs}px;
     `;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -16,13 +16,13 @@ export const StyledDateRange = styled.div`
 export const StyledManualDate = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       border-bottom: 1px solid ${colors?.gray[200]};
-      padding-bottom: ${(spacings?.xxs ?? 0) + (spacings?.m ?? 0)}px;
-      padding-top: ${spacings?.m}px;
-      padding-right: ${spacings?.xxs}px;
-      padding-left: ${spacings?.xxs}px;
+      padding-bottom: ${(spaces?.xxs ?? 0) + (spaces?.m ?? 0)}px;
+      padding-top: ${spaces?.m}px;
+      padding-right: ${spaces?.xxs}px;
+      padding-left: ${spaces?.xxs}px;
     `;
   }}
 `;
@@ -31,19 +31,19 @@ export const StyledText = styled.span`
   ${fontBodyXs}
   ${(props) => {
     const fontWeights = getFontWeights(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       font-weight: ${fontWeights?.semibold};
-      margin: 0 ${spacings?.xs}px;
+      margin: 0 ${spaces?.xs}px;
     `;
   }}
 `;
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-top: ${spacings?.xs}px;
+      margin-top: ${spaces?.xs}px;
     `;
   }}
 `;

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -22,11 +22,11 @@ export const StyledFilterPanel = styled("div", {
   ${(props: ExtraProps) => {
     const { isOpen } = props;
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      border-right: ${spacings?.xxxs}px ${colors?.gray[200]} solid;
+      border-right: ${spaces?.xxxs}px ${colors?.gray[200]} solid;
       display: ${isOpen ? "block" : "none"};
-      padding: ${spacings?.xl}px;
+      padding: ${spaces?.xl}px;
       width: 240px;
     `;
   }}
@@ -40,9 +40,9 @@ export const StyledInputDropdown = styled(InputDropdown)`
 
 export const StyledFilterWrapper = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin: ${spacings?.l}px 0;
+      margin: ${spaces?.l}px 0;
 
       &:first-child {
         margin: 0;
@@ -53,18 +53,18 @@ export const StyledFilterWrapper = styled.div`
 
 export const StyledChip = styled(Chip)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin: ${spacings?.xxs}px ${spacings?.xxs}px 0 0;
+      margin: ${spaces?.xxs}px ${spaces?.xxs}px 0 0;
     `;
   }}
 `;
 
 export const StyledComplexFilter = styled(ComplexFilter)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin: ${spacings?.l}px 0;
+      margin: ${spaces?.l}px 0;
       width: 200px;
       }
     `;

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -4,7 +4,7 @@ import {
   ComplexFilter,
   fontCapsXxxs,
   getColors,
-  getSpacings,
+  getSpaces,
   InputDropdown,
   Props,
 } from "czifui";
@@ -22,7 +22,7 @@ export const StyledFilterPanel = styled("div", {
   ${(props: ExtraProps) => {
     const { isOpen } = props;
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       border-right: ${spacings?.xxxs}px ${colors?.gray[200]} solid;
       display: ${isOpen ? "block" : "none"};
@@ -40,7 +40,7 @@ export const StyledInputDropdown = styled(InputDropdown)`
 
 export const StyledFilterWrapper = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin: ${spacings?.l}px 0;
 
@@ -53,7 +53,7 @@ export const StyledFilterWrapper = styled.div`
 
 export const StyledChip = styled(Chip)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin: ${spacings?.xxs}px ${spacings?.xxs}px 0 0;
     `;
@@ -62,7 +62,7 @@ export const StyledChip = styled(Chip)`
 
 export const StyledComplexFilter = styled(ComplexFilter)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin: ${spacings?.l}px 0;
       width: 200px;

--- a/src/frontend/src/components/Instructions/style.ts
+++ b/src/frontend/src/components/Instructions/style.ts
@@ -4,11 +4,11 @@ import { fontHeaderXs, getColors, getSpaces } from "czifui";
 export const Wrapper = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[100]};
-      padding: ${spacings?.xl}px;
+      padding: ${spaces?.xl}px;
     `;
   }}
 `;
@@ -17,9 +17,9 @@ export const Title = styled.div`
   ${fontHeaderXs}
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-bottom: ${spacings?.xxs}px;
+      margin-bottom: ${spaces?.xxs}px;
     `;
   }}
 `;

--- a/src/frontend/src/components/Instructions/style.ts
+++ b/src/frontend/src/components/Instructions/style.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
-import { fontHeaderXs, getColors, getSpacings } from "czifui";
+import { fontHeaderXs, getColors, getSpaces } from "czifui";
 
 export const Wrapper = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[100]};
@@ -17,7 +17,7 @@ export const Title = styled.div`
   ${fontHeaderXs}
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-bottom: ${spacings?.xxs}px;
     `;

--- a/src/frontend/src/components/NavBar/components/RightNav/style.ts
+++ b/src/frontend/src/components/NavBar/components/RightNav/style.ts
@@ -6,11 +6,11 @@ export const UploadButton = styled(Button)`
   border: 1px solid white;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-      margin-right: ${spacings?.xl}px;
+      margin-right: ${spaces?.xl}px;
 
       &:hover {
         color: black;

--- a/src/frontend/src/components/NavBar/components/RightNav/style.ts
+++ b/src/frontend/src/components/NavBar/components/RightNav/style.ts
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
-import { Button, getColors, getSpacings } from "czifui";
+import { Button, getColors, getSpaces } from "czifui";
 
 export const UploadButton = styled(Button)`
   color: white;
   border: 1px solid white;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
 
     return `

--- a/src/frontend/src/components/NavBar/style.ts
+++ b/src/frontend/src/components/NavBar/style.ts
@@ -6,10 +6,10 @@ export const Logo = styled(LogoImage)`
   height: 25px;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-right: ${spacings?.l}px;
+      margin-right: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/components/NavBar/style.ts
+++ b/src/frontend/src/components/NavBar/style.ts
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
-import { getSpacings } from "czifui";
+import { getSpaces } from "czifui";
 import LogoImage from "src/common/images/logo.svg";
 
 export const Logo = styled(LogoImage)`
   height: 25px;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-right: ${spacings?.l}px;

--- a/src/frontend/src/views/AgreeTerms/style.tsx
+++ b/src/frontend/src/views/AgreeTerms/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontBodyS, fontHeaderXl, getSpacings } from "czifui";
+import { fontBodyS, fontHeaderXl, getSpaces } from "czifui";
 
 export const Title = styled.div`
   ${fontHeaderXl}
@@ -9,7 +9,7 @@ export const Details = styled.p`
   ${fontBodyS}
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-top: ${spacings?.xl}px;

--- a/src/frontend/src/views/AgreeTerms/style.tsx
+++ b/src/frontend/src/views/AgreeTerms/style.tsx
@@ -9,10 +9,10 @@ export const Details = styled.p`
   ${fontBodyS}
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-top: ${spacings?.xl}px;
+      margin-top: ${spaces?.xl}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Data/components/FilterPanelToggle/style.ts
+++ b/src/frontend/src/views/Data/components/FilterPanelToggle/style.ts
@@ -10,10 +10,10 @@ export const StyledDiv = styled.div`
   position: relative;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin: ${spacings?.s}px ${spacings?.l}px;
+      margin: ${spaces?.s}px ${spaces?.l}px;
     `;
   }}
 

--- a/src/frontend/src/views/Data/components/FilterPanelToggle/style.ts
+++ b/src/frontend/src/views/Data/components/FilterPanelToggle/style.ts
@@ -54,7 +54,7 @@ export const StyledBadge = styled.div`
   }}
 `;
 
-// TODO (mlila): get these spacings from czifui
+// TODO (mlila): get these spaces from czifui
 export const tooltipStyles = css`
   margin: 0;
   padding: 8px 14px !important;

--- a/src/frontend/src/views/Data/components/FilterPanelToggle/style.ts
+++ b/src/frontend/src/views/Data/components/FilterPanelToggle/style.ts
@@ -1,6 +1,6 @@
 import { css } from "@emotion/css";
 import styled from "@emotion/styled";
-import { fontHeaderXxxs, getColors, getCorners, getSpacings } from "czifui";
+import { fontHeaderXxxs, getColors, getCorners, getSpaces } from "czifui";
 
 export const StyledDiv = styled.div`
   display: flex;
@@ -10,7 +10,7 @@ export const StyledDiv = styled.div`
   position: relative;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin: ${spacings?.s}px ${spacings?.l}px;

--- a/src/frontend/src/views/Data/components/LineageTooltip/style.ts
+++ b/src/frontend/src/views/Data/components/LineageTooltip/style.ts
@@ -10,10 +10,10 @@ export const Label = styled.span`
   ${fontHeaderXs}
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-right: ${spacings?.m}px;
+      margin-right: ${spaces?.m}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Data/components/LineageTooltip/style.ts
+++ b/src/frontend/src/views/Data/components/LineageTooltip/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontBodyXs, fontHeaderXs, getSpacings } from "czifui";
+import { fontBodyXs, fontHeaderXs, getSpaces } from "czifui";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -10,7 +10,7 @@ export const Label = styled.span`
   ${fontHeaderXs}
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-right: ${spacings?.m}px;

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/style.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
-import { Chip, getSpacings } from "czifui";
+import { Chip, getSpaces } from "czifui";
 
 export const StyledChip = styled(Chip)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin: 0 ${spacings?.xs}px;

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/components/PhyloTreeStatusTag/style.ts
@@ -3,10 +3,10 @@ import { Chip, getSpaces } from "czifui";
 
 export const StyledChip = styled(Chip)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin: 0 ${spacings?.xs}px;
+      margin: 0 ${spaces?.xs}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { getColors, getSpacings, Props } from "czifui";
+import { getColors, getSpaces, Props } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import OpenInNewIcon from "src/common/icons/OpenInNew.svg";
 import { icon } from "../../../../common/components/library/data_table/style";
@@ -17,7 +17,7 @@ export const StyledOpenInNewIcon = styled(OpenInNewIcon, {
   flex: 0 0 auto;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin: 0 0 0 ${spacings?.l}px;
     `;

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -17,9 +17,9 @@ export const StyledOpenInNewIcon = styled(OpenInNewIcon, {
   flex: 0 0 auto;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin: 0 0 0 ${spacings?.l}px;
+      margin: 0 0 0 ${spaces?.l}px;
     `;
   }}
 

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Chip, fontBodyXxs, getColors, getSpacings } from "czifui";
+import { Chip, fontBodyXxs, getColors, getSpaces } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import { PageContent } from "src/common/styles/mixins/global";
 
@@ -40,7 +40,7 @@ export const UnderlinedRowContent = styled(RowContent)`
 
 export const StyledChip = styled(Chip)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-top: ${spacings?.xxs}px;

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -40,10 +40,10 @@ export const UnderlinedRowContent = styled(RowContent)`
 
 export const StyledChip = styled(Chip)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-top: ${spacings?.xxs}px;
+      margin-top: ${spaces?.xxs}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Homepage/style.ts
+++ b/src/frontend/src/views/Homepage/style.ts
@@ -30,12 +30,12 @@ export const Card = styled.div`
 
   ${(props) => {
     const shadows = getShadows(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       height: 360px;
       width: 400px;
-      padding: ${spacings?.xxl}px ${spacings?.xl}px ${spacings?.xxl}px ${spacings?.xxl}px;
+      padding: ${spaces?.xxl}px ${spaces?.xl}px ${spaces?.xxl}px ${spaces?.xxl}px;
       box-shadow: ${shadows?.s};
     `;
   }}
@@ -67,10 +67,10 @@ export const Content = styled.div`
   ${fontBodyM}
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.xl}px;
+      margin-bottom: ${spaces?.xl}px;
     `;
   }}
 `;
@@ -129,9 +129,9 @@ export const FooterButtonContainer = styled.div`
 `;
 
 function marginBottom(props: { theme?: AppThemeOptions }) {
-  const spacings = getSpaces(props);
+  const spaces = getSpaces(props);
 
   return `
-      margin-bottom: ${spacings?.s}px;
+      margin-bottom: ${spaces?.s}px;
     `;
 }

--- a/src/frontend/src/views/Homepage/style.ts
+++ b/src/frontend/src/views/Homepage/style.ts
@@ -7,7 +7,7 @@ import {
   fontHeaderXxl,
   getColors,
   getShadows,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 import { PageContent } from "src/common/styles/mixins/global";
 import ConsensusGenomes from "./ConsensusGenomes.svg";
@@ -30,7 +30,7 @@ export const Card = styled.div`
 
   ${(props) => {
     const shadows = getShadows(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       height: 360px;
@@ -67,7 +67,7 @@ export const Content = styled.div`
   ${fontBodyM}
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.xl}px;
@@ -129,7 +129,7 @@ export const FooterButtonContainer = styled.div`
 `;
 
 function marginBottom(props: { theme?: AppThemeOptions }) {
-  const spacings = getSpacings(props);
+  const spacings = getSpaces(props);
 
   return `
       margin-bottom: ${spacings?.s}px;

--- a/src/frontend/src/views/Privacy/style.ts
+++ b/src/frontend/src/views/Privacy/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontBodyS, fontHeaderS, getColors, getSpacings } from "czifui";
+import { fontBodyS, fontHeaderS, getColors, getSpaces } from "czifui";
 
 export const Table = styled.table`
   margin: 25px 0px;
@@ -13,7 +13,7 @@ export const Table = styled.table`
     text-align: left;
 
     ${(props) => {
-      const spacings = getSpacings(props);
+      const spacings = getSpaces(props);
       const colors = getColors(props);
 
       return `

--- a/src/frontend/src/views/Privacy/style.ts
+++ b/src/frontend/src/views/Privacy/style.ts
@@ -13,11 +13,11 @@ export const Table = styled.table`
     text-align: left;
 
     ${(props) => {
-      const spacings = getSpaces(props);
+      const spaces = getSpaces(props);
       const colors = getColors(props);
 
       return `
-        padding: ${spacings?.m}px 15px;
+        padding: ${spaces?.m}px 15px;
         border: 1px solid ${colors?.gray[300]};
       `;
     }}

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/style.ts
@@ -5,11 +5,11 @@ import DownloadTemplate from "../DownloadTemplate";
 export const Wrapper = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[100]};
-      padding: ${spacings?.xl}px;
+      padding: ${spaces?.xl}px;
     `;
   }}
 `;
@@ -18,10 +18,10 @@ export const Title = styled.div`
   ${fontHeaderXs}
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.xxs}px;
+      margin-bottom: ${spaces?.xxs}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/style.ts
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
-import { fontBodyXs, fontHeaderXs, getColors, getSpacings } from "czifui";
+import { fontBodyXs, fontHeaderXs, getColors, getSpaces } from "czifui";
 import DownloadTemplate from "../DownloadTemplate";
 
 export const Wrapper = styled.div`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[100]};
@@ -18,7 +18,7 @@ export const Title = styled.div`
   ${fontHeaderXs}
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.xxs}px;

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/style.ts
@@ -10,10 +10,10 @@ export const TitleWrapper = styled.div`
   align-items: center;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.s}px;
+      margin-bottom: ${spaces?.s}px;
     `;
   }}
 `;
@@ -23,20 +23,20 @@ export const IntroWrapper = styled.div`
   flex-direction: column;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.l}px;
+      margin-bottom: ${spaces?.l}px;
     `;
   }}
 `;
 
 export const Wrapper = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.xxl}px;
+      margin-bottom: ${spaces?.xxl}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontHeaderL, getSpacings } from "czifui";
+import { fontHeaderL, getSpaces } from "czifui";
 
 export const Title = styled.span`
   ${fontHeaderL}
@@ -10,7 +10,7 @@ export const TitleWrapper = styled.div`
   align-items: center;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.s}px;
@@ -23,7 +23,7 @@ export const IntroWrapper = styled.div`
   flex-direction: column;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.l}px;
@@ -33,7 +33,7 @@ export const IntroWrapper = styled.div`
 
 export const Wrapper = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.xxl}px;

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/style.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 import TextField from "@material-ui/core/TextField";
-import { getSpacings, Props } from "czifui";
+import { getSpaces, Props } from "czifui";
 
 export const StyledTextField = styled(TextField)`
   ${(props: Props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       width: ${(spacings?.l || 0) + 200}px;

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/FreeTextField/style.ts
@@ -4,11 +4,11 @@ import { getSpaces, Props } from "czifui";
 
 export const StyledTextField = styled(TextField)`
   ${(props: Props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      width: ${(spacings?.l || 0) + 200}px;
-      padding-right: ${spacings?.l}px;
+      width: ${(spaces?.l || 0) + 200}px;
+      padding-right: ${spaces?.l}px;
       margin: 0;
     `;
   }}

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/style.ts
@@ -4,11 +4,11 @@ import { fontBodyXxs, getColors, getSpaces } from "czifui";
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      min-width: ${(spacings?.l || 0) + 195}px;
-      padding-right: ${spacings?.l}px;
+      min-width: ${(spaces?.l || 0) + 195}px;
+      padding-right: ${spaces?.l}px;
       margin: 0;
     `;
   }}

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/style.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 import TextField from "@material-ui/core/TextField";
-import { fontBodyXxs, getColors, getSpacings } from "czifui";
+import { fontBodyXxs, getColors, getSpaces } from "czifui";
 
 export const StyledTextField = styled(TextField)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       min-width: ${(spacings?.l || 0) + 195}px;

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/style.ts
@@ -21,10 +21,10 @@ export const Id = styled.div`
   flex-direction: column;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.m}px 0 ${spacings?.m}px ${spacings?.s}px
+      padding: ${spaces?.m}px 0 ${spaces?.m}px ${spaces?.s}px
     `;
   }}
 `;
@@ -47,21 +47,21 @@ export const StyledTableRow = styled(TableRow)`
 
 export const StyledTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
     `;
   }}
 `;
 
 export const IsPrivateTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
       border-left: solid 2px ${colors?.gray[200]};
       border-right: solid 2px ${colors?.gray[200]};
     `;
@@ -70,10 +70,10 @@ export const IsPrivateTableCell = styled(TableCell)`
 
 export const StyledDiv = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding-right: ${spacings?.l}px;
+      padding-right: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/style.ts
@@ -7,7 +7,7 @@ import {
 import {
   fontHeaderS,
   getColors,
-  getSpacings,
+  getSpaces,
   Props as CzifuiProps,
 } from "czifui";
 
@@ -21,7 +21,7 @@ export const Id = styled.div`
   flex-direction: column;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.m}px 0 ${spacings?.m}px ${spacings?.s}px
@@ -47,7 +47,7 @@ export const StyledTableRow = styled(TableRow)`
 
 export const StyledTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.m}px 0;
@@ -57,7 +57,7 @@ export const StyledTableCell = styled(TableCell)`
 
 export const IsPrivateTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
 
     return `
@@ -70,7 +70,7 @@ export const IsPrivateTableCell = styled(TableCell)`
 
 export const StyledDiv = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding-right: ${spacings?.l}px;

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/style.ts
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { TableCell, TableContainer, TableRow } from "@material-ui/core";
-import { fontBodyM, fontHeaderXs, getColors, getSpacings } from "czifui";
+import { fontBodyM, fontHeaderXs, getColors, getSpaces } from "czifui";
 
 export const Overflow = styled.div`
   overflow: auto;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding-bottom: ${spacings?.m}px;
@@ -21,7 +21,7 @@ export const StyledTableContainer = styled(TableContainer)`
 
 export const IdColumn = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding-left: ${spacings?.s}px;
@@ -34,7 +34,7 @@ export const StyledTableCell = styled(TableCell)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       color: ${colors?.gray[500]};
@@ -47,7 +47,7 @@ export const StyledTableCell = styled(TableCell)`
 export const IsPrivateTableCell = styled(StyledTableCell)`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.l}px ${spacings?.l}px;
@@ -59,7 +59,7 @@ export const IsPrivateTableCell = styled(StyledTableCell)`
 
 export const SubmittedToGisaidTableCell = styled(StyledTableCell)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.l}px;

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/style.ts
@@ -6,11 +6,11 @@ export const Overflow = styled.div`
   overflow: auto;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding-bottom: ${spacings?.m}px;
-      margin-bottom: ${spacings?.xxl}px;
+      padding-bottom: ${spaces?.m}px;
+      margin-bottom: ${spaces?.xxl}px;
     `;
   }}
 `;
@@ -21,10 +21,10 @@ export const StyledTableContainer = styled(TableContainer)`
 
 export const IdColumn = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding-left: ${spacings?.s}px;
+      padding-left: ${spaces?.s}px;
     `;
   }}
 `;
@@ -34,11 +34,11 @@ export const StyledTableCell = styled(TableCell)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       color: ${colors?.gray[500]};
-      padding: ${spacings?.l}px ${spacings?.l}px ${spacings?.l}px 0;
+      padding: ${spaces?.l}px ${spaces?.l}px ${spaces?.l}px 0;
       border-bottom: solid 2px ${colors?.gray[200]};
     `;
   }}
@@ -47,10 +47,10 @@ export const StyledTableCell = styled(TableCell)`
 export const IsPrivateTableCell = styled(StyledTableCell)`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.l}px ${spacings?.l}px;
+      padding: ${spaces?.l}px ${spaces?.l}px;
       border-left: solid 2px ${colors?.gray[200]};
       border-right: solid 2px ${colors?.gray[200]};
     `;
@@ -59,10 +59,10 @@ export const IsPrivateTableCell = styled(StyledTableCell)`
 
 export const SubmittedToGisaidTableCell = styled(StyledTableCell)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.l}px;
+      padding: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Review/components/Table/components/Row/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Table/components/Row/style.ts
@@ -22,10 +22,10 @@ export const Id = styled.div`
   flex-direction: column;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.m}px 0 ${spacings?.m}px ${spacings?.s}px
+      padding: ${spaces?.m}px 0 ${spaces?.m}px ${spaces?.s}px
     `;
   }}
 `;
@@ -48,21 +48,21 @@ export const StyledTableRow = styled(TableRow)`
 
 export const StyledTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
     `;
   }}
 `;
 
 export const IsPrivateTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
       border-left: solid 2px ${colors?.gray[200]};
       border-right: solid 2px ${colors?.gray[200]};
     `;
@@ -78,10 +78,10 @@ export const IsPrivateContent = styled.div`
 
 export const StyledLock = styled(Lock)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-right: ${spacings?.xs}px;
+      margin-right: ${spaces?.xs}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Review/components/Table/components/Row/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Table/components/Row/style.ts
@@ -8,7 +8,7 @@ import { Lock } from "@material-ui/icons";
 import {
   fontHeaderS,
   getColors,
-  getSpacings,
+  getSpaces,
   Props as CzifuiProps,
 } from "czifui";
 
@@ -22,7 +22,7 @@ export const Id = styled.div`
   flex-direction: column;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.m}px 0 ${spacings?.m}px ${spacings?.s}px
@@ -48,7 +48,7 @@ export const StyledTableRow = styled(TableRow)`
 
 export const StyledTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.m}px 0;
@@ -58,7 +58,7 @@ export const StyledTableCell = styled(TableCell)`
 
 export const IsPrivateTableCell = styled(TableCell)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
 
     return `
@@ -78,7 +78,7 @@ export const IsPrivateContent = styled.div`
 
 export const StyledLock = styled(Lock)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-right: ${spacings?.xs}px;

--- a/src/frontend/src/views/Upload/components/Review/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Table/style.ts
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { TableCell, TableContainer, TableRow } from "@material-ui/core";
-import { fontHeaderXs, getColors, getSpacings } from "czifui";
+import { fontHeaderXs, getColors, getSpaces } from "czifui";
 
 export const Overflow = styled.div`
   overflow: auto;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding-bottom: ${spacings?.m}px;
@@ -21,7 +21,7 @@ export const StyledTableContainer = styled(TableContainer)`
 
 export const IdColumn = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding-left: ${spacings?.s}px;
@@ -34,7 +34,7 @@ export const StyledTableCell = styled(TableCell)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       color: ${colors?.gray[500]};
@@ -47,7 +47,7 @@ export const StyledTableCell = styled(TableCell)`
 export const IsPrivateTableCell = styled(StyledTableCell)`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.l}px 0;
@@ -59,7 +59,7 @@ export const IsPrivateTableCell = styled(StyledTableCell)`
 
 export const SubmittedToGisaidTableCell = styled(StyledTableCell)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       padding: ${spacings?.l}px;

--- a/src/frontend/src/views/Upload/components/Review/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Table/style.ts
@@ -6,11 +6,11 @@ export const Overflow = styled.div`
   overflow: auto;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding-bottom: ${spacings?.m}px;
-      margin-bottom: ${spacings?.xxl}px;
+      padding-bottom: ${spaces?.m}px;
+      margin-bottom: ${spaces?.xxl}px;
     `;
   }}
 `;
@@ -21,10 +21,10 @@ export const StyledTableContainer = styled(TableContainer)`
 
 export const IdColumn = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding-left: ${spacings?.s}px;
+      padding-left: ${spaces?.s}px;
     `;
   }}
 `;
@@ -34,11 +34,11 @@ export const StyledTableCell = styled(TableCell)`
 
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
       color: ${colors?.gray[500]};
-      padding: ${spacings?.l}px ${spacings?.l}px ${spacings?.l}px 0;
+      padding: ${spaces?.l}px ${spaces?.l}px ${spaces?.l}px 0;
       border-bottom: solid 2px ${colors?.gray[200]};
     `;
   }}
@@ -47,10 +47,10 @@ export const StyledTableCell = styled(TableCell)`
 export const IsPrivateTableCell = styled(StyledTableCell)`
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.l}px 0;
+      padding: ${spaces?.l}px 0;
       border-left: solid 2px ${colors?.gray[200]};
       border-right: solid 2px ${colors?.gray[200]};
     `;
@@ -59,10 +59,10 @@ export const IsPrivateTableCell = styled(StyledTableCell)`
 
 export const SubmittedToGisaidTableCell = styled(StyledTableCell)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      padding: ${spacings?.l}px;
+      padding: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/style.ts
@@ -19,10 +19,10 @@ export const ImageWrapper = styled.div`
   justify-content: center;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-bottom: ${spacings?.xl}px;
+      margin-bottom: ${spaces?.xl}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontBodyS, fontHeaderXl, getColors, getSpacings } from "czifui";
+import { fontBodyS, fontHeaderXl, getColors, getSpaces } from "czifui";
 import DialogActions from "src/common/components/library/Dialog/components/DialogActions";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import UploadImage from "./Upload.svg";
@@ -19,7 +19,7 @@ export const ImageWrapper = styled.div`
   justify-content: center;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-bottom: ${spacings?.xl}px;

--- a/src/frontend/src/views/Upload/components/Samples/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Samples/components/Table/style.ts
@@ -11,9 +11,9 @@ import {
 export const Overflow = styled.div`
   overflow: auto;
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding-bottom: ${spacings?.m}px;
+      padding-bottom: ${spaces?.m}px;
     `;
   }}
 `;
@@ -26,11 +26,11 @@ export const StyledTableCell = styled(TableCell)`
   ${fontBodyXs}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
       border-bottom: solid 1px ${colors?.gray[200]};
-      margin-right: ${spacings?.m}px;
+      margin-right: ${spaces?.m}px;
     `;
   }}
 `;
@@ -38,10 +38,10 @@ export const StyledTableCell = styled(TableCell)`
 export const StyledHeaderTableCell = styled(TableCell)`
   ${fontHeaderXs}
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
       color: ${colors?.gray[400]};
       border-bottom: solid 2px ${colors?.gray[200]};
 
@@ -52,9 +52,9 @@ export const StyledHeaderTableCell = styled(TableCell)`
 export const StyledTableHead = styled(TableHead)`
   ${fontHeaderXs}
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      padding: ${spacings?.m}px 0;
+      padding: ${spaces?.m}px 0;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/Samples/components/Table/style.ts
+++ b/src/frontend/src/views/Upload/components/Samples/components/Table/style.ts
@@ -5,13 +5,13 @@ import {
   fontBodyXs,
   fontHeaderXs,
   getColors,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 
 export const Overflow = styled.div`
   overflow: auto;
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding-bottom: ${spacings?.m}px;
     `;
@@ -26,7 +26,7 @@ export const StyledTableCell = styled(TableCell)`
   ${fontBodyXs}
   ${(props) => {
     const colors = getColors(props);
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding: ${spacings?.m}px 0;
       border-bottom: solid 1px ${colors?.gray[200]};
@@ -38,7 +38,7 @@ export const StyledTableCell = styled(TableCell)`
 export const StyledHeaderTableCell = styled(TableCell)`
   ${fontHeaderXs}
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       padding: ${spacings?.m}px 0;
@@ -52,7 +52,7 @@ export const StyledHeaderTableCell = styled(TableCell)`
 export const StyledTableHead = styled(TableHead)`
   ${fontHeaderXs}
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       padding: ${spacings?.m}px 0;
     `;

--- a/src/frontend/src/views/Upload/components/Samples/style.ts
+++ b/src/frontend/src/views/Upload/components/Samples/style.ts
@@ -4,7 +4,7 @@ import {
   fontCapsXxs,
   fontHeaderXl,
   getColors,
-  getSpacings,
+  getSpaces,
 } from "czifui";
 import FilePicker from "src/components/FilePicker";
 import { marginBottom } from "../common/style";
@@ -15,7 +15,7 @@ export const SemiBold = styled.span`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-right: ${spacings?.s}px;
     `;
@@ -24,7 +24,7 @@ export const StyledButton = styled(Button)`
 
 export const StyledFilePicker = styled(FilePicker)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       margin-right: ${spacings?.m}px;
       margin-bottom: ${spacings?.s}px;
@@ -35,7 +35,7 @@ export const StyledFilePicker = styled(FilePicker)`
 
 export const StyledContainerLeft = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       flex: 1;
       display: flex;
@@ -48,7 +48,7 @@ export const StyledContainerLeft = styled.div`
 
 export const StyledContainerSpaceBetween = styled.div`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
       flex: 1;
       display: flex;
@@ -62,7 +62,7 @@ export const StyledContainerSpaceBetween = styled.div`
 export const StyledInstructionsButton = styled(Button)`
   ${fontCapsXxs}
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       margin-right: ${spacings?.s}px;
@@ -79,7 +79,7 @@ export const StyledInstructionsButton = styled(Button)`
 export const StyledRemoveAllButton = styled(Button)`
   ${fontCapsXxs}
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
     return `
       margin-right: ${spacings?.s}px;
@@ -94,7 +94,7 @@ export const StyledRemoveAllButton = styled(Button)`
 
 export const StyledUploadCount = styled.span`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     return `
     font-weight: 600;
     display: block;

--- a/src/frontend/src/views/Upload/components/Samples/style.ts
+++ b/src/frontend/src/views/Upload/components/Samples/style.ts
@@ -15,46 +15,46 @@ export const SemiBold = styled.span`
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-right: ${spacings?.s}px;
+      margin-right: ${spaces?.s}px;
     `;
   }}
 `;
 
 export const StyledFilePicker = styled(FilePicker)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
-      margin-right: ${spacings?.m}px;
-      margin-bottom: ${spacings?.s}px;
-      margin-top: ${spacings?.xl}px;
+      margin-right: ${spaces?.m}px;
+      margin-bottom: ${spaces?.s}px;
+      margin-top: ${spaces?.xl}px;
     `;
   }}
 `;
 
 export const StyledContainerLeft = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       flex: 1;
       display: flex;
       align-items: center;
       justify-content: left;
-      margin-bottom: ${spacings?.xs};
+      margin-bottom: ${spaces?.xs};
   `;
   }}
 `;
 
 export const StyledContainerSpaceBetween = styled.div`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
       flex: 1;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      margin-bottom: ${spacings?.m};
+      margin-bottom: ${spaces?.m};
     `;
   }}
 `;
@@ -62,12 +62,12 @@ export const StyledContainerSpaceBetween = styled.div`
 export const StyledInstructionsButton = styled(Button)`
   ${fontCapsXxs}
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      margin-right: ${spacings?.s}px;
-      margin-left: ${spacings?.m}px;
-      margin-top: ${spacings?.s}px;
+      margin-right: ${spaces?.s}px;
+      margin-left: ${spaces?.m}px;
+      margin-top: ${spaces?.s}px;
       &:hover {
         background-color: transparent;
         color: ${colors?.primary[500]};
@@ -79,11 +79,11 @@ export const StyledInstructionsButton = styled(Button)`
 export const StyledRemoveAllButton = styled(Button)`
   ${fontCapsXxs}
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      margin-right: ${spacings?.s}px;
-      margin-left: ${spacings?.s}px;
+      margin-right: ${spaces?.s}px;
+      margin-left: ${spaces?.s}px;
       &:hover {
         background-color: transparent;
         color: ${colors?.primary[500]};
@@ -94,12 +94,12 @@ export const StyledRemoveAllButton = styled(Button)`
 
 export const StyledUploadCount = styled.span`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     return `
     font-weight: 600;
     display: block;
-    margin-bottom: ${spacings?.xl}px;
-    margin-top: ${spacings?.xl}px;
+    margin-bottom: ${spaces?.xl}px;
+    margin-top: ${spaces?.xl}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Upload/components/common/style.ts
+++ b/src/frontend/src/views/Upload/components/common/style.ts
@@ -4,13 +4,13 @@ import {
   fontBodyS,
   fontHeaderXxl,
   getColors,
-  getSpacings,
+  getSpaces,
   Props,
 } from "czifui";
 import Instructions from "src/components/Instructions";
 
 export function marginBottom(props: Props): string {
-  const spacings = getSpacings(props);
+  const spacings = getSpaces(props);
 
   return `
       margin-bottom: ${spacings?.xl}px;
@@ -23,7 +23,7 @@ export const Header = styled.div`
   align-items: center;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
     const colors = getColors(props);
 
     return `
@@ -37,7 +37,7 @@ export const Content = styled.div`
   flex: 2;
 
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
         margin: ${spacings?.xxl}px 125px ${spacings?.l}px 125px;
@@ -63,7 +63,7 @@ export const StyledInstructions = styled(Instructions)`
 
 export const ContinueButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpacings(props);
+    const spacings = getSpaces(props);
 
     return `
       margin-right: ${spacings?.xs}px;

--- a/src/frontend/src/views/Upload/components/common/style.ts
+++ b/src/frontend/src/views/Upload/components/common/style.ts
@@ -10,10 +10,10 @@ import {
 import Instructions from "src/components/Instructions";
 
 export function marginBottom(props: Props): string {
-  const spacings = getSpaces(props);
+  const spaces = getSpaces(props);
 
   return `
-      margin-bottom: ${spacings?.xl}px;
+      margin-bottom: ${spaces?.xl}px;
     `;
 }
 
@@ -23,11 +23,11 @@ export const Header = styled.div`
   align-items: center;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-        padding: ${spacings?.xl}px 125px;
+        padding: ${spaces?.xl}px 125px;
         border-bottom: 5px solid ${colors?.gray[100]};
     `;
   }}
@@ -37,10 +37,10 @@ export const Content = styled.div`
   flex: 2;
 
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-        margin: ${spacings?.xxl}px 125px ${spacings?.l}px 125px;
+        margin: ${spaces?.xxl}px 125px ${spaces?.l}px 125px;
     `;
   }}
 `;
@@ -63,10 +63,10 @@ export const StyledInstructions = styled(Instructions)`
 
 export const ContinueButton = styled(Button)`
   ${(props) => {
-    const spacings = getSpaces(props);
+    const spaces = getSpaces(props);
 
     return `
-      margin-right: ${spacings?.xs}px;
+      margin-right: ${spaces?.xs}px;
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Resolves 1000s of warnings in the console about `getSpacings` vs `getSpaces`
- **Why:** `getSpacings` is going to be deprecated
- **Ticket:** [[sc-168693]](https://app.shortcut.com/genepi/story/168693)
- **Env:** https://spaces-frontend.dev.genepi.czi.technology

<img width="647" alt="1" src="https://user-images.githubusercontent.com/7562933/139144579-a9aeef24-6f13-45be-8501-ef7e21b46a43.png">

### Notes
You will actually still see some of these errors in the console because SDS has not removed all instances of `getSpacings` yet. Remaining warnings will be addressed once we pick up a newer version of SDS; see https://github.com/chanzuckerberg/sci-components/pull/86.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)