### PR TITLE
Add make command to update package-lock.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,13 @@ local-dbconsole: ## Connect to the local postgres database.
 local-dbconsole-profile: ## Connect to the local postgres database and profile queries.
 	docker-compose exec utility aspen-cli db --local interact --profile
 
-.PHONY: local-update-deps
-local-update-deps: ## Update poetry.lock to reflect pyproject.toml file changes.
+.PHONY: local-update-backend-deps
+local-update-backend-deps: ## Update poetry.lock to reflect pyproject.toml file changes.
 	docker-compose exec utility /opt/poetry/bin/poetry update
+
+.PHONY: local-update-frontend-deps
+local-update-frontend-deps: ## Update package-lock.json to reflect package.json file changes.
+	docker-compose exec frontend npm install
 
 ### ACCESSING CONTAINER MAKE COMMANDS ###################################################
 utility-%: ## Run make commands in the utility container (src/backend/Makefile)

--- a/docs/DEV_ENV.md
+++ b/docs/DEV_ENV.md
@@ -33,12 +33,13 @@ Both the frontend and backend services will automatically reload when their sour
 To update frontend changes:
 
 1. add dependency to [src/frontend/package.json](src/frontend/package.json) (or add a new scripts command)
+2. run `make local-update-frontend-deps` (updates package-lock.json)
 2. run `make local-sync`
 
 To update backend dependencies:
 
 1. add the dependency to [src/backend/Pipfile](src/backend/Pipfile)
-2. run `make local-update-deps` (updates Pipfile.lock and updates requirements)
+2. run `make local-update-backend-deps` (updates Pipfile.lock and updates requirements)
 3. run `make local-sync` (rebuilds and initializes containers with new dependency)
 
 ### Update Dev Data


### PR DESCRIPTION
### Summary:
- **What:** Adds a command, `make local-update-frontend-deps` to run `npm install` on the frontend container.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `localdev`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)