### PR TITLE
Maya/166015 collapsible instructions component

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { NewTabLink } from "src/common/components/library/NewTabLink";
+import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
+import { SemiBold } from "./style";
+
+const SampleIdInput = (): JSX.Element => {
+  return (
+    <CollapsibleInstructions
+      header="Add Samples by ID (optional)"
+      items={[
+        <div key={0}>
+          Add <SemiBold>GISAID IDs</SemiBold> (e.g. USA/CA-CZB-0000/2021 or
+          hCoV-19/USA/CA-CZB-0000/2021), <SemiBold>Aspen Public IDs</SemiBold>,
+          or <SemiBold>Aspen Private IDs</SemiBold> below to include samples in
+          your tree.
+        </div>,
+        <div key={1}>
+          IDs must be separated by tabs, commas, or enter one ID per row.
+        </div>,
+        <div key={2}>
+          Depending on the Tree Type, add up to 2000 samples.{" "}
+          <NewTabLink href="https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4">
+            Learn More
+          </NewTabLink>
+        </div>,
+        <div key={3}>
+          <SemiBold>
+            As with samples uploaded directly to Aspen, sequences added by ID do
+            not undergo any QC before being added to your tree.
+          </SemiBold>
+        </div>,
+      ]}
+    />
+  );
+};
+
+export { SampleIdInput };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+import { getFontWeights } from "czifui";
+
+export const SemiBold = styled.span`
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      font-weight: ${fontWeights?.semibold};
+    `;
+  }}
+`;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
@@ -49,7 +49,6 @@ const TreeNameInput = ({
             Tree names must be no longer than 128 characters.
           </InstructionsNotSemiBold>,
         ]}
-        shouldStartOpen={false}
       />
       <StyledTextField
         fullWidth

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/index.tsx
@@ -1,17 +1,14 @@
 import React, { useEffect, useState } from "react";
+import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
 import {
-  FieldTitle,
   StyledTextField,
   TextFieldAlert,
-  TreeNameInfoWrapper,
   TreeNameTooLongAlert,
 } from "../../style";
 import {
   InstructionsNotSemiBold,
   InstructionsSemiBold,
   StyledErrorOutlinedIcon,
-  StyledInstructions,
-  StyledInstructionsButton,
 } from "./style";
 
 interface Props {
@@ -25,13 +22,11 @@ const TreeNameInput = ({
   shouldReset,
   treeName,
 }: Props): JSX.Element => {
-  const [areInstructionsShown, setInstructionsShown] = useState<boolean>(false);
   const [isTreeNameTooLong, setTreeNameTooLong] = useState<boolean>(false);
 
   // form closed or cleared
   useEffect(() => {
     if (shouldReset) {
-      setInstructionsShown(false);
       setTreeNameTooLong(false);
     }
   }, [shouldReset]);
@@ -42,35 +37,20 @@ const TreeNameInput = ({
     setTreeNameTooLong(isNameTooLong);
   }, [treeName]);
 
-  // toggle instructions
-  const handleInstructionsClick = function () {
-    setInstructionsShown((prevState: boolean) => !prevState);
-  };
-
   return (
     <div>
-      <TreeNameInfoWrapper>
-        <FieldTitle>Tree Name</FieldTitle>
-        <StyledInstructionsButton
-          color="primary"
-          onClick={handleInstructionsClick}
-        >
-          {/* TODO (mlila): refactor out collapsible instructions into its own component */}
-          {areInstructionsShown ? "LESS" : "MORE"} INFO
-        </StyledInstructionsButton>
-      </TreeNameInfoWrapper>
-      {areInstructionsShown && (
-        <StyledInstructions
-          items={[
-            <InstructionsSemiBold key="1">
-              Do not include any PII in your Tree name.
-            </InstructionsSemiBold>,
-            <InstructionsNotSemiBold key="2">
-              Tree names must be no longer than 128 characters.
-            </InstructionsNotSemiBold>,
-          ]}
-        />
-      )}
+      <CollapsibleInstructions
+        header="Tree Name"
+        items={[
+          <InstructionsSemiBold key="1">
+            Do not include any PII in your Tree name.
+          </InstructionsSemiBold>,
+          <InstructionsNotSemiBold key="2">
+            Tree names must be no longer than 128 characters.
+          </InstructionsNotSemiBold>,
+        ]}
+        shouldStartOpen={false}
+      />
       <StyledTextField
         fullWidth
         error={isTreeNameTooLong}

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/TreeNameInput/style.ts
@@ -1,29 +1,13 @@
 import styled from "@emotion/styled";
 import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
 import {
-  Button,
   fontBodyXs,
-  fontCapsXxxs,
   getColors,
   getFontWeights,
   getIconSizes,
   getSpaces,
   Props,
 } from "czifui";
-import Instructions from "src/components/Instructions";
-
-export const StyledInstructions = styled(Instructions)`
-  border-radius: 4px;
-  color: black;
-
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      margin-bottom: ${spaces?.xs}px;
-      padding: ${spaces?.l}px;
-    `;
-  }}
-`;
 
 export const InstructionsSemiBold = styled.span`
   color: black;
@@ -41,23 +25,6 @@ export const InstructionsSemiBold = styled.span`
 export const InstructionsNotSemiBold = styled.span`
   color: black;
   ${fontBodyXs}
-`;
-
-export const StyledInstructionsButton = styled(Button)`
-  ${fontCapsXxxs}
-  padding-left: 0px;
-  ${(props) => {
-    const spaces = getSpaces(props);
-    const colors = getColors(props);
-    return `
-      margin-left: ${spaces?.m}px;
-      padding-top: ${spaces?.xxs}px;
-      &:hover {
-        background-color: transparent;
-        color: ${colors?.primary[500]};
-      }
-    `;
-  }}
 `;
 
 export const StyledErrorOutlinedIcon = styled(ErrorOutlineIcon)`

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -13,6 +13,7 @@ import {
   RadioLabelNonContextualized,
   RadioLabelTargeted,
 } from "./components/RadioLabel";
+import { SampleIdInput } from "./components/SampleIdInput";
 import { TreeNameInput } from "./components/TreeNameInput";
 import {
   Content,
@@ -190,7 +191,7 @@ export const CreateNSTreeModal = ({
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               <>
                 <Separator marginSize="l" />
-                <FieldTitle>Add Samples by ID (optional)</FieldTitle>
+                <SampleIdInput />
                 <Separator marginSize="xl" />
               </>
             )}

--- a/src/frontend/src/components/CollapsibleInstructions/index.tsx
+++ b/src/frontend/src/components/CollapsibleInstructions/index.tsx
@@ -1,0 +1,64 @@
+import { List, ListItem } from "czifui";
+import React, { useState } from "react";
+import { InstructionsProps } from "./components/Instructions";
+import {
+  HeaderWrapper,
+  StyledInstructionsButton,
+  Title,
+  Wrapper,
+} from "./style";
+
+interface Props extends InstructionsProps {
+  className?: string;
+  header: string;
+  instructionListTitle?: string;
+  items: React.ReactNode[];
+  ordered?: boolean;
+  shouldStartOpen: boolean;
+}
+
+const CollapsibleInstructions = ({
+  className,
+  header,
+  instructionListTitle,
+  items,
+  ordered,
+  shouldStartOpen = false,
+}: Props): JSX.Element => {
+  const [shouldShowInstructions, setShowInstructions] =
+    useState(shouldStartOpen);
+
+  const handleInstructionsClick = () => {
+    setShowInstructions(!shouldShowInstructions);
+  };
+
+  return (
+    <>
+      <HeaderWrapper>
+        {header}
+        <StyledInstructionsButton
+          color="primary"
+          onClick={handleInstructionsClick}
+        >
+          {shouldShowInstructions ? "LESS" : "MORE"} INFO
+        </StyledInstructionsButton>
+      </HeaderWrapper>
+      {shouldShowInstructions && (
+        <Wrapper className={className}>
+          {instructionListTitle && <Title>{instructionListTitle}</Title>}
+          <List ordered={ordered}>
+            {items.map((item, index) => {
+              return (
+                <ListItem fontSize="s" key={index} ordered={ordered}>
+                  {item}
+                </ListItem>
+              );
+            })}
+          </List>
+        </Wrapper>
+      )}
+    </>
+  );
+};
+
+export { CollapsibleInstructions };

--- a/src/frontend/src/components/CollapsibleInstructions/index.tsx
+++ b/src/frontend/src/components/CollapsibleInstructions/index.tsx
@@ -3,25 +3,30 @@ import React, { useState } from "react";
 import { InstructionsProps } from "./components/Instructions";
 import {
   HeaderWrapper,
+  InstructionsTitle,
+  InstructionsWrapper,
+  SizeType,
   StyledInstructionsButton,
-  Title,
-  Wrapper,
 } from "./style";
 
 interface Props extends InstructionsProps {
-  className?: string;
+  buttonSize?: SizeType;
   header: string;
+  headerSize?: SizeType;
   instructionListTitle?: string;
   items: React.ReactNode[];
+  listPadding?: SizeType;
   ordered?: boolean;
   shouldStartOpen: boolean;
 }
 
 const CollapsibleInstructions = ({
-  className,
+  buttonSize = "xxxs",
   header,
+  headerSize = "xs",
   instructionListTitle,
   items,
+  listPadding = "l",
   ordered,
   shouldStartOpen = false,
 }: Props): JSX.Element => {
@@ -34,9 +39,10 @@ const CollapsibleInstructions = ({
 
   return (
     <>
-      <HeaderWrapper>
+      <HeaderWrapper headerSize={headerSize}>
         {header}
         <StyledInstructionsButton
+          buttonSize={buttonSize}
           color="primary"
           onClick={handleInstructionsClick}
         >
@@ -44,8 +50,10 @@ const CollapsibleInstructions = ({
         </StyledInstructionsButton>
       </HeaderWrapper>
       {shouldShowInstructions && (
-        <Wrapper className={className}>
-          {instructionListTitle && <Title>{instructionListTitle}</Title>}
+        <InstructionsWrapper listPadding={listPadding}>
+          {instructionListTitle && (
+            <InstructionsTitle>{instructionListTitle}</InstructionsTitle>
+          )}
           <List ordered={ordered}>
             {items.map((item, index) => {
               return (
@@ -55,7 +63,7 @@ const CollapsibleInstructions = ({
               );
             })}
           </List>
-        </Wrapper>
+        </InstructionsWrapper>
       )}
     </>
   );

--- a/src/frontend/src/components/CollapsibleInstructions/index.tsx
+++ b/src/frontend/src/components/CollapsibleInstructions/index.tsx
@@ -1,7 +1,7 @@
 import { List, ListItem } from "czifui";
 import React, { useState } from "react";
-import { InstructionsProps } from "./components/Instructions";
 import {
+  CapsSizeType,
   HeaderWrapper,
   InstructionsTitle,
   InstructionsWrapper,
@@ -9,15 +9,15 @@ import {
   StyledInstructionsButton,
 } from "./style";
 
-interface Props extends InstructionsProps {
-  buttonSize?: SizeType;
+interface Props {
+  buttonSize?: CapsSizeType;
   header: string;
   headerSize?: SizeType;
   instructionListTitle?: string;
   items: React.ReactNode[];
   listPadding?: SizeType;
   ordered?: boolean;
-  shouldStartOpen: boolean;
+  shouldStartOpen?: boolean;
 }
 
 const CollapsibleInstructions = ({

--- a/src/frontend/src/components/CollapsibleInstructions/style.ts
+++ b/src/frontend/src/components/CollapsibleInstructions/style.ts
@@ -6,9 +6,11 @@ import {
   fontHeaderXs,
   getColors,
   getSpaces,
+  Props,
 } from "czifui";
 
-export const SizeType = "xxxs" | "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
+export type CapsSizeType = "xxxxs" | "xxxs" | "xxs";
+export type SizeType = "xxxs" | "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
 interface HeaderProps extends Props {
   headerSize: SizeType;
 }
@@ -29,7 +31,7 @@ export const HeaderWrapper = styled("div", {
 `;
 
 interface InstructionsButtonProps extends Props {
-  buttonSize: SizeType;
+  buttonSize: CapsSizeType;
 }
 
 export const StyledInstructionsButton = styled(Button, {

--- a/src/frontend/src/components/CollapsibleInstructions/style.ts
+++ b/src/frontend/src/components/CollapsibleInstructions/style.ts
@@ -1,23 +1,40 @@
 import styled from "@emotion/styled";
 import {
   Button,
-  fontCapsXxxs,
+  fontCaps,
+  fontHeader,
   fontHeaderXs,
   getColors,
   getSpaces,
 } from "czifui";
 
-export const HeaderWrapper = styled.div`
-  ${fontHeaderXs}
+export const SizeType = "xxxs" | "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
+interface HeaderProps extends Props {
+  headerSize: SizeType;
+}
 
+const doNotForwardProps = ["buttonSize", "headerSize", "listPadding"];
+
+export const HeaderWrapper = styled("div", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
   display: flex;
   align-items: center;
   color: black;
+
+  ${(props: HeaderProps) => {
+    const { headerSize } = props;
+    return fontHeader(headerSize);
+  }}
 `;
 
-export const StyledInstructionsButton = styled(Button)`
-  ${fontCapsXxxs}
+interface InstructionsButtonProps extends Props {
+  buttonSize: SizeType;
+}
 
+export const StyledInstructionsButton = styled(Button, {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
   ${(props) => {
     const spaces = getSpaces(props);
     const colors = getColors(props);
@@ -31,25 +48,37 @@ export const StyledInstructionsButton = styled(Button)`
       }
     `;
   }}
+  ${(props: InstructionsButtonProps) => {
+    const { buttonSize } = props;
+    if (!buttonSize) return;
+    return fontCaps(buttonSize);
+  }}
 `;
 
-export const Wrapper = styled.div`
+interface InstructionsWrapperProps extends Props {
+  listPadding: SizeType;
+}
+
+export const InstructionsWrapper = styled("div", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
   border-radius: 4px;
   color: black;
 
-  ${(props) => {
+  ${(props: InstructionsWrapperProps) => {
+    const { listPadding } = props;
     const colors = getColors(props);
     const spaces = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[100]};
       margin-bottom: ${spaces?.xs}px;
-      padding: ${spaces?.l}px;
+      padding: ${spaces?.[listPadding]}px;
     `;
   }}
 `;
 
-export const Title = styled.div`
+export const InstructionsTitle = styled.div`
   ${fontHeaderXs}
 
   ${(props) => {

--- a/src/frontend/src/components/CollapsibleInstructions/style.ts
+++ b/src/frontend/src/components/CollapsibleInstructions/style.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+import {
+  Button,
+  fontCapsXxxs,
+  fontHeaderXs,
+  getColors,
+  getSpaces,
+} from "czifui";
+
+export const HeaderWrapper = styled.div`
+  ${fontHeaderXs}
+
+  display: flex;
+  align-items: center;
+  color: black;
+`;
+
+export const StyledInstructionsButton = styled(Button)`
+  ${fontCapsXxxs}
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    const colors = getColors(props);
+
+    return `
+      margin-left: ${spaces?.xxxs}px;
+      margin-top: ${spaces?.xxxs}px;
+      &:hover {
+        background-color: transparent;
+        color: ${colors?.primary[500]};
+      }
+    `;
+  }}
+`;
+
+export const Wrapper = styled.div`
+  border-radius: 4px;
+  color: black;
+
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      background-color: ${colors?.gray[100]};
+      margin-bottom: ${spaces?.xs}px;
+      padding: ${spaces?.l}px;
+    `;
+  }}
+`;
+
+export const Title = styled.div`
+  ${fontHeaderXs}
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.xxs}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -5,12 +5,12 @@ import Link from "next/link";
 import React, { useEffect, useState } from "react";
 import { ROUTES } from "src/common/routes";
 import AlertAccordion from "src/components/AlertAccordion";
+import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
 import Progress from "../common/Progress";
 import {
   ButtonWrapper,
   Content,
   Header,
-  StyledInstructions,
   Subtitle,
   Title,
 } from "../common/style";
@@ -21,12 +21,9 @@ import {
   ContentWrapper,
   SemiBold,
   StyledButton,
-  StyledContainerLeft,
   StyledContainerSpaceBetween,
   StyledFilePicker,
-  StyledInstructionsButton,
   StyledRemoveAllButton,
-  StyledTitle,
   StyledUploadCount,
 } from "./style";
 import {
@@ -40,7 +37,6 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
   const [parseErrors, setParseErrors] = useState<ParseErrors | null>(null);
   const [sampleCount, setSampleCount] = useState(0);
   const [fileCount, setFileCount] = useState(0);
-  const [showInstructions, setShowInstructions] = useState(true);
   const [isLoadingFile, setIsLoadingFile] = useState(false);
   const [tooManySamples, setTooManySamples] = useState(false);
 
@@ -77,10 +73,6 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
     setParseErrors(null);
   };
 
-  const handleInstructionsClick = () => {
-    setShowInstructions(!showInstructions);
-  };
-
   return (
     <>
       <Head>
@@ -97,41 +89,35 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
         <Progress step="1" />
       </Header>
       <Content>
-        <StyledContainerLeft>
-          <StyledTitle>Select SARS-CoV-2 Consensus Genome Files</StyledTitle>
-          <StyledInstructionsButton
-            color="primary"
-            onClick={handleInstructionsClick}
-          >
-            {showInstructions ? "LESS" : "MORE"} INFO
-          </StyledInstructionsButton>
-        </StyledContainerLeft>
-        {showInstructions && (
-          <StyledInstructions
-            title="File instructions"
-            items={[
-              <span key="1">
-                <SemiBold>
-                  Do not include any PII in the Sample name or file name.
-                </SemiBold>{" "}
-                Your sample name should be the sample&apos;s Private ID.
-              </span>,
-              <span key="2">
-                Accepted file formats: fasta (.fa or .fasta), fasta.gz (.fa.gz),
-                fasta.zip
-              </span>,
-              <span key="3">
-                Sample names must be no longer than 120 characters and can only
-                contain letters from the English alphabet (A-Z, upper and lower
-                case), numbers (0-9), periods (.), hyphens (-), underscores (_),
-                spaces ( ), and forward slashes (/).
-              </span>,
-              <span key="4">
-                The maximum number of samples accommodated per upload is 500.
-              </span>,
-            ]}
-          />
-        )}
+        <CollapsibleInstructions
+          buttonSize="xxs"
+          header="Select SARS-CoV-2 Consensus Genome Files"
+          headerSize="xl"
+          instructionListTitle="File instructions"
+          listPadding="xl"
+          shouldStartOpen
+          items={[
+            <span key="1">
+              <SemiBold>
+                Do not include any PII in the Sample name or file name.
+              </SemiBold>{" "}
+              Your sample name should be the sample&apos;s Private ID.
+            </span>,
+            <span key="2">
+              Accepted file formats: fasta (.fa or .fasta), fasta.gz (.fa.gz),
+              fasta.zip
+            </span>,
+            <span key="3">
+              Sample names must be no longer than 120 characters and can only
+              contain letters from the English alphabet (A-Z, upper and lower
+              case), numbers (0-9), periods (.), hyphens (-), underscores (_),
+              spaces ( ), and forward slashes (/).
+            </span>,
+            <span key="4">
+              The maximum number of samples accommodated per upload is 500.
+            </span>,
+          ]}
+        />
         <ContentWrapper>
           <StyledFilePicker
             text={isLoadingFile ? "Loading..." : "Select Fasta Files"}

--- a/src/frontend/src/views/Upload/components/Samples/style.ts
+++ b/src/frontend/src/views/Upload/components/Samples/style.ts
@@ -1,11 +1,5 @@
 import styled from "@emotion/styled";
-import {
-  Button,
-  fontCapsXxs,
-  fontHeaderXl,
-  getColors,
-  getSpaces,
-} from "czifui";
+import { Button, fontCapsXxs, getColors, getSpaces } from "czifui";
 import FilePicker from "src/components/FilePicker";
 import { marginBottom } from "../common/style";
 

--- a/src/frontend/src/views/Upload/components/Samples/style.ts
+++ b/src/frontend/src/views/Upload/components/Samples/style.ts
@@ -33,19 +33,6 @@ export const StyledFilePicker = styled(FilePicker)`
   }}
 `;
 
-export const StyledContainerLeft = styled.div`
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: left;
-      margin-bottom: ${spaces?.xs};
-  `;
-  }}
-`;
-
 export const StyledContainerSpaceBetween = styled.div`
   ${(props) => {
     const spaces = getSpaces(props);
@@ -55,23 +42,6 @@ export const StyledContainerSpaceBetween = styled.div`
       align-items: center;
       justify-content: space-between;
       margin-bottom: ${spaces?.m};
-    `;
-  }}
-`;
-
-export const StyledInstructionsButton = styled(Button)`
-  ${fontCapsXxs}
-  ${(props) => {
-    const spaces = getSpaces(props);
-    const colors = getColors(props);
-    return `
-      margin-right: ${spaces?.s}px;
-      margin-left: ${spaces?.m}px;
-      margin-top: ${spaces?.s}px;
-      &:hover {
-        background-color: transparent;
-        color: ${colors?.primary[500]};
-      }
     `;
   }}
 `;
@@ -102,10 +72,6 @@ export const StyledUploadCount = styled.span`
     margin-top: ${spaces?.xl}px;
     `;
   }}
-`;
-
-export const StyledTitle = styled.span`
-  ${fontHeaderXl}
 `;
 
 export const ContentWrapper = styled.div`


### PR DESCRIPTION
### Summary
- **What:** 
  - Create a collapsible instructions component that manages its own styling and open/close state
  - Add sample id input instructions for gisaid ingest
- **Why:** DRY
- **Ticket:** [[sc-166015]](https://app.shortcut.com/genepi/story/166015)
- **Env:** https://gisaid-frontend.dev.genepi.czi.technology
- **Design:** https://www.figma.com/file/E7SnuofUBpy8xixY6eUiWz/Self-Serve-Tree-V2---GISAID-Ingest?node-id=1976%3A98763

### Demos
<img width="549" alt="Screen Shot 2021-11-01 at 5 22 54 PM" src="https://user-images.githubusercontent.com/7562933/139762888-ee17008e-df98-45bc-98d9-fc54dccccf36.png">

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)