### PR TITLE
pin ncov in docker file

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -240,8 +240,9 @@ task AlignGISAID {
 
     start_time=$(date +%s)
     build_id=$(date +%Y%m%d-%H%M)
-
-    git clone --depth 1 git://github.com/nextstrain/ncov /ncov
+    
+    # We're pinning to a specific git hash in the Dockerfile so we're not cloning this here.
+    # git clone --depth 1 git://github.com/nextstrain/ncov /ncov
     ncov_git_rev=$(git -C /ncov rev-parse HEAD)
 
     # fetch the gisaid dataset

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -53,6 +53,13 @@ RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetr
 
 RUN pip3 install nextstrain-cli csv-diff s3fs[boto3] aiobotocore[awscli,boto3] envdir fsspec pandas arrow
 
+RUN mkdir /ncov && \
+    cd /ncov && \
+    git init && \
+    git remote add origin https://github.com/nextstrain/ncov.git && \
+    git fetch origin 6691370325e5980d4f6073f7672759711c305a05 && \
+    git reset --hard FETCH_HEAD
+
 # Poetry: install app
 WORKDIR /usr/src/app
 COPY pyproject.toml poetry.lock environment.yaml ./


### PR DESCRIPTION
### Summary:
- **What:** Since we pin `ncov` for tree runs, we should pin the same version for GISAID job which pre-processes the sequences. Since we clone and pin `ncov` in the tree run Docker file, I moved the cloning and pin step to the GISAID Docker file to be consistent. This is effectively **reversing** our recent changes in this [PR] which is snapshotted below: (https://github.com/chanzuckerberg/aspen/commit/fe22c0b1d00118f44d63a48345b60028bcffac9f)
![image](https://user-images.githubusercontent.com/20667188/142045729-1ac4b612-6037-4785-a928-ac1357505df5.png)
![image](https://user-images.githubusercontent.com/20667188/142045827-e4eb5341-82bd-4494-8b8e-1541ee9d1a4d.png)

### Demos:
Merge to staging and see how it goes?

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)