### PR TITLE
Maya/166015 gisaid input styling

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   hasValidName: boolean;
   isInEditMode: boolean;
   isValidTreeType: boolean;
+  onClick(e): void;
 }
 
 const CreateTreeButton = ({
@@ -14,6 +15,7 @@ const CreateTreeButton = ({
   hasValidName,
   isInEditMode,
   isValidTreeType,
+  onClick,
 }: Props): JSX.Element => {
   const NO_NAME_NO_SAMPLES =
     "Your tree requires a Tree Name & at least 1 Sample or Sample ID.";
@@ -36,6 +38,7 @@ const CreateTreeButton = ({
     <Tooltip
       arrow
       disableHoverListener={!isTreeBuildDisabled || !tooltipTitle}
+      placement="top"
       title={tooltipTitle}
     >
       <StyledButtonWrapper>
@@ -46,6 +49,7 @@ const CreateTreeButton = ({
           disabled={isTreeBuildDisabled}
           type="submit"
           value="Submit"
+          onClick={onClick}
         >
           Create Tree
         </StyledButton>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "czifui";
-import React from "react";
+import React, { MouseEventHandler } from "react";
 import { StyledButton, StyledButtonWrapper } from "./style";
 
 interface Props {
@@ -7,7 +7,7 @@ interface Props {
   hasValidName: boolean;
   isInEditMode: boolean;
   isValidTreeType: boolean;
-  onClick(e): void;
+  onClick: MouseEventHandler;
 }
 
 const CreateTreeButton = ({

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/style.ts
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import { Button, getColors } from "czifui";
 
 export const StyledButton = styled(Button)`
+  margin-top: 0;
+
   ${(props) => {
     const colors = getColors(props);
     return `

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
@@ -1,9 +1,17 @@
 import { Collapse } from "@material-ui/core";
-import { List, ListItem } from "czifui";
 import React, { useState } from "react";
 import { pluralize } from "src/common/utils/strUtils";
-import { SemiBold, StyledCallout } from "../../../FailedSampleAlert/style";
-import { StyledArrowDownIcon, StyledArrowUpIcon } from "./style";
+import { SemiBold } from "../../../FailedSampleAlert/style";
+import {
+  ColumnFlexContainer,
+  RowFlexContainer,
+  StaticSizeDiv,
+  StyledArrowDownIcon,
+  StyledArrowUpIcon,
+  StyledCallout,
+  StyledList,
+  StyledListItem,
+} from "./style";
 
 interface Props {
   missingSamples: string[];
@@ -21,22 +29,26 @@ const MissingSampleAlert = ({ missingSamples }: Props): JSX.Element | null => {
 
   return (
     <StyledCallout intent="warning" onClick={toggleCollapse}>
-      <div>
-        <SemiBold>
-          {numMissingSamples} Sample {pluralize("ID", numMissingSamples)}{" "}
-          couldn’t be found
-        </SemiBold>{" "}
-        and may not appear on your tree. Please double check and correct any
-        errors.
+      <RowFlexContainer>
+        <ColumnFlexContainer>
+          <StaticSizeDiv>
+            <SemiBold>
+              {numMissingSamples} Sample {pluralize("ID", numMissingSamples)}{" "}
+              couldn’t be found
+            </SemiBold>{" "}
+            and may not appear on your tree. Please double check and correct any
+            errors.
+          </StaticSizeDiv>
+          <Collapse in={areMissingIdsShown}>
+            <StyledList>
+              {missingSamples.map((sample) => {
+                return <StyledListItem key={sample}>{sample}</StyledListItem>;
+              })}
+            </StyledList>
+          </Collapse>
+        </ColumnFlexContainer>
         {areMissingIdsShown ? <StyledArrowUpIcon /> : <StyledArrowDownIcon />}
-      </div>
-      <Collapse in={areMissingIdsShown}>
-        <List>
-          {missingSamples.map((sample) => {
-            return <ListItem key={sample}>{sample}</ListItem>;
-          })}
-        </List>
-      </Collapse>
+      </RowFlexContainer>
     </StyledCallout>
   );
 };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
@@ -1,11 +1,13 @@
 import styled from "@emotion/styled";
-import { getIconSizes, Props } from "czifui";
+import { fontBodyXs, getColors, getIconSizes, getSpaces, ListItem, Props } from "czifui";
 import ArrowDownIcon from "src/common/icons/IconArrowDownSmall.svg";
 import ArrowUpIcon from "src/common/icons/IconArrowUpSmall.svg";
+import { StyledCallout as Callout } from "../../../FailedSampleAlert/style";
 
 const smallIcon = (props: Props) => {
   const iconSizes = getIconSizes(props);
   return `
+    flex: 0 0 auto;
     height: ${iconSizes?.s.height}px;
     width: ${iconSizes?.s.width}px;
   `;
@@ -17,4 +19,52 @@ export const StyledArrowDownIcon = styled(ArrowDownIcon)`
 
 export const StyledArrowUpIcon = styled(ArrowUpIcon)`
   ${smallIcon}
+`;
+
+export const RowFlexContainer = styled.div`
+  display: flex;
+  height: 100%;
+
+  .MuiCollapse-root {
+    overflow-y: scroll;
+  }
+`;
+
+export const ColumnFlexContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StaticSizeDiv = styled.div`
+  flex: 0 0 auto;
+`;
+
+export const StyledList = styled.ul`
+  padding: 0;
+
+  li:nth-child(odd) {
+    ${(props) => {
+      const colors = getColors(props);
+      return `
+        background-color: #F4EEE4;
+      `;
+    }}
+  }
+`;
+
+export const StyledListItem = styled.li`
+  ${fontBodyXs}
+  list-style-type: none;
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      padding: ${spaces?.m}px;
+    `;
+  }}
+`;
+
+export const StyledCallout = styled(Callout)`
+  max-height: 250px;
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
@@ -26,7 +26,7 @@ export const RowFlexContainer = styled.div`
   height: 100%;
 
   .MuiCollapse-root {
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 `;
 
@@ -42,7 +42,7 @@ export const StaticSizeDiv = styled.div`
 export const StyledList = styled.ul`
   padding: 0;
 
-  li:nth-child(odd) {
+  li:nth-of-type(odd) {
     ${(props) => {
       const colors = getColors(props);
       return `

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontBodyXs, getColors, getIconSizes, getSpaces, ListItem, Props } from "czifui";
+import { fontBodyXs, getIconSizes, getSpaces, Props } from "czifui";
 import ArrowDownIcon from "src/common/icons/IconArrowDownSmall.svg";
 import ArrowUpIcon from "src/common/icons/IconArrowUpSmall.svg";
 import { StyledCallout as Callout } from "../../../FailedSampleAlert/style";
@@ -42,13 +42,9 @@ export const StaticSizeDiv = styled.div`
 export const StyledList = styled.ul`
   padding: 0;
 
+  /* TODO (mlila): this should be exported from SDS */
   li:nth-of-type(odd) {
-    ${(props) => {
-      const colors = getColors(props);
-      return `
-        background-color: #F4EEE4;
-      `;
-    }}
+    background-color: #f4eee4;
   }
 `;
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
@@ -1,36 +1,38 @@
 import React from "react";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
-import { SemiBold } from "./style";
+import { SemiBold, StyledWrapper } from "./style";
 
 const InputInstructions = (): JSX.Element => {
   return (
-    <CollapsibleInstructions
-      header="Add Samples by ID (optional)"
-      items={[
-        <div key={0}>
-          Add <SemiBold>GISAID IDs</SemiBold> (e.g. USA/CA-CZB-0000/2021 or
-          hCoV-19/USA/CA-CZB-0000/2021), <SemiBold>Aspen Public IDs</SemiBold>,
-          or <SemiBold>Aspen Private IDs</SemiBold> below to include samples in
-          your tree.
-        </div>,
-        <div key={1}>
-          IDs must be separated by tabs, commas, or enter one ID per row.
-        </div>,
-        <div key={2}>
-          Depending on the Tree Type, add up to 2000 samples.{" "}
-          <NewTabLink href="https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4">
-            Learn More
-          </NewTabLink>
-        </div>,
-        <div key={3}>
-          <SemiBold>
-            As with samples uploaded directly to Aspen, sequences added by ID do
-            not undergo any QC before being added to your tree.
-          </SemiBold>
-        </div>,
-      ]}
-    />
+    <StyledWrapper>
+      <CollapsibleInstructions
+        header="Add Samples by ID (optional)"
+        items={[
+          <div key={0}>
+            Add <SemiBold>GISAID IDs</SemiBold> (e.g. USA/CA-CZB-0000/2021 or
+            hCoV-19/USA/CA-CZB-0000/2021), <SemiBold>Aspen Public IDs</SemiBold>
+            , or <SemiBold>Aspen Private IDs</SemiBold> below to include samples
+            in your tree.
+          </div>,
+          <div key={1}>
+            IDs must be separated by tabs, commas, or enter one ID per row.
+          </div>,
+          <div key={2}>
+            Depending on the Tree Type, add up to 2000 samples.{" "}
+            <NewTabLink href="https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4">
+              Learn More
+            </NewTabLink>
+          </div>,
+          <div key={3}>
+            <SemiBold>
+              As with samples uploaded directly to Aspen, sequences added by ID
+              do not undergo any QC before being added to your tree.
+            </SemiBold>
+          </div>,
+        ]}
+      />
+    </StyledWrapper>
   );
 };
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { getFontWeights, getSpaces } from "czifui";
+import { fontBodyXs, getFontWeights, getSpaces } from "czifui";
 
 export const SemiBold = styled.span`
   ${(props) => {
@@ -11,6 +11,10 @@ export const SemiBold = styled.span`
 `;
 
 export const StyledWrapper = styled.div`
+  .MuiListItem-root {
+    ${fontBodyXs}
+  }
+
   ${(props) => {
     const spaces = getSpaces(props);
     return `

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/style.ts
@@ -11,7 +11,7 @@ export const SemiBold = styled.span`
 `;
 
 export const StyledWrapper = styled.div`
-  .MuiListItem-root {
+  .MuiListItem-root div {
     ${fontBodyXs}
   }
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/style.ts
@@ -1,11 +1,20 @@
 import styled from "@emotion/styled";
-import { getFontWeights } from "czifui";
+import { getFontWeights, getSpaces } from "czifui";
 
 export const SemiBold = styled.span`
   ${(props) => {
     const fontWeights = getFontWeights(props);
     return `
       font-weight: ${fontWeights?.semibold};
+    `;
+  }}
+`;
+
+export const StyledWrapper = styled.div`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.xxxs}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -1,11 +1,17 @@
-import { Button } from "czifui";
 import { compact, filter } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { useMutation } from "react-query";
 import { validateSampleIdentifiers } from "src/common/queries/samples";
 import { pluralize } from "src/common/utils/strUtils";
 import { InputInstructions } from "./components/InputInstructions";
-import { StyledLabel, StyledLoadingAnimation, StyledTextArea } from "./style";
+import {
+  FlexContainer,
+  StyledAddButton,
+  StyledEditButton,
+  StyledLoadingAnimation,
+  StyledSampleCount,
+  StyledTextArea,
+} from "./style";
 
 interface Props {
   handleInputModeChange(isEditing: boolean): void;
@@ -122,38 +128,43 @@ const SampleIdInput = ({
         fullWidth
         multiline
         variant="outlined"
-        rows={3}
-        size="small"
+        rows={!isInEditMode ? 4 : 3}
         value={isInEditMode ? inputValue : inputDisplayValue}
         placeholder="e.g. USA/CA-CZB-0000/2021, USA/CA-CDPH-000000/2021"
       />
       {shouldShowAddButton && (
-        <Button
+        <StyledAddButton
           disabled={isValidating}
           onClick={validateIds}
           sdsStyle="square"
           sdsType="primary"
         >
           {isValidating ? (
-            <StyledLabel>
+            <FlexContainer>
               <StyledLoadingAnimation />
               Adding
-            </StyledLabel>
+            </FlexContainer>
           ) : (
             "Add"
           )}
-        </Button>
+        </StyledAddButton>
       )}
       {!isInEditMode && (
-        <div>
-          {foundSampleIds.length} {pluralize("Sample", foundSampleIds.length)}{" "}
-          Added
+        <FlexContainer>
+          <StyledSampleCount>
+            {foundSampleIds.length} {pluralize("Sample", foundSampleIds.length)}{" "}
+            Added
+          </StyledSampleCount>
           {!isValidating && (
-            <Button sdsStyle="minimal" sdsType="primary" onClick={onClickEdit}>
+            <StyledEditButton
+              sdsStyle="minimal"
+              sdsType="primary"
+              onClick={onClickEdit}
+            >
               Edit
-            </Button>
+            </StyledEditButton>
           )}
-        </div>
+        </FlexContainer>
       )}
     </>
   );

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -125,6 +125,7 @@ const SampleIdInput = ({
         rows={3}
         size="small"
         value={isInEditMode ? inputValue : inputDisplayValue}
+        placeholder="e.g. USA/CA-CZB-0000/2021, USA/CA-CDPH-000000/2021"
       />
       {shouldShowAddButton && (
         <Button

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -32,6 +32,7 @@ const SampleIdInput = ({
   const [shouldShowAddButton, setShowAddButton] = useState<boolean>(false);
   const [idsInFlight, setIdsInFlight] = useState<string[]>([]);
   const [foundSampleIds, setFoundSampleIds] = useState<string[]>([]);
+  const [missingSampleIds, setMissingSampleIds] = useState<string[]>([]);
   const [shouldValidate, setShouldValidate] = useState<boolean>(false);
 
   // clear the input
@@ -45,6 +46,7 @@ const SampleIdInput = ({
       setShowAddButton(false);
       setIdsInFlight([]);
       setFoundSampleIds([]);
+      setMissingSampleIds([]);
       setShouldValidate(false);
     }
   }, [shouldReset]);
@@ -71,6 +73,7 @@ const SampleIdInput = ({
         setValidating(false);
         setShowAddButton(false);
         setFoundSampleIds([]);
+        setMissingSampleIds([]);
         setIdsInFlight([]);
         handleInputValidation([], []);
         setInputDisplayValue("");
@@ -86,6 +89,7 @@ const SampleIdInput = ({
 
         setIdsInFlight([]);
         setFoundSampleIds(foundIds);
+        setMissingSampleIds(missingIds);
         handleInputValidation(foundIds, missingIds);
       },
     }
@@ -127,6 +131,8 @@ const SampleIdInput = ({
     setHasUnsavedChanges(!!value);
   };
 
+  const numParsedSamples = foundSampleIds.length + missingSampleIds.length;
+
   return (
     <>
       <InputInstructions />
@@ -163,8 +169,7 @@ const SampleIdInput = ({
       {!isInEditMode && (
         <FlexContainer>
           <StyledSampleCount>
-            {foundSampleIds.length} {pluralize("Sample", foundSampleIds.length)}{" "}
-            Added
+            {numParsedSamples} {pluralize("Sample", numParsedSamples)} Added
           </StyledSampleCount>
           {!isValidating && (
             <StyledEditButton

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { TextField } from "@material-ui/core";
 import {
+  Button,
   fontBodyXs,
   getColors,
   getCorners,
@@ -19,36 +20,45 @@ const inputPadding = (props: Props) => {
   `;
 };
 
-// TODO (mlila): input doesn't displace button
 export const StyledTextArea = styled(TextField)`
-  ${fontBodyXs}
   ${inputPadding}
-  height: 70px;
+
+  .MuiInputBase-root {
+    min-height: 70px;
+  }
 
   textarea {
+    ${fontBodyXs}
     resize: both;
   }
-`;
 
-export const DisabledStyledTextArea = styled(TextField)`
-  ${fontBodyXs}
-  ${inputPadding}
-  height: 90px;
+  ${(props: Props) => {
+    const { disabled } = props;
 
-  ${(props) => {
-    const colors = getColors(props);
-    const corners = getCorners(props);
-    const spaces = getSpaces(props);
+    if (disabled) {
+      const colors = getColors(props);
+      const corners = getCorners(props);
+      const spaces = getSpaces(props);
 
-    return `
-      background-color: ${colors?.gray[100]};
-      border-radius: ${corners?.m}px;
-      margin: ${spaces?.xxxs}px 0;
-    `;
+      return `
+        background-color: ${colors?.gray[100]};
+        border-radius: ${corners?.m}px;
+        margin: ${spaces?.xxxs}px 0;
+
+        .MuiInputBase-root {
+          height: 90px;
+        }
+
+        textarea {
+          color: black;
+          resize: none;
+        }
+      `;
+    }
   }}
 `;
 
-export const StyledLabel = styled.div`
+export const FlexContainer = styled.div`
   display: flex;
   align-items: center;
 `;
@@ -65,6 +75,37 @@ export const StyledLoadingAnimation = styled(LoadingAnimation)`
       }
       height: ${iconSizes?.l.height}px;
       width: ${iconSizes?.l.width}px;
+      margin-right: ${spaces?.m}px;
+    `;
+  }}
+`;
+
+export const StyledAddButton = styled(Button)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.m}px;
+    `;
+  }}
+`;
+
+export const StyledEditButton = styled(Button)`
+  padding: 0;
+  min-width: 0;
+
+  span {
+    margin: 0;
+  }
+`;
+
+export const StyledSampleCount = styled.span`
+  ${fontBodyXs}
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      color: ${colors?.gray[500]};
       margin-right: ${spaces?.m}px;
     `;
   }}

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
@@ -33,7 +33,12 @@ export const StyledTextArea = styled(TextField)`
 
   textarea {
     ${fontBodyXs}
-    resize: both;
+    resize: vertical;
+    scrollbar-color: transparent unset;
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
   }
 
   ${(props: ExtraProps) => {
@@ -51,6 +56,10 @@ export const StyledTextArea = styled(TextField)`
 
         .MuiInputBase-root {
           height: 90px;
+        }
+
+        fieldset {
+          border: none;
         }
 
         textarea {

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/style.ts
@@ -20,6 +20,10 @@ const inputPadding = (props: Props) => {
   `;
 };
 
+interface ExtraProps extends Props {
+  disabled?: boolean;
+}
+
 export const StyledTextArea = styled(TextField)`
   ${inputPadding}
 
@@ -32,7 +36,7 @@ export const StyledTextArea = styled(TextField)`
     resize: both;
   }
 
-  ${(props: Props) => {
+  ${(props: ExtraProps) => {
     const { disabled } = props;
 
     if (disabled) {

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -1,5 +1,6 @@
 import RadioGroup from "@material-ui/core/RadioGroup";
 import CloseIcon from "@material-ui/icons/Close";
+import { uniq } from "lodash";
 import React, { SyntheticEvent, useEffect, useState } from "react";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { useCreateTree } from "src/common/queries/trees";
@@ -135,10 +136,14 @@ export const CreateNSTreeModal = ({
     </div>
   );
 
-  const allPossibleSamples = sampleIds.concat(validatedInputSamples);
+  const allPossibleTreeSamples = sampleIds.concat(validatedInputSamples);
   const allFailedOrMissingSamples = failedSamples.concat(missingInputSamples);
-  const allValidSamplesForTreeCreation = allPossibleSamples.filter(
+  const allValidSamplesForTreeCreation = allPossibleTreeSamples.filter(
     (id) => !allFailedOrMissingSamples.includes(id)
+  );
+
+  const allSamplesRequestedTableAndInput = uniq(
+    allPossibleTreeSamples.concat(allFailedOrMissingSamples)
   );
 
   const handleSubmit = (evt: SyntheticEvent) => {
@@ -165,7 +170,7 @@ export const CreateNSTreeModal = ({
         </StyledIconButton>
         <Header>Create New Phylogenetic Tree</Header>
         <Title>
-          {allValidSamplesForTreeCreation.length}{" "}
+          {allSamplesRequestedTableAndInput.length}{" "}
           {pluralize("Sample", allValidSamplesForTreeCreation.length)} Total
         </Title>
       </StyledDialogTitle>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -1,4 +1,3 @@
-import { Dialog } from "@material-ui/core";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import CloseIcon from "@material-ui/icons/Close";
 import React, { SyntheticEvent, useEffect, useState } from "react";
@@ -18,12 +17,13 @@ import {
 import { SampleIdInput } from "./components/SampleIdInput";
 import { TreeNameInput } from "./components/TreeNameInput";
 import {
-  Content,
   CreateTreeInfo,
   FieldTitle,
   Separator,
+  StyledDialog,
   StyledDialogContent,
   StyledDialogTitle,
+  StyledFooter,
   StyledFormControlLabel,
   StyledInfoOutlinedIcon,
   StyledRadio,
@@ -151,7 +151,7 @@ export const CreateNSTreeModal = ({
   };
 
   return (
-    <Dialog
+    <StyledDialog
       disableBackdropClick
       disableEscapeKeyDown
       open={open}
@@ -169,87 +169,87 @@ export const CreateNSTreeModal = ({
           {pluralize("Sample", allValidSamplesForTreeCreation.length)} Total
         </Title>
       </StyledDialogTitle>
-      <StyledDialogContent>
-        <Content data-test-id="modal-content">
-          <form onSubmit={handleSubmit}>
-            <TreeNameInput setTreeName={setTreeName} treeName={treeName} />
-            <TreeTypeSection>
-              <TreeNameInfoWrapper>
-                <FieldTitle>Tree Type: </FieldTitle>
-                <StyledTooltip
-                  arrow
-                  leaveDelay={1000}
-                  title={TREE_TYPE_TOOLTIP_TEXT}
-                  placement="top"
-                >
-                  <StyledInfoOutlinedIcon />
-                </StyledTooltip>
-              </TreeNameInfoWrapper>
-              <RadioGroup
-                value={treeType}
-                onChange={(e) => setTreeType(e.target.value as TreeType)}
-              >
-                <StyledFormControlLabel
-                  value={TreeTypes.Targeted}
-                  checked={treeType === TreeTypes.Targeted}
-                  control={<StyledRadio />}
-                  label={
-                    <RadioLabelTargeted
-                      selected={treeType === TreeTypes.Targeted}
-                    />
-                  }
+      <StyledDialogContent data-test-id="modal-content">
+        <TreeNameInput setTreeName={setTreeName} treeName={treeName} />
+        <TreeTypeSection>
+          <TreeNameInfoWrapper>
+            <FieldTitle>Tree Type: </FieldTitle>
+            <StyledTooltip
+              arrow
+              leaveDelay={1000}
+              title={TREE_TYPE_TOOLTIP_TEXT}
+              placement="top"
+            >
+              <StyledInfoOutlinedIcon />
+            </StyledTooltip>
+          </TreeNameInfoWrapper>
+          <RadioGroup
+            value={treeType}
+            onChange={(e) => setTreeType(e.target.value as TreeType)}
+          >
+            <StyledFormControlLabel
+              value={TreeTypes.Targeted}
+              checked={treeType === TreeTypes.Targeted}
+              control={<StyledRadio />}
+              label={
+                <RadioLabelTargeted
+                  selected={treeType === TreeTypes.Targeted}
                 />
-                <StyledFormControlLabel
-                  value={TreeTypes.NonContextualized}
-                  checked={treeType === TreeTypes.NonContextualized}
-                  control={<StyledRadio />}
-                  label={
-                    <RadioLabelNonContextualized
-                      selected={treeType === TreeTypes.NonContextualized}
-                    />
-                  }
+              }
+            />
+            <StyledFormControlLabel
+              value={TreeTypes.NonContextualized}
+              checked={treeType === TreeTypes.NonContextualized}
+              control={<StyledRadio />}
+              label={
+                <RadioLabelNonContextualized
+                  selected={treeType === TreeTypes.NonContextualized}
                 />
-              </RadioGroup>
-            </TreeTypeSection>
-            {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
-              <>
-                <Separator marginSize="l" />
-                <SampleIdInput
-                  handleInputModeChange={handleInputModeChange}
-                  handleInputValidation={handleInputValidation}
-                  shouldReset={shouldReset}
-                />
-                <Separator marginSize="xl" />
-              </>
-            )}
-            <MissingSampleAlert missingSamples={missingInputSamples} />
-            <FailedSampleAlert numFailedSamples={failedSamples?.length} />
-            {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
-              <CreateTreeButton
-                hasValidName={hasValidName}
-                hasSamples={allValidSamplesForTreeCreation.length > 0}
-                isInEditMode={isInputInEditMode}
-                isValidTreeType={Object.values(TreeTypes).includes(treeType)}
-              />
-            )}
-            {!usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
-              <StyledButton
-                color="primary"
-                variant="contained"
-                isRounded
-                disabled={isTreeBuildDisabled}
-                type="submit"
-                value="Submit"
-              >
-                Create Tree
-              </StyledButton>
-            )}
-          </form>
-          <CreateTreeInfo>
-            Creating a new tree can take up to 12 hours.
-          </CreateTreeInfo>
-        </Content>
+              }
+            />
+          </RadioGroup>
+        </TreeTypeSection>
+        {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
+          <>
+            <Separator marginSize="l" />
+            <SampleIdInput
+              handleInputModeChange={handleInputModeChange}
+              handleInputValidation={handleInputValidation}
+              shouldReset={shouldReset}
+            />
+            <Separator marginSize="xl" />
+          </>
+        )}
+        <MissingSampleAlert missingSamples={missingInputSamples} />
+        <FailedSampleAlert numFailedSamples={failedSamples?.length} />
       </StyledDialogContent>
-    </Dialog>
+      <StyledFooter>
+        {usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
+          <CreateTreeButton
+            hasValidName={hasValidName}
+            hasSamples={allValidSamplesForTreeCreation.length > 0}
+            isInEditMode={isInputInEditMode}
+            isValidTreeType={Object.values(TreeTypes).includes(treeType)}
+            onClick={handleSubmit}
+          />
+        )}
+        {!usesFeatureFlag(FEATURE_FLAGS.gisaidIngest) && (
+          <StyledButton
+            color="primary"
+            variant="contained"
+            isRounded
+            disabled={isTreeBuildDisabled}
+            type="submit"
+            value="Submit"
+            onClick={handleSubmit}
+          >
+            Create Tree
+          </StyledButton>
+        )}
+        <CreateTreeInfo>
+          Creating a new tree can take up to 12 hours.
+        </CreateTreeInfo>
+      </StyledFooter>
+    </StyledDialog>
   );
 };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Radio from "@material-ui/core/Radio";
-import TextField from "@material-ui/core/TextField";
+import { Dialog, FormControlLabel, Radio, TextField } from "@material-ui/core";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import {
   fontBodyS,
@@ -16,13 +14,30 @@ import {
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 
+export const StyledDialog = styled(Dialog)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .MuiDialog-container {
+    max-height: 85%;
+  }
+`;
+
 export const StyledDialogContent = styled(DialogContent)`
+  ${fontBodyS}
+
   width: 600px;
+  padding-bottom: 0;
+  overflow-y: auto;
+  div:last-child {
+    margin-bottom: 0;
+  }
 
   ${(props) => {
-    const spaces = getSpaces(props);
+    const colors = getColors(props);
     return `
-      padding-bottom: ${spaces?.xxl}px;
+      color: ${colors?.gray[500]};
     `;
   }}
 `;
@@ -40,6 +55,8 @@ export const Title = styled.span`
 `;
 
 export const StyledDialogTitle = styled(DialogTitle)`
+  flex: 0 0 auto;
+
   ${(props) => {
     const spaces = getSpaces(props);
     return `
@@ -206,12 +223,15 @@ export const StyledFormControlLabel = styled(FormControlLabel)`
   }}
 `;
 
-export const Content = styled.div`
-  ${fontBodyS}
+export const StyledFooter = styled.div`
+  flex: 0 0 auto;
+
   ${(props) => {
-    const colors = getColors(props);
+    const spaces = getSpaces(props);
     return `
-      color: ${colors?.gray[500]};
+      margin-bottom: ${spaces?.xxl}px;
+      margin-left: ${spaces?.xxl}px;
+      margin-top: ${spaces?.xl}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -95,7 +95,6 @@ export const TreeTypeSection = styled.div`
     const spaces = getSpaces(props);
     return `
       margin-top: ${spaces?.s}px;
-      margin-bottom: ${spaces?.s}px;
     `;
   }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -20,7 +20,7 @@ export const StyledDialog = styled(Dialog)`
   justify-content: center;
 
   .MuiDialog-container {
-    max-height: 85%;
+    max-height: 100vh;
   }
 `;
 
@@ -30,7 +30,7 @@ export const StyledDialogContent = styled(DialogContent)`
   width: 600px;
   padding-bottom: 0;
   overflow-y: auto;
-  div:last-child {
+  & > div:last-child {
     margin-bottom: 0;
   }
 

--- a/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/FailedSampleAlert/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Callout, getFontWeights, getSpaces } from "czifui";
+import { Callout, getFontWeights } from "czifui";
 
 export const SemiBold = styled.span`
   ${(props) => {
@@ -12,11 +12,4 @@ export const SemiBold = styled.span`
 
 export const StyledCallout = styled(Callout)`
   width: 100%;
-
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      margin: ${spaces?.xl}px 0;
-    `;
-  }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -10,7 +10,6 @@ import {
 } from "src/common/queries/trees";
 import { pluralize } from "src/common/utils/strUtils";
 import {
-  Content,
   StyledDialogTitle,
   StyledTooltip,
   Title,
@@ -19,11 +18,11 @@ import {
 import { Header } from "../../../DownloadModal/style";
 import { FailedSampleAlert } from "../../../FailedSampleAlert";
 import {
+  Content,
   FlexWrapper,
   StyledButton,
   StyledCloseIcon,
   StyledDialogContent,
-  StyledFailedSampleAlert,
   StyledFieldTitleText,
   StyledInfoIcon,
   StyledInputDropdown,
@@ -286,9 +285,7 @@ export const UsherPlacementModal = ({
                   </StyledSuggestionWrapper>
                 )}
               </StyledTextField>
-              <FailedSampleAlert
-                numFailedSamples={failedSamples?.length}
-              />
+              <FailedSampleAlert numFailedSamples={failedSamples?.length} />
             </div>
             <StyledButton
               color="primary"

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -23,6 +23,7 @@ import {
   StyledButton,
   StyledCloseIcon,
   StyledDialogContent,
+  StyledFailedSampleAlert,
   StyledFieldTitleText,
   StyledInfoIcon,
   StyledInputDropdown,
@@ -285,7 +286,9 @@ export const UsherPlacementModal = ({
                   </StyledSuggestionWrapper>
                 )}
               </StyledTextField>
-              <FailedSampleAlert numFailedSamples={failedSamples?.length} />
+              <FailedSampleAlert
+                numFailedSamples={failedSamples?.length}
+              />
             </div>
             <StyledButton
               color="primary"

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -4,6 +4,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import ErrorOutlineOutlinedIcon from "@material-ui/icons/ErrorOutlineOutlined";
 import {
   Button,
+  fontBodyS,
   fontBodyXs,
   fontBodyXxxs,
   fontHeaderM,
@@ -189,4 +190,14 @@ export const StyledCloseIcon = styled(CloseIcon)`
 
 export const StyledInfoIcon = styled(InfoIcon)`
   margin-top: 3px;
+`;
+
+export const Content = styled.div`
+  ${fontBodyS}
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      color: ${colors?.gray[500]};
+    `;
+  }}
 `;

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/style.ts
@@ -152,10 +152,13 @@ export const StyledWarningIcon = styled(ErrorOutlineOutlinedIcon)`
 export const StyledButton = styled(Button)`
   ${(props) => {
     const colors = getColors(props);
+    const spaces = getSpaces(props);
     return `
       &:active {
         background-color: ${colors?.gray[400]};
       }
+
+      margin-top: ${spaces?.xl}px;
     `;
   }}
 `;

--- a/src/frontend/src/components/CollapsibleInstructions/style.ts
+++ b/src/frontend/src/components/CollapsibleInstructions/style.ts
@@ -21,7 +21,7 @@ export const HeaderWrapper = styled("div", {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   display: flex;
-  align-items: center;
+  align-items: baseline;
   color: black;
 
   ${(props: HeaderProps) => {
@@ -38,12 +38,9 @@ export const StyledInstructionsButton = styled(Button, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props) => {
-    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-      margin-left: ${spaces?.xxxs}px;
-      margin-top: ${spaces?.xxxs}px;
       &:hover {
         background-color: transparent;
         color: ${colors?.primary[500]};


### PR DESCRIPTION
### Summary
- **What:** Styling for gisaid ingest
- **Ticket:** [[sc-166015]](https://app.shortcut.com/genepi/story/166015)
- **Env:** https://gisaid-frontend.dev.genepi.czi.technology?gisaidIngest=true
- **Design:** https://www.figma.com/file/E7SnuofUBpy8xixY6eUiWz/Self-Serve-Tree-V2---GISAID-Ingest?node-id=1976%3A98763

### Notes
- I strongly suggest you view this PR with whitespace changes off (it accounts for about 1/3 of the changed lines).
![Screen Shot 2021-11-09 at 6 34 17 PM](https://user-images.githubusercontent.com/7562933/141039237-f85a43c8-2a1c-4ff6-a122-c8b837b56543.png)
- I identified a bug just before opening this PR, so please ignore this failure in functionality when giving feedback. If you type in the ID of a failed sample into the input, it shows as successfully added to the tree in the UI. The sample would still be rightfully excluded if you choose it from the samples table using the checkbox. This bug only applies to the new input. I will tackle this tomorrow.

### Demos
![Screen Shot 2021-11-09 at 6 31 13 PM](https://user-images.githubusercontent.com/7562933/141038960-47831386-6f8b-4a57-89a4-323002d44fed.png)
![Screen Shot 2021-11-09 at 6 29 01 PM](https://user-images.githubusercontent.com/7562933/141038963-fd6e0f3c-d082-4e2f-bddd-456a643b86a0.png)
![Screen Shot 2021-11-09 at 6 29 11 PM](https://user-images.githubusercontent.com/7562933/141038964-7eff7f2f-a1ff-4716-ba89-70b61955521a.png)
![Screen Shot 2021-11-09 at 6 31 22 PM](https://user-images.githubusercontent.com/7562933/141038966-380941bb-2a36-46c3-a5f8-4f4183be8a27.png)

![Screen Shot 2021-11-09 at 6 28 45 PM](https://user-images.githubusercontent.com/7562933/141039016-2cd109f9-0d6e-4a49-9ae1-a8e90e966496.png)
![Screen Shot 2021-11-09 at 6 28 53 PM](https://user-images.githubusercontent.com/7562933/141039018-73775616-3157-4bf6-9370-f534e802825b.png)
![Screen Shot 2021-11-09 at 6 29 29 PM](https://user-images.githubusercontent.com/7562933/141039019-53365993-5871-4b4f-9fec-b5276435c37a.png)

![Screen Shot 2021-11-09 at 6 30 27 PM](https://user-images.githubusercontent.com/7562933/141039060-dc4cdedd-6cd9-46dd-a496-e07bc13fc2cf.png)
![Screen Shot 2021-11-09 at 6 30 40 PM](https://user-images.githubusercontent.com/7562933/141039061-758fb132-1d63-4b4f-b11b-d262d9a36fbd.png)
![Screen Shot 2021-11-09 at 6 30 03 PM](https://user-images.githubusercontent.com/7562933/141039057-3f681505-6e1f-4fa6-956d-8c2fbd63fc3e.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)