### PR TITLE
Maya/173806 uploader name

### DIFF
--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -3,7 +3,7 @@ import { jsonToType } from "src/common/utils";
 
 export enum API {
   USER_INFO = "/api/usergroup",
-  SAMPLES = "/api/samples",
+  SAMPLES = "/v2/samples",
   LOG_IN = "/login",
   LOG_OUT = "/logout",
   PHYLO_TREES = "/api/phylo_trees",
@@ -99,7 +99,9 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
   ["private_identifier", "privateId"],
   ["public_identifier", "publicId"],
   ["upload_date", "uploadDate"],
+  ["uploaded_by", "uploadedBy"],
   ["sequencing_date", "sequencingDate"],
+  ["submitting_group", "submittingGroup"],
   ["czb_failed_genome_recovery", "CZBFailedGenomeRecovery"],
 ]);
 

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -3,7 +3,7 @@ import { jsonToType } from "src/common/utils";
 
 export enum API {
   USER_INFO = "/api/usergroup",
-  SAMPLES = "/v2/samples",
+  SAMPLES = "/v2/samples/",
   LOG_IN = "/login",
   LOG_OUT = "/logout",
   PHYLO_TREES = "/api/phylo_trees",

--- a/src/frontend/src/common/components/library/data_table/components/HeaderRow/components/TableHeader/style.ts
+++ b/src/frontend/src/common/components/library/data_table/components/HeaderRow/components/TableHeader/style.ts
@@ -9,7 +9,7 @@ interface AlignProps extends Props {
 export const StyledTableHeader = styled("div")`
   ${(props: AlignProps) => {
     const { align, wide } = props;
-    const justify = align ?? "left";
+    const justify = align ?? "center";
 
     const iconSizes = getIconSizes(props);
     const spaces = getSpaces(props);

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -60,8 +60,29 @@ function sortData(
   ascending: boolean
 ): TableItem[] {
   return data.sort((a, b): number => {
-    const order = defaultSorting(a, b, sortKey);
-    return ascending ? order : order * -1;
+    let order = 0;
+    // Keep failed samples at the bottom of the table
+    if (sortKey[0] === "uploadDate") {
+      const uploadDateAIsNull = a["uploadDate"] === null;
+      const uploadDateBIsNull = b["uploadDate"] === null;
+      if (uploadDateAIsNull && uploadDateBIsNull) {
+        order = 0;
+      } else if (uploadDateAIsNull && !uploadDateBIsNull) {
+        order = -1;
+      } else if (uploadDateBIsNull && !uploadDateAIsNull) {
+        order = 1;
+      } else {
+        order = defaultSorting(a, b, sortKey);
+      }
+    } else {
+      order = defaultSorting(a, b, sortKey);
+    }
+
+    if (!ascending) {
+      return order * -1;
+    } else {
+      return order;
+    }
   });
 }
 

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -33,7 +33,7 @@ const ITEM_HEIGHT_PX = 60;
 
 const LOADING_STATE_ROW_COUNT = 10;
 
-const UNDEFINED_TEXT = "-";
+export const UNDEFINED_TEXT = "-";
 
 export function defaultCellRenderer({
   value,

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -60,28 +60,8 @@ function sortData(
   ascending: boolean
 ): TableItem[] {
   return data.sort((a, b): number => {
-    let order = 0;
-    if (sortKey[0] === "uploadDate") {
-      const uploadDateAIsNA = a["uploadDate"] === "N/A";
-      const uploadDateBIsNA = b["uploadDate"] === "N/A";
-      if (uploadDateAIsNA && uploadDateBIsNA) {
-        order = 0;
-      } else if (uploadDateAIsNA && !uploadDateBIsNA) {
-        order = -1;
-      } else if (uploadDateBIsNA && !uploadDateAIsNA) {
-        order = 1;
-      } else {
-        order = defaultSorting(a, b, sortKey);
-      }
-    } else {
-      order = defaultSorting(a, b, sortKey);
-    }
-
-    if (!ascending) {
-      return order * -1;
-    } else {
-      return order;
-    }
+    const order = defaultSorting(a, b, sortKey);
+    return ascending ? order : order * -1;
   });
 }
 

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -61,7 +61,10 @@ function sortData(
 ): TableItem[] {
   return data.sort((a, b): number => {
     let order = 0;
-    // Keep failed samples at the bottom of the table
+    // Typically, DPH doesn't want to interact with failed samples.
+    // As a result, we make extar efforts to keep failed samples at
+    // the bottom of the table. For samples that have failed, we set
+    // the upload date to null. Hence the special sort case here.
     if (sortKey[0] === "uploadDate") {
       const uploadDateAIsNull = a["uploadDate"] === null;
       const uploadDateBIsNull = b["uploadDate"] === null;

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -33,7 +33,7 @@ const ITEM_HEIGHT_PX = 60;
 
 const LOADING_STATE_ROW_COUNT = 10;
 
-const UNDEFINED_TEXT = "---";
+const UNDEFINED_TEXT = "-";
 
 export function defaultCellRenderer({
   value,

--- a/src/frontend/src/common/components/library/data_table/style.ts
+++ b/src/frontend/src/common/components/library/data_table/style.ts
@@ -32,7 +32,7 @@ export const RowContent = styled("div", {
 
   ${(props: ExtraProps) => {
     const { header } = props;
-    const align = header?.align ?? "left";
+    const align = header?.align ?? "center";
     const spaces = getSpaces(props);
 
     return `

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -26,9 +26,17 @@ interface Sample extends BioinformaticsType {
   privateId: string;
   publicId: string;
   uploadDate: string;
+  uploadedBy: {
+    id: number;
+    name: string;
+  };
   collectionDate: string;
   collectionLocation: string;
   sequencingDate: string;
+  submittingGroup: {
+    id: number;
+    name: string;
+  };
   gisaid: GISAID;
   CZBFailedGenomeRecovery: boolean;
   lineage: Lineage;

--- a/src/frontend/src/common/utils/tableUtils.tsx
+++ b/src/frontend/src/common/utils/tableUtils.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/display-name */
-
-const UNDEFINED_TEXT = "-";
+import { UNDEFINED_TEXT } from "../components/library/data_table";
 
 export function createTableCellRenderer(
   customRenderers: Record<string, CellRenderer>,

--- a/src/frontend/src/common/utils/tableUtils.tsx
+++ b/src/frontend/src/common/utils/tableUtils.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 
-const UNDEFINED_TEXT = "---";
+const UNDEFINED_TEXT = "-";
 
 export function createTableCellRenderer(
   customRenderers: Record<string, CellRenderer>,

--- a/src/frontend/src/common/utils/timeUtils.tsx
+++ b/src/frontend/src/common/utils/timeUtils.tsx
@@ -1,0 +1,9 @@
+export const formatTZDate = (d: Date): string => {
+  if (!d || d === "-") return d;
+
+  const date = new Date(d);
+  const offset = date.getTimezoneOffset();
+  const offsetSeconds = offset * 60 * 1000;
+  const utcDate = new Date(date.getTime() - offsetSeconds);
+  return utcDate.toISOString().split("T")[0];
+};

--- a/src/frontend/src/common/utils/timeUtils.tsx
+++ b/src/frontend/src/common/utils/timeUtils.tsx
@@ -1,5 +1,5 @@
 export const formatTZDate = (d: string): string => {
-  if (!d || d === "-") return d;
+  if (!d || d.startsWith("-")) return d;
 
   const date = new Date(d);
   const offset = date.getTimezoneOffset();

--- a/src/frontend/src/common/utils/timeUtils.tsx
+++ b/src/frontend/src/common/utils/timeUtils.tsx
@@ -1,4 +1,4 @@
-export const formatTZDate = (d: Date): string => {
+export const formatTZDate = (d: string): string => {
   if (!d || d === "-") return d;
 
   const date = new Date(d);

--- a/src/frontend/src/common/utils/timeUtils.tsx
+++ b/src/frontend/src/common/utils/timeUtils.tsx
@@ -1,5 +1,12 @@
-export const formatTZDate = (d: string): string => {
-  if (!d || d.startsWith("-")) return d;
+import { UNDEFINED_TEXT } from "../components/library/data_table";
+
+// Takes ISO8601 datetime with TZ and returns corresponding date
+// (only) on user's machine.
+// Eg, if user is in Pacific TZ
+// datetimeWithTzToLocalDate("2021-12-02T01:07:48+00:00") => "2021-12-01"
+export const datetimeWithTzToLocalDate = (d: string): string => {
+  // We use this as a stand in for missing values in the tables
+  if (!d || d.startsWith(UNDEFINED_TEXT)) return d;
 
   const date = new Date(d);
   const offset = date.getTimezoneOffset();

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
-import { formatTZDate } from "src/common/utils/timeUtils";
+import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
 import { DATE_REGEX } from "../DateField/constants";
 import { CollectionDateFilter } from "./components/CollectionDateFilter";
 import { GenomeRecoveryFilter } from "./components/GenomeRecoveryFilter";
@@ -84,7 +84,7 @@ const DATA_FILTER_INIT = {
       end: undefined,
       start: undefined,
     },
-    transform: (d: Sample) => formatTZDate(d.uploadDate),
+    transform: (d: Sample) => datetimeWithTzToLocalDate(d.uploadDate),
     type: TypeFilterType.Date,
   },
 };

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { formatTZDate } from "src/common/utils/timeUtils";
 import { DATE_REGEX } from "../DateField/constants";
 import { CollectionDateFilter } from "./components/CollectionDateFilter";
 import { GenomeRecoveryFilter } from "./components/GenomeRecoveryFilter";
@@ -83,7 +84,7 @@ const DATA_FILTER_INIT = {
       end: undefined,
       start: undefined,
     },
-    transform: (d: Sample) => d.uploadDate,
+    transform: (d: Sample) => formatTZDate(d.uploadDate),
     type: TypeFilterType.Date,
   },
 };

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -9,7 +9,7 @@ import { RowContent } from "src/common/components/library/data_table/style";
 import { TREE_STATUS } from "src/common/constants/types";
 import SampleIcon from "src/common/icons/Sample.svg";
 import { createTableCellRenderer, stringGuard } from "src/common/utils";
-import { formatTZDate } from "src/common/utils/timeUtils";
+import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
 import TreeTableDownloadMenu from "src/components/TreeTableDownloadMenu";
 import { Lineage, LineageTooltip } from "./components/LineageTooltip";
 import TreeTableNameCell from "./components/TreeTableNameCell";
@@ -137,7 +137,7 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   },
 
   uploadDate: ({ value }): JSX.Element => {
-    return <RowContent>{formatTZDate(value)}</RowContent>;
+    return <RowContent>{datetimeWithTzToLocalDate(value)}</RowContent>;
   },
 };
 

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -9,17 +9,20 @@ import { RowContent } from "src/common/components/library/data_table/style";
 import { TREE_STATUS } from "src/common/constants/types";
 import SampleIcon from "src/common/icons/Sample.svg";
 import { createTableCellRenderer, stringGuard } from "src/common/utils";
+import { formatTZDate } from "src/common/utils/timeUtils";
 import TreeTableDownloadMenu from "src/components/TreeTableDownloadMenu";
 import { Lineage, LineageTooltip } from "./components/LineageTooltip";
 import TreeTableNameCell from "./components/TreeTableNameCell";
 import { TreeTypeTooltip } from "./components/TreeTypeTooltip";
 import style from "./index.module.scss";
 import {
+  CenteredFlexContainer,
   GISAIDCell,
   PrivacyIcon,
   PrivateIdValueWrapper,
   SampleIconWrapper,
   StyledChip,
+  StyledUploaderName,
   Subtext,
   UnderlinedCell,
   UnderlinedRowContent,
@@ -81,10 +84,12 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     value: string;
     item: Sample;
   }): JSX.Element => {
-    const { CZBFailedGenomeRecovery, private: isPrivate } = item;
+    const { CZBFailedGenomeRecovery, private: isPrivate, uploadedBy } = item;
     const label = CZBFailedGenomeRecovery
       ? LABEL_STATUS.error
       : LABEL_STATUS.success;
+
+    const { name } = uploadedBy ?? {};
 
     return (
       <RowContent>
@@ -100,13 +105,16 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
             </PrivacyIcon>
           </SampleIconWrapper>
           <PrivateIdValueWrapper>
-            {value}
-            <StyledChip
-              data-test-id="sample-status"
-              size="small"
-              label={label.label}
-              status={label.status}
-            />
+            <CenteredFlexContainer>
+              <span>{value}</span>
+              <StyledChip
+                data-test-id="sample-status"
+                size="small"
+                label={label.label}
+                status={label.status}
+              />
+            </CenteredFlexContainer>
+            <StyledUploaderName>{name}</StyledUploaderName>
           </PrivateIdValueWrapper>
         </div>
       </RowContent>
@@ -126,6 +134,10 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
       header,
       value: displayValue,
     } as CustomTableRenderProps);
+  },
+
+  uploadDate: ({ value }): JSX.Element => {
+    return <RowContent>{formatTZDate(value)}</RowContent>;
   },
 };
 

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -121,21 +121,6 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     );
   },
 
-  // Preferably, we would just use defaultCellRenderer for this column, but we want
-  // to intercept its value and change it out in some cases before rendering.
-  sequencingDate: ({ header, value }): JSX.Element => {
-    let displayValue = value;
-    if (value === "N/A") {
-      displayValue = "-";
-    }
-    // defaultCellRenderer only uses `value` and `header` but its input type asks
-    // for more than that, so just forcing typescript to be cool.
-    return defaultCellRenderer({
-      header,
-      value: displayValue,
-    } as CustomTableRenderProps);
-  },
-
   uploadDate: ({ value }): JSX.Element => {
     return <RowContent>{datetimeWithTzToLocalDate(value)}</RowContent>;
   },

--- a/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
+++ b/src/frontend/src/views/Data/components/TreeTableNameCell/style.ts
@@ -39,6 +39,7 @@ export const StyledRowContent = styled(RowContent, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   flex: 2 0 40%;
+  justify-content: left;
 
   ${(props: ExtraProps) => {
     const { disabled } = props;

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -115,6 +115,7 @@ export const SAMPLE_SUBHEADERS: Record<string, SubHeader[]> = {
 
 export const TREE_HEADERS: Header[] = [
   {
+    align: "left",
     key: "name",
     sortKey: ["name"],
     text: "Tree Name",
@@ -125,7 +126,6 @@ export const TREE_HEADERS: Header[] = [
     },
   },
   {
-    align: "center",
     key: "startedDate",
     sortKey: ["startedDate"],
     // using startedDate instead of creationDate,
@@ -137,7 +137,6 @@ export const TREE_HEADERS: Header[] = [
     },
   },
   {
-    align: "center",
     key: "treeType",
     sortKey: ["treeType"],
     text: "Tree Type",

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -43,7 +43,7 @@ export const StyledChip = styled(Chip)`
     const spaces = getSpaces(props);
 
     return `
-      margin-top: ${spaces?.xxs}px;
+      margin-left: ${spaces?.xs}px;
     `;
   }}
 `;
@@ -70,4 +70,23 @@ export const PrivacyIcon = styled.span`
 
 export const FlexContainer = styled.div`
   display: flex;
+`;
+
+export const CenteredFlexContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const StyledUploaderName = styled.span`
+  ${fontBodyXxs}
+
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      color: ${colors?.gray[500]};
+      margin-top: ${spaces?.xxxs}px;
+    `;
+  }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Add sample uploader name to samples table
- **Why:** Clarity around origin of data
- **Ticket:** [[sc-173806]](https://app.shortcut.com/genepi/story/173806)
- **Env:** https://sampleuploader-frontend.dev.genepi.czi.technology/data/samples
- **Design:** https://www.figma.com/proto/QuQtuWj8iU7nqI6AREd0RE/CRUD-V0?node-id=197%3A74360&scaling=min-zoom&page-id=88%3A64261&starting-point-node-id=111%3A80433

### Testing
1. View samples table
1. Ensure user name appear underneath the sample ID in grey text

### Demos
![Screen Shot 2021-11-30 at 10 29 38 PM](https://user-images.githubusercontent.com/7562933/144183635-1156e20d-070f-4ef7-a4a5-8ccb1303fc39.png)

### Notes
TODO: Add code for CZ Biohub label.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)