### PR TITLE
Danrlu/pin ncov 1109

### DIFF
--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -75,7 +75,7 @@ task nextstrain_workflow {
     mkdir -p ncov/my_profiles/aspen ncov/results
     (cd ncov &&
      git init &&
-     git fetch --depth 1 git://github.com/nextstrain/ncov.git &&
+     git fetch --depth 1 git://github.com/nextstrain/ncov.git df90b457f48ef3d7500927656536cacb16c9a83f &&
      git checkout FETCH_HEAD
     )
     ncov_git_rev=$(cd ncov && git rev-parse HEAD)

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -26,7 +26,7 @@ aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$aspen_config")"
 mkdir -p ncov/my_profiles/aspen ncov/results
 (cd ncov &&
  git init &&
- git fetch --depth 1 git://github.com/nextstrain/ncov.git &&
+ git fetch --depth 1 git://github.com/nextstrain/ncov.git df90b457f48ef3d7500927656536cacb16c9a83f &&
  git checkout FETCH_HEAD
 )
 ncov_git_rev=$(cd ncov && git rev-parse HEAD)

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -41,7 +41,7 @@ echo "${workflow_id}" >| "/tmp/workflow_id"
 mkdir -p ncov/my_profiles/aspen ncov/results
 (cd ncov &&
  git init &&
- git fetch --depth 1 git://github.com/nextstrain/ncov.git &&
+ git fetch --depth 1 git://github.com/nextstrain/ncov.git df90b457f48ef3d7500927656536cacb16c9a83f &&
  git checkout FETCH_HEAD
 )
 ncov_git_rev=$(cd ncov && git rev-parse HEAD)


### PR DESCRIPTION
### Summary:
- **What:** Nextstrain had 2 changes related to crowding penalty: 
    - [here](https://github.com/nextstrain/ncov/pull/772/files) they changed the way it is calculated, which made trees look different and I need to further understand why; 
    - [here](https://github.com/nextstrain/ncov/blob/9833274e1595c5eaa9f14ca42776fae2f59bf07b/workflow/snakemake_rules/main_workflow.smk#L491-L500) they surfaced crowding penalty as a parameter, which with my limited understanding will not be compatible with our patch [here](https://github.com/chanzuckerberg/aspen/blob/trunk/src/backend/aspen/workflows/nextstrain_run/patches/local_ncov_settings.patch)?? **(if our patch will still work, then we don't need to deploy right away!)**
- Pinned to a version before the 2 above changes.

- **Ticket:** [sc<num>](https://app.shortcut.com/genepi/story/173121/hotfix-pin-old-ncov-version-fixes-patch-issue-with-crowding-penalty)

### Demos:
Tried the pinned version with tree EC2 and all looks good.

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)