### PR TITLE
Support phylo trees w/o any aspen samples.

### DIFF
--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -33,7 +33,7 @@ class GroupResponse(BaseResponse):
 
     id: int
     name: StrictStr
-    location: StrictStr
+    location: Optional[StrictStr]
 
 
 class UserResponse(BaseResponse):

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -97,7 +97,7 @@ async def kick_off_phylo_run(
     pathogen_genomes: MutableSequence[PathogenGenome] = list()
     for sample in user_visible_samples:
         pathogen_genomes.append(sample.uploaded_pathogen_genome)
-    if len(pathogen_genomes) == 0:
+    if len(pathogen_genomes) == 0 and len(gisaid_ids) == 0:
         sentry_sdk.capture_message(
             f"No sequences selected for run from {sample_ids}.", "error"
         )


### PR DESCRIPTION
### Summary:
- **What:** Support creating phylo runs with *only* gisaid samples. Don't break if we don't find any aspen samples.

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)