### PR TITLE
Danrlu/remove adjustment

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/group_plus_context.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/group_plus_context.yaml
@@ -11,7 +11,7 @@ builds:
     country: USA
     division: {division}
     location: {location}
-    region: North America
+    region: global
     subsampling_scheme: group_plus_context
     title: '{location}, {division} and related contextual samples for overview'
 

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/non_contextualized.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/non_contextualized.yaml
@@ -14,7 +14,7 @@ builds:
     country: USA
     division: {division}
     location: {location}
-    region: North America
+    region: global
     subsampling_scheme: group_only
     title: '{location}, {division} samples, non-contextualized tree'
 

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/targeted.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/targeted.yaml
@@ -14,7 +14,7 @@ builds:
     country: USA
     division: {division}
     location: {location}
-    region: North America
+    region: global
     subsampling_scheme: group_plus_context
     title: '{location}, {division} and related contextual samples for targeted investigations'
 

--- a/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
+++ b/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
@@ -5,6 +5,11 @@
     {"name": "Chan Zuckerberg Initiative",
      "url": "https://chanzuckerberg.com"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
     {
       "key": "emerging_lineage",


### PR DESCRIPTION
### Summary:
- **What:** 
    -  During bug bash I noticed that our trees sometimes label countries or divisions as continent (`region` in Nextstrain). It turned out to be a default Nextstrain set up. 

     - This PR will label country with country names (same for divisions) by setting `region` as `global` in builds.yaml and bypass [this step](https://github.com/nextstrain/ncov/blob/4ccc5faf82c246b4eebca1dc015ee2582d3ac066/workflow/snakemake_rules/main_workflow.smk#L650-L674) of country/division name conversion. We could also remove the `region` row in builds.yaml. Keep it for now to be explicit. 
     
    - Added GISAID logo along the way, which is a convention for all applications using GISAID data.
    
### Demos:
Before (all current trees):
<img src="https://user-images.githubusercontent.com/20667188/144775311-3770e066-0efb-49ed-b281-f39c3090b197.png" width="500">`

After:
<img src="https://user-images.githubusercontent.com/20667188/144775282-0c1905c3-b0ab-493f-b8c9-406c3d914629.png" width="500">`
### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)