### PR TITLE
change daily tree build to weekly

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -1,8 +1,7 @@
-# SCC runs are enabled for both prod and staging.  All other runs are only enabled for prod.
 locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
-  nextstrain_cron_schedule = local.deployment_stage == "prod" ? ["cron(0 5 ? * MON-SAT *)"] : []
+  nextstrain_cron_schedule = local.deployment_stage == "prod" ? ["cron(0 5 ? * MON *)"] : []
 }
 
 module nextstrain_scc_contextual_sfn_config {


### PR DESCRIPTION
**On Monday of the week**

### Summary:
- **What:** Per Alli's email to users announcing self serve tree build, we're changing tree schedule to weekly. Also note that we don't do a staging run anymore so I removed the comment.

- **Ticket:** [sc150146](https://app.shortcut.com/genepi/story/150146/discontinue-nightly-local-builds-and-switch-contextual-builds-to-weekly)

### Demos:

### Notes:
Will update tree user manual google doc and let Janeece know for this [ticket](https://app.shortcut.com/genepi/story/157594/let-users-know-when-weekly-build-occurs).

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)