### PR TITLE
Add sample delete endpoint

### DIFF
--- a/src/backend/aspen/api/conftest.py
+++ b/src/backend/aspen/api/conftest.py
@@ -105,6 +105,7 @@ async def override_get_auth_user(
     if not found_auth_user:
         raise ex.UnauthorizedException("invalid user")
     request.state.auth_user = found_auth_user
+    return found_auth_user
 
 
 @pytest.fixture()

--- a/src/backend/aspen/api/conftest.py
+++ b/src/backend/aspen/api/conftest.py
@@ -16,6 +16,7 @@ from aspen.api.main import get_app
 from aspen.database import connection as aspen_connection
 from aspen.database import schema
 from aspen.database.connection import init_async_db
+from aspen.database.models import User
 
 USERNAME = "user_rw"
 PASSWORD = "password_rw"
@@ -100,7 +101,7 @@ async def override_get_db(
 
 async def override_get_auth_user(
     request: Request, session: AsyncSession = Depends(get_db)
-) -> None:
+) -> User:
     found_auth_user = await setup_userinfo(session, request.headers.get("user_id"))
     if not found_auth_user:
         raise ex.UnauthorizedException("invalid user")

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -1,6 +1,6 @@
 from pydantic import constr
 
-from aspen.api.schemas.base import BaseRequest
+from aspen.api.schemas.base import BaseRequest, BaseResponse
 
 
 class SampleRequestSchema(BaseRequest):
@@ -8,5 +8,9 @@ class SampleRequestSchema(BaseRequest):
     name: constr(min_length=1, max_length=128, strict=True)  # type: ignore
 
 
-class SampleResponseSchema(BaseRequest):
+class SampleResponseSchema(BaseResponse):
     name: str
+
+
+class SampleDeleteResponse(BaseResponse):
+    id: int

--- a/src/backend/aspen/api/schemas/users.py
+++ b/src/backend/aspen/api/schemas/users.py
@@ -4,6 +4,7 @@ from aspen.api.schemas.base import BaseResponse
 
 
 class UserBase(BaseResponse):
+    group_id: int
     agreed_to_tos: bool = False
 
 

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -1,11 +1,15 @@
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.exc import NoResultFound
 from starlette.requests import Request
 
 from aspen.api.auth import get_auth_user
 from aspen.api.deps import get_db, get_settings
+from aspen.api.error import http_exceptions as ex
+from aspen.api.schemas.samples import SampleDeleteResponse
 from aspen.api.settings import Settings
-from aspen.database.models import User
+from aspen.database.models import Sample, User
 
 router = APIRouter()
 
@@ -20,12 +24,36 @@ async def list_samples(
     return False
 
 
-@router.delete("/{sample_id}")
+async def get_owned_sample_by_id(db, sample_id, user):
+    # TODO - We don't prevent a collision between public & private identifiers at the moment!!!
+    query = sa.select(Sample).filter(
+        sa.and_(
+            Sample.submitting_group == user.group,
+            sa.or_(
+                Sample.public_identifier == sample_id,
+                Sample.private_identifier == sample_id,
+            ),
+        )
+    )
+    results = await db.execute(query)
+    try:
+        return results.scalars().one()
+    except NoResultFound:
+        raise ex.NotFoundException("sample not found")
+
+
+@router.delete("/{sample_id:path}")
 async def delete_sample(
     sample_id: str,
     request: Request,
     db: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
-) -> bool:
-    return False
+) -> SampleDeleteResponse:
+    # Make sure this sample exists and is delete-able by the current user.
+    sample = await get_owned_sample_by_id(db, sample_id, user)
+    sample_db_id = sample.id
+
+    await db.delete(sample)
+    await db.commit()
+    return SampleDeleteResponse(id=sample_db_id)

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -24,15 +24,13 @@ async def list_samples(
     return False
 
 
-async def get_owned_sample_by_id(db, sample_id, user):
-    # TODO - We don't prevent a collision between public & private identifiers at the moment!!!
+async def get_owned_sample_by_id(db, group_id, sample_id, user):
     query = sa.select(Sample).filter(
         sa.and_(
-            Sample.submitting_group == user.group,
-            sa.or_(
-                Sample.public_identifier == sample_id,
-                Sample.private_identifier == sample_id,
-            ),
+            Sample.submitting_group == user.group,  # This is an access control check!
+            Sample.submitting_group_id
+            == group_id,  # This makes sure we included the correct group ID in our path.
+            Sample.public_identifier == sample_id,
         )
     )
     results = await db.execute(query)
@@ -42,8 +40,9 @@ async def get_owned_sample_by_id(db, sample_id, user):
         raise ex.NotFoundException("sample not found")
 
 
-@router.delete("/{sample_id:path}")
+@router.delete("/{group_id}/{sample_id:path}")
 async def delete_sample(
+    group_id: int,
     sample_id: str,
     request: Request,
     db: AsyncSession = Depends(get_db),
@@ -51,7 +50,7 @@ async def delete_sample(
     user: User = Depends(get_auth_user),
 ) -> SampleDeleteResponse:
     # Make sure this sample exists and is delete-able by the current user.
-    sample = await get_owned_sample_by_id(db, sample_id, user)
+    sample = await get_owned_sample_by_id(db, group_id, sample_id, user)
     sample_db_id = sample.id
 
     await db.delete(sample)

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -25,7 +25,7 @@ async def list_samples(
 
 
 async def get_owned_sample_by_public_id(db, group_id, public_id, user):
-    query = sa.select(Sample).filter(
+    query = sa.select(Sample).filter(  # type: ignore
         sa.and_(
             Sample.submitting_group == user.group,  # This is an access control check!
             Sample.submitting_group_id

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -24,13 +24,15 @@ async def list_samples(
     return False
 
 
-async def get_owned_sample_by_public_id(db, group_id, public_id, user):
+async def get_owned_sample_by_id(
+    db: AsyncSession, group_id: int, sample_id: int, user: User
+) -> Sample:
     query = sa.select(Sample).filter(  # type: ignore
         sa.and_(
             Sample.submitting_group == user.group,  # This is an access control check!
             Sample.submitting_group_id
             == group_id,  # This makes sure we included the correct group ID in our path.
-            Sample.public_identifier == public_id,
+            Sample.id == sample_id,
         )
     )
     results = await db.execute(query)
@@ -40,20 +42,17 @@ async def get_owned_sample_by_public_id(db, group_id, public_id, user):
         raise ex.NotFoundException("sample not found")
 
 
-# Since our public identifiers typically contain / characters, we need to
-# tell fastapi/starlette that it's ok to use the entire path suffix as our
-# resource ID, using the `:path` convertor: https://www.starlette.io/routing/
-@router.delete("/{group_id}/{public_id:path}")
+@router.delete("/{group_id}/{sample_id}")
 async def delete_sample(
     group_id: int,
-    public_id: str,
+    sample_id: int,
     request: Request,
     db: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
 ) -> SampleDeleteResponse:
     # Make sure this sample exists and is delete-able by the current user.
-    sample = await get_owned_sample_by_public_id(db, group_id, public_id, user)
+    sample = await get_owned_sample_by_id(db, group_id, sample_id, user)
     sample_db_id = sample.id
 
     await db.delete(sample)

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -40,6 +40,9 @@ async def get_owned_sample_by_public_id(db, group_id, public_id, user):
         raise ex.NotFoundException("sample not found")
 
 
+# Since our public identifiers typically contain / characters, we need to
+# tell fastapi/starlette that it's ok to use the entire path suffix as our
+# resource ID, using the `:path` convertor: https://www.starlette.io/routing/
 @router.delete("/{group_id}/{public_id:path}")
 async def delete_sample(
     group_id: int,

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -24,13 +24,13 @@ async def list_samples(
     return False
 
 
-async def get_owned_sample_by_id(db, group_id, sample_id, user):
+async def get_owned_sample_by_public_id(db, group_id, public_id, user):
     query = sa.select(Sample).filter(
         sa.and_(
             Sample.submitting_group == user.group,  # This is an access control check!
             Sample.submitting_group_id
             == group_id,  # This makes sure we included the correct group ID in our path.
-            Sample.public_identifier == sample_id,
+            Sample.public_identifier == public_id,
         )
     )
     results = await db.execute(query)
@@ -40,17 +40,17 @@ async def get_owned_sample_by_id(db, group_id, sample_id, user):
         raise ex.NotFoundException("sample not found")
 
 
-@router.delete("/{group_id}/{sample_id:path}")
+@router.delete("/{group_id}/{public_id:path}")
 async def delete_sample(
     group_id: int,
-    sample_id: str,
+    public_id: str,
     request: Request,
     db: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
 ) -> SampleDeleteResponse:
     # Make sure this sample exists and is delete-able by the current user.
-    sample = await get_owned_sample_by_id(db, group_id, sample_id, user)
+    sample = await get_owned_sample_by_public_id(db, group_id, public_id, user)
     sample_db_id = sample.id
 
     await db.delete(sample)

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -25,13 +25,11 @@ async def list_samples(
 
 
 async def get_owned_sample_by_id(
-    db: AsyncSession, group_id: int, sample_id: int, user: User
+    db: AsyncSession, sample_id: int, user: User
 ) -> Sample:
     query = sa.select(Sample).filter(  # type: ignore
         sa.and_(
             Sample.submitting_group == user.group,  # This is an access control check!
-            Sample.submitting_group_id
-            == group_id,  # This makes sure we included the correct group ID in our path.
             Sample.id == sample_id,
         )
     )
@@ -42,9 +40,8 @@ async def get_owned_sample_by_id(
         raise ex.NotFoundException("sample not found")
 
 
-@router.delete("/{group_id}/{sample_id}")
+@router.delete("/{sample_id}")
 async def delete_sample(
-    group_id: int,
     sample_id: int,
     request: Request,
     db: AsyncSession = Depends(get_db),
@@ -52,7 +49,7 @@ async def delete_sample(
     user: User = Depends(get_auth_user),
 ) -> SampleDeleteResponse:
     # Make sure this sample exists and is delete-able by the current user.
-    sample = await get_owned_sample_by_id(db, group_id, sample_id, user)
+    sample = await get_owned_sample_by_id(db, sample_id, user)
     sample_db_id = sample.id
 
     await db.delete(sample)

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -1,0 +1,112 @@
+import pytest
+import sqlalchemy as sa
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.exc import NoResultFound
+
+from aspen.database.models import Sample
+from aspen.test_infra.models.sample import sample_factory
+from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
+from aspen.test_infra.models.usergroup import group_factory, user_factory
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+async def test_delete_sample_success(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    """
+    Test successful sample deletion by public & private ID
+    """
+    group = group_factory()
+    user = user_factory(group)
+    samples = [
+        sample_factory(
+            group,
+            user,
+            public_identifier="path/to/sample_id1",
+            private_identifier="i_dont_have_spaces1",
+        ),
+        sample_factory(
+            group,
+            user,
+            public_identifier="path/to/sample id2",
+            private_identifier="i have spaces2",
+        ),
+        sample_factory(
+            group,
+            user,
+            public_identifier="path/to/sample_id3",
+            private_identifier="i have spaces3",
+        ),
+    ]
+    for sample in samples:
+        upg = uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+        async_session.add(upg)
+    async_session.add(group)
+    await async_session.commit()
+
+    samples_to_delete = {
+        samples[0].public_identifier: samples[0].id,
+        samples[1].private_identifier: samples[1].id,
+    }
+    for identifier, sample_id in samples_to_delete.items():
+        auth_headers = {"user_id": user.auth0_user_id}
+        res = await http_client.delete(
+            f"/v2/samples/{identifier}", headers=auth_headers
+        )
+        assert res.status_code == 200
+        response = res.json()
+        assert response["id"] == sample_id
+    # Make sure 0 and 1 were deleted and 3 is still there.
+    rows = 0
+    for sample in samples:
+        res = await async_session.execute(
+            sa.select(Sample).filter(Sample.id == sample.id)
+        )
+        try:
+            row = res.scalars().one()
+        except NoResultFound:
+            assert sample.id in [samples[0].id, samples[1].id]
+            rows += 1
+            continue
+        assert row.id == samples[2].id
+        rows += 1
+    # Make sure we actually processed the results above.
+    assert rows == 3
+
+
+async def test_delete_sample_failures(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    """
+    Test a sample deletion failure by a user without write access
+    """
+    group = group_factory()
+    user = user_factory(group)
+    sample = sample_factory(group, user)
+    upg = uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    async_session.add(upg)
+    async_session.add(group)
+
+    # A group that doesn't have access to our sample.
+    group2 = group_factory(name="The Other Group")
+    user2 = user_factory(
+        group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
+    )
+    async_session.add(group2)
+    await async_session.commit()
+
+    # Request this sample as a user who shouldn't be able to delete it.
+    auth_headers = {"user_id": user2.auth0_user_id}
+    res = await http_client.delete(
+        f"/v2/samples/{sample.public_identifier}", headers=auth_headers
+    )
+    assert res.status_code == 404
+    # Make sure our sample is still in the db.
+    res = await async_session.execute(sa.select(Sample).filter(Sample.id == sample.id))
+    found_sample = res.scalars().one()
+    assert found_sample.id == sample.id

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -51,7 +51,7 @@ async def test_delete_sample_success(
     for sample in [samples[0], samples[1]]:
         auth_headers = {"user_id": user.auth0_user_id}
         res = await http_client.delete(
-            f"/v2/samples/{sample.submitting_group_id}/{sample.id}",
+            f"/v2/samples/{sample.id}",
             headers=auth_headers,
         )
         assert res.status_code == 200
@@ -100,7 +100,7 @@ async def test_delete_sample_failures(
     # Request this sample as a user who shouldn't be able to delete it.
     auth_headers = {"user_id": user2.auth0_user_id}
     res = await http_client.delete(
-        f"/v2/samples/{sample.submitting_group_id}/{sample.id}",
+        f"/v2/samples/{sample.id}",
         headers=auth_headers,
     )
     assert res.status_code == 404

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -18,7 +18,7 @@ async def test_delete_sample_success(
     http_client: AsyncClient,
 ):
     """
-    Test successful sample deletion by public & private ID
+    Test successful sample deletion by ID
     """
     group = group_factory()
     user = user_factory(group)
@@ -51,7 +51,7 @@ async def test_delete_sample_success(
     for sample in [samples[0], samples[1]]:
         auth_headers = {"user_id": user.auth0_user_id}
         res = await http_client.delete(
-            f"/v2/samples/{sample.submitting_group_id}/{sample.public_identifier}",
+            f"/v2/samples/{sample.submitting_group_id}/{sample.id}",
             headers=auth_headers,
         )
         assert res.status_code == 200
@@ -100,7 +100,7 @@ async def test_delete_sample_failures(
     # Request this sample as a user who shouldn't be able to delete it.
     auth_headers = {"user_id": user2.auth0_user_id}
     res = await http_client.delete(
-        f"/v2/samples/{sample.submitting_group_id}/{sample.public_identifier}",
+        f"/v2/samples/{sample.submitting_group_id}/{sample.id}",
         headers=auth_headers,
     )
     assert res.status_code == 404

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -61,10 +61,10 @@ async def test_delete_sample_success(
     rows = 0
     for sample in samples:
         res = await async_session.execute(
-            sa.select(Sample).filter(Sample.id == sample.id)
+            sa.select(Sample).filter(Sample.id == sample.id)  # type: ignore
         )
         try:
-            row = res.scalars().one()
+            row = res.scalars().one()  # type: ignore
         except NoResultFound:
             assert sample.id in [samples[0].id, samples[1].id]
             rows += 1
@@ -105,6 +105,6 @@ async def test_delete_sample_failures(
     )
     assert res.status_code == 404
     # Make sure our sample is still in the db.
-    res = await async_session.execute(sa.select(Sample).filter(Sample.id == sample.id))
-    found_sample = res.scalars().one()
+    res = await async_session.execute(sa.select(Sample).filter(Sample.id == sample.id))  # type: ignore
+    found_sample = res.scalars().one()  # type: ignore
     assert found_sample.id == sample.id

--- a/src/backend/aspen/api/views/tests/test_users.py
+++ b/src/backend/aspen/api/views/tests/test_users.py
@@ -18,4 +18,4 @@ async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -
         "/v2/users/me", headers={"user_id": user.auth0_user_id}
     )
     assert response.status_code == 200
-    assert response.json() == {"agreed_to_tos": True}
+    assert response.json() == {"agreed_to_tos": True, "group_id": 1}

--- a/src/backend/aspen/database/models/sequences.py
+++ b/src/backend/aspen/database/models/sequences.py
@@ -213,7 +213,7 @@ class UploadedPathogenGenome(PathogenGenome):
     sample_id = Column(Integer, ForeignKey(Sample.id), unique=True, nullable=False)
     sample = relationship(  # type: ignore
         Sample,
-        backref=backref("uploaded_pathogen_genome", uselist=False),
+        backref=backref("uploaded_pathogen_genome", uselist=False, cascade="delete"),
     )
 
     sequencing_depth = Column(Float)

--- a/src/backend/aspen/database/models/sequences.py
+++ b/src/backend/aspen/database/models/sequences.py
@@ -211,9 +211,11 @@ class UploadedPathogenGenome(PathogenGenome):
         Integer, ForeignKey(PathogenGenome.entity_id), primary_key=True
     )
     sample_id = Column(Integer, ForeignKey(Sample.id), unique=True, nullable=False)
+    # The default value of cascade is "save-update, merge", so if we want to enable "delete", we 
+    # need to include the other options as well to maintain backwards compatibility.
     sample = relationship(  # type: ignore
         Sample,
-        backref=backref("uploaded_pathogen_genome", uselist=False, cascade="delete"),
+        backref=backref("uploaded_pathogen_genome", uselist=False, cascade="delete, merge, save-update"),
     )
 
     sequencing_depth = Column(Float)

--- a/src/backend/aspen/database/models/sequences.py
+++ b/src/backend/aspen/database/models/sequences.py
@@ -211,11 +211,15 @@ class UploadedPathogenGenome(PathogenGenome):
         Integer, ForeignKey(PathogenGenome.entity_id), primary_key=True
     )
     sample_id = Column(Integer, ForeignKey(Sample.id), unique=True, nullable=False)
-    # The default value of cascade is "save-update, merge", so if we want to enable "delete", we 
+    # The default value of cascade is "save-update, merge", so if we want to enable "delete", we
     # need to include the other options as well to maintain backwards compatibility.
     sample = relationship(  # type: ignore
         Sample,
-        backref=backref("uploaded_pathogen_genome", uselist=False, cascade="delete, merge, save-update"),
+        backref=backref(
+            "uploaded_pathogen_genome",
+            uselist=False,
+            cascade="delete, merge, save-update",
+        ),
     )
 
     sequencing_depth = Column(Float)

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -322,8 +322,11 @@ def download_samples(ctx, sample_ids):
 @click.pass_context
 def delete_samples(ctx, sample_ids):
     api_client = ctx.obj["api_client"]
+    userinfo = api_client.get("/v2/users/me")
+    user_group_id = userinfo.json()["group_id"]
+
     for sample in sample_ids:
-        resp = api_client.delete(f"/v2/samples/{sample}")
+        resp = api_client.delete(f"/v2/samples/{user_group_id}/{sample}")
         print(resp.headers)
         print(resp.text)
 

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -322,11 +322,8 @@ def download_samples(ctx, sample_ids):
 @click.pass_context
 def delete_samples(ctx, sample_ids):
     api_client = ctx.obj["api_client"]
-    userinfo = api_client.get("/v2/users/me")
-    user_group_id = userinfo.json()["group_id"]
-
     for sample in sample_ids:
-        resp = api_client.delete(f"/v2/samples/{user_group_id}/{sample}")
+        resp = api_client.delete(f"/v2/samples/{sample}")
         print(resp.headers)
         print(resp.text)
 

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -317,6 +317,17 @@ def download_samples(ctx, sample_ids):
     print(resp.text)
 
 
+@samples.command(name="delete")
+@click.argument("sample_ids", nargs=-1)
+@click.pass_context
+def delete_samples(ctx, sample_ids):
+    api_client = ctx.obj["api_client"]
+    for sample in sample_ids:
+        resp = api_client.delete(f"/v2/samples/{sample}")
+        print(resp.headers)
+        print(resp.text)
+
+
 @samples.command(name="update_public_ids")
 @click.option("group_id", "--group-id", type=int, required=True)
 @click.option(


### PR DESCRIPTION
### Summary:
- **What:** Add an endpoint for deleting samples, and restrict it to be accessible only by the group that owns those samples.
- **Ticket:** [sc171771](https://app.shortcut.com/genepi/story/171771)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)