### PR TITLE
Maya/173844 delete modal

### DIFF
--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -36,6 +36,12 @@ export const DEFAULT_POST_OPTIONS: RequestInit = {
   ...DEFAULT_HEADERS_MUTATION_OPTIONS,
 };
 
+export const DEFAULT_DELETE_OPTIONS: RequestInit = {
+  credentials: "include",
+  method: "DELETE",
+  ...DEFAULT_HEADERS_MUTATION_OPTIONS,
+};
+
 /** Generic functions to interface with the backend API **/
 
 const API_KEY_TO_TYPE: Record<string, string> = {

--- a/src/frontend/src/common/components/library/Dialog/components/DialogActions/style.ts
+++ b/src/frontend/src/common/components/library/Dialog/components/DialogActions/style.ts
@@ -21,7 +21,7 @@ export const StyledDialogActions = styled(DialogActions, {
     return `
       padding: 0 ${spaces?.xxl}px ${spaces?.xxl}px ${spaces?.xxl}px;
 
-      &.MuiDialogActions-spacing > :not(:first-child) {
+      &.MuiDialogActions-spacing > :not(:first-of-type) {
         margin-left: ${spaces?.m}px;
       }
     `;

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { noop } from "src/common/constants/empty";
+import { pluralize } from "src/common/utils/strUtils";
+import { DeleteDialog } from "src/components/DeleteDialog";
+
+interface Props {
+  checkedSamples: string[];
+  onClose(): void;
+  open: boolean;
+}
+
+const DeleteSamplesConfirmationModal = ({
+  checkedSamples,
+  onClose,
+  open,
+}: Props): JSX.Element | null => {
+  if (!open) return null;
+
+  const numSamples = checkedSamples.length;
+  const title = `Are you sure you want to delete ${numSamples} ${pluralize(
+    "sample",
+    numSamples
+  )}?`;
+
+  const content =
+    "Deleted samples will be removed from Aspen. If these samples were included in previously generated trees, they will be shown with their public IDs only. You will not be able to undo this action.";
+
+  return (
+    <DeleteDialog
+      open={open}
+      onClose={onClose}
+      onDelete={noop}
+      title={title}
+      content={content}
+    />
+  );
+};
+
+export { DeleteSamplesConfirmationModal };

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { noop } from "src/common/constants/empty";
 import { useDeleteSamples } from "src/common/queries/samples";
 import { pluralize } from "src/common/utils/strUtils";
 import { DeleteDialog } from "src/components/DeleteDialog";
@@ -14,6 +15,22 @@ const DeleteSamplesConfirmationModal = ({
   onClose,
   open,
 }: Props): JSX.Element | null => {
+  // TODO (mlila): update these callbacks to display notifications
+  // TODO          as part of #173849
+  const deleteSampleMutation = useDeleteSamples({
+    onSuccess: noop,
+    onError: noop,
+  });
+
+  const onDelete = () => {
+    deleteSampleMutation.mutate({
+      // TODO (mlila): this should be an array of db unique ids
+      // TODO          this requires a refactor
+      samplesToDelete: checkedSamples,
+    });
+    onClose();
+  };
+
   if (!open) return null;
 
   const numSamples = checkedSamples.length;

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { noop } from "src/common/constants/empty";
+import { useDeleteSamples } from "src/common/queries/samples";
 import { pluralize } from "src/common/utils/strUtils";
 import { DeleteDialog } from "src/components/DeleteDialog";
 
@@ -29,7 +29,7 @@ const DeleteSamplesConfirmationModal = ({
     <DeleteDialog
       open={open}
       onClose={onClose}
-      onDelete={noop}
+      onDelete={onDelete}
       title={title}
       content={content}
     />

--- a/src/frontend/src/common/components/library/data_subview/components/MoreActionMenu/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/MoreActionMenu/index.tsx
@@ -55,6 +55,7 @@ const MoreActionsMenu = ({ disabled }: Props): JSX.Element => {
         keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
+        getContentAnchorEl={null}
       >
         <MenuItem>
           <StyledTrashIcon />

--- a/src/frontend/src/common/components/library/data_subview/components/MoreActionMenu/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/MoreActionMenu/index.tsx
@@ -6,9 +6,13 @@ import { StyledMoreActionsIcon, StyledText, StyledTrashIcon } from "./style";
 
 interface Props {
   disabled: boolean;
+  onDeleteSelected(): void;
 }
 
-const MoreActionsMenu = ({ disabled }: Props): JSX.Element => {
+const MoreActionsMenu = ({
+  disabled,
+  onDeleteSelected,
+}: Props): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   const TOOLTIP_TEXT_DISABLED = (
@@ -30,6 +34,11 @@ const MoreActionsMenu = ({ disabled }: Props): JSX.Element => {
 
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleDeleteSamples = () => {
+    onDeleteSelected();
+    handleClose();
   };
 
   return (
@@ -57,7 +66,7 @@ const MoreActionsMenu = ({ disabled }: Props): JSX.Element => {
         onClose={handleClose}
         getContentAnchorEl={null}
       >
-        <MenuItem>
+        <MenuItem onClick={handleDeleteSamples}>
           <StyledTrashIcon />
           <StyledText>Delete Samples</StyledText>
         </MenuItem>

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -13,6 +13,7 @@ import { ROUTES } from "src/common/routes";
 import { FEATURE_FLAGS, usesFeatureFlag } from "src/common/utils/featureFlags";
 import Notification from "src/components/Notification";
 import { CreateNSTreeModal } from "./components/CreateNSTreeModal";
+import { DeleteSamplesConfirmationModal } from "./components/DeleteSamplesConfirmationModal";
 import DownloadModal from "./components/DownloadModal";
 import { IconButton } from "./components/IconButton";
 import { MoreActionsMenu } from "./components/MoreActionMenu";
@@ -148,6 +149,8 @@ const DataSubview: FunctionComponent<Props> = ({
   const [hasCreateTreeStarted, setCreateTreeStarted] = useState<boolean>(false);
   const [didCreateTreeFailed, setCreateTreeFailed] = useState<boolean>(false);
   const [shouldStartUsherFlow, setShouldStartUsherFlow] =
+    useState<boolean>(false);
+  const [isDeleteConfirmationOpen, setDeleteConfirmationOpen] =
     useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState<string>("");
 
@@ -290,7 +293,10 @@ const DataSubview: FunctionComponent<Props> = ({
             tooltipTextEnabled={DOWNLOAD_TOOLTIP_TEXT_ENABLED}
           />
           {usesFeatureFlag(FEATURE_FLAGS.crudV0) && (
-            <MoreActionsMenu disabled={!hasCheckedSamples} />
+            <MoreActionsMenu
+              disabled={!hasCheckedSamples}
+              onDeleteSelected={() => setDeleteConfirmationOpen(true)}
+            />
           )}
         </DownloadWrapper>
       );
@@ -325,6 +331,11 @@ const DataSubview: FunctionComponent<Props> = ({
               checkedSamples={checkedSamples}
               failedSamples={failedSamples}
               shouldStartUsherFlow={shouldStartUsherFlow}
+            />
+            <DeleteSamplesConfirmationModal
+              checkedSamples={checkedSamples}
+              onClose={() => setDeleteConfirmationOpen(false)}
+              open={isDeleteConfirmationOpen}
             />
           </>
         )}

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -156,11 +156,7 @@ export async function deleteSamples({
     body: JSON.stringify(payload),
   });
 
-  if (response.ok) {
-    const tmp = await response.json();
-    console.log(tmp);
-    return tmp;
-  }
+  if (response.ok) return await response.json();
 
   throw Error(`${response.statusText}: ${await response.text()}`);
 }

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -4,7 +4,7 @@ import {
   SampleIdToMetadata,
   Samples,
 } from "src/views/Upload/components/common/types";
-import { API, DEFAULT_POST_OPTIONS } from "../api";
+import { API, DEFAULT_DELETE_OPTIONS, DEFAULT_POST_OPTIONS } from "../api";
 import { API_URL } from "../constants/ENV";
 import { MutationCallbacks } from "./types";
 

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -137,3 +137,51 @@ export async function createSamples({
 
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
+
+// * Proceed with caution, you are entering the DANGER ZONE!
+// * Code below this line is destructive!
+interface DeleteSamplesPayload {
+  ids: string[];
+}
+
+export async function deleteSamples({
+  samplesToDelete,
+}: SampleDeleteRequestType): Promise<SampleDeleteResponseType> {
+  const payload: DeleteSamplesPayload = {
+    ids: samplesToDelete,
+  };
+
+  const response = await fetch(API_URL + API.SAMPLES, {
+    ...DEFAULT_DELETE_OPTIONS,
+    body: JSON.stringify(payload),
+  });
+
+  if (response.ok) {
+    const tmp = await response.json();
+    console.log(tmp);
+    return tmp;
+  }
+
+  throw Error(`${response.statusText}: ${await response.text()}`);
+}
+
+interface SampleDeleteRequestType {
+  samplesToDelete: string[];
+}
+
+export interface SampleDeleteResponseType {
+  missing_sample_ids: string[];
+}
+
+type SampleDeleteCallbacks = MutationCallbacks<SampleDeleteResponseType>;
+
+export function useDeleteSamples(
+  callbacks: SampleDeleteCallbacks
+): UseMutationResult<
+  SampleDeleteResponseType,
+  unknown,
+  SampleDeleteRequestType,
+  unknown
+> {
+  return useMutation(deleteSamples, callbacks);
+}

--- a/src/frontend/src/components/ConfirmDialog/index.tsx
+++ b/src/frontend/src/components/ConfirmDialog/index.tsx
@@ -6,7 +6,7 @@ import DialogContent from "src/common/components/library/Dialog/components/Dialo
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import { Content, StyledFooter, Title } from "./style";
 
-interface Props {
+export interface ConfirmDialogProps {
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
@@ -24,7 +24,7 @@ export default function ConfirmDialog({
   title,
   content,
   footer,
-}: Props): JSX.Element {
+}: ConfirmDialogProps): JSX.Element {
   const confirmButton = customConfirmButton ?? (
     <Button color="primary" variant="contained" isRounded>
       Continue
@@ -50,7 +50,7 @@ export default function ConfirmDialog({
           Cancel
         </Button>
       </DialogActions>
-      <StyledFooter narrow>{footer}</StyledFooter>
+      {footer && <StyledFooter narrow>{footer}</StyledFooter>}
     </Dialog>
   );
 }

--- a/src/frontend/src/components/DeleteDialog/index.tsx
+++ b/src/frontend/src/components/DeleteDialog/index.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import ConfirmDialog from "src/components/ConfirmDialog";
+import ConfirmDialog, {
+  ConfirmDialogProps,
+} from "src/components/ConfirmDialog";
 import { StyledButton, StyledSpan } from "./style";
 
-interface Props extends ConfirmDialogProps {
+interface Props extends Omit<ConfirmDialogProps, "onConfirm"> {
   onDelete(): void;
 }
 
@@ -23,10 +25,10 @@ const DeleteDialog = ({
 
   return (
     <ConfirmDialog
+      {...props}
       customConfirmButton={deleteButton}
       onConfirm={onDelete}
       title={styledTitle}
-      {...props}
     />
   );
 };

--- a/src/frontend/src/components/DeleteDialog/index.tsx
+++ b/src/frontend/src/components/DeleteDialog/index.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import ConfirmDialog from "src/components/ConfirmDialog";
+import { StyledButton, StyledSpan } from "./style";
+
+interface Props extends ConfirmDialogProps {
+  onDelete(): void;
+}
+
+const DeleteDialog = ({
+  onDelete,
+  title,
+  ...props
+}: Props): JSX.Element | null => {
+  if (!open) return null;
+
+  const styledTitle = <StyledSpan>{title}</StyledSpan>;
+
+  const deleteButton = (
+    <StyledButton color="primary" variant="contained" isRounded>
+      Delete
+    </StyledButton>
+  );
+
+  return (
+    <ConfirmDialog
+      customConfirmButton={deleteButton}
+      onConfirm={onDelete}
+      title={styledTitle}
+      {...props}
+    />
+  );
+};
+
+export { DeleteDialog };

--- a/src/frontend/src/components/DeleteDialog/style.ts
+++ b/src/frontend/src/components/DeleteDialog/style.ts
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import { Button, fontHeaderXl, getColors } from "czifui";
+
+export const StyledSpan = styled.span`
+  ${fontHeaderXl}
+`;
+
+export const StyledButton = styled(Button)`
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      background-color: ${colors?.error[400]};
+
+      &:hover,
+      &:active {
+        background-color: ${colors?.error[600]};
+      }
+    `;
+  }}
+`;


### PR DESCRIPTION
### Summary
- **What:**
  - Add ui and api call to delete samples
  - Resolve a material UI error stemming from the styling on the original Dialog component
- **Why:** CRUD v0
- **Ticket:** [[sc-173844]](https://app.shortcut.com/genepi/story/173844)
- **Env:** https://deletemodal-frontend.dev.genepi.czi.technology?crudV0=true [pending]
- **Design:** https://www.figma.com/file/QuQtuWj8iU7nqI6AREd0RE/CRUD-V0?node-id=88%3A64261

### Demos
![Screen Shot 2021-12-06 at 2 59 41 PM](https://user-images.githubusercontent.com/7562933/144936361-3f5788cf-ac3b-4a7f-a8e7-74abeab0504c.png)

### Notes
Does not actually delete samples! I need to refactor the front end to pass sample objects down so I can send the correct IDs. Attempts to delete samples will just fail, currently.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)