### PR TITLE
keep Chicago as Chicago instead of Cook County

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -163,6 +163,7 @@ task TransformGISAID {
     sed -i -e 's/Southern San Joaquin Valley\tNorth America\/USA\/California\//Southern San Joaquin Valley\tNorth America\/USA\/California\/Tulare County/' \
     -e 's/Orange County CA/Orange County/' \
     -e 's/Monterey County CA/Monterey County/' \
+    -e '/Illinois\/Chicago\tNorth America/d' \
     /ncov-ingest/source-data/gisaid_geoLocationRules.tsv
 
     # decompress the gisaid dataset and transform it.


### PR DESCRIPTION
### Summary:
- **What:** GISAID ingest job will convert all "Chicago" in the `location` field into "Cook County" and we cannot build a tree for Chicago samples. This PR remove this conversion step by deleting this line
```
North America/USA/Illinois/Chicago	North America/USA/Illinois/Cook County IL
```
from [the file](https://github.com/nextstrain/ncov-ingest/blob/master/source-data/gisaid_geoLocationRules.tsv) which instructs how GISAID ingest does location name conversion.

- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:
Ran the full gisaid.wdl with the change here 
![image](https://user-images.githubusercontent.com/20667188/141392235-889ec6b9-842f-4ec4-9b18-06e4e2a75b0b.png)


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)