### PR TITLE
Allow Spaces in Private IDs

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -208,6 +208,7 @@ def getfastaurl():
     user = g.auth_user
     request_data = request.get_json()
     sample_ids = request_data["samples"]
+    downstream_consumer = request_data.get("downstream_consumer")
 
     s3_bucket = application.aspen_config.EXTERNAL_AUSPICE_BUCKET
     s3_resource = boto3.resource(
@@ -222,7 +223,7 @@ def getfastaurl():
         f"s3://{s3_bucket}/{s3_key}", "w", transport_params=dict(client=s3_client)
     )
     # Write selected samples to s3
-    streamer = FastaStreamer(user, sample_ids, g.db_session)
+    streamer = FastaStreamer(user, sample_ids, g.db_session, downstream_consumer)
     for line in streamer.stream():
         s3_write_fh.write(line)
     s3_write_fh.close()

--- a/src/backend/aspen/fileio/fasta_streamer.py
+++ b/src/backend/aspen/fileio/fasta_streamer.py
@@ -80,11 +80,10 @@ class FastaStreamer:
         Certain downstream consumers (eg, UShER) restrict what characters can be
         used in the ID. Also handles any modifications that must be made to ID
         characters so they don't break the downstream consumer."""
+        output_id = identifier  # default, might get changed if specialty case
         if self.downstream_consumer == SpecialtyDownstreams.USHER.value:
-            output_ready_id = self._handle_usher_id(identifier)
-        else:
-            output_ready_id = identifier
-        return f">{output_ready_id}\n"
+            output_id = self._handle_usher_id(identifier)
+        return f">{output_id}\n"
 
     def _handle_usher_id(self, identifier) -> str:
         """Convert identifier into something that is UShER safe and roughly the same.

--- a/src/backend/aspen/fileio/fasta_streamer.py
+++ b/src/backend/aspen/fileio/fasta_streamer.py
@@ -1,4 +1,6 @@
-from typing import Set
+import re
+from enum import Enum
+from typing import Iterator, Optional, Set
 
 from sqlalchemy.orm import joinedload, Session
 from sqlalchemy.orm.query import Query
@@ -8,8 +10,20 @@ from aspen.database.models import DataType, Sample, UploadedPathogenGenome
 from aspen.database.models.usergroup import User
 
 
+class SpecialtyDownstreams(Enum):
+    """Canonical internal/external names for downstreams that require special logic."""
+
+    USHER = "USHER"
+
+
 class FastaStreamer:
-    def __init__(self, user: User, sample_ids: Set[str], db_session: Session):
+    def __init__(
+        self,
+        user: User,
+        sample_ids: Set[str],
+        db_session: Session,
+        downstream_consumer: Optional[str] = None,
+    ):
         self.user = user
         self.cansee_groups_private_identifiers: Set[int] = {
             cansee.owner_group_id
@@ -30,8 +44,10 @@ class FastaStreamer:
         )
         # Enforce AuthZ
         self.all_samples = authz_sample_filters(self.all_samples, sample_ids, user)
+        # Certain consumers have different requirements on fasta
+        self.downstream_consumer = downstream_consumer
 
-    def stream(self):
+    def stream(self) -> Iterator[str]:
         for sample in self.all_samples:
             if sample.uploaded_pathogen_genome:
                 pathogen_genome: UploadedPathogenGenome = (
@@ -40,7 +56,7 @@ class FastaStreamer:
                 sequence: str = "".join(
                     [
                         line
-                        for line in pathogen_genome.sequence.splitlines()  # type: ignore
+                        for line in pathogen_genome.sequence.splitlines()
                         if not (line.startswith(">") or line.startswith(";"))
                     ]
                 )
@@ -52,8 +68,37 @@ class FastaStreamer:
                     in self.cansee_groups_private_identifiers
                     or self.user.system_admin
                 ):
-                    yield (f">{sample.private_identifier}\n")  # type: ignore
+                    yield self._output_id_line(sample.private_identifier)
                 else:
-                    yield (f">{sample.public_identifier}\n")
-                yield (stripped_sequence)
-                yield ("\n")
+                    yield self._output_id_line(sample.public_identifier)
+                yield stripped_sequence
+                yield "\n"
+
+    def _output_id_line(self, identifier) -> str:
+        """Produces the ID line for current sequence in fasta.
+
+        Certain downstream consumers (eg, UShER) restrict what characters can be
+        used in the ID. Also handles any modifications that must be made to ID
+        characters so they don't break the downstream consumer."""
+        if self.downstream_consumer == SpecialtyDownstreams.USHER.value:
+            output_ready_id = self._handle_usher_id(identifier)
+        else:
+            output_ready_id = identifier
+        return f">{output_ready_id}\n"
+
+    def _handle_usher_id(self, identifier) -> str:
+        """Convert identifier into something that is UShER safe and roughly the same.
+
+        UShER is allergic to a lot of characters in its sequence ID. It's hard to
+        figure out exactly what characters cause problems. I (Vince) mostly figured
+        it out from a combo of looking over the source code for handling that aspect
+            https://github.com/ucscGenomeBrowser/kent/blob/master/src/lib/phyloTree.c
+        and from doing manual testing with characters I wasn't sure about.
+
+        As of Oct 28, 2021, UShER seems happy with only the following characters:
+        any latin alpha, any digit, `.`, `_`, `/`, `-`
+        With that in mind, anything outside of that we convert to an underscore.
+        """
+        USHER_UNSAFE_CHARS = r"[^a-zA-Z0-9._/-]"  # complement of the allowed chars
+        # Convert every unsafe char into an underscore
+        return re.sub(USHER_UNSAFE_CHARS, "_", identifier)

--- a/src/frontend/.eslintrc.js
+++ b/src/frontend/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
       "asc",
       {
         caseSensitive: true,
-        minKeys: 2,
+        minKeys: 5, // 4 keys or fewer means this rule does not kick in
         natural: false,
       },
     ],

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -121,7 +121,10 @@ export const UsherPlacementModal = ({
   const handleSubmit = (evt: SyntheticEvent) => {
     evt.preventDefault();
     sampleIds = sampleIds.filter((id) => !failedSamples.includes(id));
-    fastaFetch.mutate({ sampleIds });
+    fastaFetch.mutate({
+      sampleIds,
+      downstreamConsumer: "USHER", // Let backend know eventual destination for this fasta
+    });
     setIsLoading(true);
   };
 

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -33,10 +33,12 @@ interface CreateTreeType {
 // * very convoluted: https://stackoverflow.com/questions/44323441
 interface FastaURLPayloadType {
   samples: string[];
+  downstream_consumer?: string;
 }
 
 interface FastaRequestType {
   sampleIds: string[];
+  downstreamConsumer?: string;
 }
 
 export interface FastaResponseType {
@@ -73,11 +75,13 @@ export async function createTree({
 
 export async function getFastaURL({
   sampleIds,
-}: {
-  sampleIds: string[];
-}): Promise<FastaResponseType> {
+  downstreamConsumer,
+}: FastaRequestType): Promise<FastaResponseType> {
   const payload: FastaURLPayloadType = {
     samples: sampleIds,
+    // If specialty downstream consumer, set this to have FASTA generate accordingly
+    // If left as undefined, will be stripped out from payload during JSON.stringify
+    downstream_consumer: downstreamConsumer,
   };
   const response = await fetch(API_URL + API.GET_FASTA_URL, {
     ...DEFAULT_POST_OPTIONS,

--- a/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
@@ -14,7 +14,7 @@ const ERROR_CODE_MESSAGES: Record<ERROR_CODE, string> = {
   [ERROR_CODE.DEFAULT]:
     "Something went wrong and we are unable to read this file. Please check the file or contact us for help.",
   [ERROR_CODE.INVALID_NAME]:
-    "Sample Private ID did not meet our requirements, please update and retry. Sample names must be no longer than 120 characters and can only contain letters from the English alphabet (A-Z, upper and lower case), numbers (0-9), periods (.), hyphens (-), underscores (_), and backslashes (/). Spaces are not allowed.  ",
+    "Sample Private ID did not meet our requirements, please update and retry. Sample names must be no longer than 120 characters and can only contain letters from the English alphabet (A-Z, upper and lower case), numbers (0-9), periods (.), hyphens (-), underscores (_), spaces ( ), and forward slashes (/).",
   [ERROR_CODE.MISSING_FIELD]: "placeholder",
   [ERROR_CODE.OVER_MAX_SAMPLES]:
     "This file contains more than 500 samples, which exceeds the maximum for each upload process. Please limit the samples to 500 or less",

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -124,7 +124,7 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
                 Sample names must be no longer than 120 characters and can only
                 contain letters from the English alphabet (A-Z, upper and lower
                 case), numbers (0-9), periods (.), hyphens (-), underscores (_),
-                and backslashes (/). Spaces are not allowed.
+                spaces ( ), and forward slashes (/).
               </span>,
               <span key="4">
                 The maximum number of samples accommodated per upload is 500.

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -116,7 +116,7 @@ function handleFastaText(text: string, filename: string): ParseOutcome {
     }
 
     // Invalid name
-    if (iLine.includes(" ") || iLine.length > MAX_NAME_LENGTH) {
+    if (iLine.length > MAX_NAME_LENGTH) {
       errors = {
         ...errors,
         [ERROR_CODE.INVALID_NAME]: [

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -134,7 +134,10 @@ function handleFastaText(text: string, filename: string): ParseOutcome {
     i = newIndex;
 
     if (sequence) {
-      const id = iLine.replace(">", "");
+      // The `>` indicates the ID. We toss it, along with any spaces between it and ID.
+      // Regex matches start of the line `>` and as many spaces as appear before ID
+      const REGEX_ID_PREAMBLE = /^> */;
+      const id = iLine.replace(REGEX_ID_PREAMBLE, "");
 
       result = {
         ...result,

--- a/src/frontend/src/views/Upload/components/common/types.ts
+++ b/src/frontend/src/views/Upload/components/common/types.ts
@@ -20,6 +20,11 @@ export interface ParseOutcome {
   errors: ParseErrors;
 }
 
+export interface ParseFastaSeqIDLineOutcome {
+  hasError: boolean;
+  id: string;
+}
+
 export enum WARNING_CODE {
   /**
    * (thuang): We have detected conflicting info and auto-corrected something


### PR DESCRIPTION
### Summary:
- **What:** Allow spaces in Private ID for samples
- **Ticket:** [sc<165800>](https://app.shortcut.com/genepi/story/<165800>)
- **Env:** https://private-id-spaces-frontend.dev.genepi.czi.technology

### Notes:
Various related things came up in the process of working on this:
- Looked into downstream impacts on the TSV metadata upload (if the new ID changes would affect anything), found some issues
  - => Wrote up a ticket and also documented a part of the TSV upload process that took me awhile to understand.
- Found out that UShER has pretty strict ID name requirements, lots of characters will cause it to completely break
  - => Took awhile to figure out what exactly those requirements are (I couldn't find it documented anywhere). Changed our backend fasta generator to produce different versions of the ID depending on the eventual downstream consumer, so now when a fasta is destined for usher, it will handle those naming requirements (eg, `my spaced id` in Aspen will become `my_spaced_id` when sent to UShER).
- Discovered that frontend was not enforcing most of the ID naming rules it stated in the upload instructions.
   - => At first this didn't seem like a big issue since it could be useful for international users to be flexible on characters. However, after understanding the restrictions when working with UShER, decided to just enforce our previously stated restrictions since that basically makes us usher-safe for IDs.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- ~[ ] I have notified others of changes they need to make locally~ (none needed)