### PR TITLE
add uploader name for cz biohub

### DIFF
--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -29,6 +29,8 @@ import {
   UnderlinedRowContent,
 } from "./style";
 
+const CZ_BIOHUB_GROUP = "CZI";
+
 const LABEL_STATUS: Record<
   string,
   { label: string; status: NonNullable<ChipProps["status"]> }
@@ -85,12 +87,18 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     value: string;
     item: Sample;
   }): JSX.Element => {
-    const { CZBFailedGenomeRecovery, private: isPrivate, uploadedBy } = item;
+    const {
+      CZBFailedGenomeRecovery,
+      private: isPrivate,
+      submittingGroup,
+      uploadedBy,
+    } = item;
     const label = CZBFailedGenomeRecovery
       ? LABEL_STATUS.error
       : LABEL_STATUS.success;
 
-    const { name } = uploadedBy ?? {};
+    const displayName =
+      submittingGroup?.name === CZ_BIOHUB_GROUP ? "CZ Biohub" : uploadedBy.name;
 
     return (
       <RowContent>
@@ -116,7 +124,7 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
               />
             </CenteredFlexContainer>
             {usesFeatureFlag(FEATURE_FLAGS.crudV0) && (
-              <StyledUploaderName>{name}</StyledUploaderName>
+              <StyledUploaderName>{displayName}</StyledUploaderName>
             )}
           </PrivateIdValueWrapper>
         </div>

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -98,7 +98,9 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
       : LABEL_STATUS.success;
 
     const displayName =
-      submittingGroup?.name === CZ_BIOHUB_GROUP ? "CZ Biohub" : uploadedBy.name;
+      submittingGroup?.name === CZ_BIOHUB_GROUP
+        ? "CZ Biohub"
+        : uploadedBy?.name;
 
     return (
       <RowContent>


### PR DESCRIPTION
### Summary
- **What:** Follow up to #825: show `CZ Biohub` as uploader name if an admin uploaded it.
- **Ticket:** [[sc-173806]](https://app.shortcut.com/genepi/story/173806)
- **Env:** https://czbiohubupload-frontend.dev.genepi.czi.technology?crudV0=true
- **Design:** https://www.figma.com/proto/QuQtuWj8iU7nqI6AREd0RE/CRUD-V0?node-id=140%3A75501&scaling=min-zoom&page-id=88%3A64261&starting-point-node-id=111%3A80433

### Demos
#### Before: 
![Screen Shot 2021-12-06 at 6 18 42 PM](https://user-images.githubusercontent.com/7562933/144954123-5ff08865-31b5-4cda-8a36-167dfd546c69.png)

#### After: 
![Screen Shot 2021-12-06 at 6 18 23 PM](https://user-images.githubusercontent.com/7562933/144954145-30e32714-6f7d-4529-8505-5c3e40de98c3.png)

### Notes
I'm not clear on whether this is the best way to check for CZ uploads, but this seemed like a good choice, since checking the uploader name wouldn't be reliable in dev environments (for example, all my dev data is ASPEN ADMIN upload name, but are shown as uploaded by Orange County).

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)