### PR TITLE
Update ncov pin to label the new variant B.1.1.529/omicron

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 6691370325e5980d4f6073f7672759711c305a05 && \
+    git fetch origin dc8c7d03774c1ed99dc8a2509494bb5dc9f05bbf && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin dc8c7d03774c1ed99dc8a2509494bb5dc9f05bbf && \
+    git fetch origin master && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -37,7 +37,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin dc8c7d03774c1ed99dc8a2509494bb5dc9f05bbf && \
+    git fetch origin master && \
     git reset --hard FETCH_HEAD
 
 ADD aspen/workflows/nextstrain_run/patches/crowding_penalty.patch /tmp/

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -37,7 +37,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 6691370325e5980d4f6073f7672759711c305a05 && \
+    git fetch origin dc8c7d03774c1ed99dc8a2509494bb5dc9f05bbf && \
     git reset --hard FETCH_HEAD
 
 ADD aspen/workflows/nextstrain_run/patches/crowding_penalty.patch /tmp/


### PR DESCRIPTION
### Summary:
- **What:** Ncov made updates to label/color the newly discovered variant, so we're updating our ncov version. The situation is a bit fluid as we learn more about Omicron so there is continuous update on ncov side, we'll release the pin for now to keep things up to date.

### Demos: 
Testing tree run with ncov `dc8c7d0` released on Friday, there is 1 more update since then which shouldn't break things (the samples are biased, don't read anything into it other than the run worked and the new variant is properly labeled.)
![image](https://user-images.githubusercontent.com/20667188/143626144-f593c1a5-fa58-4139-91cd-075508ce2d66.png)

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)