### PR TITLE
Rebrand: Terms and Privacy pages

### DIFF
--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -33,30 +33,31 @@ const PrivacyPolicy = (): JSX.Element => {
       <P>
         The Chan Zuckerberg Initiative Foundation, a 501(c)(3) nonprofit private
         foundation (&quot;<B>CZIF</B>,&quot; &quot;we,&quot; &quot;us,&quot; or
-        &quot;our&quot;), provides the Chan Zuckerberg GEN EPI product (&quot;Services&quot; or
-        &quot;CZ GEN EPI&quot;) in close collaboration with the Chan Zuckerberg
-        Biohub (&quot;<B>CZB</B>&quot;), and the Chan Zuckerberg Initiative, LLC
-        (&quot;<B>CZI LLC</B>&quot;). This Privacy Policy describes the types of
-        information we collect or that is uploaded by CZ GEN EPI Users (collectively
-        &quot;Users&quot; or &quot;you&quot;, ex: registered public health
-        officials at state and/or county level Departments of Public Health
-        (&quot;<B>DPH</B>&quot;), other public health researchers), and how we
-        use, share, and protect that information.
+        &quot;our&quot;), provides the Chan Zuckerberg GEN EPI product
+        (&quot;Services&quot; or &quot;CZ GEN EPI&quot;) in close collaboration
+        with the Chan Zuckerberg Biohub (&quot;<B>CZB</B>&quot;), and the Chan
+        Zuckerberg Initiative, LLC (&quot;<B>CZI LLC</B>&quot;). This Privacy
+        Policy describes the types of information we collect or that is uploaded
+        by CZ GEN EPI Users (collectively &quot;Users&quot; or &quot;you&quot;,
+        ex: registered public health officials at state and/or county level
+        Departments of Public Health (&quot;<B>DPH</B>&quot;), other public
+        health researchers), and how we use, share, and protect that
+        information.
       </P>
       <H3>About CZ GEN EPI</H3>
       <P>
-        CZ GEN EPI is a tool that uses pathogen genomic sequence data to help you
-        infer how pathogens are moving through a population and how cases and
-        outbreaks are related. In order to become a User of CZ GEN EPI you must be
-        acting in your organizational capacity, which means a couple things: (1)
-        your use of CZ GEN EPI may be subject to your organization’s policies and (2)
-        upon sign-up, you’ll be placed into a group with other users from your
-        organization.
+        CZ GEN EPI is a tool that uses pathogen genomic sequence data to help
+        you infer how pathogens are moving through a population and how cases
+        and outbreaks are related. In order to become a User of CZ GEN EPI you
+        must be acting in your organizational capacity, which means a couple
+        things: (1) your use of CZ GEN EPI may be subject to your organization’s
+        policies and (2) upon sign-up, you’ll be placed into a group with other
+        users from your organization.
       </P>
       <P>
-        Here’s how CZ GEN EPI processes and manages Upload Data: Users submit Raw
-        Sequence Data (as described below) as well as information about those
-        sequences, such as the date the sample was collected (&quot;Sample
+        Here’s how CZ GEN EPI processes and manages Upload Data: Users submit
+        Raw Sequence Data (as described below) as well as information about
+        those sequences, such as the date the sample was collected (&quot;Sample
         Metadata&quot; as further defined below -- Raw Sequence Data and Sample
         Metadata together make &quot;Upload Data&quot;). Any human genetic data
         contained within the Raw Sequence Data is filtered out and deleted
@@ -68,7 +69,8 @@ const PrivacyPolicy = (): JSX.Element => {
         <B>
           By default, these analytical outputs will be visible to the User that
           uploaded the Sample and other members of the User’s organization
-          (&quot;Group&quot;, ex: a Department of Public Health) using CZ GEN EPI.
+          (&quot;Group&quot;, ex: a Department of Public Health) using CZ GEN
+          EPI.
         </B>
       </P>
       <P>
@@ -81,8 +83,8 @@ const PrivacyPolicy = (): JSX.Element => {
         To help you better understand our Privacy Policy, we’ve created the
         below Summary, which includes bullets regarding Key Things to Know, as
         well as a Table summarizing key aspects of our data practices. For more
-        information about the rules governing your use of CZ GEN EPI, please also see
-        our{" "}
+        information about the rules governing your use of CZ GEN EPI, please
+        also see our{" "}
         <NewTabLink href={ROUTES.TERMS}>
           Terms of Use (&quot;Terms&quot;)
         </NewTabLink>
@@ -99,7 +101,8 @@ const PrivacyPolicy = (): JSX.Element => {
         <ListItem>CZ GEN EPI is a free and open-source tool.</ListItem>
         <ListItem>
           You always own the data you upload. You decide how you want your data
-          to be shared, and you can delete your data from CZ GEN EPI at any time.
+          to be shared, and you can delete your data from CZ GEN EPI at any
+          time.
         </ListItem>
         <ListItem>
           You’re using CZ GEN EPI in your professional capacity, which means any
@@ -129,8 +132,8 @@ const PrivacyPolicy = (): JSX.Element => {
             upload (e.g., you can choose to list only the state, or to redact
             collection dates before uploading). We collect this metadata only
             for the purposes of providing analyses for you, enabling you to link
-            back to your epidemiological data (outside of CZ GEN EPI), and optionally
-            submitting to public repositories.
+            back to your epidemiological data (outside of CZ GEN EPI), and
+            optionally submitting to public repositories.
           </span>
         </ListItem>
       </List>
@@ -221,15 +224,15 @@ const PrivacyPolicy = (): JSX.Element => {
                 <P>
                   This data is also accessible by technical partners (CZ Biohub
                   and CZI, LLC) and Service Providers (ex: AWS) that help
-                  operate and secure CZ GEN EPI. For example, we need to be able to
-                  access your data in order to back up and maintain the
+                  operate and secure CZ GEN EPI. For example, we need to be able
+                  to access your data in order to back up and maintain the
                   database.
                 </P>
 
                 <P>
                   This Privacy Policy applies to all parties that access data to
-                  support CZ GEN EPI and they will not use the data for any purpose
-                  beyond operating and securing CZ GEN EPI.
+                  support CZ GEN EPI and they will not use the data for any
+                  purpose beyond operating and securing CZ GEN EPI.
                 </P>
 
                 <P>
@@ -250,9 +253,9 @@ const PrivacyPolicy = (): JSX.Element => {
             <td>
               <P>See above.</P>
               <P>
-                Users may also upload this data to CZ GEN EPI directly if they have
-                assembled a pathogen consensus genome in a different program,
-                but would like to analyze that genome in CZ GEN EPI.
+                Users may also upload this data to CZ GEN EPI directly if they
+                have assembled a pathogen consensus genome in a different
+                program, but would like to analyze that genome in CZ GEN EPI.
               </P>
             </td>
             <td>
@@ -277,8 +280,8 @@ const PrivacyPolicy = (): JSX.Element => {
               phylogenetic trees).
             </td>
             <td>
-              Users use CZ GEN EPI to drive analytical results that they can then
-              choose to share more broadly.
+              Users use CZ GEN EPI to drive analytical results that they can
+              then choose to share more broadly.
             </td>
             <td>
               Analytical results you create are visible to other users in your
@@ -297,19 +300,19 @@ const PrivacyPolicy = (): JSX.Element => {
               <B>User Data</B>
             </td>
             <td>
-              Data about researchers with CZ GEN EPI accounts such as name, email,
-              institution, basic information about how they are using CZ GEN EPI, and
-              information provided for user support (ex: resolving support
-              requests).
+              Data about researchers with CZ GEN EPI accounts such as name,
+              email, institution, basic information about how they are using CZ
+              GEN EPI, and information provided for user support (ex: resolving
+              support requests).
             </td>
             <td>
-              We use this data only to operate, secure, and improve the CZ GEN EPI
-              services.
+              We use this data only to operate, secure, and improve the CZ GEN
+              EPI services.
             </td>
             <td>
               <P>
-                Basic CZ GEN EPI account information such as name and institution may
-                be visible to other CZ GEN EPI Users.
+                Basic CZ GEN EPI account information such as name and
+                institution may be visible to other CZ GEN EPI Users.
               </P>
               <P>
                 This data is also shared with technical partners (CZ Biohub and
@@ -318,8 +321,8 @@ const PrivacyPolicy = (): JSX.Element => {
               </P>
               <P>
                 This Privacy Policy applies to all parties that access data to
-                support CZ GEN EPI and they will not use the data for any purpose
-                beyond operating and securing CZ GEN EPI.
+                support CZ GEN EPI and they will not use the data for any
+                purpose beyond operating and securing CZ GEN EPI.
               </P>
               <P>
                 We will never sell your data or share it with anyone that does.
@@ -340,9 +343,9 @@ const PrivacyPolicy = (): JSX.Element => {
             </td>
             <td>
               Device Data (ex: browser type and operating system) and Analytics
-              Information (ex: links within CZ GEN EPI you click on and how often you
-              log into CZ GEN EPI) includes basic information about how Users and
-              Visitors are interacting with CZ GEN EPI.
+              Information (ex: links within CZ GEN EPI you click on and how
+              often you log into CZ GEN EPI) includes basic information about
+              how Users and Visitors are interacting with CZ GEN EPI.
             </td>
             <td>See above.</td>
             <td>See above.</td>
@@ -358,9 +361,9 @@ const PrivacyPolicy = (): JSX.Element => {
         <Number>1.</Number>Upload Data
       </H2>
       <P>
-        &quot;Upload Data&quot; is data that Users upload to CZ GEN EPI (other than
-        the information which is provided during registration to create a User
-        account). Upload Data consists of pathogen genomic data (including
+        &quot;Upload Data&quot; is data that Users upload to CZ GEN EPI (other
+        than the information which is provided during registration to create a
+        User account). Upload Data consists of pathogen genomic data (including
         &quot;Raw Sequence Data&quot;, which includes both host and pathogenic
         genome data and &quot;Pathogen Consensus Genomes,&quot; which is only
         pathogenic genome data) and corresponding metadata (&quot;Sample
@@ -387,13 +390,13 @@ const PrivacyPolicy = (): JSX.Element => {
             <ListItemLabel>Raw Sequence Data:</ListItemLabel> &quot;Raw Sequence
             Data&quot; is genomic sequence data, including both host and
             pathogenic data. As part of the process of processing this data
-            uploaded to CZ GEN EPI, any identifiable human genetic data is filtered
-            and removed. This means that CZ GEN EPI should <B>not</B> contain any
-            human sequence data. Note that if there are no issues identified
-            with the corresponding Pathogen Consensus Genome, the Raw Sequencing
-            Data will be permanently deleted from our backend after 90 days. We
-            encourage Users to submit raw reads to the Sequencing Read Archive
-            for long-term storage.
+            uploaded to CZ GEN EPI, any identifiable human genetic data is
+            filtered and removed. This means that CZ GEN EPI should <B>not</B>{" "}
+            contain any human sequence data. Note that if there are no issues
+            identified with the corresponding Pathogen Consensus Genome, the Raw
+            Sequencing Data will be permanently deleted from our backend after
+            90 days. We encourage Users to submit raw reads to the Sequencing
+            Read Archive for long-term storage.
           </span>
         </ListItem>
         <ListItem>
@@ -401,8 +404,8 @@ const PrivacyPolicy = (): JSX.Element => {
             <ListItemLabel>Pathogen Consensus Genomes:</ListItemLabel>{" "}
             &quot;Pathogen Consensus Genomes&quot; are genetic sequences of
             pathogens, such as SARS-CoV-2, mapped to pathogen-specific reference
-            genomes. These may either be uploaded directly to CZ GEN EPI or generated
-            by CZ GEN EPI from uploaded Raw Sequence Data (see below).
+            genomes. These may either be uploaded directly to CZ GEN EPI or
+            generated by CZ GEN EPI from uploaded Raw Sequence Data (see below).
           </span>
         </ListItem>
         <ListItem>
@@ -418,8 +421,8 @@ const PrivacyPolicy = (): JSX.Element => {
         </ListItem>
       </List>
       <P>
-        If you are able to find data in CZ GEN EPI or any Sample Metadata that you
-        believe is identifying, please let us know at{" "}
+        If you are able to find data in CZ GEN EPI or any Sample Metadata that
+        you believe is identifying, please let us know at{" "}
         <NewTabLink href="mailto:aspenprivacy@chanzuckerberg.com">
           aspenprivacy@chanzuckerberg.com
         </NewTabLink>{" "}
@@ -470,10 +473,10 @@ const PrivacyPolicy = (): JSX.Element => {
         required by law. For example, certain Users in California currently
         allow the California Department of Public Health (&quot;CDPH&quot;) to
         access data from their Group. Where such access is allowed by Groups,
-        the third party can access this data through their own CZ GEN EPI accounts,
-        and may have similar viewing permissions as members of the uploading
-        Group. However, they will not have access to your private, internal
-        identifiers.
+        the third party can access this data through their own CZ GEN EPI
+        accounts, and may have similar viewing permissions as members of the
+        uploading Group. However, they will not have access to your private,
+        internal identifiers.
       </P>
       <P>
         You control the sharing of Raw Sequence Data and Sample Metadata which
@@ -482,12 +485,12 @@ const PrivacyPolicy = (): JSX.Element => {
         share it more broadly. <B>We don’t own, rent, or sell your data.</B>
       </P>
       <P>
-        Pathogen Consensus Genomes, whether uploaded by you or generated by
-        CZ GEN EPI, will be shared by us with public repositories (as set out below)
-        unless you choose to mark this information as &quot;private.&quot; In
-        the event that the Pathogen Consensus Genome is created by us, it will
-        automatically be marked as private if the corresponding Raw Sequence
-        Data is marked private.
+        Pathogen Consensus Genomes, whether uploaded by you or generated by CZ
+        GEN EPI, will be shared by us with public repositories (as set out
+        below) unless you choose to mark this information as
+        &quot;private.&quot; In the event that the Pathogen Consensus Genome is
+        created by us, it will automatically be marked as private if the
+        corresponding Raw Sequence Data is marked private.
       </P>
       <P>
         <UnderLineHeader>
@@ -495,17 +498,17 @@ const PrivacyPolicy = (): JSX.Element => {
         </UnderLineHeader>
       </P>
       <P>
-        Data uploaded to CZ GEN EPI by Users should <B>always</B> be anonymous. The
-        pathogen genome does not contain personal data, as it cannot be
+        Data uploaded to CZ GEN EPI by Users should <B>always</B> be anonymous.
+        The pathogen genome does not contain personal data, as it cannot be
         personally linked with an identifiable individual.
       </P>
       <P>
         In the rare event that human genetic data is not successfully deleted in
-        the initial upload process, CZ GEN EPI may process this data only insofar as
-        necessary in order to delete it. This processing is in our legitimate
-        interest, and in the legitimate interests of CZB and CZI LLC, in order
-        for us to ensure that no personal data is contained within the genomic
-        data stored on CZ GEN EPI.
+        the initial upload process, CZ GEN EPI may process this data only
+        insofar as necessary in order to delete it. This processing is in our
+        legitimate interest, and in the legitimate interests of CZB and CZI LLC,
+        in order for us to ensure that no personal data is contained within the
+        genomic data stored on CZ GEN EPI.
       </P>
     </>
   );
@@ -526,9 +529,9 @@ const PrivacyPolicy = (): JSX.Element => {
         genome.
       </P>
       <P>
-        CZ GEN EPI also gives you the ability to create new analytical outputs from
-        pathogen genomes, such as phylogenetic trees that allow you to better
-        map the relationship between strains.
+        CZ GEN EPI also gives you the ability to create new analytical outputs
+        from pathogen genomes, such as phylogenetic trees that allow you to
+        better map the relationship between strains.
       </P>
 
       <UnderLineHeader>
@@ -595,8 +598,8 @@ const PrivacyPolicy = (): JSX.Element => {
             which we collect for analytics purposes will be stored in a
             de-identified and aggregated manner wherever possible; any analytics
             data that is not able to be aggregated and de-identified will not be
-            shared beyond the CZ GEN EPI team and will be stored for no longer than
-            is necessary.
+            shared beyond the CZ GEN EPI team and will be stored for no longer
+            than is necessary.
           </span>
         </ListItem>
       </List>
@@ -613,15 +616,17 @@ const PrivacyPolicy = (): JSX.Element => {
           log in to and use CZ GEN EPI.
         </ListItem>
         <ListItem>
-          To provide you with notices about your account and updates about
-          CZ GEN EPI.
+          To provide you with notices about your account and updates about CZ
+          GEN EPI.
         </ListItem>
         <ListItem>To respond to your inquiries and requests.</ListItem>
         <ListItem>
-          To analyze broadly how Users are using CZ GEN EPI so we can optimize and
-          improve it.
+          To analyze broadly how Users are using CZ GEN EPI so we can optimize
+          and improve it.
         </ListItem>
-        <ListItem>To protect the security and integrity of CZ GEN EPI.</ListItem>
+        <ListItem>
+          To protect the security and integrity of CZ GEN EPI.
+        </ListItem>
       </List>
       <P>
         <UnderLineHeader>
@@ -631,10 +636,10 @@ const PrivacyPolicy = (): JSX.Element => {
       <P>
         We (along with CZB and CZI LLC) have a legitimate interest in using
         personal data within User Data in the ways described in this Privacy
-        Policy to provide, protect, and improve CZ GEN EPI. This allows us to improve
-        the service that we provide to Users which, in turn, supports research
-        regarding the study of infectious disease with the potential to benefit
-        global public health.
+        Policy to provide, protect, and improve CZ GEN EPI. This allows us to
+        improve the service that we provide to Users which, in turn, supports
+        research regarding the study of infectious disease with the potential to
+        benefit global public health.
       </P>
     </>
   );
@@ -646,18 +651,18 @@ const PrivacyPolicy = (): JSX.Element => {
       </H2>
       <P>
         CZB, CZIF, and CZI LLC collaborate closely in order to build, design,
-        and operate CZ GEN EPI so that it can be as useful as possible to researchers
-        and the public health community. CZB and CZIF provide scientific and
-        data analysis leadership and CZI LLC focuses on maintaining CZ GEN EPI’s
-        infrastructure, security, and compliance. The three parties are all data
-        controllers for CZ GEN EPI and will all only use data as described in this
-        Privacy Policy.
+        and operate CZ GEN EPI so that it can be as useful as possible to
+        researchers and the public health community. CZB and CZIF provide
+        scientific and data analysis leadership and CZI LLC focuses on
+        maintaining CZ GEN EPI’s infrastructure, security, and compliance. The
+        three parties are all data controllers for CZ GEN EPI and will all only
+        use data as described in this Privacy Policy.
       </P>
       <P>
         We also use service providers, such as database providers like Amazon
-        Web Services, to support the operation of CZ GEN EPI. These service providers
-        are data processors and their use is limited to the purposes disclosed
-        in this Privacy Policy.
+        Web Services, to support the operation of CZ GEN EPI. These service
+        providers are data processors and their use is limited to the purposes
+        disclosed in this Privacy Policy.
       </P>
       <P>
         Users have the option to share their analytical outputs with certain
@@ -702,16 +707,17 @@ const PrivacyPolicy = (): JSX.Element => {
       </H2>
       <P>
         We use industry standard security measures to ensure the
-        confidentiality, integrity and availability of data uploaded into CZ GEN EPI.
-        This includes practices like encrypting connections to CZ GEN EPI using TLS
-        (encrypting data while in transit), hosting CZ GEN EPI on leading cloud
-        providers with robust physical security, and ensuring that access to any
-        personal data within CZ GEN EPI by CZIF, CZB, and CZI LLC staff is limited to
-        those staff who need access to operate the Service.
+        confidentiality, integrity and availability of data uploaded into CZ GEN
+        EPI. This includes practices like encrypting connections to CZ GEN EPI
+        using TLS (encrypting data while in transit), hosting CZ GEN EPI on
+        leading cloud providers with robust physical security, and ensuring that
+        access to any personal data within CZ GEN EPI by CZIF, CZB, and CZI LLC
+        staff is limited to those staff who need access to operate the Service.
       </P>
       <P>
         Security takes ongoing work and we will continue to monitor and adjust
-        our security measures as CZ GEN EPI develops. Please notify us immediately at{" "}
+        our security measures as CZ GEN EPI develops. Please notify us
+        immediately at{" "}
         <NewTabLink href="mailto:aspensecurity@chanzuckerberg.com">
           aspensecurity@chanzuckerberg.com
         </NewTabLink>{" "}
@@ -733,8 +739,8 @@ const PrivacyPolicy = (): JSX.Element => {
         <ListItem>
           <span>
             We retain Pathogen Consensus Genomes, Sample Metadata and analytical
-            outputs until Users delete them from CZ GEN EPI. Users may delete their
-            data by contacting us at{" "}
+            outputs until Users delete them from CZ GEN EPI. Users may delete
+            their data by contacting us at{" "}
             <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
               helloaspen@chanzuckerberg.com
             </NewTabLink>
@@ -750,9 +756,9 @@ const PrivacyPolicy = (): JSX.Element => {
         </ListItem>
         <ListItem>
           <span>
-            User Data is retained until Users delete their CZ GEN EPI account because
-            this data is required to manage the service. Users may submit
-            account deletion requests by emailing{" "}
+            User Data is retained until Users delete their CZ GEN EPI account
+            because this data is required to manage the service. Users may
+            submit account deletion requests by emailing{" "}
             <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
               helloaspen@chanzuckerberg.com
             </NewTabLink>
@@ -780,7 +786,8 @@ const PrivacyPolicy = (): JSX.Element => {
           `Users are able to request the deletion of User Data that constitutes
           their personal data, or Upload Data that they submitted to CZ GEN EPI.
           Users may also request the deletion from CZ GEN EPI of the Pathogen
-          Consensus Genomes created by CZ GEN EPI on the basis of their Upload Data.
+          Consensus Genomes created by CZ GEN EPI on the basis of their Upload
+          Data.
         </ListItem>
         <ListItem>
           Users have full control over any analytical outputs created by any
@@ -812,11 +819,12 @@ const PrivacyPolicy = (): JSX.Element => {
         <Number>8.</Number>Data Location
       </H2>
       <P>
-        CZ GEN EPI is a US-based service. If you want to use CZ GEN EPI, you must first
-        agree to our <NewTabLink href={ROUTES.TERMS}>Terms</NewTabLink>, which
-        set out the contract between CZ GEN EPI and our Users. We operate in the
-        United States, and use technical infrastructure in the United States to
-        to deliver the Services to you.
+        CZ GEN EPI is a US-based service. If you want to use CZ GEN EPI, you
+        must first agree to our{" "}
+        <NewTabLink href={ROUTES.TERMS}>Terms</NewTabLink>, which set out the
+        contract between CZ GEN EPI and our Users. We operate in the United
+        States, and use technical infrastructure in the United States to to
+        deliver the Services to you.
       </P>
     </>
   );

--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -27,34 +27,34 @@ const PrivacyPolicy = (): JSX.Element => {
   const renderIntro = () => (
     <>
       <Title>
-        <H1>Aspen Privacy Policy</H1>
+        <H1>Chan Zuckerberg GEN EPI (formerly Aspen) Privacy Policy</H1>
         <H4>Last Updated: September 30, 2021</H4>
       </Title>
       <P>
         The Chan Zuckerberg Initiative Foundation, a 501(c)(3) nonprofit private
         foundation (&quot;<B>CZIF</B>,&quot; &quot;we,&quot; &quot;us,&quot; or
-        &quot;our&quot;), provides the Aspen product (&quot;Services&quot; or
-        &quot;Aspen&quot;) in close collaboration with the Chan Zuckerberg
+        &quot;our&quot;), provides the Chan Zuckerberg GEN EPI product (&quot;Services&quot; or
+        &quot;CZ GEN EPI&quot;) in close collaboration with the Chan Zuckerberg
         Biohub (&quot;<B>CZB</B>&quot;), and the Chan Zuckerberg Initiative, LLC
         (&quot;<B>CZI LLC</B>&quot;). This Privacy Policy describes the types of
-        information we collect or that is uploaded by Aspen Users (collectively
+        information we collect or that is uploaded by CZ GEN EPI Users (collectively
         &quot;Users&quot; or &quot;you&quot;, ex: registered public health
         officials at state and/or county level Departments of Public Health
         (&quot;<B>DPH</B>&quot;), other public health researchers), and how we
         use, share, and protect that information.
       </P>
-      <H3>About Aspen</H3>
+      <H3>About CZ GEN EPI</H3>
       <P>
-        Aspen is a tool that uses pathogen genomic sequence data to help you
+        CZ GEN EPI is a tool that uses pathogen genomic sequence data to help you
         infer how pathogens are moving through a population and how cases and
-        outbreaks are related. In order to become a User of Aspen you must be
+        outbreaks are related. In order to become a User of CZ GEN EPI you must be
         acting in your organizational capacity, which means a couple things: (1)
-        your use of Aspen may be subject to your organization’s policies and (2)
+        your use of CZ GEN EPI may be subject to your organization’s policies and (2)
         upon sign-up, you’ll be placed into a group with other users from your
         organization.
       </P>
       <P>
-        Here’s how Aspen processes and manages Upload Data: Users submit Raw
+        Here’s how CZ GEN EPI processes and manages Upload Data: Users submit Raw
         Sequence Data (as described below) as well as information about those
         sequences, such as the date the sample was collected (&quot;Sample
         Metadata&quot; as further defined below -- Raw Sequence Data and Sample
@@ -68,7 +68,7 @@ const PrivacyPolicy = (): JSX.Element => {
         <B>
           By default, these analytical outputs will be visible to the User that
           uploaded the Sample and other members of the User’s organization
-          (&quot;Group&quot;, ex: a Department of Public Health) using Aspen.
+          (&quot;Group&quot;, ex: a Department of Public Health) using CZ GEN EPI.
         </B>
       </P>
       <P>
@@ -81,14 +81,14 @@ const PrivacyPolicy = (): JSX.Element => {
         To help you better understand our Privacy Policy, we’ve created the
         below Summary, which includes bullets regarding Key Things to Know, as
         well as a Table summarizing key aspects of our data practices. For more
-        information about the rules governing your use of Aspen, please also see
+        information about the rules governing your use of CZ GEN EPI, please also see
         our{" "}
         <NewTabLink href={ROUTES.TERMS}>
           Terms of Use (&quot;Terms&quot;)
         </NewTabLink>
         .{" "}
         <B>
-          Please remember that you are using Aspen in your organizational
+          Please remember that you are using CZ GEN EPI in your organizational
           capacity, which means that your organization’s policies will apply to
           your use.
         </B>
@@ -96,13 +96,13 @@ const PrivacyPolicy = (): JSX.Element => {
 
       <H3>Key Things to Know</H3>
       <List>
-        <ListItem>Aspen is a free and open-source tool.</ListItem>
+        <ListItem>CZ GEN EPI is a free and open-source tool.</ListItem>
         <ListItem>
           You always own the data you upload. You decide how you want your data
-          to be shared, and you can delete your data from Aspen at any time.
+          to be shared, and you can delete your data from CZ GEN EPI at any time.
         </ListItem>
         <ListItem>
-          You’re using Aspen in your professional capacity, which means any
+          You’re using CZ GEN EPI in your professional capacity, which means any
           pathogen sample data you upload, and any data that we generate on the
           basis of this, are visible to other members (Users) in your Group.
           This data is only available to anyone outside of your organization
@@ -117,7 +117,7 @@ const PrivacyPolicy = (): JSX.Element => {
         </ListItem>
         <ListItem>
           <span>
-            Similarly, Aspen{" "}
+            Similarly, CZ GEN EPI{" "}
             <B>
               does not contain any personally identifying metadata or
               health-related information
@@ -129,7 +129,7 @@ const PrivacyPolicy = (): JSX.Element => {
             upload (e.g., you can choose to list only the state, or to redact
             collection dates before uploading). We collect this metadata only
             for the purposes of providing analyses for you, enabling you to link
-            back to your epidemiological data (outside of Aspen), and optionally
+            back to your epidemiological data (outside of CZ GEN EPI), and optionally
             submitting to public repositories.
           </span>
         </ListItem>
@@ -150,7 +150,7 @@ const PrivacyPolicy = (): JSX.Element => {
           </TopRow>
           <SectionRow>
             <td colSpan={5}>
-              <B>Data you upload to or create using Aspen</B>
+              <B>Data you upload to or create using CZ GEN EPI</B>
             </td>
           </SectionRow>
           <ContentRow>
@@ -180,14 +180,14 @@ const PrivacyPolicy = (): JSX.Element => {
               </P>
               <P>
                 Other than as specifically requested by you, such as to debug an
-                issue, staff working on Aspen never access this data.
+                issue, staff working on CZ GEN EPI never access this data.
               </P>
             </td>
             <td rowSpan={4}>
               <P>
                 Users can request deletion of Raw Sequence Data, Sample
                 Metadata, Pathogen Consensus Genomes, analytical outputs, or
-                their Aspen account data by contacting us at{" "}
+                their CZ GEN EPI account data by contacting us at{" "}
                 <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
                   helloaspen@chanzuckerberg.com
                 </NewTabLink>{" "}
@@ -196,7 +196,7 @@ const PrivacyPolicy = (): JSX.Element => {
               <P>
                 Please be aware, however, that we cannot delete any Pathogen
                 Consensus Genomes or analytical outputs which have been shared
-                outside of Aspen.
+                outside of CZ GEN EPI.
               </P>
             </td>
           </ContentRow>
@@ -221,15 +221,15 @@ const PrivacyPolicy = (): JSX.Element => {
                 <P>
                   This data is also accessible by technical partners (CZ Biohub
                   and CZI, LLC) and Service Providers (ex: AWS) that help
-                  operate and secure Aspen. For example, we need to be able to
+                  operate and secure CZ GEN EPI. For example, we need to be able to
                   access your data in order to back up and maintain the
                   database.
                 </P>
 
                 <P>
                   This Privacy Policy applies to all parties that access data to
-                  support Aspen and they will not use the data for any purpose
-                  beyond operating and securing Aspen.
+                  support CZ GEN EPI and they will not use the data for any purpose
+                  beyond operating and securing CZ GEN EPI.
                 </P>
 
                 <P>
@@ -250,9 +250,9 @@ const PrivacyPolicy = (): JSX.Element => {
             <td>
               <P>See above.</P>
               <P>
-                Users may also upload this data to Aspen directly if they have
+                Users may also upload this data to CZ GEN EPI directly if they have
                 assembled a pathogen consensus genome in a different program,
-                but would like to analyze that genome in Aspen.
+                but would like to analyze that genome in CZ GEN EPI.
               </P>
             </td>
             <td>
@@ -277,7 +277,7 @@ const PrivacyPolicy = (): JSX.Element => {
               phylogenetic trees).
             </td>
             <td>
-              Users use Aspen to drive analytical results that they can then
+              Users use CZ GEN EPI to drive analytical results that they can then
               choose to share more broadly.
             </td>
             <td>
@@ -289,7 +289,7 @@ const PrivacyPolicy = (): JSX.Element => {
 
           <SectionRow>
             <td colSpan={5}>
-              <B>Data Aspen collects</B>
+              <B>Data CZ GEN EPI collects</B>
             </td>
           </SectionRow>
           <ContentRow>
@@ -297,36 +297,36 @@ const PrivacyPolicy = (): JSX.Element => {
               <B>User Data</B>
             </td>
             <td>
-              Data about researchers with Aspen accounts such as name, email,
-              institution, basic information about how they are using Aspen, and
+              Data about researchers with CZ GEN EPI accounts such as name, email,
+              institution, basic information about how they are using CZ GEN EPI, and
               information provided for user support (ex: resolving support
               requests).
             </td>
             <td>
-              We use this data only to operate, secure, and improve the Aspen
+              We use this data only to operate, secure, and improve the CZ GEN EPI
               services.
             </td>
             <td>
               <P>
-                Basic Aspen account information such as name and institution may
-                be visible to other Aspen Users.
+                Basic CZ GEN EPI account information such as name and institution may
+                be visible to other CZ GEN EPI Users.
               </P>
               <P>
                 This data is also shared with technical partners (CZ Biohub and
                 CZI, LLC) and Service Providers (ex: AWS) that help operate and
-                secure Aspen.
+                secure CZ GEN EPI.
               </P>
               <P>
                 This Privacy Policy applies to all parties that access data to
-                support Aspen and they will not use the data for any purpose
-                beyond operating and securing Aspen.
+                support CZ GEN EPI and they will not use the data for any purpose
+                beyond operating and securing CZ GEN EPI.
               </P>
               <P>
                 We will never sell your data or share it with anyone that does.
               </P>
             </td>
             <td rowSpan={2}>
-              Users can request deletion of their Aspen account data by
+              Users can request deletion of their CZ GEN EPI account data by
               contacting us at{" "}
               <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
                 helloaspen@chanzuckerberg.com
@@ -340,9 +340,9 @@ const PrivacyPolicy = (): JSX.Element => {
             </td>
             <td>
               Device Data (ex: browser type and operating system) and Analytics
-              Information (ex: links within Aspen you click on and how often you
-              log into Aspen) includes basic information about how Users and
-              Visitors are interacting with Aspen.
+              Information (ex: links within CZ GEN EPI you click on and how often you
+              log into CZ GEN EPI) includes basic information about how Users and
+              Visitors are interacting with CZ GEN EPI.
             </td>
             <td>See above.</td>
             <td>See above.</td>
@@ -358,7 +358,7 @@ const PrivacyPolicy = (): JSX.Element => {
         <Number>1.</Number>Upload Data
       </H2>
       <P>
-        &quot;Upload Data&quot; is data that Users upload to Aspen (other than
+        &quot;Upload Data&quot; is data that Users upload to CZ GEN EPI (other than
         the information which is provided during registration to create a User
         account). Upload Data consists of pathogen genomic data (including
         &quot;Raw Sequence Data&quot;, which includes both host and pathogenic
@@ -387,8 +387,8 @@ const PrivacyPolicy = (): JSX.Element => {
             <ListItemLabel>Raw Sequence Data:</ListItemLabel> &quot;Raw Sequence
             Data&quot; is genomic sequence data, including both host and
             pathogenic data. As part of the process of processing this data
-            uploaded to Aspen, any identifiable human genetic data is filtered
-            and removed. This means that Aspen should <B>not</B> contain any
+            uploaded to CZ GEN EPI, any identifiable human genetic data is filtered
+            and removed. This means that CZ GEN EPI should <B>not</B> contain any
             human sequence data. Note that if there are no issues identified
             with the corresponding Pathogen Consensus Genome, the Raw Sequencing
             Data will be permanently deleted from our backend after 90 days. We
@@ -401,8 +401,8 @@ const PrivacyPolicy = (): JSX.Element => {
             <ListItemLabel>Pathogen Consensus Genomes:</ListItemLabel>{" "}
             &quot;Pathogen Consensus Genomes&quot; are genetic sequences of
             pathogens, such as SARS-CoV-2, mapped to pathogen-specific reference
-            genomes. These may either be uploaded directly to Aspen or generated
-            by Aspen from uploaded Raw Sequence Data (see below).
+            genomes. These may either be uploaded directly to CZ GEN EPI or generated
+            by CZ GEN EPI from uploaded Raw Sequence Data (see below).
           </span>
         </ListItem>
         <ListItem>
@@ -418,7 +418,7 @@ const PrivacyPolicy = (): JSX.Element => {
         </ListItem>
       </List>
       <P>
-        If you are able to find data in Aspen or any Sample Metadata that you
+        If you are able to find data in CZ GEN EPI or any Sample Metadata that you
         believe is identifying, please let us know at{" "}
         <NewTabLink href="mailto:aspenprivacy@chanzuckerberg.com">
           aspenprivacy@chanzuckerberg.com
@@ -441,8 +441,8 @@ const PrivacyPolicy = (): JSX.Element => {
           phylogenetic trees.
         </ListItem>
         <ListItem>
-          To improve the way Aspen processes Pathogen Consensus Genomes and
-          Users’ ability to use Aspen to create useful analytical outputs.
+          To improve the way CZ GEN EPI processes Pathogen Consensus Genomes and
+          Users’ ability to use CZ GEN EPI to create useful analytical outputs.
         </ListItem>
         <ListItem>
           To troubleshoot in the event you reach out to us with a specific issue
@@ -461,7 +461,7 @@ const PrivacyPolicy = (): JSX.Element => {
         uploaded the data, as well as other Users within the same organization
         (your &quot;Group&quot;). Please note that while the Raw Sequence Data
         is temporarily visible to other members of your Group, this data is not
-        retained on the Aspen platform.
+        retained on the CZ GEN EPI platform.
       </P>
       <P>
         We may also share your Pathogen Consensus Genomes (whether uploaded by
@@ -470,7 +470,7 @@ const PrivacyPolicy = (): JSX.Element => {
         required by law. For example, certain Users in California currently
         allow the California Department of Public Health (&quot;CDPH&quot;) to
         access data from their Group. Where such access is allowed by Groups,
-        the third party can access this data through their own Aspen accounts,
+        the third party can access this data through their own CZ GEN EPI accounts,
         and may have similar viewing permissions as members of the uploading
         Group. However, they will not have access to your private, internal
         identifiers.
@@ -483,7 +483,7 @@ const PrivacyPolicy = (): JSX.Element => {
       </P>
       <P>
         Pathogen Consensus Genomes, whether uploaded by you or generated by
-        Aspen, will be shared by us with public repositories (as set out below)
+        CZ GEN EPI, will be shared by us with public repositories (as set out below)
         unless you choose to mark this information as &quot;private.&quot; In
         the event that the Pathogen Consensus Genome is created by us, it will
         automatically be marked as private if the corresponding Raw Sequence
@@ -495,17 +495,17 @@ const PrivacyPolicy = (): JSX.Element => {
         </UnderLineHeader>
       </P>
       <P>
-        Data uploaded to Aspen by Users should <B>always</B> be anonymous. The
+        Data uploaded to CZ GEN EPI by Users should <B>always</B> be anonymous. The
         pathogen genome does not contain personal data, as it cannot be
         personally linked with an identifiable individual.
       </P>
       <P>
         In the rare event that human genetic data is not successfully deleted in
-        the initial upload process, Aspen may process this data only insofar as
+        the initial upload process, CZ GEN EPI may process this data only insofar as
         necessary in order to delete it. This processing is in our legitimate
         interest, and in the legitimate interests of CZB and CZI LLC, in order
         for us to ensure that no personal data is contained within the genomic
-        data stored on Aspen.
+        data stored on CZ GEN EPI.
       </P>
     </>
   );
@@ -526,7 +526,7 @@ const PrivacyPolicy = (): JSX.Element => {
         genome.
       </P>
       <P>
-        Aspen also gives you the ability to create new analytical outputs from
+        CZ GEN EPI also gives you the ability to create new analytical outputs from
         pathogen genomes, such as phylogenetic trees that allow you to better
         map the relationship between strains.
       </P>
@@ -562,10 +562,10 @@ const PrivacyPolicy = (): JSX.Element => {
         <Number>3.</Number>User Data
       </H2>
       <P>
-        Aspen also collects information about Users in order to offer the
+        CZ GEN EPI also collects information about Users in order to offer the
         Service. Other than basic information required to create an account
         (e.g. email address, name, Group affiliation), the User determines what
-        information they want to upload onto Aspen.
+        information they want to upload onto CZ GEN EPI.
       </P>
 
       <UnderLineHeader>What We Collect</UnderLineHeader>
@@ -595,7 +595,7 @@ const PrivacyPolicy = (): JSX.Element => {
             which we collect for analytics purposes will be stored in a
             de-identified and aggregated manner wherever possible; any analytics
             data that is not able to be aggregated and de-identified will not be
-            shared beyond the Aspen team and will be stored for no longer than
+            shared beyond the CZ GEN EPI team and will be stored for no longer than
             is necessary.
           </span>
         </ListItem>
@@ -610,18 +610,18 @@ const PrivacyPolicy = (): JSX.Element => {
       <List>
         <ListItem>
           To create a profile for Users, and verify Users’ identity so you can
-          log in to and use Aspen.
+          log in to and use CZ GEN EPI.
         </ListItem>
         <ListItem>
           To provide you with notices about your account and updates about
-          Aspen.
+          CZ GEN EPI.
         </ListItem>
         <ListItem>To respond to your inquiries and requests.</ListItem>
         <ListItem>
-          To analyze broadly how Users are using Aspen so we can optimize and
+          To analyze broadly how Users are using CZ GEN EPI so we can optimize and
           improve it.
         </ListItem>
-        <ListItem>To protect the security and integrity of Aspen.</ListItem>
+        <ListItem>To protect the security and integrity of CZ GEN EPI.</ListItem>
       </List>
       <P>
         <UnderLineHeader>
@@ -631,7 +631,7 @@ const PrivacyPolicy = (): JSX.Element => {
       <P>
         We (along with CZB and CZI LLC) have a legitimate interest in using
         personal data within User Data in the ways described in this Privacy
-        Policy to provide, protect, and improve Aspen. This allows us to improve
+        Policy to provide, protect, and improve CZ GEN EPI. This allows us to improve
         the service that we provide to Users which, in turn, supports research
         regarding the study of infectious disease with the potential to benefit
         global public health.
@@ -646,16 +646,16 @@ const PrivacyPolicy = (): JSX.Element => {
       </H2>
       <P>
         CZB, CZIF, and CZI LLC collaborate closely in order to build, design,
-        and operate Aspen so that it can be as useful as possible to researchers
+        and operate CZ GEN EPI so that it can be as useful as possible to researchers
         and the public health community. CZB and CZIF provide scientific and
-        data analysis leadership and CZI LLC focuses on maintaining Aspen’s
+        data analysis leadership and CZI LLC focuses on maintaining CZ GEN EPI’s
         infrastructure, security, and compliance. The three parties are all data
-        controllers for Aspen and will all only use data as described in this
+        controllers for CZ GEN EPI and will all only use data as described in this
         Privacy Policy.
       </P>
       <P>
         We also use service providers, such as database providers like Amazon
-        Web Services, to support the operation of Aspen. These service providers
+        Web Services, to support the operation of CZ GEN EPI. These service providers
         are data processors and their use is limited to the purposes disclosed
         in this Privacy Policy.
       </P>
@@ -672,9 +672,9 @@ const PrivacyPolicy = (): JSX.Element => {
         results from their Group.
       </P>
       <P>
-        In the unlikely event that we can no longer keep operating Aspen or
+        In the unlikely event that we can no longer keep operating CZ GEN EPI or
         believe that its purpose is better served by having another entity
-        operating it, we may transfer Aspen and all data existing therein
+        operating it, we may transfer CZ GEN EPI and all data existing therein
         (Upload Data, analytical outputs, and User Data) so that Users can
         continue to be served. We will always let you know <B>before</B> this
         happens, and you will have the option to delete your account and any
@@ -702,21 +702,21 @@ const PrivacyPolicy = (): JSX.Element => {
       </H2>
       <P>
         We use industry standard security measures to ensure the
-        confidentiality, integrity and availability of data uploaded into Aspen.
-        This includes practices like encrypting connections to Aspen using TLS
-        (encrypting data while in transit), hosting Aspen on leading cloud
+        confidentiality, integrity and availability of data uploaded into CZ GEN EPI.
+        This includes practices like encrypting connections to CZ GEN EPI using TLS
+        (encrypting data while in transit), hosting CZ GEN EPI on leading cloud
         providers with robust physical security, and ensuring that access to any
-        personal data within Aspen by CZIF, CZB, and CZI LLC staff is limited to
+        personal data within CZ GEN EPI by CZIF, CZB, and CZI LLC staff is limited to
         those staff who need access to operate the Service.
       </P>
       <P>
         Security takes ongoing work and we will continue to monitor and adjust
-        our security measures as Aspen develops. Please notify us immediately at{" "}
+        our security measures as CZ GEN EPI develops. Please notify us immediately at{" "}
         <NewTabLink href="mailto:aspensecurity@chanzuckerberg.com">
           aspensecurity@chanzuckerberg.com
         </NewTabLink>{" "}
         if you suspect your account has been compromised or are aware of any
-        other security issues relating to Aspen.
+        other security issues relating to CZ GEN EPI.
       </P>
     </>
   );
@@ -733,7 +733,7 @@ const PrivacyPolicy = (): JSX.Element => {
         <ListItem>
           <span>
             We retain Pathogen Consensus Genomes, Sample Metadata and analytical
-            outputs until Users delete them from Aspen. Users may delete their
+            outputs until Users delete them from CZ GEN EPI. Users may delete their
             data by contacting us at{" "}
             <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
               helloaspen@chanzuckerberg.com
@@ -750,7 +750,7 @@ const PrivacyPolicy = (): JSX.Element => {
         </ListItem>
         <ListItem>
           <span>
-            User Data is retained until Users delete their Aspen account because
+            User Data is retained until Users delete their CZ GEN EPI account because
             this data is required to manage the service. Users may submit
             account deletion requests by emailing{" "}
             <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
@@ -764,7 +764,7 @@ const PrivacyPolicy = (): JSX.Element => {
       <P>
         Please note that we do not control, and so cannot delete Pathogen
         Consensus Genomes and analytical outputs that have been shared outside
-        of Aspen.
+        of CZ GEN EPI.
       </P>
     </>
   );
@@ -778,9 +778,9 @@ const PrivacyPolicy = (): JSX.Element => {
       <List>
         <ListItem>
           `Users are able to request the deletion of User Data that constitutes
-          their personal data, or Upload Data that they submitted to Aspen.
-          Users may also request the deletion from Aspen of the Pathogen
-          Consensus Genomes created by Aspen on the basis of their Upload Data.
+          their personal data, or Upload Data that they submitted to CZ GEN EPI.
+          Users may also request the deletion from CZ GEN EPI of the Pathogen
+          Consensus Genomes created by CZ GEN EPI on the basis of their Upload Data.
         </ListItem>
         <ListItem>
           Users have full control over any analytical outputs created by any
@@ -790,7 +790,7 @@ const PrivacyPolicy = (): JSX.Element => {
         <ListItem>
           Users are able to access and download analytical results relating to
           Upload Data submitted by a member of their organization group within
-          Aspen.
+          CZ GEN EPI.
         </ListItem>
         <ListItem>
           <span>
@@ -812,9 +812,9 @@ const PrivacyPolicy = (): JSX.Element => {
         <Number>8.</Number>Data Location
       </H2>
       <P>
-        Aspen is a US-based service. If you want to use Aspen, you must first
+        CZ GEN EPI is a US-based service. If you want to use CZ GEN EPI, you must first
         agree to our <NewTabLink href={ROUTES.TERMS}>Terms</NewTabLink>, which
-        set out the contract between Aspen and our Users. We operate in the
+        set out the contract between CZ GEN EPI and our Users. We operate in the
         United States, and use technical infrastructure in the United States to
         to deliver the Services to you.
       </P>

--- a/src/frontend/src/views/Privacy/index.tsx
+++ b/src/frontend/src/views/Privacy/index.tsx
@@ -28,7 +28,7 @@ const PrivacyPolicy = (): JSX.Element => {
     <>
       <Title>
         <H1>Chan Zuckerberg GEN EPI (formerly Aspen) Privacy Policy</H1>
-        <H4>Last Updated: September 30, 2021</H4>
+        <H4>Last Updated: December 6, 2021</H4>
       </Title>
       <P>
         The Chan Zuckerberg Initiative Foundation, a 501(c)(3) nonprofit private

--- a/src/frontend/src/views/Terms/index.tsx
+++ b/src/frontend/src/views/Terms/index.tsx
@@ -22,19 +22,21 @@ export default function Terms(): JSX.Element {
         <H4>Last Updated: September 30, 2021. </H4>
       </Title>
       <P>
-        Please read these Terms of Use (&quot;Terms&quot;) before using Chan Zuckerberg GEN EPI
-        (&quot;Services&quot; or &quot;CZ GEN EPI&quot;). These Terms are entered
-        into between the Chan Zuckerberg Initiative Foundation, a 501(c)(3)
-        nonprofit private foundation, (&quot;CZIF&quot;, &quot;we&quot;,
-        &quot;us&quot; or &quot;our&quot;) and you (&quot;User&quot; or
-        &quot;you&quot;) and govern your and your organization’s use of CZ GEN EPI.
+        Please read these Terms of Use (&quot;Terms&quot;) before using Chan
+        Zuckerberg GEN EPI (&quot;Services&quot; or &quot;CZ GEN EPI&quot;).
+        These Terms are entered into between the Chan Zuckerberg Initiative
+        Foundation, a 501(c)(3) nonprofit private foundation, (&quot;CZIF&quot;,
+        &quot;we&quot;, &quot;us&quot; or &quot;our&quot;) and you
+        (&quot;User&quot; or &quot;you&quot;) and govern your and your
+        organization’s use of CZ GEN EPI.
       </P>
       <P>
-        CZ GEN EPI is a tool that helps you infer how pathogens are moving through a
-        population and how cases are related to one another. CZ GEN EPI comprises our
-        Genomic Epidemiology portal, any associated online services or platforms
-        that link to or refer to these Terms, and any databases or data
-        accessible through the portal, associated services or platforms.
+        CZ GEN EPI is a tool that helps you infer how pathogens are moving
+        through a population and how cases are related to one another. CZ GEN
+        EPI comprises our Genomic Epidemiology portal, any associated online
+        services or platforms that link to or refer to these Terms, and any
+        databases or data accessible through the portal, associated services or
+        platforms.
       </P>
       <P>
         CZ GEN EPI is offered by the Chan Zuckerberg Initiative Foundation
@@ -45,8 +47,8 @@ export default function Terms(): JSX.Element {
       <P>
         Please carefully read these terms and indicate your acceptance by
         registering for CZ GEN EPI. If you do not agree to these Terms, do not
-        register for an account to use CZ GEN EPI. For more information about our
-        privacy practices, please see the &quot;Privacy Notice&quot;).
+        register for an account to use CZ GEN EPI. For more information about
+        our privacy practices, please see the &quot;Privacy Notice&quot;).
       </P>
       <P>
         <B>
@@ -88,13 +90,13 @@ export default function Terms(): JSX.Element {
           </ListItem>
           <ListItem>
             <span>
-              In order to use CZ GEN EPI, you must be acting in your professional
-              capacity. This means a couple things: (1) your use of CZ GEN EPI may be
-              subject to your organization’s policies and (2) upon sign-up,
-              you’ll be placed into a group with other users from your
-              organization (3) your Upload Data, and analytical results may be
-              shared with third parties in accordance with your organization’s
-              policies.
+              In order to use CZ GEN EPI, you must be acting in your
+              professional capacity. This means a couple things: (1) your use of
+              CZ GEN EPI may be subject to your organization’s policies and (2)
+              upon sign-up, you’ll be placed into a group with other users from
+              your organization (3) your Upload Data, and analytical results may
+              be shared with third parties in accordance with your
+              organization’s policies.
             </span>
           </ListItem>
           <ListItem>
@@ -107,11 +109,11 @@ export default function Terms(): JSX.Element {
           <ListItem>
             <span>
               The outputs (ex: analytical outputs, such as phylogenetic trees)
-              you create with CZ GEN EPI are <B>not</B> personally identifiable. You
-              must also ensure that the data you upload to CZ GEN EPI (Raw Sequence
-              Data, Pathogen Consensus Genomes, and Sample Metadata) are
-              similarly <B>not</B> personally identifiable. This means removing
-              all{" "}
+              you create with CZ GEN EPI are <B>not</B> personally identifiable.
+              You must also ensure that the data you upload to CZ GEN EPI (Raw
+              Sequence Data, Pathogen Consensus Genomes, and Sample Metadata)
+              are similarly <B>not</B> personally identifiable. This means
+              removing all{" "}
               <NewTabLink href="https://docs.google.com/document/d/1sboOmbafvMh3VYjK1-3MAUt0I13UUJfkQseq8ANLPl8/edit">
                 direct identifiers
               </NewTabLink>{" "}
@@ -120,9 +122,9 @@ export default function Terms(): JSX.Element {
             </span>
           </ListItem>
           <ListItem>
-            CZ GEN EPI does not provide medical advice. The output from CZ GEN EPI does
-            not constitute and should not be relied upon to provide medical
-            advice, diagnosis or treatment. It is intended for research,
+            CZ GEN EPI does not provide medical advice. The output from CZ GEN
+            EPI does not constitute and should not be relied upon to provide
+            medical advice, diagnosis or treatment. It is intended for research,
             educational, or informational purposes only.
           </ListItem>
         </List>
@@ -139,10 +141,10 @@ export default function Terms(): JSX.Element {
         <ListItem>
           <span>
             <ListItemLabel>No personally identifying data.</ListItemLabel>
-            The data you upload to CZ GEN EPI consists of Raw Sequence Data, Pathogen
-            Consensus Genomes, and Sample Metadata (ex: date collected and
-            county-level location data). You should <B>not</B> be uploading any
-            information that would allow identification of any specific
+            The data you upload to CZ GEN EPI consists of Raw Sequence Data,
+            Pathogen Consensus Genomes, and Sample Metadata (ex: date collected
+            and county-level location data). You should <B>not</B> be uploading
+            any information that would allow identification of any specific
             individuals to which the Samples may relate, such as{" "}
             <NewTabLink href="https://docs.google.com/document/d/1sboOmbafvMh3VYjK1-3MAUt0I13UUJfkQseq8ANLPl8/edit">
               direct identifiers
@@ -154,28 +156,28 @@ export default function Terms(): JSX.Element {
         <ListItem>
           <span>
             <ListItemLabel>Compliance with laws.</ListItemLabel>
-            By uploading data to CZ GEN EPI, you represent and warrant to us that (A)
-            you have all consents, permissions, and authorizations necessary for
-            uploading the data to CZ GEN EPI and (B) that your uploading this data to
-            CZ GEN EPI complies with applicable laws, rules, and regulations,
-            including the Nagoya Protocol and relevant export laws and industry
-            guidelines and ethical standards that apply to you (e.g. CIOMS or
-            GA4GH). Please note that we filter out human sequence data as part
-            of processing Raw Sequence Data as such information is not necessary
-            for providing CZ GEN EPI.
+            By uploading data to CZ GEN EPI, you represent and warrant to us
+            that (A) you have all consents, permissions, and authorizations
+            necessary for uploading the data to CZ GEN EPI and (B) that your
+            uploading this data to CZ GEN EPI complies with applicable laws,
+            rules, and regulations, including the Nagoya Protocol and relevant
+            export laws and industry guidelines and ethical standards that apply
+            to you (e.g. CIOMS or GA4GH). Please note that we filter out human
+            sequence data as part of processing Raw Sequence Data as such
+            information is not necessary for providing CZ GEN EPI.
           </span>
         </ListItem>
         <ListItem>
           <span>
             <ListItemLabel>Our rights and your rights.</ListItemLabel>
             We need some basic rights to use your Upload data in order to offer
-            CZ GEN EPI’s services to you. Specifically, you grant to us a license to
-            use (ex: store your data in the CZ GEN EPI database), reproduce (ex:
-            backing up the CZ GEN EPI database), distribute, display, and create
-            derivative works (ex: produce phylogenetic trees per your requests)
-            from Upload data in connection with offering and improving CZ GEN EPI.
-            You can request deletion of your Upload Data from CZ GEN EPI by emailing
-            us at{" "}
+            CZ GEN EPI’s services to you. Specifically, you grant to us a
+            license to use (ex: store your data in the CZ GEN EPI database),
+            reproduce (ex: backing up the CZ GEN EPI database), distribute,
+            display, and create derivative works (ex: produce phylogenetic trees
+            per your requests) from Upload data in connection with offering and
+            improving CZ GEN EPI. You can request deletion of your Upload Data
+            from CZ GEN EPI by emailing us at{" "}
             <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
               helloaspen@chanzuckerberg.com
             </NewTabLink>{" "}
@@ -186,24 +188,24 @@ export default function Terms(): JSX.Element {
             <ListItemLabel>
               Sharing pathogen genomes and analytical outputs.
             </ListItemLabel>
-            CZ GEN EPI gives you tools to analyze pathogen genomes and create further
-            analytical outputs from them (ex: phylogenetic trees) that allow you
-            to better understand the relationship between different pathogen
-            genomes.
+            CZ GEN EPI gives you tools to analyze pathogen genomes and create
+            further analytical outputs from them (ex: phylogenetic trees) that
+            allow you to better understand the relationship between different
+            pathogen genomes.
             <List>
               <ListItem>
                 <span>
                   <ListItemLabel>Within your organization:</ListItemLabel>
                   The pathogen genomes created from your Samples and the
-                  analytical outputs you create using CZ GEN EPI are visible to other
-                  Users at your organization (ex: your DPH). You, along with
-                  other members of your Group, control whether you permit us to
-                  share this information with Users outside your organization.
-                  In certain circumstances, we may also share your data with
-                  third party entities, through the CZ GEN EPI tool, in line with
-                  your organization’s policies or in line with applicable law.
-                  Samples marked &quot;private&quot; will never be shared with
-                  any 3rd parties unless you choose to mark them
+                  analytical outputs you create using CZ GEN EPI are visible to
+                  other Users at your organization (ex: your DPH). You, along
+                  with other members of your Group, control whether you permit
+                  us to share this information with Users outside your
+                  organization. In certain circumstances, we may also share your
+                  data with third party entities, through the CZ GEN EPI tool,
+                  in line with your organization’s policies or in line with
+                  applicable law. Samples marked &quot;private&quot; will never
+                  be shared with any 3rd parties unless you choose to mark them
                   &quot;public&quot; later on.
                 </span>
               </ListItem>
@@ -221,17 +223,17 @@ export default function Terms(): JSX.Element {
       </H2>
       <List>
         <ListItem>
-          You are using CZ GEN EPI in your professional capacity as a User from your
-          organization. This means that in addition to CZ GEN EPI’s Terms and Privacy
-          Policy, your organization’s policies also likely apply to your and
-          your colleagues’ use of CZ GEN EPI. Please see your organization for
-          questions related to their policies.
+          You are using CZ GEN EPI in your professional capacity as a User from
+          your organization. This means that in addition to CZ GEN EPI’s Terms
+          and Privacy Policy, your organization’s policies also likely apply to
+          your and your colleagues’ use of CZ GEN EPI. Please see your
+          organization for questions related to their policies.
         </ListItem>
         <ListItem>
           CZ GEN EPI may not be used to provide medical or other services to any
-          third party (for instance, to inform or provide disease diagnoses).
-          CZ GEN EPI is not intended to diagnose, treat, cure, or prevent any disease
-          and is not a substitute for medical advice.
+          third party (for instance, to inform or provide disease diagnoses). CZ
+          GEN EPI is not intended to diagnose, treat, cure, or prevent any
+          disease and is not a substitute for medical advice.
         </ListItem>
       </List>
     </>
@@ -244,10 +246,11 @@ export default function Terms(): JSX.Element {
       </H2>
       <List>
         <ListItem>
-          You shall not otherwise access or use, or attempt to access or use,
-          CZ GEN EPI to take any action that could harm us, CZ GEN EPI or its Users, or
-          any third party, or use CZ GEN EPI in any manner that violates applicable
-          law or infringes or otherwise violates third party rights.
+          You shall not otherwise access or use, or attempt to access or use, CZ
+          GEN EPI to take any action that could harm us, CZ GEN EPI or its
+          Users, or any third party, or use CZ GEN EPI in any manner that
+          violates applicable law or infringes or otherwise violates third party
+          rights.
         </ListItem>
         <ListItem>
           <span>
@@ -273,11 +276,12 @@ export default function Terms(): JSX.Element {
       <List>
         <ListItem>
           <span>
-            <ListItemLabel>Changes to CZ GEN EPI.</ListItemLabel>CZ GEN EPI is a free
-            tool. We can’t promise CZ GEN EPI will always be up and offered as it is
-            today, but if we are making material changes to its features or that
-            impact its availability, we will give you a chance to download
-            and/or delete your data so you can take it off of CZ GEN EPI.
+            <ListItemLabel>Changes to CZ GEN EPI.</ListItemLabel>CZ GEN EPI is a
+            free tool. We can’t promise CZ GEN EPI will always be up and offered
+            as it is today, but if we are making material changes to its
+            features or that impact its availability, we will give you a chance
+            to download and/or delete your data so you can take it off of CZ GEN
+            EPI.
           </span>
         </ListItem>
         <ListItem>
@@ -316,8 +320,8 @@ export default function Terms(): JSX.Element {
             <NewTabLink href="mailto:aspensecurity@chanzuckerberg.com">
               aspensecurity@chanzuckerberg.com
             </NewTabLink>
-            . CZ GEN EPI is not intended as a storage service, so please back up your
-            Upload Data using a secure service of your choice, such as the
+            . CZ GEN EPI is not intended as a storage service, so please back up
+            your Upload Data using a secure service of your choice, such as the
             NCBI’s Sequence Read Archive (SRA) repository.
           </span>
         </ListItem>
@@ -327,23 +331,23 @@ export default function Terms(): JSX.Element {
             <List>
               <ListItem>
                 <span>
-                  YOUR ACCESS AND USE CZ GEN EPI AT YOUR SOLE RISK AND AGREE THAT WE
-                  AND OUR SERVICE PROVIDERS WILL NOT BE RESPONSIBLE FOR ANY
-                  ACTIONS YOU TAKE BASED ON CZ GEN EPI OR FOR ANY INACCURATE DATA OR
-                  OUTPUTS OF CZ GEN EPI.
+                  YOUR ACCESS AND USE CZ GEN EPI AT YOUR SOLE RISK AND AGREE
+                  THAT WE AND OUR SERVICE PROVIDERS WILL NOT BE RESPONSIBLE FOR
+                  ANY ACTIONS YOU TAKE BASED ON CZ GEN EPI OR FOR ANY INACCURATE
+                  DATA OR OUTPUTS OF CZ GEN EPI.
                 </span>
               </ListItem>
               <ListItem>
                 <span>
-                  CZ GEN EPI IS PROVIDED &quot;AS IS&quot; WITH ALL FAULTS, AND WE
-                  AND OUR SERVICE PROVIDERS HEREBY DISCLAIM ALL REPRESENTATIONS
-                  AND WARRANTIES, EXPRESS, STATUTORY, OR IMPLIED (INCLUDING,
-                  WITHOUT LIMITATION, IMPLIED WARRANTIES OF TITLE,
+                  CZ GEN EPI IS PROVIDED &quot;AS IS&quot; WITH ALL FAULTS, AND
+                  WE AND OUR SERVICE PROVIDERS HEREBY DISCLAIM ALL
+                  REPRESENTATIONS AND WARRANTIES, EXPRESS, STATUTORY, OR IMPLIED
+                  (INCLUDING, WITHOUT LIMITATION, IMPLIED WARRANTIES OF TITLE,
                   NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR
                   PURPOSE, AND ALL WARRANTIES ARISING FROM THE COURSE OF
                   DEALING, USAGE, OR TRADE PRACTICE) WITH RESPECT TO CZ GEN EPI.
-                  CZ GEN EPI IS NOT INTENDED TO BE USED AND SHOULD NOT BE USED AS A
-                  MEDICAL DEVICE OR FOR PURPOSES OF MEDICAL DIAGNOSIS OR
+                  CZ GEN EPI IS NOT INTENDED TO BE USED AND SHOULD NOT BE USED
+                  AS A MEDICAL DEVICE OR FOR PURPOSES OF MEDICAL DIAGNOSIS OR
                   TREATMENT.
                 </span>
               </ListItem>
@@ -352,12 +356,13 @@ export default function Terms(): JSX.Element {
                   FOR CLARITY AND WITHOUT LIMITING THE FOREGOING, WE AND OUR
                   SERVICE PROVIDERS DO NOT MAKE ANY GUARANTEES (I) REGARDING THE
                   ACCURACY, COMPLETENESS, TIMELINESS, SECURITY, AVAILABILITY OR
-                  INTEGRITY OF CZ GEN EPI, (II) THAT CZ GEN EPI WILL BE UNINTERRUPTED OR
-                  OPERATE IN COMBINATION WITH ANY SOFTWARE, SERVICE, SYSTEM OR
-                  OTHER DATA, OR (III) THAT CZ GEN EPI WILL MEET ANY REQUIREMENTS OF
-                  ANY PERSON OR ENTITY, OR ANY REGULATORY APPROVALS OR
-                  REQUIREMENTS. WITHOUT LIMITATION, YOU ACKNOWLEDGE THAT CZ GEN EPI
-                  IS NOT A BUSINESS ASSOCIATE FOR PURPOSES OF HIPAA.
+                  INTEGRITY OF CZ GEN EPI, (II) THAT CZ GEN EPI WILL BE
+                  UNINTERRUPTED OR OPERATE IN COMBINATION WITH ANY SOFTWARE,
+                  SERVICE, SYSTEM OR OTHER DATA, OR (III) THAT CZ GEN EPI WILL
+                  MEET ANY REQUIREMENTS OF ANY PERSON OR ENTITY, OR ANY
+                  REGULATORY APPROVALS OR REQUIREMENTS. WITHOUT LIMITATION, YOU
+                  ACKNOWLEDGE THAT CZ GEN EPI IS NOT A BUSINESS ASSOCIATE FOR
+                  PURPOSES OF HIPAA.
                 </span>
               </ListItem>
             </List>
@@ -447,13 +452,13 @@ export default function Terms(): JSX.Element {
           <span>
             <ListItemLabel>Dispute Resolution.</ListItemLabel>
             In the unlikely event we have a dispute arising out of or related to
-            the use of CZ GEN EPI (&quot;Dispute&quot;) that we can’t resolve between
-            us, you and we agree that we shall (in good faith) meet and attempt
-            to resolve the Dispute within thirty (30) days. If the Dispute is
-            not resolved during such time period, then you and a representative
-            of CZIF shall (in good faith) meet and attempt to resolve the
-            Dispute through non-binding mediation with a mutually agreed upon
-            mediator within thirty (30) additional days.
+            the use of CZ GEN EPI (&quot;Dispute&quot;) that we can’t resolve
+            between us, you and we agree that we shall (in good faith) meet and
+            attempt to resolve the Dispute within thirty (30) days. If the
+            Dispute is not resolved during such time period, then you and a
+            representative of CZIF shall (in good faith) meet and attempt to
+            resolve the Dispute through non-binding mediation with a mutually
+            agreed upon mediator within thirty (30) additional days.
           </span>
         </ListItem>
         <ListItem>
@@ -530,9 +535,9 @@ export default function Terms(): JSX.Element {
         </ListItem>
         <ListItem>
           Entire Agreement. These Terms (along with the Privacy Notice)
-          constitute the entire agreement between you and us regarding CZ GEN EPI. If
-          you wish to modify these Terms, any amendment must be provided to us
-          in writing and signed by our authorized representative.
+          constitute the entire agreement between you and us regarding CZ GEN
+          EPI. If you wish to modify these Terms, any amendment must be provided
+          to us in writing and signed by our authorized representative.
         </ListItem>
       </List>
     </>

--- a/src/frontend/src/views/Terms/index.tsx
+++ b/src/frontend/src/views/Terms/index.tsx
@@ -18,34 +18,34 @@ export default function Terms(): JSX.Element {
   const renderIntro = () => (
     <>
       <Title>
-        <H1>Aspen Terms of Use</H1>
+        <H1>Chan Zuckerberg GEN EPI (formerly Aspen) Terms of Use</H1>
         <H4>Last Updated: September 30, 2021. </H4>
       </Title>
       <P>
-        Please read these Terms of Use (&quot;Terms&quot;) before using Aspen
-        (&quot;Services&quot; or &quot;Aspen&quot;). These Terms are entered
+        Please read these Terms of Use (&quot;Terms&quot;) before using Chan Zuckerberg GEN EPI
+        (&quot;Services&quot; or &quot;CZ GEN EPI&quot;). These Terms are entered
         into between the Chan Zuckerberg Initiative Foundation, a 501(c)(3)
         nonprofit private foundation, (&quot;CZIF&quot;, &quot;we&quot;,
         &quot;us&quot; or &quot;our&quot;) and you (&quot;User&quot; or
-        &quot;you&quot;) and govern your and your organization’s use of Aspen.
+        &quot;you&quot;) and govern your and your organization’s use of CZ GEN EPI.
       </P>
       <P>
-        Aspen is a tool that helps you infer how pathogens are moving through a
-        population and how cases are related to one another. Aspen comprises our
+        CZ GEN EPI is a tool that helps you infer how pathogens are moving through a
+        population and how cases are related to one another. CZ GEN EPI comprises our
         Genomic Epidemiology portal, any associated online services or platforms
         that link to or refer to these Terms, and any databases or data
         accessible through the portal, associated services or platforms.
       </P>
       <P>
-        Aspen is offered by the Chan Zuckerberg Initiative Foundation
+        CZ GEN EPI is offered by the Chan Zuckerberg Initiative Foundation
         (&quot;CZIF&quot;), in close collaboration with the Chan Zuckerberg
         Biohub (&quot;CZB&quot;) and the Chan Zuckerberg Initiative, LLC
         (&quot;CZI LLC&quot;).
       </P>
       <P>
         Please carefully read these terms and indicate your acceptance by
-        registering for Aspen. If you do not agree to these Terms, do not
-        register for an account to use Aspen. For more information about our
+        registering for CZ GEN EPI. If you do not agree to these Terms, do not
+        register for an account to use CZ GEN EPI. For more information about our
         privacy practices, please see the &quot;Privacy Notice&quot;).
       </P>
       <P>
@@ -72,24 +72,24 @@ export default function Terms(): JSX.Element {
         <List>
           <ListItem>
             <span>
-              Aspen is a tool that helps you infer how pathogens are moving
+              CZ GEN EPI is a tool that helps you infer how pathogens are moving
               through a population and how cases are related to one another.
             </span>
           </ListItem>
           <ListItem>
             <span>
-              Aspen is offered by the Chan Zuckerberg Initiative Foundation
+              CZ GEN EPI is offered by the Chan Zuckerberg Initiative Foundation
               (CZIF), in close collaboration with the Chan Zuckerberg Biohub
               (CZB) and the Chan Zuckerberg Initiative, LLC (CZI LLC).
             </span>
           </ListItem>
           <ListItem>
-            <span>Aspen is a free and open-source tool.</span>
+            <span>CZ GEN EPI is a free and open-source tool.</span>
           </ListItem>
           <ListItem>
             <span>
-              In order to use Aspen, you must be acting in your professional
-              capacity. This means a couple things: (1) your use of Aspen may be
+              In order to use CZ GEN EPI, you must be acting in your professional
+              capacity. This means a couple things: (1) your use of CZ GEN EPI may be
               subject to your organization’s policies and (2) upon sign-up,
               you’ll be placed into a group with other users from your
               organization (3) your Upload Data, and analytical results may be
@@ -107,8 +107,8 @@ export default function Terms(): JSX.Element {
           <ListItem>
             <span>
               The outputs (ex: analytical outputs, such as phylogenetic trees)
-              you create with Aspen are <B>not</B> personally identifiable. You
-              must also ensure that the data you upload to Aspen (Raw Sequence
+              you create with CZ GEN EPI are <B>not</B> personally identifiable. You
+              must also ensure that the data you upload to CZ GEN EPI (Raw Sequence
               Data, Pathogen Consensus Genomes, and Sample Metadata) are
               similarly <B>not</B> personally identifiable. This means removing
               all{" "}
@@ -116,11 +116,11 @@ export default function Terms(): JSX.Element {
                 direct identifiers
               </NewTabLink>{" "}
               like name, address, dates, telephone numbers, e-mail addresses, or
-              medical record numbers from data you upload to Aspen.
+              medical record numbers from data you upload to CZ GEN EPI.
             </span>
           </ListItem>
           <ListItem>
-            Aspen does not provide medical advice. The output from Aspen does
+            CZ GEN EPI does not provide medical advice. The output from CZ GEN EPI does
             not constitute and should not be relied upon to provide medical
             advice, diagnosis or treatment. It is intended for research,
             educational, or informational purposes only.
@@ -139,7 +139,7 @@ export default function Terms(): JSX.Element {
         <ListItem>
           <span>
             <ListItemLabel>No personally identifying data.</ListItemLabel>
-            The data you upload to Aspen consists of Raw Sequence Data, Pathogen
+            The data you upload to CZ GEN EPI consists of Raw Sequence Data, Pathogen
             Consensus Genomes, and Sample Metadata (ex: date collected and
             county-level location data). You should <B>not</B> be uploading any
             information that would allow identification of any specific
@@ -154,27 +154,27 @@ export default function Terms(): JSX.Element {
         <ListItem>
           <span>
             <ListItemLabel>Compliance with laws.</ListItemLabel>
-            By uploading data to Aspen, you represent and warrant to us that (A)
+            By uploading data to CZ GEN EPI, you represent and warrant to us that (A)
             you have all consents, permissions, and authorizations necessary for
-            uploading the data to Aspen and (B) that your uploading this data to
-            Aspen complies with applicable laws, rules, and regulations,
+            uploading the data to CZ GEN EPI and (B) that your uploading this data to
+            CZ GEN EPI complies with applicable laws, rules, and regulations,
             including the Nagoya Protocol and relevant export laws and industry
             guidelines and ethical standards that apply to you (e.g. CIOMS or
             GA4GH). Please note that we filter out human sequence data as part
             of processing Raw Sequence Data as such information is not necessary
-            for providing Aspen.
+            for providing CZ GEN EPI.
           </span>
         </ListItem>
         <ListItem>
           <span>
             <ListItemLabel>Our rights and your rights.</ListItemLabel>
             We need some basic rights to use your Upload data in order to offer
-            Aspen’s services to you. Specifically, you grant to us a license to
-            use (ex: store your data in the Aspen database), reproduce (ex:
-            backing up the Aspen database), distribute, display, and create
+            CZ GEN EPI’s services to you. Specifically, you grant to us a license to
+            use (ex: store your data in the CZ GEN EPI database), reproduce (ex:
+            backing up the CZ GEN EPI database), distribute, display, and create
             derivative works (ex: produce phylogenetic trees per your requests)
-            from Upload data in connection with offering and improving Aspen.
-            You can request deletion of your Upload Data from Aspen by emailing
+            from Upload data in connection with offering and improving CZ GEN EPI.
+            You can request deletion of your Upload Data from CZ GEN EPI by emailing
             us at{" "}
             <NewTabLink href="mailto:helloaspen@chanzuckerberg.com">
               helloaspen@chanzuckerberg.com
@@ -186,7 +186,7 @@ export default function Terms(): JSX.Element {
             <ListItemLabel>
               Sharing pathogen genomes and analytical outputs.
             </ListItemLabel>
-            Aspen gives you tools to analyze pathogen genomes and create further
+            CZ GEN EPI gives you tools to analyze pathogen genomes and create further
             analytical outputs from them (ex: phylogenetic trees) that allow you
             to better understand the relationship between different pathogen
             genomes.
@@ -195,12 +195,12 @@ export default function Terms(): JSX.Element {
                 <span>
                   <ListItemLabel>Within your organization:</ListItemLabel>
                   The pathogen genomes created from your Samples and the
-                  analytical outputs you create using Aspen are visible to other
+                  analytical outputs you create using CZ GEN EPI are visible to other
                   Users at your organization (ex: your DPH). You, along with
                   other members of your Group, control whether you permit us to
                   share this information with Users outside your organization.
                   In certain circumstances, we may also share your data with
-                  third party entities, through the Aspen tool, in line with
+                  third party entities, through the CZ GEN EPI tool, in line with
                   your organization’s policies or in line with applicable law.
                   Samples marked &quot;private&quot; will never be shared with
                   any 3rd parties unless you choose to mark them
@@ -217,20 +217,20 @@ export default function Terms(): JSX.Element {
   const renderAuthorizationToUseAspen = () => (
     <>
       <H2>
-        <Number>2.</Number>Authorization To Use Aspen
+        <Number>2.</Number>Authorization To Use CZ GEN EPI
       </H2>
       <List>
         <ListItem>
-          You are using Aspen in your professional capacity as a User from your
-          organization. This means that in addition to Aspen’s Terms and Privacy
+          You are using CZ GEN EPI in your professional capacity as a User from your
+          organization. This means that in addition to CZ GEN EPI’s Terms and Privacy
           Policy, your organization’s policies also likely apply to your and
-          your colleagues’ use of Aspen. Please see your organization for
+          your colleagues’ use of CZ GEN EPI. Please see your organization for
           questions related to their policies.
         </ListItem>
         <ListItem>
-          Aspen may not be used to provide medical or other services to any
+          CZ GEN EPI may not be used to provide medical or other services to any
           third party (for instance, to inform or provide disease diagnoses).
-          Aspen is not intended to diagnose, treat, cure, or prevent any disease
+          CZ GEN EPI is not intended to diagnose, treat, cure, or prevent any disease
           and is not a substitute for medical advice.
         </ListItem>
       </List>
@@ -245,8 +245,8 @@ export default function Terms(): JSX.Element {
       <List>
         <ListItem>
           You shall not otherwise access or use, or attempt to access or use,
-          Aspen to take any action that could harm us, Aspen or its Users, or
-          any third party, or use Aspen in any manner that violates applicable
+          CZ GEN EPI to take any action that could harm us, CZ GEN EPI or its Users, or
+          any third party, or use CZ GEN EPI in any manner that violates applicable
           law or infringes or otherwise violates third party rights.
         </ListItem>
         <ListItem>
@@ -257,7 +257,7 @@ export default function Terms(): JSX.Element {
           </span>
         </ListItem>
         <ListItem>
-          We may restrict or terminate your access to Aspen at any time,
+          We may restrict or terminate your access to CZ GEN EPI at any time,
           including for breach of these Terms. If this happens, we will attempt
           to provide you notice through the contact information we have for you.
         </ListItem>
@@ -268,16 +268,16 @@ export default function Terms(): JSX.Element {
   const renderChangesToAspenOrTerms = () => (
     <>
       <H2>
-        <Number>4.</Number>Changes To Aspen Or These Terms
+        <Number>4.</Number>Changes To CZ GEN EPI Or These Terms
       </H2>
       <List>
         <ListItem>
           <span>
-            <ListItemLabel>Changes to Aspen.</ListItemLabel>Aspen is a free
-            tool. We can’t promise Aspen will always be up and offered as it is
+            <ListItemLabel>Changes to CZ GEN EPI.</ListItemLabel>CZ GEN EPI is a free
+            tool. We can’t promise CZ GEN EPI will always be up and offered as it is
             today, but if we are making material changes to its features or that
             impact its availability, we will give you a chance to download
-            and/or delete your data so you can take it off of Aspen.
+            and/or delete your data so you can take it off of CZ GEN EPI.
           </span>
         </ListItem>
         <ListItem>
@@ -311,12 +311,12 @@ export default function Terms(): JSX.Element {
         <ListItem>
           <span>
             We and our service providers do not review or correct any data
-            uploaded into Aspen. If you would like to report any issue with
-            Aspen please contact us at{" "}
+            uploaded into CZ GEN EPI. If you would like to report any issue with
+            CZ GEN EPI please contact us at{" "}
             <NewTabLink href="mailto:aspensecurity@chanzuckerberg.com">
               aspensecurity@chanzuckerberg.com
             </NewTabLink>
-            . Aspen is not intended as a storage service, so please back up your
+            . CZ GEN EPI is not intended as a storage service, so please back up your
             Upload Data using a secure service of your choice, such as the
             NCBI’s Sequence Read Archive (SRA) repository.
           </span>
@@ -327,22 +327,22 @@ export default function Terms(): JSX.Element {
             <List>
               <ListItem>
                 <span>
-                  YOUR ACCESS AND USE ASPEN AT YOUR SOLE RISK AND AGREE THAT WE
+                  YOUR ACCESS AND USE CZ GEN EPI AT YOUR SOLE RISK AND AGREE THAT WE
                   AND OUR SERVICE PROVIDERS WILL NOT BE RESPONSIBLE FOR ANY
-                  ACTIONS YOU TAKE BASED ON ASPEN OR FOR ANY INACCURATE DATA OR
-                  OUTPUTS OF ASPEN.
+                  ACTIONS YOU TAKE BASED ON CZ GEN EPI OR FOR ANY INACCURATE DATA OR
+                  OUTPUTS OF CZ GEN EPI.
                 </span>
               </ListItem>
               <ListItem>
                 <span>
-                  ASPEN IS PROVIDED &quot;AS IS&quot; WITH ALL FAULTS, AND WE
+                  CZ GEN EPI IS PROVIDED &quot;AS IS&quot; WITH ALL FAULTS, AND WE
                   AND OUR SERVICE PROVIDERS HEREBY DISCLAIM ALL REPRESENTATIONS
                   AND WARRANTIES, EXPRESS, STATUTORY, OR IMPLIED (INCLUDING,
                   WITHOUT LIMITATION, IMPLIED WARRANTIES OF TITLE,
                   NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR
                   PURPOSE, AND ALL WARRANTIES ARISING FROM THE COURSE OF
-                  DEALING, USAGE, OR TRADE PRACTICE) WITH RESPECT TO ASPEN.
-                  ASPEN IS NOT INTENDED TO BE USED AND SHOULD NOT BE USED AS A
+                  DEALING, USAGE, OR TRADE PRACTICE) WITH RESPECT TO CZ GEN EPI.
+                  CZ GEN EPI IS NOT INTENDED TO BE USED AND SHOULD NOT BE USED AS A
                   MEDICAL DEVICE OR FOR PURPOSES OF MEDICAL DIAGNOSIS OR
                   TREATMENT.
                 </span>
@@ -352,11 +352,11 @@ export default function Terms(): JSX.Element {
                   FOR CLARITY AND WITHOUT LIMITING THE FOREGOING, WE AND OUR
                   SERVICE PROVIDERS DO NOT MAKE ANY GUARANTEES (I) REGARDING THE
                   ACCURACY, COMPLETENESS, TIMELINESS, SECURITY, AVAILABILITY OR
-                  INTEGRITY OF ASPEN, (II) THAT ASPEN WILL BE UNINTERRUPTED OR
+                  INTEGRITY OF CZ GEN EPI, (II) THAT CZ GEN EPI WILL BE UNINTERRUPTED OR
                   OPERATE IN COMBINATION WITH ANY SOFTWARE, SERVICE, SYSTEM OR
-                  OTHER DATA, OR (III) THAT ASPEN WILL MEET ANY REQUIREMENTS OF
+                  OTHER DATA, OR (III) THAT CZ GEN EPI WILL MEET ANY REQUIREMENTS OF
                   ANY PERSON OR ENTITY, OR ANY REGULATORY APPROVALS OR
-                  REQUIREMENTS. WITHOUT LIMITATION, YOU ACKNOWLEDGE THAT ASPEN
+                  REQUIREMENTS. WITHOUT LIMITATION, YOU ACKNOWLEDGE THAT CZ GEN EPI
                   IS NOT A BUSINESS ASSOCIATE FOR PURPOSES OF HIPAA.
                 </span>
               </ListItem>
@@ -409,7 +409,7 @@ export default function Terms(): JSX.Element {
           proceeding (a &quot;Claim&quot;) to the extent arising from: (1) your
           gross negligence, willful misconduct or fraud; and/or (2) any
           misrepresentation you make regarding your permission to submit data to
-          Aspen for your organization’s use.
+          CZ GEN EPI for your organization’s use.
         </ListItem>
         <ListItem>
           Indemnification is conditioned upon the Protected Parties giving you
@@ -447,7 +447,7 @@ export default function Terms(): JSX.Element {
           <span>
             <ListItemLabel>Dispute Resolution.</ListItemLabel>
             In the unlikely event we have a dispute arising out of or related to
-            the use of Aspen (&quot;Dispute&quot;) that we can’t resolve between
+            the use of CZ GEN EPI (&quot;Dispute&quot;) that we can’t resolve between
             us, you and we agree that we shall (in good faith) meet and attempt
             to resolve the Dispute within thirty (30) days. If the Dispute is
             not resolved during such time period, then you and a representative
@@ -530,7 +530,7 @@ export default function Terms(): JSX.Element {
         </ListItem>
         <ListItem>
           Entire Agreement. These Terms (along with the Privacy Notice)
-          constitute the entire agreement between you and us regarding Aspen. If
+          constitute the entire agreement between you and us regarding CZ GEN EPI. If
           you wish to modify these Terms, any amendment must be provided to us
           in writing and signed by our authorized representative.
         </ListItem>

--- a/src/frontend/src/views/Terms/index.tsx
+++ b/src/frontend/src/views/Terms/index.tsx
@@ -19,7 +19,7 @@ export default function Terms(): JSX.Element {
     <>
       <Title>
         <H1>Chan Zuckerberg GEN EPI (formerly Aspen) Terms of Use</H1>
-        <H4>Last Updated: September 30, 2021. </H4>
+        <H4>Last Updated: December 6, 2021</H4>
       </Title>
       <P>
         Please read these Terms of Use (&quot;Terms&quot;) before using Chan


### PR DESCRIPTION
### Summary:
- **What:** Convert Terms of Service page and Privacy Policy page to new name
- **Ticket:** [sc<172584>](https://app.shortcut.com/genepi/story/<172584>)
- **Env:** No rdev yet, will eventually put one up on the happy-trails branch for more general review

### Notes:
I added in a date update for the pages, but didn't get an official date to make it yet. Just wanted to make sure it doesn't get forgotten in all the work later on. I've got a note to follow up and get the official date at some point before launch.

### Checklist:
- [ ] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)