### PR TITLE
Maya/166015 gisaid input

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
@@ -17,6 +17,7 @@ const CreateTreeButton = ({
 }: Props): JSX.Element => {
   const NO_NAME_NO_SAMPLES =
     "Your tree requires a Tree Name & at least 1 Sample or Sample ID.";
+  const NO_NAME = "Your tree requires a Tree Name.";
   const NO_SAMPLES = "Your tree requires at least 1 Sample or Sample ID.";
   const SAMPLES_ARE_IN_EDIT =
     "Finish adding Sample IDs before creating your tree.";
@@ -24,6 +25,7 @@ const CreateTreeButton = ({
   let tooltipTitle = "";
 
   if (!hasValidName && !hasSamples) tooltipTitle = NO_NAME_NO_SAMPLES;
+  else if (!hasValidName) tooltipTitle = NO_NAME;
   else if (!hasSamples) tooltipTitle = NO_SAMPLES;
   else if (isInEditMode) tooltipTitle = SAMPLES_ARE_IN_EDIT;
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/style.ts
@@ -1,13 +1,10 @@
 import styled from "@emotion/styled";
-import { Button, getColors, getSpaces } from "czifui";
+import { Button, getColors } from "czifui";
 
 export const StyledButton = styled(Button)`
   ${(props) => {
-    const spaces = getSpaces(props);
     const colors = getColors(props);
     return `
-      margin-top: ${spaces?.xxl}px;
-
       &:active {
         background-color: ${colors?.gray[400]};
       }

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
@@ -1,4 +1,5 @@
 import { Collapse } from "@material-ui/core";
+import { List, ListItem } from "czifui";
 import React, { useState } from "react";
 import { pluralize } from "src/common/utils/strUtils";
 import { SemiBold, StyledCallout } from "../../../FailedSampleAlert/style";
@@ -30,7 +31,11 @@ const MissingSampleAlert = ({ missingSamples }: Props): JSX.Element | null => {
         {areMissingIdsShown ? <StyledArrowUpIcon /> : <StyledArrowDownIcon />}
       </div>
       <Collapse in={areMissingIdsShown}>
-        <div>{missingSamples}</div>
+        <List>
+          {missingSamples.map((sample) => {
+            return <ListItem key={sample}>{sample}</ListItem>
+          })}
+        </List>
       </Collapse>
     </StyledCallout>
   );

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
@@ -1,0 +1,39 @@
+import { Collapse } from "@material-ui/core";
+import React, { useState } from "react";
+import { pluralize } from "src/common/utils/strUtils";
+import { SemiBold, StyledCallout } from "../../../FailedSampleAlert/style";
+import { StyledArrowDownIcon, StyledArrowUpIcon } from "./style";
+
+interface Props {
+  missingSamples: string[];
+}
+
+const MissingSampleAlert = ({ missingSamples }: Props): JSX.Element | null => {
+  const [areMissingIdsShown, setMissingIdsShown] = useState<boolean>(false);
+
+  const numMissingSamples = missingSamples.length;
+  if (numMissingSamples <= 0) return null;
+
+  const toggleCollapse = () => {
+    setMissingIdsShown(!areMissingIdsShown);
+  };
+
+  return (
+    <StyledCallout intent="warning" onClick={toggleCollapse}>
+      <div>
+        <SemiBold>
+          {numMissingSamples} Sample {pluralize("ID", numMissingSamples)}{" "}
+          couldn’t be found
+        </SemiBold>{" "}
+        and may not appear on your tree. Please double check and correct any
+        errors.
+        {areMissingIdsShown ? <StyledArrowUpIcon /> : <StyledArrowDownIcon />}
+      </div>
+      <Collapse in={areMissingIdsShown}>
+        <div>{missingSamples}</div>
+      </Collapse>
+    </StyledCallout>
+  );
+};
+
+export { MissingSampleAlert };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
@@ -33,7 +33,7 @@ const MissingSampleAlert = ({ missingSamples }: Props): JSX.Element | null => {
       <Collapse in={areMissingIdsShown}>
         <List>
           {missingSamples.map((sample) => {
-            return <ListItem key={sample}>{sample}</ListItem>
+            return <ListItem key={sample}>{sample}</ListItem>;
           })}
         </List>
       </Collapse>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
-import { getIconSizes } from "czifui";
+import { getIconSizes, Props } from "czifui";
 import ArrowDownIcon from "src/common/icons/IconArrowDownSmall.svg";
 import ArrowUpIcon from "src/common/icons/IconArrowUpSmall.svg";
 
-const smallIcon = (props) => {
+const smallIcon = (props: Props) => {
   const iconSizes = getIconSizes(props);
   return `
     height: ${iconSizes?.s.height}px;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
@@ -1,0 +1,20 @@
+import styled from "@emotion/styled";
+import { getIconSizes } from "czifui";
+import ArrowDownIcon from "src/common/icons/IconArrowDownSmall.svg";
+import ArrowUpIcon from "src/common/icons/IconArrowUpSmall.svg";
+
+const smallIcon = (props) => {
+  const iconSizes = getIconSizes(props);
+  return `
+    height: ${iconSizes?.s.height}px;
+    width: ${iconSizes?.s.width}px;
+  `;
+};
+
+export const StyledArrowDownIcon = styled(ArrowDownIcon)`
+  ${smallIcon}
+`;
+
+export const StyledArrowUpIcon = styled(ArrowUpIcon)`
+  ${smallIcon}
+`;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -26,11 +26,24 @@ const SampleIdInput = ({
   const [foundSampleIds, setFoundSampleIds] = useState<string[]>([]);
   const [shouldValidate, setShouldValidate] = useState<boolean>(false);
 
+  // clear the input
   useEffect(() => {
     if (shouldReset) {
       setInputValue("");
+      setInputDisplayValue("");
+      setInEditMode(true);
+      setValidating(false);
+      setShowAddButton(false);
+      setIdsInFlight([]);
+      setFoundSampleIds([]);
+      setShouldValidate(false);
     }
   }, [shouldReset]);
+
+  // whenever we change the input mode, let the parent know
+  useEffect(() => {
+    handleInputModeChange(isInEditMode);
+  }, [handleInputModeChange, isInEditMode]);
 
   const parseInputIds = useCallback(() => {
     const tokens = inputValue.split(/[\n\t,]/g);
@@ -47,6 +60,8 @@ const SampleIdInput = ({
         setFoundSampleIds([]);
         setIdsInFlight([]);
         handleInputValidation([], []);
+        setInputDisplayValue("");
+        setInEditMode(true);
       },
       onSuccess: (data: any) => {
         setValidating(false);
@@ -75,12 +90,7 @@ const SampleIdInput = ({
         });
       }
     }
-  }, [
-    handleInputModeChange,
-    idsInFlight,
-    shouldValidate,
-    validateSampleIdentifiersMutation,
-  ]);
+  }, [idsInFlight, shouldValidate, validateSampleIdentifiersMutation]);
 
   const validateIds = () => {
     const sampleIdsToValidate = parseInputIds();
@@ -90,7 +100,6 @@ const SampleIdInput = ({
 
   const onClickEdit = () => {
     setInEditMode(true);
-    handleInputModeChange(true);
     setShowAddButton(true);
   };
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -18,6 +18,8 @@ const SampleIdInput = ({
   handleInputValidation,
   shouldReset,
 }: Props): JSX.Element => {
+  const [hasEverFocusedInput, setHasEverFocusedInput] =
+    useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>("");
   const [inputDisplayValue, setInputDisplayValue] = useState<string>("");
   const [isInEditMode, setInEditMode] = useState<boolean>(true);
@@ -41,10 +43,14 @@ const SampleIdInput = ({
     }
   }, [shouldReset]);
 
-  // whenever we change the input mode, let the parent know
+  // whenever we change the input mode, let the parent know. This controls
+  // disabling the create button and tooltip associated with edit mode.
+  // if they never clicked into the input, don't force them to add something
+  // and save before moving forward
   useEffect(() => {
-    handleInputModeChange(isInEditMode);
-  }, [handleInputModeChange, isInEditMode]);
+    const mode = hasEverFocusedInput ? isInEditMode : false;
+    handleInputModeChange(mode);
+  }, [handleInputModeChange, hasEverFocusedInput, isInEditMode]);
 
   const parseInputIds = useCallback(() => {
     const tokens = inputValue.split(/[\n\t,]/g);
@@ -79,7 +85,7 @@ const SampleIdInput = ({
   );
 
   useEffect(() => {
-    if (shouldValidate && idsInFlight.length > 0) {
+    if (shouldValidate) {
       setShouldValidate(false);
       setValidating(true);
       setInEditMode(false);
@@ -109,7 +115,10 @@ const SampleIdInput = ({
         // TODO (mlila): should be replaced with sds InputText when available
         disabled={!isInEditMode}
         onChange={(e) => setInputValue(e?.target?.value)}
-        onFocus={() => setShowAddButton(true)}
+        onFocus={() => {
+          setShowAddButton(true);
+          setHasEverFocusedInput(true);
+        }}
         fullWidth
         multiline
         variant="outlined"

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -79,17 +79,15 @@ const SampleIdInput = ({
   );
 
   useEffect(() => {
-    if (shouldValidate) {
+    if (shouldValidate && idsInFlight.length > 0) {
       setShouldValidate(false);
       setValidating(true);
       setInEditMode(false);
       setInputDisplayValue(idsInFlight.join("\n"));
 
-      if (idsInFlight.length > 0) {
-        validateSampleIdentifiersMutation.mutate({
-          sampleIdsToValidate: idsInFlight,
-        });
-      }
+      validateSampleIdentifiersMutation.mutate({
+        sampleIdsToValidate: idsInFlight,
+      });
     }
   }, [idsInFlight, shouldValidate, validateSampleIdentifiersMutation]);
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -34,7 +34,8 @@ const SampleIdInput = ({
 
   const parseInputIds = useCallback(() => {
     const tokens = inputValue.split(/[\n\t,]/g);
-    return compact(tokens);
+    const trimmedTokens = tokens.map((t) => t.trim());
+    return compact(trimmedTokens);
   }, [inputValue]);
 
   const validateSampleIdentifiersMutation = useMutation(

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -74,7 +74,12 @@ const SampleIdInput = ({
         });
       }
     }
-  }, [idsInFlight, shouldValidate, validateSampleIdentifiersMutation]);
+  }, [
+    handleInputModeChange,
+    idsInFlight,
+    shouldValidate,
+    validateSampleIdentifiersMutation,
+  ]);
 
   const validateIds = () => {
     const sampleIdsToValidate = parseInputIds();

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -97,6 +97,7 @@ const SampleIdInput = ({
     <>
       <InputInstructions />
       <StyledTextArea
+        // TODO (mlila): should be replaced with sds InputText when available
         disabled={!isInEditMode}
         onChange={(e) => setInputValue(e?.target?.value)}
         onFocus={() => setShowAddButton(true)}

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -19,6 +19,7 @@ const SampleIdInput = ({
   shouldReset,
 }: Props): JSX.Element => {
   const [inputValue, setInputValue] = useState<string>("");
+  const [inputDisplayValue, setInputDisplayValue] = useState<string>("");
   const [isInEditMode, setInEditMode] = useState<boolean>(true);
   const [isValidating, setValidating] = useState<boolean>(false);
   const [shouldShowAddButton, setShowAddButton] = useState<boolean>(false);
@@ -82,7 +83,7 @@ const SampleIdInput = ({
       setShouldValidate(false);
       setValidating(true);
       setInEditMode(false);
-      handleInputModeChange(false);
+      setInputDisplayValue(idsInFlight.join("\n"));
 
       if (idsInFlight.length > 0) {
         validateSampleIdentifiersMutation.mutate({
@@ -116,7 +117,7 @@ const SampleIdInput = ({
         variant="outlined"
         rows={3}
         size="small"
-        value={inputValue}
+        value={isInEditMode ? inputValue : inputDisplayValue}
       />
       {shouldShowAddButton && (
         <Button

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
@@ -1,13 +1,49 @@
 import styled from "@emotion/styled";
 import { TextField } from "@material-ui/core";
-import { getColors, getIconSizes, getSpaces } from "czifui";
+import {
+  fontBodyXs,
+  getColors,
+  getCorners,
+  getIconSizes,
+  getSpaces,
+} from "czifui";
 import LoadingAnimation from "src/common/icons/IconLoadingAnimated.svg";
 
+const inputPadding = (props) => {
+  const spaces = getSpaces(props);
+  return `
+    .MuiInputBase-root {
+      padding: ${spaces?.s}px ${spaces?.l}px;
+    }
+  `;
+};
+
 export const StyledTextArea = styled(TextField)`
+  // TODO (mlila): input doesn't displace button
+  ${fontBodyXs}
+  ${inputPadding}
+  height: 70px;
+
   textarea {
-    color: black;
     resize: both;
   }
+`;
+
+export const DisabledStyledTextArea = styled(TextField)`
+  ${fontBodyXs}
+  ${inputPadding}
+  height: 90px;
+
+  ${(props) => {
+    const colors = getColors(props);
+    const corners = getCorners(props);
+
+    return `
+      background-color: ${colors?.gray[100]};
+      border-radius: ${corners?.m}px;
+      margin: ${spaces?.xxxs}px 0;
+    `;
+  }}
 `;
 
 export const StyledLabel = styled.div`

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
@@ -6,10 +6,11 @@ import {
   getCorners,
   getIconSizes,
   getSpaces,
+  Props,
 } from "czifui";
 import LoadingAnimation from "src/common/icons/IconLoadingAnimated.svg";
 
-const inputPadding = (props) => {
+const inputPadding = (props: Props) => {
   const spaces = getSpaces(props);
   return `
     .MuiInputBase-root {
@@ -18,8 +19,8 @@ const inputPadding = (props) => {
   `;
 };
 
+// TODO (mlila): input doesn't displace button
 export const StyledTextArea = styled(TextField)`
-  // TODO (mlila): input doesn't displace button
   ${fontBodyXs}
   ${inputPadding}
   height: 70px;
@@ -37,6 +38,7 @@ export const DisabledStyledTextArea = styled(TextField)`
   ${(props) => {
     const colors = getColors(props);
     const corners = getCorners(props);
+    const spaces = getSpaces(props);
 
     return `
       background-color: ${colors?.gray[100]};

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -74,6 +74,8 @@ export const CreateNSTreeModal = ({
     setShouldReset(true);
     setTreeName("");
     setTreeType(TreeTypes.Targeted);
+    setMissingInputSamples([]);
+    setValidatedInputSamples([]);
   };
 
   const handleClose = function () {
@@ -221,9 +223,7 @@ export const CreateNSTreeModal = ({
               </>
             )}
             <MissingSampleAlert missingSamples={missingInputSamples} />
-            <FailedSampleAlert
-              numFailedSamples={allFailedOrMissingSamples?.length}
-            />
+            <FailedSampleAlert numFailedSamples={failedSamples?.length} />
             {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
               <CreateTreeButton
                 hasValidName={hasValidName}

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -10,6 +10,7 @@ import { Header, StyledIconButton } from "../DownloadModal/style";
 import { FailedSampleAlert } from "../FailedSampleAlert";
 import { CreateTreeButton } from "./components/CreateTreeButton";
 import { StyledButton } from "./components/CreateTreeButton/style";
+import { MissingSampleAlert } from "./components/MissingSampleAlert";
 import {
   RadioLabelNonContextualized,
   RadioLabelTargeted,
@@ -219,6 +220,7 @@ export const CreateNSTreeModal = ({
                 <Separator marginSize="xl" />
               </>
             )}
+            <MissingSampleAlert missingSamples={missingInputSamples} />
             <FailedSampleAlert
               numFailedSamples={allFailedOrMissingSamples?.length}
             />

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -18,6 +18,13 @@ import DialogTitle from "src/common/components/library/Dialog/components/DialogT
 
 export const StyledDialogContent = styled(DialogContent)`
   width: 600px;
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      padding-bottom: ${spaces?.xxl}px;
+    `;
+  }}
 `;
 
 export const Title = styled.span`


### PR DESCRIPTION
### Summary
- **What:** The last of the functionality for gisaid
  - Add a tooltip for when tree doesn't have a name
  - Add a warning with a collapsible list of ID that were not found in the database
  - Don't show "Finish adding samples" tooltip if user never interacted with input (was a bug)
  - Trims leading and trailing whitespace from all IDs before validating with BE
  - Clear all input state when reset, rather than just the input value
  - Fix a bug where the input froze if you saved when it was empty (😬  oops)
  - Logic for alternating input value display when input is in edit mode vs disabled (one id per line when disabled)
  - Begin styling work
- **Ticket:** [[sc-166015]](https://app.shortcut.com/genepi/story/166015)
- **Env:** https://gisaid-frontend.dev.genepi.czi.technology
- **Design:** https://www.figma.com/file/E7SnuofUBpy8xixY6eUiWz/Self-Serve-Tree-V2---GISAID-Ingest?node-id=1976%3A107536

### Demos
![Screen Shot 2021-11-05 at 11 10 18 AM](https://user-images.githubusercontent.com/7562933/140559083-87dc91b9-7810-45e7-a063-684df3fd56d3.png)
![after](https://user-images.githubusercontent.com/7562933/140559099-3f77b7f3-0129-4712-9660-b504bb51e98d.gif)

### Notes
On to styling next!

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)