### PR TITLE
Add gisaid isl and country to gisaid metadata table.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,8 @@ services:
         - HAPPY_COMMIT
         - HAPPY_BRANCH
     command: ["true"]
+    volumes:
+      - ./src/backend:/usr/src/app
     environment:
       - AWS_REGION=us-west-2
       - BOTO_ENDPOINT_URL=http://localstack.genepinet.localdev:4566

--- a/src/backend/aspen/database/models/gisaid_metadata.py
+++ b/src/backend/aspen/database/models/gisaid_metadata.py
@@ -12,9 +12,11 @@ class GisaidMetadata(base, DictMixin):  # type: ignore
     strain = Column(String, primary_key=True)
     pango_lineage = Column(String, nullable=True)
     gisaid_clade = Column(String, nullable=True)
+    gisaid_epi_isl = Column(String, nullable=True)
     date = Column(DateTime, nullable=True)
     region = Column(
         String, nullable=True
     )  # Can be a value outside our RegionTable enum
+    country = Column(String, nullable=True)
     division = Column(String, nullable=True)
     location = Column(String, nullable=True)

--- a/src/backend/aspen/workflows/import_gisaid/save.py
+++ b/src/backend/aspen/workflows/import_gisaid/save.py
@@ -64,7 +64,9 @@ def cli(
         "strain",
         "pango_lineage",
         "GISAID_clade",
+        "gisaid_epi_isl",
         "region",
+        "country",
         "division",
         "location",
     ]

--- a/src/backend/database_migrations/versions/20211117_213610_add_country_to_gisaid_metadata.py
+++ b/src/backend/database_migrations/versions/20211117_213610_add_country_to_gisaid_metadata.py
@@ -1,0 +1,39 @@
+"""Add Country to Gisaid Metadata
+
+Create Date: 2021-11-17 21:36:12.153099
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20211117_213610"
+down_revision = "20211109_213333"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "gisaid_metadata",
+        sa.Column(
+            "gisaid_epi_isl",
+            sa.String(),
+            nullable=True,
+        ),
+        schema="aspen",
+    )
+    op.add_column(
+        "gisaid_metadata",
+        sa.Column(
+            "country",
+            sa.String(),
+            nullable=True,
+        ),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### Summary:
- **What:** Add country and gisaid isl data to our nightly gisaid import.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)