### PR TITLE
adding in validation endpoint call

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -553,7 +553,7 @@ def update_sample_public_ids():
     return jsonify(success=True)
 
 
-@application.route("/api/samples/validate-ids")
+@application.route("/api/samples/validate-ids", methods=["POST"])
 @requires_auth
 def validate_ids():
     """

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1173,7 +1173,7 @@ def test_validation_endpoint(
     data = {
         "sample_ids": [sample.public_identifier, f"hCoV-19/{gisaid_sample.strain}"],
     }
-    res = client.get("/api/samples/validate-ids", json=data)
+    res = client.post("/api/samples/validate-ids", json=data)
 
     assert res.status == "200 OK"
     response = res.json
@@ -1197,7 +1197,7 @@ def test_validation_endpoint_missing_identifier(
             "this_is_missing",
         ],
     }
-    res = client.get("/api/samples/validate-ids", json=data)
+    res = client.post("/api/samples/validate-ids", json=data)
 
     # request should not fail, should return list of samples that are missing from the DB
     assert res.status == "200 OK"

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -12,6 +12,7 @@ export enum API {
   CREATE_TREE = "/v2/phylo_runs/",
   GET_FASTA_URL = "/api/sequences/getfastaurl",
   USHER_TREE_OPTIONS = "/api/usher/tree_options",
+  SAMPLES_VALIDATE_IDS = "/api/samples/validate-ids",
 }
 
 export const DEFAULT_HEADERS_MUTATION_OPTIONS: RequestInit = {

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -59,6 +59,9 @@ export const CreateNSTreeModal = ({
   const [isTreeBuildDisabled, setTreeBuildDisabled] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<TreeType>("TARGETED");
   const [areInstructionsShown, setInstructionsShown] = useState<boolean>(false);
+  // comment back in when ready to use validation endpoint
+  // const [sampleIdsToValidate, setSampleIdsToValidate] = useState<string[]>([]);
+  // const [missingSampleIdentifiers, setMissingSampleIdentifiers] = useState<string[]>([]);
   useState<boolean>(false);
 
   const clearState = function () {
@@ -89,6 +92,20 @@ export const CreateNSTreeModal = ({
       }
     }
   }, [treeName, treeType]);
+
+  // Comment below back in when ready to use validation endpoint
+  // const validateSampleIdentifiersMutation = useMutation(
+  //   validateSampleIdentifiers,
+  //   {
+  //     onError: () => {
+  //       // placeholder
+  //     },
+  //     onSuccess: (data: any) => {
+  //       // set samples identifiers that were not found in the aspen database as missing
+  //       setMissingSampleIdentifiers(data["missing_sample_ids"]);
+  //     },
+  //   }
+  // );
 
   const mutation = useCreateTree({
     onError: () => {
@@ -231,6 +248,18 @@ export const CreateNSTreeModal = ({
           <CreateTreeInfo>
             Creating a new tree can take up to 12 hours.
           </CreateTreeInfo>
+          {/* 
+          Placeholder for when we add in actual id validation text box
+          <StyledButton
+            color="primary"
+            variant="contained"
+            isRounded
+            onClick={() => {
+              validateSampleIdentifiersMutation.mutate({ sampleIdsToValidate });
+            }}
+          >
+            test validate validateSampleIdentifiers
+          </StyledButton> */}
         </Content>
       </StyledDialogContent>
     </Dialog>

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -24,6 +24,10 @@ interface SampleFastaDownloadPayload {
   };
 }
 
+interface ValidateSampleIdentifiersPayload {
+  sample_ids: string[];
+}
+
 export async function downloadSamplesFasta({
   sampleIds,
 }: {
@@ -37,6 +41,24 @@ export async function downloadSamplesFasta({
     body: JSON.stringify(payload),
   });
   if (response.ok) return await response.blob();
+
+  throw Error(`${response.statusText}: ${await response.text()}`);
+}
+
+export async function validateSampleIdentifiers({
+  sampleIdsToValidate,
+}: {
+  sampleIdsToValidate: string[];
+}): Promise<unknown> {
+  const payload: ValidateSampleIdentifiersPayload = {
+    sample_ids: sampleIdsToValidate,
+  };
+
+  const response = await fetch(API_URL + API.SAMPLES_VALIDATE_IDS, {
+    ...DEFAULT_POST_OPTIONS,
+    body: JSON.stringify(payload),
+  });
+  if (response.ok) return await response.json();
 
   throw Error(`${response.statusText}: ${await response.text()}`);
 }


### PR DESCRIPTION
### Summary:
- **What:** add validation call to backend to find missing identifiers in request, this is applicable to when users submit their own list of gisaid identifiers for self serve tree building.
- **Ticket:** [sc170937](https://app.shortcut.com/genepi/story/170937)
- **Env:** no surfacing changes, so i didn't make one, i have commented out code that i was using for testing

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)