### PR TITLE
update isl accessions

### DIFF
--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -549,10 +549,10 @@ def update_sample_public_ids():
             isl_number = private_to_public[s.private_identifier]
             accessions = s.uploaded_pathogen_genome.accessions()
 
-            # if the accessions length == 1 that means that currently no isl number exists on the uploaded_pathogen_genome
-            if not len(accessions) == 1:
-                # first accession public_identifier is 'gisaid_public_identifier', the second accession returned is the one that we want to update
-                accessions[1].public_identifier = isl_number
+            if accessions:
+                for accession in accessions:
+                    if isinstance(accession, GisaidAccession):
+                        accession.public_identifier = isl_number
             else:
                 # create a new accession if DNE
                 s.uploaded_pathogen_genome.add_accession(

--- a/src/backend/aspen/app/views/sample.py
+++ b/src/backend/aspen/app/views/sample.py
@@ -561,25 +561,25 @@ def update_sample_public_ids():
                     workflow_start_datetime=datetime.datetime.now(),
                     workflow_end_datetime=datetime.datetime.now(),
                 )
-
-        return jsonify(success=True)
-
-    else:
-        # check that public_identifiers don't already exist
-        existing_public_ids: list[str] = api_utils.get_existing_public_ids(
-            request_public_ids, g.db_session, group_id=group_id
-        )
-        if existing_public_ids:
-            raise ex.BadRequestException(
-                f"Public Identifiers {existing_public_ids} are already in the database",
-            )
-
-        for s in samples_to_update.all():
-            s.public_identifier = private_to_public[s.private_identifier]
-            g.db_session.add(s)
-
+                g.db_session.add(s)
         g.db_session.commit()
         return jsonify(success=True)
+
+    # check that public_identifiers don't already exist
+    existing_public_ids: list[str] = api_utils.get_existing_public_ids(
+        request_public_ids, g.db_session, group_id=group_id
+    )
+    if existing_public_ids:
+        raise ex.BadRequestException(
+            f"Public Identifiers {existing_public_ids} are already in the database",
+        )
+
+    for s in samples_to_update.all():
+        s.public_identifier = private_to_public[s.private_identifier]
+        g.db_session.add(s)
+
+    g.db_session.commit()
+    return jsonify(success=True)
 
 
 @application.route("/api/samples/validate-ids", methods=["POST"])

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1219,9 +1219,7 @@ def test_update_sample_new_gisaid_isl(
         sample = sample_factory(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
-        uploaded_pathogen_genome_factory(
-            sample, sequence="ATGCAAAAAA"
-        )
+        uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
         session.add(sample)
 
     session.commit()

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1219,7 +1219,9 @@ def test_update_sample_new_gisaid_isl(
         sample = sample_factory(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
-        uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA", add_accessions=False)
+        uploaded_pathogen_genome_factory(
+            sample, sequence="ATGCAAAAAA", add_accessions=False
+        )
         session.add(sample)
 
     session.commit()

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1199,6 +1199,61 @@ def test_update_sample_gisaid_isl(
     assert accessions[1].public_identifier == private_to_public[r.private_identifier]
 
 
+def test_update_sample_new_gisaid_isl(
+    session,
+    app,
+    client,
+):
+    group = group_factory()
+    user = user_factory(group, system_admin=True)
+    session.add(group)
+
+    private_to_public = dict(
+        zip(
+            ["private1", "private2", "private3"],
+            ["isl_1", "isl_2", "isl_3"],
+        )
+    )
+
+    for priv, pub in private_to_public.items():
+        sample = sample_factory(
+            group, user, private_identifier=priv, public_identifier=f"{pub}_public"
+        )
+        uploaded_pathogen_genome_factory(
+            sample, sequence="ATGCAAAAAA"
+        )
+        session.add(sample)
+
+    session.commit()
+
+    with client.session_transaction() as sess:
+        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
+
+    data = {
+        "group_id": group.id,
+        "id_mapping": private_to_public,
+        "public_ids_are_gisaid_isl": True,
+    }
+
+    res = client.post(
+        "/api/samples/update/publicids", json=data, content_type="application/json"
+    )
+
+    assert res.status == "200 OK"
+
+    # assert samples have been updated:
+    s = (
+        session.query(Sample)
+        .options(joinedload(Sample.uploaded_pathogen_genome))
+        .filter(Sample.private_identifier.in_(private_to_public.keys()))
+        .all()
+    )
+    for r in s:
+        accessions = r.uploaded_pathogen_genome.accessions()
+        # first accession 'gisaid_public_identifier', the second accession returned is the one that we want to update
+    assert accessions[1].public_identifier == private_to_public[r.private_identifier]
+
+
 def setup_validation_data(session: Session, client: FlaskClient):
     group = group_factory()
     user = user_factory(group)

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1164,7 +1164,7 @@ def test_update_sample_gisaid_isl(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
         uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-            sample, sequence="ATGCAAAAAA"
+            sample, sequence="ATGCAAAAAA", add_accessions=False
         )
         gisaid_accession_factory(uploaded_pathogen_genome, f"{pub}_old")
         session.add(sample)
@@ -1195,8 +1195,8 @@ def test_update_sample_gisaid_isl(
     )
     for r in s:
         accessions = r.uploaded_pathogen_genome.accessions()
-        # first accession 'gisaid_public_identifier', the second accession returned is the one that we want to update
-    assert accessions[1].public_identifier == private_to_public[r.private_identifier]
+        for a in accessions:
+            assert a.public_identifier == private_to_public[r.private_identifier]
 
 
 def test_update_sample_new_gisaid_isl(
@@ -1219,7 +1219,7 @@ def test_update_sample_new_gisaid_isl(
         sample = sample_factory(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
-        uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+        uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA", add_accessions=False)
         session.add(sample)
 
     session.commit()
@@ -1248,8 +1248,8 @@ def test_update_sample_new_gisaid_isl(
     )
     for r in s:
         accessions = r.uploaded_pathogen_genome.accessions()
-        # first accession 'gisaid_public_identifier', the second accession returned is the one that we want to update
-    assert accessions[1].public_identifier == private_to_public[r.private_identifier]
+        for a in accessions:
+            assert a.public_identifier == private_to_public[r.private_identifier]
 
 
 def setup_validation_data(session: Session, client: FlaskClient):

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1219,9 +1219,7 @@ def test_update_sample_new_gisaid_isl(
         sample = sample_factory(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
-        uploaded_pathogen_genome_factory(
-            sample, sequence="ATGCAAAAAA", accessions=()
-        )
+        uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA", accessions=())
         session.add(sample)
 
     session.commit()

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1164,7 +1164,7 @@ def test_update_sample_gisaid_isl(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
         uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-            sample, sequence="ATGCAAAAAA", add_accessions=False
+            sample, sequence="ATGCAAAAAA", accessions=()
         )
         gisaid_accession_factory(uploaded_pathogen_genome, f"{pub}_old")
         session.add(sample)
@@ -1220,7 +1220,7 @@ def test_update_sample_new_gisaid_isl(
             group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
         uploaded_pathogen_genome_factory(
-            sample, sequence="ATGCAAAAAA", add_accessions=False
+            sample, sequence="ATGCAAAAAA", accessions=()
         )
         session.add(sample)
 

--- a/src/backend/aspen/test_infra/models/gisaid_accession.py
+++ b/src/backend/aspen/test_infra/models/gisaid_accession.py
@@ -1,0 +1,12 @@
+import datetime
+
+from aspen.database.models import PublicRepositoryType
+
+
+def gisaid_accession_factory(uploaded_pathogen_genome, isl_accession_number):
+    uploaded_pathogen_genome.add_accession(
+        repository_type=PublicRepositoryType.GISAID,
+        public_identifier=isl_accession_number,
+        workflow_start_datetime=datetime.datetime.now(),
+        workflow_end_datetime=datetime.datetime.now(),
+    )

--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -48,7 +48,7 @@ def uploaded_pathogen_genome_factory(
     pangolin_last_updated=datetime.datetime.now(),
     sequencing_depth=0.1,
     upload_date=datetime.datetime.now(),
-    add_accessions=True
+    add_accessions=True,
 ):
 
     uploaded_pathogen_genome = UploadedPathogenGenome(
@@ -67,13 +67,15 @@ def uploaded_pathogen_genome_factory(
 
     if add_accessions:
         accessions: Sequence[AccessionWorkflowDirective] = (
-                                                               AccessionWorkflowDirective(
-                                                                   PublicRepositoryType.GISAID,
-                                                                   datetime.datetime.now(),
-                                                                   datetime.datetime.now(),
-                                                                   "gisaid_public_identifier",
-                                                               ),
-                                                           ),
+            (
+                AccessionWorkflowDirective(
+                    PublicRepositoryType.GISAID,
+                    datetime.datetime.now(),
+                    datetime.datetime.now(),
+                    "gisaid_public_identifier",
+                ),
+            ),
+        )
         for accession_workflow_directive in accessions:
             if accession_workflow_directive.end_datetime is None:
                 public_repository_metadata: PublicRepositoryTypeMetadata = (

--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -48,15 +48,9 @@ def uploaded_pathogen_genome_factory(
     pangolin_last_updated=datetime.datetime.now(),
     sequencing_depth=0.1,
     upload_date=datetime.datetime.now(),
-    accessions: Sequence[AccessionWorkflowDirective] = (
-        AccessionWorkflowDirective(
-            PublicRepositoryType.GISAID,
-            datetime.datetime.now(),
-            datetime.datetime.now(),
-            "gisaid_public_identifier",
-        ),
-    ),
+    add_accessions=True
 ):
+
     uploaded_pathogen_genome = UploadedPathogenGenome(
         sample=sample,
         sequence=sequence,
@@ -70,26 +64,36 @@ def uploaded_pathogen_genome_factory(
         sequencing_depth=sequencing_depth,
         upload_date=upload_date,
     )
-    for accession_workflow_directive in accessions:
-        if accession_workflow_directive.end_datetime is None:
-            public_repository_metadata: PublicRepositoryTypeMetadata = (
-                accession_workflow_directive.repository_type.value
-            )
-            uploaded_pathogen_genome.consuming_workflows.append(
-                public_repository_metadata.accession_workflow_cls(
-                    software_versions={},
-                    workflow_status=WorkflowStatusType.FAILED,
-                    start_datetime=accession_workflow_directive.start_datetime,
+
+    if add_accessions:
+        accessions: Sequence[AccessionWorkflowDirective] = (
+                                                               AccessionWorkflowDirective(
+                                                                   PublicRepositoryType.GISAID,
+                                                                   datetime.datetime.now(),
+                                                                   datetime.datetime.now(),
+                                                                   "gisaid_public_identifier",
+                                                               ),
+                                                           ),
+        for accession_workflow_directive in accessions:
+            if accession_workflow_directive.end_datetime is None:
+                public_repository_metadata: PublicRepositoryTypeMetadata = (
+                    accession_workflow_directive.repository_type.value
                 )
-            )
-        else:
-            assert accession_workflow_directive.repository_type is not None
-            assert accession_workflow_directive.public_identifier is not None
-            uploaded_pathogen_genome.add_accession(
-                repository_type=accession_workflow_directive.repository_type,
-                public_identifier=accession_workflow_directive.public_identifier,
-                workflow_start_datetime=accession_workflow_directive.start_datetime,
-                workflow_end_datetime=accession_workflow_directive.end_datetime,
-            )
+                uploaded_pathogen_genome.consuming_workflows.append(
+                    public_repository_metadata.accession_workflow_cls(
+                        software_versions={},
+                        workflow_status=WorkflowStatusType.FAILED,
+                        start_datetime=accession_workflow_directive.start_datetime,
+                    )
+                )
+            else:
+                assert accession_workflow_directive.repository_type is not None
+                assert accession_workflow_directive.public_identifier is not None
+                uploaded_pathogen_genome.add_accession(
+                    repository_type=accession_workflow_directive.repository_type,
+                    public_identifier=accession_workflow_directive.public_identifier,
+                    workflow_start_datetime=accession_workflow_directive.start_datetime,
+                    workflow_end_datetime=accession_workflow_directive.end_datetime,
+                )
 
     return uploaded_pathogen_genome

--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -48,9 +48,15 @@ def uploaded_pathogen_genome_factory(
     pangolin_last_updated=datetime.datetime.now(),
     sequencing_depth=0.1,
     upload_date=datetime.datetime.now(),
-    add_accessions=True,
+    accessions: Sequence[AccessionWorkflowDirective] = (
+        AccessionWorkflowDirective(
+            PublicRepositoryType.GISAID,
+            datetime.datetime.now(),
+            datetime.datetime.now(),
+            "gisaid_public_identifier",
+        ),
+    ),
 ):
-
     uploaded_pathogen_genome = UploadedPathogenGenome(
         sample=sample,
         sequence=sequence,
@@ -64,38 +70,26 @@ def uploaded_pathogen_genome_factory(
         sequencing_depth=sequencing_depth,
         upload_date=upload_date,
     )
-
-    if add_accessions:
-        accessions: Sequence[AccessionWorkflowDirective] = (
-            (
-                AccessionWorkflowDirective(
-                    PublicRepositoryType.GISAID,
-                    datetime.datetime.now(),
-                    datetime.datetime.now(),
-                    "gisaid_public_identifier",
-                ),
-            ),
-        )
-        for accession_workflow_directive in accessions:
-            if accession_workflow_directive.end_datetime is None:
-                public_repository_metadata: PublicRepositoryTypeMetadata = (
-                    accession_workflow_directive.repository_type.value
+    for accession_workflow_directive in accessions:
+        if accession_workflow_directive.end_datetime is None:
+            public_repository_metadata: PublicRepositoryTypeMetadata = (
+                accession_workflow_directive.repository_type.value
+            )
+            uploaded_pathogen_genome.consuming_workflows.append(
+                public_repository_metadata.accession_workflow_cls(
+                    software_versions={},
+                    workflow_status=WorkflowStatusType.FAILED,
+                    start_datetime=accession_workflow_directive.start_datetime,
                 )
-                uploaded_pathogen_genome.consuming_workflows.append(
-                    public_repository_metadata.accession_workflow_cls(
-                        software_versions={},
-                        workflow_status=WorkflowStatusType.FAILED,
-                        start_datetime=accession_workflow_directive.start_datetime,
-                    )
-                )
-            else:
-                assert accession_workflow_directive.repository_type is not None
-                assert accession_workflow_directive.public_identifier is not None
-                uploaded_pathogen_genome.add_accession(
-                    repository_type=accession_workflow_directive.repository_type,
-                    public_identifier=accession_workflow_directive.public_identifier,
-                    workflow_start_datetime=accession_workflow_directive.start_datetime,
-                    workflow_end_datetime=accession_workflow_directive.end_datetime,
-                )
+            )
+        else:
+            assert accession_workflow_directive.repository_type is not None
+            assert accession_workflow_directive.public_identifier is not None
+            uploaded_pathogen_genome.add_accession(
+                repository_type=accession_workflow_directive.repository_type,
+                public_identifier=accession_workflow_directive.public_identifier,
+                workflow_start_datetime=accession_workflow_directive.start_datetime,
+                workflow_end_datetime=accession_workflow_directive.end_datetime,
+            )
 
     return uploaded_pathogen_genome

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -330,6 +330,7 @@ def delete_samples(ctx, sample_ids):
 
 @samples.command(name="update_public_ids")
 @click.option("group_id", "--group-id", type=int, required=True)
+@click.option("is_gisaid_isl", "--is-gisaid-isl", is_flag=True)
 @click.option(
     "private_to_public_id_mapping_fh",
     "--private-to-public-id-mapping",
@@ -337,7 +338,7 @@ def delete_samples(ctx, sample_ids):
     required=True,
 )
 @click.pass_context
-def update_public_ids(ctx, group_id, private_to_public_id_mapping_fh):
+def update_public_ids(ctx, group_id, is_gisaid_isl, private_to_public_id_mapping_fh):
     api_client = ctx.obj["api_client"]
 
     csvreader = csv.DictReader(private_to_public_id_mapping_fh)
@@ -350,6 +351,11 @@ def update_public_ids(ctx, group_id, private_to_public_id_mapping_fh):
         "group_id": group_id,
         "id_mapping": private_to_public
     }
+
+    # check if public_identifiers to be updated are gisaid isl accession numbers
+    if is_gisaid_isl:
+        payload["public_ids_are_gisaid_isl"] = True
+
     resp = api_client.post("/api/samples/update/publicids", json=payload)
     print(resp.headers)
     print(resp.text)

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -331,6 +331,7 @@ def delete_samples(ctx, sample_ids):
 @samples.command(name="update_public_ids")
 @click.option("group_id", "--group-id", type=int, required=True)
 @click.option("is_gisaid_isl", "--is-gisaid-isl", is_flag=True)
+# csv file should have headers private_identifier and public_identifier
 @click.option(
     "private_to_public_id_mapping_fh",
     "--private-to-public-id-mapping",


### PR DESCRIPTION
### Summary:
- **What:** we also want to be able to update gisaid isl numbers through the update cli command. This will be used to fulfill an on call request 
- **Ticket:** [sc173210](https://app.shortcut.com/genepi/story/173210)
- **Env:** `<rdev link>`

### Demos:
usage: 
`python src/cli/aspencli.py --env staging samples update_public_ids --group-id 7 --private-to-public-id-mapping ~/Downloads/Aspen_Accessions_OC.csv --is-gisaid-isl
`
### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)