### PR TITLE
Add aspencli command to query v2 sample list

### DIFF
--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -304,6 +304,13 @@ def get_tree_sample_ids(ctx, tree_id):
 def samples():
     pass
 
+@samples.command(name="list")
+@click.pass_context
+def list_samples(ctx):
+    api_client = ctx.obj["api_client"]
+    resp = api_client.get("/v2/samples/")
+    print(resp.text)
+
 
 @samples.command(name="download")
 @click.argument("sample_ids", nargs=-1)


### PR DESCRIPTION
### Summary:
- **What:** Adds a command to `aspencli` to hit the v2 sample list endpoint.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)