### PR TITLE
use callout in usher modal

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/index.tsx
@@ -1,11 +1,6 @@
-import { Alert } from "czifui";
 import React from "react";
 import { pluralize } from "src/common/utils/strUtils";
-import {
-  AlertInstructionsNotSemiBold,
-  AlertInstructionsSemiBold,
-  StyledWarningIcon,
-} from "./style";
+import { SemiBold, StyledCallout } from "./style";
 
 interface Props {
   numFailedSamples: number;
@@ -15,17 +10,15 @@ const FailedSampleAlert = ({ numFailedSamples }: Props): JSX.Element | null => {
   if (numFailedSamples <= 0) return null;
 
   return (
-    <Alert icon={<StyledWarningIcon />} severity="warning">
-      <AlertInstructionsSemiBold>
+    <StyledCallout intent="warning">
+      <SemiBold>
         {" "}
         {numFailedSamples} Selected {pluralize("Sample", numFailedSamples)}
         {" won't "}
         be included in your tree{" "}
-      </AlertInstructionsSemiBold>
-      <AlertInstructionsNotSemiBold>
-        because they failed genome recovery.
-      </AlertInstructionsNotSemiBold>
-    </Alert>
+      </SemiBold>
+      because they failed genome recovery.
+    </StyledCallout>
   );
 };
 

--- a/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
@@ -1,19 +1,7 @@
 import styled from "@emotion/styled";
-import ErrorOutlineOutlinedIcon from "@material-ui/icons/ErrorOutlineOutlined";
-import {
-  fontBodyXxxs,
-  getFontWeights,
-  getIconSizes,
-  getSpacings,
-} from "czifui";
+import { Callout, getFontWeights, getSpaces } from "czifui";
 
-const AlertInstructionsCommon = `
-  ${fontBodyXxxs}
-  color: black;
-`;
-
-export const AlertInstructionsSemiBold = styled.span`
-  ${AlertInstructionsCommon}
+export const SemiBold = styled.span`
   ${(props) => {
     const fontWeights = getFontWeights(props);
     return `
@@ -22,18 +10,13 @@ export const AlertInstructionsSemiBold = styled.span`
   }}
 `;
 
-export const AlertInstructionsNotSemiBold = styled.span`
-  ${AlertInstructionsCommon}
-`;
+export const StyledCallout = styled(Callout)`
+  width: 100%;
 
-export const StyledWarningIcon = styled(ErrorOutlineOutlinedIcon)`
   ${(props) => {
-    const iconSizes = getIconSizes(props);
-    const spacings = getSpacings(props);
+    const spaces = getSpaces(props);
     return `
-      height: ${iconSizes?.s.height}px;
-      width: ${iconSizes?.s.width}px;
-      margin-top: ${spacings?.xxs}px;
+      margin: ${spaces?.xl}px 0;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@material-ui/core";
+import { Dialog, TextField } from "@material-ui/core";
 import { DefaultMenuSelectOption, Dropdown, InputDropdown } from "czifui";
 import { cloneDeep, debounce } from "lodash";
 import React, { SyntheticEvent, useEffect, useState } from "react";
@@ -30,6 +30,7 @@ import {
   StyledListItem,
   StyledSectionHeader,
   StyledSuggestionText,
+  StyledSuggestionWrapper,
   StyledTextField,
   StyledWarningIcon,
 } from "./style";
@@ -265,20 +266,22 @@ export const UsherPlacementModal = ({
                   <StyledInfoIcon />
                 </StyledTooltip>
               </StyledFieldTitleText>
-              <StyledTextField
-                id="outlined-basic"
-                variant="outlined"
-                defaultValue={defaultNumSamples}
-                onChange={onNumSamplesChange}
-              />
-              {shouldShowWarning && (
-                <FlexWrapper>
-                  <StyledWarningIcon />
-                  <StyledSuggestionText>
-                    We recommend a value no lower than 50.
-                  </StyledSuggestionText>
-                </FlexWrapper>
-              )}
+              <StyledTextField>
+                <TextField
+                  id="outlined-basic"
+                  variant="outlined"
+                  defaultValue={defaultNumSamples}
+                  onChange={onNumSamplesChange}
+                />
+                {shouldShowWarning && (
+                  <StyledSuggestionWrapper>
+                    <StyledWarningIcon />
+                    <StyledSuggestionText>
+                      We recommend a value no lower than 50.
+                    </StyledSuggestionText>
+                  </StyledSuggestionWrapper>
+                )}
+              </StyledTextField>
               <FailedSampleAlert numFailedSamples={failedSamples?.length} />
             </div>
             <StyledButton

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -1,6 +1,7 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import TextField from "@material-ui/core/TextField";
 import CloseIcon from "@material-ui/icons/Close";
+import ErrorOutlineOutlinedIcon from "@material-ui/icons/ErrorOutlineOutlined";
 import {
   Button,
   fontBodyXs,
@@ -8,6 +9,8 @@ import {
   fontHeaderM,
   fontHeaderXs,
   getColors,
+  getIconSizes,
+  getSpaces,
   getSpacings,
   InputDropdown,
   List,
@@ -17,7 +20,6 @@ import {
   StyledDialogContent as DialogContent,
   StyledInfoOutlinedIcon as InfoIcon,
 } from "../../../CreateNSTreeModal/style";
-import { StyledWarningIcon as WarningIcon } from "../../../FailedSampleAlert/style";
 
 const INPUT_HEIGHT = "34px";
 
@@ -83,23 +85,29 @@ export const StyledFieldTitleText = styled.div`
   }}
 `;
 
-export const StyledTextField = styled(TextField)`
+export const StyledTextField = styled.div`
+  .MuiInputBase-root {
+    height: ${INPUT_HEIGHT};
+    width: 150px;
+  }
+
   ${(props) => {
     const spacings = getSpacings(props);
     return `
       margin-bottom: ${spacings?.xl}px;
-      width: 150px;
-
-      .MuiInputBase-root {
-        height: ${INPUT_HEIGHT};
-      }
     `;
   }}
 `;
 
+const flex = () => {
+  return css`
+    display: flex;
+    align-items: center;
+  `;
+};
+
 export const FlexWrapper = styled.div`
-  display: flex;
-  align-items: center;
+  ${flex}
 `;
 
 export const StyledSuggestionText = styled.div`
@@ -116,12 +124,25 @@ export const StyledSuggestionText = styled.div`
   }}
 `;
 
-export const StyledWarningIcon = styled(WarningIcon)`
+export const StyledSuggestionWrapper = styled.div`
+  ${flex}
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.xxs}px;
+    `;
+  }}
+`;
+
+export const StyledWarningIcon = styled(ErrorOutlineOutlinedIcon)`
   ${(props) => {
     const colors = getColors(props);
+    const iconSizes = getIconSizes(props);
 
     return `
       color: ${colors?.warning[400]};
+      height: ${iconSizes?.s.height}px;
+      width: ${iconSizes?.s.width}px;
       margin-top: 0;
     `;
   }}

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -86,15 +86,15 @@ export const StyledFieldTitleText = styled.div`
 `;
 
 export const StyledTextField = styled.div`
-  .MuiInputBase-root {
-    height: ${INPUT_HEIGHT};
-    width: 150px;
-  }
-
   ${(props) => {
     const spacings = getSpacings(props);
     return `
       margin-bottom: ${spacings?.xl}px;
+
+      .MuiInputBase-root {
+        height: ${INPUT_HEIGHT};
+        width: 150px;
+      }
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Implement SDS `Callout` in aspen
- **Why:** Clean up task for usher
- **Ticket:** [[sc-164873]](https://app.shortcut.com/sci-design-system/story/164873/implement-callout-in-aspen)
- **Env:** https://callout-frontend.dev.genepi.czi.technology

### Demos
| Before | After |
|---|---|
| ![suggestionbefore](https://user-images.githubusercontent.com/7562933/139145454-6c7d123f-0c5f-4ee0-b479-da0863196752.png) | ![suggestionafter](https://user-images.githubusercontent.com/7562933/139145462-49d19a27-a919-4acd-bb6c-3a92f1387ccb.png) |
| ![calloutbefore](https://user-images.githubusercontent.com/7562933/139145555-20be4899-7098-473f-bf8c-a8c573246d4f.png) | ![calloutafter](https://user-images.githubusercontent.com/7562933/139145563-0a9e2e0e-1aee-47b5-a8be-94e678b2e365.png) |
|  ![bothbefore](https://user-images.githubusercontent.com/7562933/139145594-e7fd7f08-003f-4971-9727-023e46704dbe.png) | ![bothafter](https://user-images.githubusercontent.com/7562933/139145615-519009c7-7a0b-48b8-bf1c-a794cdf3d77f.png) |
| ![noneafter](https://user-images.githubusercontent.com/7562933/139145652-aecba0f0-0d8a-427b-b8d2-6b55a9e09fe7.png) | ![noneafter](https://user-images.githubusercontent.com/7562933/139145652-aecba0f0-0d8a-427b-b8d2-6b55a9e09fe7.png) |

### Notes
I also had to fix some of the styling for the existing callouts/inputs as a result of implementing the callout.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)