### PR TITLE
Maya/166015 gisaid input

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "./style";
 
 interface Props {
-  setTreeName(): void;
+  setTreeName(name: string): void;
   shouldReset?: boolean;
   treeName?: string;
 }
@@ -38,7 +38,7 @@ const TreeNameInput = ({
 
   // show name errors
   useEffect(() => {
-    const isNameTooLong = treeName?.length > 128;
+    const isNameTooLong = (treeName?.length ?? 0) > 128;
     setTreeNameTooLong(isNameTooLong);
   }, [treeName]);
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import {
+  FieldTitle,
+  StyledTextField,
+  TextFieldAlert,
+  TreeNameInfoWrapper,
+  TreeNameTooLongAlert,
+} from "../../style";
+import {
+  InstructionsNotSemiBold,
+  InstructionsSemiBold,
+  StyledErrorOutlinedIcon,
+  StyledInstructions,
+  StyledInstructionsButton,
+} from "./style";
+
+interface Props {
+  setTreeName(): void;
+  treeName?: string;
+}
+
+const TreeNameInput = ({ setTreeName, treeName }: Props): JSX.Element => {
+  const [areInstructionsShown, setInstructionsShown] = useState<boolean>(false);
+  const [isTreeNameTooLong, setTreeNameTooLong] = useState<boolean>(false);
+
+  useEffect(() => {
+    const isNameTooLong = treeName?.length > 128;
+    setTreeNameTooLong(isNameTooLong);
+  }, [treeName]);
+
+  const handleInstructionsClick = function () {
+    setInstructionsShown((prevState: boolean) => !prevState);
+  };
+
+  return (
+    <div>
+      <TreeNameInfoWrapper>
+        <FieldTitle>Tree Name</FieldTitle>
+        <StyledInstructionsButton
+          color="primary"
+          onClick={handleInstructionsClick}
+        >
+          {/* TODO (mlila): refactor out collapsible instructions into its own component */}
+          {areInstructionsShown ? "LESS" : "MORE"} INFO
+        </StyledInstructionsButton>
+      </TreeNameInfoWrapper>
+      {areInstructionsShown && (
+        <StyledInstructions
+          items={[
+            <InstructionsSemiBold key="1">
+              Do not include any PII in your Tree name.
+            </InstructionsSemiBold>,
+            <InstructionsNotSemiBold key="2">
+              Tree names must be no longer than 128 characters.
+            </InstructionsNotSemiBold>,
+          ]}
+        />
+      )}
+      <StyledTextField
+        fullWidth
+        error={isTreeNameTooLong}
+        id="outlined-basic"
+        variant="outlined"
+        value={treeName}
+        size="small"
+        onChange={(e) => setTreeName(e.target.value)}
+      />
+      {isTreeNameTooLong && (
+        <TreeNameTooLongAlert>
+          <StyledErrorOutlinedIcon />
+          <TextFieldAlert>Name exceeds the 128 character limit.</TextFieldAlert>
+        </TreeNameTooLongAlert>
+      )}
+    </div>
+  );
+};
+
+export { TreeNameInput };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
@@ -16,18 +16,33 @@ import {
 
 interface Props {
   setTreeName(): void;
+  shouldReset?: boolean;
   treeName?: string;
 }
 
-const TreeNameInput = ({ setTreeName, treeName }: Props): JSX.Element => {
+const TreeNameInput = ({
+  setTreeName,
+  shouldReset,
+  treeName,
+}: Props): JSX.Element => {
   const [areInstructionsShown, setInstructionsShown] = useState<boolean>(false);
   const [isTreeNameTooLong, setTreeNameTooLong] = useState<boolean>(false);
 
+  // form closed or cleared
+  useEffect(() => {
+    if (shouldReset) {
+      setInstructionsShown(false);
+      setTreeNameTooLong(false);
+    }
+  }, [shouldReset]);
+
+  // show name errors
   useEffect(() => {
     const isNameTooLong = treeName?.length > 128;
     setTreeNameTooLong(isNameTooLong);
   }, [treeName]);
 
+  // toggle instructions
   const handleInstructionsClick = function () {
     setInstructionsShown((prevState: boolean) => !prevState);
   };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/style.ts
@@ -1,0 +1,75 @@
+import styled from "@emotion/styled";
+import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
+import {
+  Button,
+  fontBodyXs,
+  fontCapsXxxs,
+  getColors,
+  getFontWeights,
+  getIconSizes,
+  getSpaces,
+  Props,
+} from "czifui";
+import Instructions from "src/components/CollapsibleInstructions/components/Instructions";
+
+export const StyledInstructions = styled(Instructions)`
+  border-radius: 4px;
+  color: black;
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.xs}px;
+      padding: ${spaces?.l}px;
+    `;
+  }}
+`;
+
+export const InstructionsSemiBold = styled.span`
+  color: black;
+  ${fontBodyXs}
+  ${(props: Props) => {
+    const fontWeights = getFontWeights(props);
+    const spaces = getSpaces(props);
+    return `
+      font-weight: ${fontWeights?.semibold};
+      margin-bottom: ${spaces?.xxxs};
+    `;
+  }}
+`;
+
+export const InstructionsNotSemiBold = styled.span`
+  color: black;
+  ${fontBodyXs}
+`;
+
+export const StyledInstructionsButton = styled(Button)`
+  ${fontCapsXxxs}
+  padding-left: 0px;
+  ${(props) => {
+    const spaces = getSpaces(props);
+    const colors = getColors(props);
+    return `
+      margin-left: ${spaces?.m}px;
+      padding-top: ${spaces?.xxs}px;
+      &:hover {
+        background-color: transparent;
+        color: ${colors?.primary[500]};
+      }
+    `;
+  }}
+`;
+
+export const StyledErrorOutlinedIcon = styled(ErrorOutlineIcon)`
+  ${(props) => {
+    const colors = getColors(props);
+    const iconSizes = getIconSizes(props);
+    const spaces = getSpaces(props);
+    return `
+      color: ${colors?.error[400]};
+      margin-right: ${spaces?.xs}px;
+      height: ${iconSizes?.s.height}px;
+      width: ${iconSizes?.s.width}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/style.ts
@@ -10,7 +10,7 @@ import {
   getSpaces,
   Props,
 } from "czifui";
-import Instructions from "src/components/CollapsibleInstructions/components/Instructions";
+import Instructions from "src/components/Instructions";
 
 export const StyledInstructions = styled(Instructions)`
   border-radius: 4px;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -189,9 +189,9 @@ export const CreateNSTreeModal = ({
             </TreeTypeSection>
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               <>
-                <Separator size="l" />
+                <Separator marginSize="l" />
                 <FieldTitle>Add Samples by ID (optional)</FieldTitle>
-                <Separator size="xl" />
+                <Separator marginSize="xl" />
               </>
             )}
             <FailedSampleAlert numFailedSamples={failedSamples?.length} />

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -187,9 +187,13 @@ export const CreateNSTreeModal = ({
                 />
               </RadioGroup>
             </TreeTypeSection>
-            <Separator size="l" />
-            <FieldTitle>Add Samples by ID (optional)</FieldTitle>
-            <Separator size="xl" />
+            {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
+              <>
+                <Separator size="l" />
+                <FieldTitle>Add Samples by ID (optional)</FieldTitle>
+                <Separator size="xl" />
+              </>
+            )}
             <FailedSampleAlert numFailedSamples={failedSamples?.length} />
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               <Tooltip

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -52,16 +52,20 @@ export const CreateNSTreeModal = ({
 }: Props): JSX.Element => {
   const [treeName, setTreeName] = useState<string>("");
   const [isTreeBuildDisabled, setTreeBuildDisabled] = useState<boolean>(false);
+  const [shouldReset, setShouldReset] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<TreeType>("TARGETED");
   // comment back in when ready to use validation endpoint
   // const [sampleIdsToValidate, setSampleIdsToValidate] = useState<string[]>([]);
   // const [missingSampleIdentifiers, setMissingSampleIdentifiers] = useState<string[]>([]);
 
+  useEffect(() => {
+    if (shouldReset) setShouldReset(false);
+  }, [shouldReset]);
+
   const clearState = function () {
+    setShouldReset(true);
     setTreeName("");
     setTreeType("TARGETED");
-    setInstructionsShown(false);
-    setTreeNameTooLong(false);
   };
 
   const handleClose = function () {
@@ -71,13 +75,9 @@ export const CreateNSTreeModal = ({
 
   useEffect(() => {
     const treeNameLength = treeName.length;
-    if (treeNameLength > 128) {
-      setTreeNameTooLong(true);
-      setTreeBuildDisabled(true);
-    } else if (treeNameLength === 0) {
+    if (treeNameLength > 128 || treeNameLength === 0) {
       setTreeBuildDisabled(true);
     } else {
-      setTreeNameTooLong(false);
       if (treeType === "TARGETED" || treeType === "NON_CONTEXTUALIZED") {
         setTreeBuildDisabled(false);
       } else {

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -2,30 +2,19 @@ import styled from "@emotion/styled";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Radio from "@material-ui/core/Radio";
 import TextField from "@material-ui/core/TextField";
-import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import {
   Button,
   fontBodyS,
-  fontBodyXs,
   fontBodyXxs,
   fontBodyXxxs,
-  fontCapsXxxs,
   fontHeaderXs,
   getColors,
-  getFontWeights,
-  getIconSizes,
   getSpaces,
-  Props,
   Tooltip,
 } from "czifui";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
-import Instructions from "src/components/Instructions";
-
-const InstructionsCommon = `
-  color: black;
-`;
 
 export const StyledDialogContent = styled(DialogContent)`
   width: 600px;
@@ -70,53 +59,6 @@ export const FieldTitle = styled.div`
     const spaces = getSpaces(props);
     return `
       margin-bottom: ${spaces?.xxs}px;
-    `;
-  }}
-`;
-
-export const StyledInstructions = styled(Instructions)`
-  border-radius: 4px;
-  color: black;
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      margin-bottom: ${spaces?.xs}px;
-      padding: ${spaces?.l}px;
-    `;
-  }}
-`;
-
-export const InstructionsSemiBold = styled.span`
-  ${InstructionsCommon}
-  ${fontBodyXs}
-  ${(props: Props) => {
-    const fontWeights = getFontWeights(props);
-    const spaces = getSpaces(props);
-    return `
-      font-weight: ${fontWeights?.semibold};
-      margin-bottom: ${spaces?.xxxs};
-    `;
-  }}
-`;
-
-export const InstructionsNotSemiBold = styled.span`
-  ${InstructionsCommon}
-  ${fontBodyXs}
-`;
-
-export const StyledInstructionsButton = styled(Button)`
-  ${fontCapsXxxs}
-  padding-left: 0px;
-  ${(props) => {
-    const spaces = getSpaces(props);
-    const colors = getColors(props);
-    return `
-      margin-left: ${spaces?.m}px;
-      padding-top: ${spaces?.xxs}px;
-      &:hover {
-        background-color: transparent;
-        color: ${colors?.primary[500]};
-      }
     `;
   }}
 `;
@@ -187,9 +129,29 @@ export const StyledButton = styled(Button)`
     const colors = getColors(props);
     return `
       margin-top: ${spaces?.xxl}px;
+
       &:active {
         background-color: ${colors?.gray[400]};
       }
+    `;
+  }}
+`;
+
+const doNotForwardProps = ["size"];
+
+export const Separator = styled("div", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  height: 0;
+
+  ${(props) => {
+    const { size } = props;
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      border-top: 1px solid ${colors?.gray[200]};
+      margin: ${spaces?.[size]}px 0;
     `;
   }}
 `;
@@ -223,20 +185,6 @@ export const TextFieldAlert = styled.div`
     const colors = getColors(props);
     return `
       color: ${colors?.error[400]};
-    `;
-  }}
-`;
-
-export const StyledErrorOutlinedIcon = styled(ErrorOutlineIcon)`
-  ${(props) => {
-    const colors = getColors(props);
-    const iconSizes = getIconSizes(props);
-    const spaces = getSpaces(props);
-    return `
-      color: ${colors?.error[400]};
-      margin-right: ${spaces?.xs}px;
-      height: ${iconSizes?.s.height}px;
-      width: ${iconSizes?.s.width}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -11,6 +11,7 @@ import {
   fontHeaderXs,
   getColors,
   getSpaces,
+  Props,
   Tooltip,
 } from "czifui";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
@@ -137,21 +138,25 @@ export const StyledButton = styled(Button)`
   }}
 `;
 
-const doNotForwardProps = ["size"];
+interface SeparatorProps extends Props {
+  marginSize: "l" | "xl";
+}
+
+const doNotForwardProps = ["marginSize"];
 
 export const Separator = styled("div", {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   height: 0;
 
-  ${(props) => {
-    const { size } = props;
+  ${(props: SeparatorProps) => {
+    const { marginSize } = props;
     const colors = getColors(props);
     const spaces = getSpaces(props);
 
     return `
       border-top: 1px solid ${colors?.gray[200]};
-      margin: ${spaces?.[size]}px 0;
+      margin: ${spaces?.[marginSize]}px 0;
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** 
  - Refactor tree name input in nextstrain tree create modal into its own component
  - Add one of the tooltips for create button
- **Ticket:** [[sc-166015]](https://app.shortcut.com/genepi/story/166015)
- **Env:** https://gisaid-frontend.dev.genepi.czi.technology

### Demos
Should be no visual changes for current users.

### Notes
Not ready for design review. More PR to come for this ticket.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)