### PR TITLE
Fix sample ID validation.

### DIFF
--- a/src/backend/aspen/api/utils/gisaid.py
+++ b/src/backend/aspen/api/utils/gisaid.py
@@ -29,7 +29,10 @@ async def get_matching_gisaid_ids(
     # (Gisaid data is prepped by Nextstrain which strips off this prefix)
 
     # first create a mapping of ids that were stripped (so we can return unstripped id later)
-    stripped_mapping: Mapping[str, str] = {s.strip("hCoV-19/"): s for s in sample_ids}
+    stripped_mapping: Mapping[str, str] = {
+        (s.replace("hCoV-19/", "") if s.startswith("hCoV-19/") else s): s
+        for s in sample_ids
+    }
 
     gisaid_matches_query = sa.select(GisaidMetadata).filter(  # type: ignore
         GisaidMetadata.strain.in_(stripped_mapping.keys())

--- a/src/backend/aspen/app/views/api_utils.py
+++ b/src/backend/aspen/app/views/api_utils.py
@@ -296,7 +296,10 @@ def get_matching_gisaid_ids(sample_ids: Iterable[str], session: Session) -> Set[
     # (Gisaid data is prepped by Nextstrain which strips off this prefix)
 
     # first create a mapping of ids that were stripped (so we can return unstripped id later)
-    stripped_mapping: Mapping[str, str] = {s.strip("hCoV-19/"): s for s in sample_ids}
+    stripped_mapping: Mapping[str, str] = {
+        (s.replace("hCoV-19/", "") if s.startswith("hCoV-19/") else s): s
+        for s in sample_ids
+    }
 
     gisaid_matches: Iterable[GisaidMetadata] = session.query(GisaidMetadata).filter(
         GisaidMetadata.strain.in_(stripped_mapping.keys())

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1020,7 +1020,10 @@ def test_update_sample_public_ids(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group, user, private_identifier=priv, public_identifier=pub.strip("_update")
+            group,
+            user,
+            private_identifier=priv,
+            public_identifier=pub.replace("_update", ""),
         )
         session.add(sample)
 

--- a/src/backend/aspen/test_infra/models/gisaid_metadata.py
+++ b/src/backend/aspen/test_infra/models/gisaid_metadata.py
@@ -4,7 +4,7 @@ from aspen.database.models import GisaidMetadata
 
 
 def gisaid_metadata_factory(
-    strain="gisaid_identifier",
+    strain="gisaid_identifier/hCoV-19",
     pango_lineage="B.1.617.2",
     gisaid_clade="T",  # T for test
     date=None,

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -381,6 +381,19 @@ def start_phylo_run_v2(ctx, name, tree_type, sample_ids, show_headers):
     print(resp.text)
     print(resp)
 
+@samples.command(name="validate-ids")
+@click.option("-h", "--show-headers", is_flag=True)
+@click.argument("sample_ids", nargs=-1)
+@click.pass_context
+def validate_sample_ids(ctx, sample_ids, show_headers):
+    api_client = ctx.obj["api_client"]
+    payload = { "sample_ids": sample_ids }
+    resp = api_client.post("/api/samples/validate-ids", json=payload)
+    if show_headers:
+        print(resp.headers)
+    print(resp.text)
+    print(resp)
+
 
 @phylo_runs.command(name="delete")
 @click.argument("run_ids", nargs=-1)


### PR DESCRIPTION
### Summary:
- **What:** Fix querying for gisaid sample ID's if the sample id begins/ends with 1 or more characters contained in the string "hCoV-19/"

### Notes:
`strip()` treats an input string as a **list of characters** that it should remove from the beginning/end of a string, rather than as a literal string to strip. For example:

```
>>> "hCoV-19/some-samplehCV1".strip("hCoV-19/")
'some-sample'
```

What we really want in this case is to just strip off a prefix string if it exists:
```
>>> mysample = "hCoV-19/some-samplehCV1"
>>> mysample.replace("hCoV-19/", "") if mysample.startswith("hCoV-19/") else mysample
'some-samplehCV1'
```

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)