### PR TITLE
Maya/166015 gisaid input

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -10,11 +10,13 @@ import { StyledLabel, StyledLoadingAnimation, StyledTextArea } from "./style";
 interface Props {
   handleInputModeChange(isEditing: boolean): void;
   handleInputValidation(found: string[], missing: string[]): void;
+  shouldReset?: boolean;
 }
 
 const SampleIdInput = ({
   handleInputModeChange,
   handleInputValidation,
+  shouldReset,
 }: Props): JSX.Element => {
   const [inputValue, setInputValue] = useState<string>("");
   const [isInEditMode, setInEditMode] = useState<boolean>(true);
@@ -23,6 +25,12 @@ const SampleIdInput = ({
   const [idsInFlight, setIdsInFlight] = useState<string[]>([]);
   const [foundSampleIds, setFoundSampleIds] = useState<string[]>([]);
   const [shouldValidate, setShouldValidate] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (shouldReset) {
+      setInputValue("");
+    }
+  }, [shouldReset]);
 
   const parseInputIds = useCallback(() => {
     const tokens = inputValue.split(/[\n\t,]/g);

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -8,10 +8,14 @@ import { InputInstructions } from "./components/InputInstructions";
 import { StyledLabel, StyledLoadingAnimation, StyledTextArea } from "./style";
 
 interface Props {
+  handleInputModeChange(isEditing: boolean): void;
   handleInputValidation(found: string[], missing: string[]): void;
 }
 
-const SampleIdInput = ({ handleInputValidation }: Props): JSX.Element => {
+const SampleIdInput = ({
+  handleInputModeChange,
+  handleInputValidation,
+}: Props): JSX.Element => {
   const [inputValue, setInputValue] = useState<string>("");
   const [isInEditMode, setInEditMode] = useState<boolean>(true);
   const [isValidating, setValidating] = useState<boolean>(false);
@@ -54,6 +58,7 @@ const SampleIdInput = ({ handleInputValidation }: Props): JSX.Element => {
       setShouldValidate(false);
       setValidating(true);
       setInEditMode(false);
+      handleInputModeChange(false);
 
       if (idsInFlight.length > 0) {
         validateSampleIdentifiersMutation.mutate({
@@ -71,6 +76,7 @@ const SampleIdInput = ({ handleInputValidation }: Props): JSX.Element => {
 
   const onClickEdit = () => {
     setInEditMode(true);
+    handleInputModeChange(true);
     setShowAddButton(true);
   };
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -45,7 +45,7 @@ const SampleIdInput = ({
         setShowAddButton(false);
         setFoundSampleIds([]);
         setIdsInFlight([]);
-        handleInputValidation([]);
+        handleInputValidation([], []);
       },
       onSuccess: (data: any) => {
         setValidating(false);

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -57,6 +57,7 @@ export const CreateNSTreeModal = ({
 }: Props): JSX.Element => {
   const [treeName, setTreeName] = useState<string>("");
   const [isTreeBuildDisabled, setTreeBuildDisabled] = useState<boolean>(false);
+  const [isInputInEditMode, setIsInputInEditMode] = useState<boolean>(false);
   const [shouldReset, setShouldReset] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<TreeType>(TreeTypes.Targeted);
   const [missingInputSamples, setMissingInputSamples] = useState<string[]>([]);
@@ -77,6 +78,10 @@ export const CreateNSTreeModal = ({
   const handleClose = function () {
     clearState();
     onClose();
+  };
+
+  const handleInputModeChange = (isEditing: boolean) => {
+    setIsInputInEditMode(isEditing);
   };
 
   const handleInputValidation = (
@@ -206,7 +211,11 @@ export const CreateNSTreeModal = ({
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               <>
                 <Separator marginSize="l" />
-                <SampleIdInput handleInputValidation={handleInputValidation} />
+                <SampleIdInput
+                  handleInputModeChange={handleInputModeChange}
+                  handleInputValidation={handleInputValidation}
+                  shouldReset={shouldReset}
+                />
                 <Separator marginSize="xl" />
               </>
             )}
@@ -214,11 +223,10 @@ export const CreateNSTreeModal = ({
               numFailedSamples={allFailedOrMissingSamples?.length}
             />
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
-              // TODO (mlila): ensure all of these props are accurate (state managed from input)
               <CreateTreeButton
                 hasValidName={hasValidName}
                 hasSamples={allValidSamplesForTreeCreation.length > 0}
-                isInEditMode={false}
+                isInEditMode={isInputInEditMode}
                 isValidTreeType={Object.values(TreeTypes).includes(treeType)}
               />
             )}

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -59,6 +59,10 @@ export const CreateNSTreeModal = ({
   const [isTreeBuildDisabled, setTreeBuildDisabled] = useState<boolean>(false);
   const [shouldReset, setShouldReset] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<TreeType>(TreeTypes.Targeted);
+  const [missingInputSamples, setMissingInputSamples] = useState<string[]>([]);
+  const [validatedInputSamples, setValidatedInputSamples] = useState<string[]>(
+    []
+  );
 
   useEffect(() => {
     if (shouldReset) setShouldReset(false);
@@ -73,6 +77,14 @@ export const CreateNSTreeModal = ({
   const handleClose = function () {
     clearState();
     onClose();
+  };
+
+  const handleInputValidation = (
+    foundSamples: string[],
+    missingSamples: string[]
+  ) => {
+    setValidatedInputSamples(foundSamples);
+    setMissingInputSamples(missingSamples);
   };
 
   useEffect(() => {
@@ -106,12 +118,6 @@ export const CreateNSTreeModal = ({
     },
   });
 
-  const handleSubmit = (evt: SyntheticEvent) => {
-    evt.preventDefault();
-    sampleIds = sampleIds.filter((id) => !failedSamples.includes(id));
-    mutation.mutate({ sampleIds, treeName, treeType });
-  };
-
   const TREE_TYPE_TOOLTIP_TEXT = (
     <div>
       Select the Tree Type best suited for the question you are trying to anwer.{" "}
@@ -120,6 +126,21 @@ export const CreateNSTreeModal = ({
       </NewTabLink>
     </div>
   );
+
+  const allPossibleSamples = sampleIds.concat(validatedInputSamples);
+  const allFailedOrMissingSamples = failedSamples.concat(missingInputSamples);
+  const allValidSamplesForTreeCreation = allPossibleSamples.filter(
+    (id) => !allFailedOrMissingSamples.includes(id)
+  );
+
+  const handleSubmit = (evt: SyntheticEvent) => {
+    evt.preventDefault();
+    mutation.mutate({
+      sampleIds: allValidSamplesForTreeCreation,
+      treeName,
+      treeType,
+    });
+  };
 
   return (
     <Dialog
@@ -136,7 +157,8 @@ export const CreateNSTreeModal = ({
         </StyledIconButton>
         <Header>Create New Phylogenetic Tree</Header>
         <Title>
-          {sampleIds.length} {pluralize("Sample", sampleIds.length)} Total
+          {allValidSamplesForTreeCreation.length}{" "}
+          {pluralize("Sample", allValidSamplesForTreeCreation.length)} Total
         </Title>
       </StyledDialogTitle>
       <StyledDialogContent>
@@ -184,16 +206,18 @@ export const CreateNSTreeModal = ({
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               <>
                 <Separator marginSize="l" />
-                <SampleIdInput />
+                <SampleIdInput handleInputValidation={handleInputValidation} />
                 <Separator marginSize="xl" />
               </>
             )}
-            <FailedSampleAlert numFailedSamples={failedSamples?.length} />
+            <FailedSampleAlert
+              numFailedSamples={allFailedOrMissingSamples?.length}
+            />
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               // TODO (mlila): ensure all of these props are accurate (state managed from input)
               <CreateTreeButton
                 hasValidName={hasValidName}
-                hasSamples={sampleIds.length > 0}
+                hasSamples={allValidSamplesForTreeCreation.length > 0}
                 isInEditMode={false}
                 isValidTreeType={Object.values(TreeTypes).includes(treeType)}
               />


### PR DESCRIPTION
### Summary
- **What:** 
  - Add a way to reset/clear the input (like if the modal is closed)
  - pass validated/missing ids from input to the modal, and update sample count labels with newly updated counts
  - prevent tree creation when input has unsaved content
- **Ticket:** [[sc-166015]](https://app.shortcut.com/genepi/story/166015)
- **Env:** https://gisaid-frontend.dev.genepi.czi.technology
- **Design:** https://www.figma.com/file/E7SnuofUBpy8xixY6eUiWz/Self-Serve-Tree-V2---GISAID-Ingest?node-id=1976%3A105409

### Demos
![after](https://user-images.githubusercontent.com/7562933/140463985-99c52bd6-0af9-4460-a24f-56dc5a913cb0.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)