### PR TITLE
conditionally show banner only for logged out users

### DIFF
--- a/src/frontend/src/components/NavBarV2/index.tsx
+++ b/src/frontend/src/components/NavBarV2/index.tsx
@@ -87,14 +87,16 @@ export default function NavBarV2(): JSX.Element {
 
   return (
     <HeaderContainer>
-      <AnnouncementBanner>
-        <AnnouncementText>
-          <Exclamation />
-          <AnnouncementTextBold>Looking for Aspen?</AnnouncementTextBold>
-          &nbsp;You&apos;re in the right spot. As of December, our new name is
-          CZ GEN EPI.
-        </AnnouncementText>
-      </AnnouncementBanner>
+      {!user && (
+        <AnnouncementBanner>
+          <AnnouncementText>
+            <Exclamation />
+            <AnnouncementTextBold>Looking for Aspen?</AnnouncementTextBold>
+            &nbsp;You&apos;re in the right spot. As of December, our new name is
+            CZ GEN EPI.
+          </AnnouncementText>
+        </AnnouncementBanner>
+      )}
       <HeaderMaxWidthContainer>
         <HeaderTopContainer>
           <HeaderLogoContainer href={data ? ROUTES.DATA : ROUTES.HOMEPAGE}>

--- a/src/frontend/src/components/NavBarV2/index.tsx
+++ b/src/frontend/src/components/NavBarV2/index.tsx
@@ -93,7 +93,7 @@ export default function NavBarV2(): JSX.Element {
             <Exclamation />
             <AnnouncementTextBold>Looking for Aspen?</AnnouncementTextBold>
             &nbsp;You&apos;re in the right spot. As of December, our new name is
-            CZ GEN EPI.
+            Chan Zuckerberg GEN EPI.
           </AnnouncementText>
         </AnnouncementBanner>
       )}


### PR DESCRIPTION
### Summary:
- **What:** we don't need this banner once users have logged in
- **Ticket:** [sc175625](https://app.shortcut.com/genepi/story/175625)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `happy-trails-aspen`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)