### PR TITLE
Improve perf for `happy list` command

### DIFF
--- a/.happy/requirements.txt
+++ b/.happy/requirements.txt
@@ -1,4 +1,4 @@
 click==7.1.2
 pyyaml==5.4.1
-terrasnek==0.1.2
+terrasnek==0.1.6
 boto3==1.17.47

--- a/scripts/happy
+++ b/scripts/happy
@@ -532,17 +532,15 @@ class TFEWorkspace:
         if self._outputs:
             return self._outputs
         try:
-            state_version = self.tfc.state_versions.get_current(self.workspace_id)
+            state_version = self.tfc.state_versions.get_current(self.workspace_id, include=["outputs"])
         except exceptions.TFCHTTPNotFound:
             return {}
         # terrasnek api lacks a way to append ?include=outputs to state_version requests,
         # so we have to iterate through all outputs and get them individually
         # TODO(mbarrien): Add code to Terrasnek
-        outputs = state_version["data"]["relationships"]["outputs"]["data"]
-        state_version_output_ids = (output["id"] for output in outputs)
+        outputs = (item.get("attributes") for item in state_version["included"] if item.get("type") == "state-version-outputs")
         self._outputs = {}
-        for state_version_output_id in state_version_output_ids:
-            state_version_output = self.tfc.state_version_outputs.show(state_version_output_id)["data"]["attributes"]
+        for state_version_output in outputs:
             if not state_version_output["sensitive"]:
                 key = state_version_output["name"]
                 value = state_version_output["value"]

--- a/scripts/happy
+++ b/scripts/happy
@@ -535,9 +535,6 @@ class TFEWorkspace:
             state_version = self.tfc.state_versions.get_current(self.workspace_id, include=["outputs"])
         except exceptions.TFCHTTPNotFound:
             return {}
-        # terrasnek api lacks a way to append ?include=outputs to state_version requests,
-        # so we have to iterate through all outputs and get them individually
-        # TODO(mbarrien): Add code to Terrasnek
         outputs = (item.get("attributes") for item in state_version["included"] if item.get("type") == "state-version-outputs")
         self._outputs = {}
         for state_version_output in outputs:


### PR DESCRIPTION
### Summary:
- **What:** We were having to make a request to TFE for every output associated with a TFE workspace. This PR upgrades terrasnek to the latest version, which supports fetching output data alongside workspace info with a single request. 

### Notes:
Once this PR is merged, engineers will need to run `/usr/bin/env/python3 -m pip install -r .happy/requirements.txt` to upgrade terrasnek.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)