### PR TITLE
Maya/173844 refactor

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -33,8 +33,8 @@ import {
 } from "./style";
 
 interface Props {
-  sampleIds: string[];
-  failedSamples: string[];
+  checkedSampleIds: string[];
+  failedSampleIds: string[];
   open: boolean;
   onClose: () => void;
   handleCreateTreeFailed: () => void;
@@ -48,8 +48,8 @@ const TreeTypes = {
 type TreeType = typeof TreeTypes[keyof typeof TreeTypes];
 
 export const CreateNSTreeModal = ({
-  sampleIds,
-  failedSamples,
+  checkedSampleIds,
+  failedSampleIds,
   open,
   onClose,
   handleCreateTreeFailed,
@@ -116,8 +116,8 @@ export const CreateNSTreeModal = ({
     </div>
   );
 
-  const allPossibleTreeSamples = sampleIds.concat(validatedInputSamples);
-  const allFailedOrMissingSamples = failedSamples.concat(missingInputSamples);
+  const allPossibleTreeSamples = checkedSampleIds.concat(validatedInputSamples);
+  const allFailedOrMissingSamples = failedSampleIds.concat(missingInputSamples);
   const allValidSamplesForTreeCreation = allPossibleTreeSamples.filter(
     (id) => !allFailedOrMissingSamples.includes(id)
   );
@@ -202,7 +202,7 @@ export const CreateNSTreeModal = ({
         />
         <Separator marginSize="xl" />
         <MissingSampleAlert missingSamples={missingInputSamples} />
-        <FailedSampleAlert numFailedSamples={failedSamples?.length} />
+        <FailedSampleAlert numFailedSamples={failedSampleIds?.length} />
       </StyledDialogContent>
       <StyledFooter>
         <CreateTreeButton

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -27,8 +27,8 @@ import {
 } from "./style";
 
 interface Props {
-  sampleIds: string[];
-  failedSamples: any[];
+  checkedSampleIds: string[];
+  failedSampleIds: string[];
   tsvData: [string[], string[][]] | undefined;
   open: boolean;
   onClose: () => void;
@@ -36,8 +36,8 @@ interface Props {
 }
 
 const DownloadModal = ({
-  sampleIds,
-  failedSamples,
+  checkedSampleIds,
+  failedSampleIds,
   tsvData,
   open,
   onClose,
@@ -71,12 +71,12 @@ const DownloadModal = ({
   }, [tsvData]);
 
   useEffect(() => {
-    if (JSON.stringify(sampleIds) === JSON.stringify(failedSamples)) {
+    if (JSON.stringify(checkedSampleIds) === JSON.stringify(failedSampleIds)) {
       setFastaDisabled(true);
     } else {
       setFastaDisabled(false);
     }
-  }, [sampleIds, failedSamples, setFastaDisabled]);
+  }, [checkedSampleIds, failedSampleIds, setFastaDisabled]);
 
   const handleMetadataClick = function () {
     setMetadataSelected(!isMetadataSelected);
@@ -130,7 +130,7 @@ const DownloadModal = ({
         </StyledIconButton>
         <Header>Select Download</Header>
         <Title>
-          {sampleIds.length} {pluralize("Sample", sampleIds.length)} Selected
+          {checkedSampleIds.length} {pluralize("Sample", checkedSampleIds.length)} Selected
         </Title>
       </DialogTitle>
       <DialogContent>
@@ -184,12 +184,12 @@ const DownloadModal = ({
               </CheckBoxInfo>
             </CheckBoxWrapper>
           </Container>
-          {failedSamples.length > 0 &&
+          {failedSampleIds.length > 0 &&
             !isFastaDisabled && ( //ignore alert if fasta is already disabled
               <Alert severity="warning">
                 <DownloadType>
-                  {failedSamples.length}
-                  {pluralize("sample", failedSamples.length)}
+                  {failedSampleIds.length}
+                  {pluralize("sample", failedSampleIds.length)}
                   will not be included in your Consensus Genome download
                 </DownloadType>
                 <DownloadTypeInfo>
@@ -260,7 +260,7 @@ const DownloadModal = ({
             variant="contained"
             isRounded
             onClick={() => {
-              mutation.mutate({ sampleIds });
+              mutation.mutate({ sampleIds: checkedSampleIds });
             }}
             disabled={false}
           >
@@ -277,7 +277,7 @@ const DownloadModal = ({
           variant="contained"
           isRounded
           onClick={() => {
-            mutation.mutate({ sampleIds });
+            mutation.mutate({ sampleIds: checkedSampleIds });
           }}
           disabled={false}
         >
@@ -293,7 +293,7 @@ const DownloadModal = ({
           variant="contained"
           isRounded
           onClick={() => {
-            mutation.mutate({ sampleIds });
+            mutation.mutate({ sampleIds: checkedSampleIds });
           }}
           disabled={true}
         >

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -130,7 +130,8 @@ const DownloadModal = ({
         </StyledIconButton>
         <Header>Select Download</Header>
         <Title>
-          {checkedSampleIds.length} {pluralize("Sample", checkedSampleIds.length)} Selected
+          {checkedSampleIds.length}{" "}
+          {pluralize("Sample", checkedSampleIds.length)} Selected
         </Title>
       </DialogTitle>
       <DialogContent>

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -1,6 +1,7 @@
 import { Dialog } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import { Alert, Tooltip } from "czifui";
+import { isEqual } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { CSVLink } from "react-csv";
 import { useMutation } from "react-query";
@@ -71,7 +72,7 @@ const DownloadModal = ({
   }, [tsvData]);
 
   useEffect(() => {
-    if (JSON.stringify(checkedSampleIds) === JSON.stringify(failedSampleIds)) {
+    if (isEqual(checkedSampleIds, failedSampleIds)) {
       setFastaDisabled(true);
     } else {
       setFastaDisabled(false);

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -36,8 +36,8 @@ import {
 } from "./style";
 
 interface Props {
-  sampleIds: string[];
-  failedSamples: string[];
+  checkedSampleIds: string[];
+  failedSampleIds: string[];
   open: boolean;
   onClose: () => void;
   onLinkCreateSuccess(url: string, treeType: string): void;
@@ -61,8 +61,8 @@ const getDefaultNumSamplesPerSubtree = (numSelected: number): number => {
 };
 
 export const UsherPlacementModal = ({
-  failedSamples,
-  sampleIds,
+  failedSampleIds,
+  checkedSampleIds,
   onClose,
   onLinkCreateSuccess,
   open,
@@ -76,7 +76,9 @@ export const UsherPlacementModal = ({
   const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<string>("");
 
-  const defaultNumSamples = getDefaultNumSamplesPerSubtree(sampleIds?.length);
+  const defaultNumSamples = getDefaultNumSamplesPerSubtree(
+    checkedSampleIds?.length
+  );
 
   useEffect(() => {
     const fetchUsherOpts = async () => {
@@ -101,10 +103,11 @@ export const UsherPlacementModal = ({
   }, []);
 
   useEffect(() => {
-    const hasValidSamplesSelected = sampleIds?.length > failedSamples?.length;
+    const hasValidSamplesSelected =
+      checkedSampleIds?.length > failedSampleIds?.length;
     const shouldDisable = !hasValidSamplesSelected || isLoading;
     setUsherDisabled(shouldDisable);
-  }, [sampleIds, failedSamples, isLoading]);
+  }, [checkedSampleIds, failedSampleIds, isLoading]);
 
   const fastaFetch = useFastaFetch({
     onError: () => {
@@ -120,9 +123,11 @@ export const UsherPlacementModal = ({
 
   const handleSubmit = (evt: SyntheticEvent) => {
     evt.preventDefault();
-    sampleIds = sampleIds.filter((id) => !failedSamples.includes(id));
+    checkedSampleIds = checkedSampleIds.filter(
+      (id) => !failedSampleIds.includes(id)
+    );
     fastaFetch.mutate({
-      sampleIds,
+      sampleIds: checkedSampleIds,
       downstreamConsumer: "USHER", // Let backend know eventual destination for this fasta
     });
     setIsLoading(true);
@@ -201,7 +206,8 @@ export const UsherPlacementModal = ({
           </StyledTooltip>
         </FlexWrapper>
         <Title>
-          {sampleIds.length} {pluralize("Sample", sampleIds.length)} Selected
+          {checkedSampleIds.length}{" "}
+          {pluralize("Sample", checkedSampleIds.length)} Selected
         </Title>
       </StyledDialogTitle>
       <StyledDialogContent>
@@ -285,7 +291,7 @@ export const UsherPlacementModal = ({
                   </StyledSuggestionWrapper>
                 )}
               </StyledTextField>
-              <FailedSampleAlert numFailedSamples={failedSamples?.length} />
+              <FailedSampleAlert numFailedSamples={failedSampleIds?.length} />
             </div>
             <StyledButton
               color="primary"

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -123,7 +123,7 @@ export const UsherPlacementModal = ({
 
   const handleSubmit = (evt: SyntheticEvent) => {
     evt.preventDefault();
-    sampleIdsToSubmit = checkedSampleIds.filter(
+    const sampleIdsToSubmit = checkedSampleIds.filter(
       (id) => !failedSampleIds.includes(id)
     );
     fastaFetch.mutate({

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -123,11 +123,11 @@ export const UsherPlacementModal = ({
 
   const handleSubmit = (evt: SyntheticEvent) => {
     evt.preventDefault();
-    checkedSampleIds = checkedSampleIds.filter(
+    sampleIdsToSubmit = checkedSampleIds.filter(
       (id) => !failedSampleIds.includes(id)
     );
     fastaFetch.mutate({
-      sampleIds: checkedSampleIds,
+      sampleIds: sampleIdsToSubmit,
       downstreamConsumer: "USHER", // Let backend know eventual destination for this fasta
     });
     setIsLoading(true);

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
@@ -5,8 +5,8 @@ import { UsherConfirmationModal } from "./components/UsherConfirmationModal";
 import { UsherPlacementModal } from "./components/UsherPlacementModal";
 
 interface Props {
-  checkedSamples: string[];
-  failedSamples: string[];
+  checkedSampleIds: string[];
+  failedSampleIds: string[];
   shouldStartUsherFlow: boolean;
 }
 
@@ -20,8 +20,8 @@ const generateUsherLink = (remoteFile: string, treeType: string) => {
 };
 
 const UsherTreeFlow = ({
-  checkedSamples,
-  failedSamples,
+  checkedSampleIds,
+  failedSampleIds,
   shouldStartUsherFlow,
 }: Props): JSX.Element => {
   const [isPlacementOpen, setIsPlacementOpen] = useState<boolean>(false);
@@ -71,8 +71,8 @@ const UsherTreeFlow = ({
   return (
     <>
       <UsherPlacementModal
-        sampleIds={checkedSamples}
-        failedSamples={failedSamples}
+        sampleIds={checkedSampleIds}
+        failedSampleIds={failedSampleIds}
         open={isPlacementOpen}
         onClose={() => setIsPlacementOpen(false)}
         onLinkCreateSuccess={onLinkCreateSuccess}

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
@@ -71,7 +71,7 @@ const UsherTreeFlow = ({
   return (
     <>
       <UsherPlacementModal
-        sampleIds={checkedSampleIds}
+        checkedSampleIds={checkedSampleIds}
         failedSampleIds={failedSampleIds}
         open={isPlacementOpen}
         onClose={() => setIsPlacementOpen(false)}

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -36,7 +36,7 @@ import {
 } from "./style";
 
 interface Props {
-  data?: SampleMapType | TreeMapType;
+  data?: BioinformaticsMap;
   defaultSortKey: string[];
   headers: Header[];
   subheaders: Record<string, SubHeader[]>;

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -85,11 +85,10 @@ function tsvDataMap(
     text: "Genome Recovery",
   };
   if (tableData) {
-    const filteredTableData = [...tableData];
-    const filteredTableDataForReals = filteredTableData.filter((entry) =>
+    const filteredTableData = tableData.filter((entry) =>
       checkedSampleIds.includes(String(entry["publicId"]))
     );
-    const tsvData = filteredTableDataForReals.map((entry) => {
+    const tsvData = filteredTableData.map((entry) => {
       return headersDownload.flatMap((header) => {
         if (
           typeof entry[header.key] === "object" &&

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -332,7 +332,7 @@ const DataSubview: FunctionComponent<Props> = ({
               shouldStartUsherFlow={shouldStartUsherFlow}
             />
             <DeleteSamplesConfirmationModal
-              checkedSamples={checkedSamples}
+              checkedSamples={checkedSampleIds}
               onClose={() => setDeleteConfirmationOpen(false)}
               open={isDeleteConfirmationOpen}
             />

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -187,7 +187,7 @@ const DataSubview: FunctionComponent<Props> = ({
 
   useEffect(() => {
     searcher(searchQuery);
-  }, [data]);
+  }, [dataValues]);
 
   useEffect(() => {
     // Only show checkboxes on the sample datatable

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -137,7 +137,6 @@ const DataSubview: FunctionComponent<Props> = ({
     searching: false,
   });
 
-  const [dataValues, setDataValues] = useState<Sample[] | Tree[]>();
   const [checkedSampleIds, setCheckedSampleIds] = useState<string[]>([]);
   const [showCheckboxes, setShowCheckboxes] = useState<boolean>(false);
   const [isDownloadModalOpen, setDownloadModalOpen] = useState(false);
@@ -176,17 +175,12 @@ const DataSubview: FunctionComponent<Props> = ({
   };
 
   useEffect(() => {
-    if (!data) return;
-    setDataValues(Object.values(data));
-  }, [data]);
-
-  useEffect(() => {
     if (shouldStartUsherFlow) setShouldStartUsherFlow(false);
   }, [shouldStartUsherFlow]);
 
   useEffect(() => {
     searcher(searchQuery);
-  }, [dataValues]);
+  }, [data]);
 
   useEffect(() => {
     // Only show checkboxes on the sample datatable
@@ -234,7 +228,7 @@ const DataSubview: FunctionComponent<Props> = ({
     if (data === undefined) {
       return;
     } else if (query.length === 0) {
-      dispatch({ results: dataValues });
+      dispatch({ results: Object.values(data) });
       return;
     }
 
@@ -424,8 +418,9 @@ const DataSubview: FunctionComponent<Props> = ({
     let tableData;
 
     if (data) {
-      dispatch({ results: dataValues });
-      tableData = dataValues;
+      const values = Object.values(data);
+      dispatch({ results: values });
+      tableData = values;
     }
 
     return render(tableData);

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -1,4 +1,4 @@
-import { compact, escapeRegExp, filter } from "lodash";
+import { escapeRegExp, filter } from "lodash";
 import NextLink from "next/link";
 import React, {
   FunctionComponent,
@@ -12,7 +12,6 @@ import { VIEWNAME } from "src/common/constants/types";
 import { ROUTES } from "src/common/routes";
 import { FEATURE_FLAGS, usesFeatureFlag } from "src/common/utils/featureFlags";
 import Notification from "src/components/Notification";
-import { SampleMapType, TreeMapType } from "src/views/Data";
 import { CreateNSTreeModal } from "./components/CreateNSTreeModal";
 import DownloadModal from "./components/DownloadModal";
 import { IconButton } from "./components/IconButton";
@@ -302,8 +301,6 @@ const DataSubview: FunctionComponent<Props> = ({
         </DownloadWrapper>
       );
     }
-
-    const checkedSamples = compact(checkedSampleIds.map((id) => data[id]));
 
     return (
       <>

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -20,10 +20,10 @@ interface Props {
   headers: Header[];
   defaultSortKey: string[];
   isLoading: boolean;
-  checkedSamples: any[];
-  setCheckedSamples(samples: string[]): void;
-  failedSamples: any[];
-  setFailedSamples(samples: string[]): void;
+  checkedSampleIds: string[];
+  setCheckedSampleIds(samples: string[]): void;
+  failedSampleIds: string[];
+  setFailedSampleIds(samples: string[]): void;
   showCheckboxes: boolean;
   renderer?: CustomRenderer;
 }
@@ -91,14 +91,14 @@ function sortData(
 
 function extractPublicIdsFromData(
   data: TableItem[],
-  checkedSamples: string[],
+  checkedSampleIds: string[],
   onlyCheckedSamples: boolean
 ): string[] {
   const publicIds: string[] = [];
   for (const key in data) {
     const id = String(data[key as any].publicId);
     if (onlyCheckedSamples) {
-      if (checkedSamples.includes(id)) {
+      if (checkedSampleIds.includes(id)) {
         publicIds.push(id);
       }
     } else {
@@ -109,13 +109,13 @@ function extractPublicIdsFromData(
 }
 
 function extractPublicIdsFromDataWFailedGenomeRecovery(data: TableItem[]) {
-  const failedSamples: string[] = [];
+  const failedSampleIds: string[] = [];
   for (const key in data) {
     if (data[key as any].CZBFailedGenomeRecovery) {
-      failedSamples.push(String(data[key as any].publicId));
+      failedSampleIds.push(String(data[key as any].publicId));
     }
   }
-  return failedSamples;
+  return failedSampleIds;
 }
 
 interface TableState {
@@ -133,10 +133,10 @@ export const DataTable: FunctionComponent<Props> = ({
   defaultSortKey,
   renderer = defaultCellRenderer,
   isLoading,
-  checkedSamples,
-  setCheckedSamples,
-  failedSamples,
-  setFailedSamples,
+  checkedSampleIds,
+  setCheckedSampleIds,
+  failedSampleIds,
+  setFailedSampleIds,
   showCheckboxes,
 }: Props) => {
   const [isHeaderChecked, setIsHeaderChecked] = useState<boolean>(false);
@@ -150,7 +150,7 @@ export const DataTable: FunctionComponent<Props> = ({
   useEffect(() => {
     // used to determine if header is indeterminate
     if (data) {
-      const publicIds = extractPublicIdsFromData(data, checkedSamples, true);
+      const publicIds = extractPublicIdsFromData(data, checkedSampleIds, true);
       const sizeData = Object.keys(data).length;
       if (publicIds.length === sizeData || publicIds.length === 0) {
         setHeaderIndeterminant(false);
@@ -167,31 +167,31 @@ export const DataTable: FunctionComponent<Props> = ({
         setIsHeaderChecked(false);
       }
     }
-  }, [data, checkedSamples, setHeaderIndeterminant, setIsHeaderChecked]);
+  }, [data, checkedSampleIds, setHeaderIndeterminant, setIsHeaderChecked]);
 
   function handleHeaderCheckboxClick() {
     if (!data) return;
 
-    const newPublicIds = extractPublicIdsFromData(data, checkedSamples, false);
+    const newPublicIds = extractPublicIdsFromData(data, checkedSampleIds, false);
     const newFailedIds = extractPublicIdsFromDataWFailedGenomeRecovery(data);
 
     if (isHeaderIndeterminant || isHeaderChecked) {
       // remove samples in current data selection when selecting checkbox when indeterminate
-      const newCheckedSamples = checkedSamples.filter(
+      const newCheckedSamples = checkedSampleIds.filter(
         (el) => !newPublicIds.includes(el)
       );
-      const newFailedSamples = failedSamples.filter(
+      const newFailedSamples = failedSampleIds.filter(
         (el) => !newFailedIds.includes(el)
       );
-      setCheckedSamples(newCheckedSamples);
-      setFailedSamples(newFailedSamples);
+      setCheckedSampleIds(newCheckedSamples);
+      setFailedSampleIds(newFailedSamples);
       setIsHeaderChecked(false);
       setHeaderIndeterminant(false);
     }
     if (!isHeaderChecked && !isHeaderIndeterminant) {
       // set isHeaderChecked to true, add all samples in current view
-      setCheckedSamples(checkedSamples.concat(newPublicIds));
-      setFailedSamples(failedSamples.concat(newFailedIds));
+      setCheckedSampleIds(checkedSampleIds.concat(newPublicIds));
+      setFailedSampleIds(failedSampleIds.concat(newFailedIds));
       setIsHeaderChecked(true);
     }
   }
@@ -200,15 +200,15 @@ export const DataTable: FunctionComponent<Props> = ({
     sampleId: string,
     failedGenomeRecovery: boolean
   ) {
-    if (checkedSamples.includes(sampleId)) {
-      setCheckedSamples(checkedSamples.filter((id) => id !== sampleId));
+    if (checkedSampleIds.includes(sampleId)) {
+      setCheckedSampleIds(checkedSampleIds.filter((id) => id !== sampleId));
       if (failedGenomeRecovery) {
-        setFailedSamples(failedSamples.filter((id) => id !== sampleId));
+        setFailedSampleIds(failedSampleIds.filter((id) => id !== sampleId));
       }
     } else {
-      setCheckedSamples([...checkedSamples, sampleId]);
+      setCheckedSampleIds([...checkedSampleIds, sampleId]);
       if (failedGenomeRecovery) {
-        setFailedSamples([...failedSamples, sampleId]);
+        setFailedSampleIds([...failedSampleIds, sampleId]);
       }
     }
   }
@@ -240,7 +240,7 @@ export const DataTable: FunctionComponent<Props> = ({
   };
 
   const rowCheckbox = (item: TableItem): React.ReactNode => {
-    const checked: boolean = checkedSamples.includes(item?.publicId);
+    const checked: boolean = checkedSampleIds.includes(item?.publicId);
     const handleClick = function handleClick() {
       handleRowCheckboxClick(
         String(item.publicId),

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -172,7 +172,11 @@ export const DataTable: FunctionComponent<Props> = ({
   function handleHeaderCheckboxClick() {
     if (!data) return;
 
-    const newPublicIds = extractPublicIdsFromData(data, checkedSampleIds, false);
+    const newPublicIds = extractPublicIdsFromData(
+      data,
+      checkedSampleIds,
+      false
+    );
     const newFailedIds = extractPublicIdsFromDataWFailedGenomeRecovery(data);
 
     if (isHeaderIndeterminant || isHeaderChecked) {
@@ -240,7 +244,9 @@ export const DataTable: FunctionComponent<Props> = ({
   };
 
   const rowCheckbox = (item: TableItem): React.ReactNode => {
-    const checked: boolean = checkedSampleIds.includes(item?.publicId);
+    const checked: boolean = checkedSampleIds.includes(
+      item?.publicId as string
+    );
     const handleClick = function handleClick() {
       handleRowCheckboxClick(
         String(item.publicId),

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -56,4 +56,14 @@ interface Tree extends BioinformaticsType {
 }
 
 type BioinformaticsData = Sample | Tree;
-type BioinformaticsDataArray = Array<Sample | Tree>;
+type BioinformaticsDataArray = Array<Sample> | Array<Tree>;
+
+interface SampleMap {
+  [key: string]: Sample;
+}
+
+interface TreeMap {
+  [key: string]: Tree;
+}
+
+type BioinformaticsMap = SampleMap | TreeMap;

--- a/src/frontend/src/common/types/data.d.ts
+++ b/src/frontend/src/common/types/data.d.ts
@@ -1,3 +1,11 @@
+interface SampleMapType {
+  [key: string]: Sample;
+}
+
+interface TreeMapType {
+  [key: string]: Tree;
+}
+
 interface Transform {
   key: string;
   inputs: string[];
@@ -5,7 +13,7 @@ interface Transform {
 }
 
 interface DataCategory {
-  data: BioinformaticsDataArray | undefined;
+  data: SampleMapType | TreeMapType;
   defaultSortKey: string[];
   headers: Header[];
   isDataLoading: boolean;

--- a/src/frontend/src/common/types/data.d.ts
+++ b/src/frontend/src/common/types/data.d.ts
@@ -1,11 +1,3 @@
-interface SampleMapType {
-  [key: string]: Sample;
-}
-
-interface TreeMapType {
-  [key: string]: Tree;
-}
-
 interface Transform {
   key: string;
   inputs: string[];

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -167,8 +167,8 @@ const Data: FunctionComponent = () => {
   // * using the data, but LineageFilter renders a child compnent that seems
   // * to reference the parent's props (?). Passing in only the lineages, or
   // * incomplete options causes the component to break
-  const sampleArr = viewName === "Samples" ? (samples as SampleMap) : {};
-  const lineages = uniq(compact(map(sampleArr, (d) => d.lineage?.lineage)))
+  const sampleMap = viewName === "Samples" ? (samples as SampleMap) : {};
+  const lineages = uniq(compact(map(sampleMap, (d) => d.lineage?.lineage)))
     .sort()
     .map((l) => {
       return { name: l as string };

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -7,7 +7,6 @@ import { Menu } from "semantic-ui-react";
 import { fetchSamples } from "src/common/api";
 import { HeadAppTitle } from "src/common/components";
 import { useProtectedRoute } from "src/common/queries/auth";
-import { useSampleInfo } from "src/common/queries/samples";
 import { useTreeInfo } from "src/common/queries/trees";
 import { FilterPanel } from "src/components/FilterPanel";
 import { DataSubview } from "../../common/components";
@@ -27,14 +26,6 @@ const TITLE: Record<string, string> = {
   [ROUTES.PHYLO_TREES]: "Phylogenetic Trees",
 };
 
-export interface SampleMapType {
-  [key: string]: Sample;
-}
-
-export interface TreeMapType {
-  [key: string]: Tree;
-}
-
 const mapObjectArrayToIdDict = (
   arr: Sample[] | Tree[],
   keyString: string
@@ -49,8 +40,8 @@ const mapObjectArrayToIdDict = (
 const Data: FunctionComponent = () => {
   useProtectedRoute();
 
-  const [samples, setSamples] = useState<SampleMapType | undefined>();
-  const [trees, setTrees] = useState<TreeMapType | undefined>();
+  const [samples, setSamples] = useState<SampleMapType>({});
+  const [trees, setTrees] = useState<TreeMapType>({});
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [shouldShowFilters, setShouldShowFilters] = useState<boolean>(true);
   const [dataFilterFunc, setDataFilterFunc] = useState<any>();
@@ -69,11 +60,14 @@ const Data: FunctionComponent = () => {
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];
-      const sampleMap = mapObjectArrayToIdDict(apiSamples, "publicId");
+      const sampleMap = mapObjectArrayToIdDict(
+        apiSamples,
+        "publicId"
+      ) as SampleMapType;
       setSamples(sampleMap);
 
-      const apiTrees = data?.phylo_trees;
-      const treeMap = mapObjectArrayToIdDict(apiTrees, "id");
+      const apiTrees = data?.phylo_trees ?? [];
+      const treeMap = mapObjectArrayToIdDict(apiTrees, "id") as TreeMapType;
       setTrees(treeMap);
     };
 
@@ -125,7 +119,9 @@ const Data: FunctionComponent = () => {
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Asserted above
         category.transforms!.forEach((transform) => {
-          const methodInputs = transform.inputs.map((key) => datum[key]);
+          const methodInputs = transform.inputs.map(
+            (key: string) => datum[key]
+          );
           transformedDatum[transform.key] = transform.method(methodInputs);
         });
 

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -26,7 +26,9 @@ const TITLE: Record<string, string> = {
   [ROUTES.PHYLO_TREES]: "Phylogenetic Trees",
 };
 
-const mapObjectArrayToIdDict = (
+// reduces an array of objects to a mapping between the keyString arg and the objects
+// that make up the array. Effective for quickly looking up objects by id, for example.
+const reduceObjectArrayToLookupDict = (
   arr: Sample[] | Tree[],
   keyString: string
 ): SampleMapType | TreeMapType => {
@@ -60,14 +62,17 @@ const Data: FunctionComponent = () => {
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];
-      const sampleMap = mapObjectArrayToIdDict(
+      const sampleMap = reduceObjectArrayToLookupDict(
         apiSamples,
         "publicId"
       ) as SampleMapType;
       setSamples(sampleMap);
 
       const apiTrees = data?.phylo_trees ?? [];
-      const treeMap = mapObjectArrayToIdDict(apiTrees, "id") as TreeMapType;
+      const treeMap = reduceObjectArrayToLookupDict(
+        apiTrees,
+        "id"
+      ) as TreeMapType;
       setTrees(treeMap);
     };
 

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -21,11 +21,34 @@ import style from "./index.module.scss";
 import { Container, FlexContainer } from "./style";
 import { TREE_TRANSFORMS } from "./transforms";
 
+const TITLE: Record<string, string> = {
+  [ROUTES.DATA_SAMPLES]: "Samples",
+  [ROUTES.PHYLO_TREES]: "Phylogenetic Trees",
+};
+
+interface SampleMapType {
+  [key: string]: Sample;
+}
+
+interface TreeMapType {
+  [key: string]: Tree;
+}
+
+const mapObjectArrayToIdDict = (
+  arr: Sample[] | Tree[],
+  keyString: string
+): SampleMapType | TreeMapType => {
+  return arr.map((obj) => {
+    const id = obj[keyString];
+    return [id, obj];
+  });
+};
+
 const Data: FunctionComponent = () => {
   useProtectedRoute();
 
-  const [samples, setSamples] = useState<Sample[] | undefined>();
-  const [trees, setTrees] = useState<Tree[] | undefined>();
+  const [samples, setSamples] = useState<SampleMapType | undefined>();
+  const [trees, setTrees] = useState<TreeMapType | undefined>();
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [shouldShowFilters, setShouldShowFilters] = useState<boolean>(true);
   const [dataFilterFunc, setDataFilterFunc] = useState<any>();
@@ -44,10 +67,12 @@ const Data: FunctionComponent = () => {
       setIsDataLoading(false);
 
       const apiSamples = sampleResponse["samples"];
-      const apiTrees = data?.phylo_trees;
+      const sampleMap = mapObjectArrayToIdDict(apiSamples, "publicId");
+      setSamples(sampleMap);
 
-      setSamples(apiSamples);
-      setTrees(apiTrees);
+      const apiTrees = data?.phylo_trees;
+      const treeMap = mapObjectArrayToIdDict(apiTrees, "id");
+      setTrees(treeMap);
     };
 
     setBioinformaticsData();
@@ -91,19 +116,21 @@ const Data: FunctionComponent = () => {
       return;
     }
 
-    const transformedData = category.data.map((datum: BioinformaticsData) => {
-      const transformedDatum = Object.assign({}, datum);
+    const transformedData = category.data.map(
+      ([key, datum]: [key: string, datum: BioinformaticsData]) => {
+        const transformedDatum = Object.assign({}, datum);
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Asserted above
-      category.transforms!.forEach((transform) => {
-        const methodInputs = transform.inputs.map((key) => datum[key]);
-        transformedDatum[transform.key] = transform.method(methodInputs);
-      });
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Asserted above
+        category.transforms!.forEach((transform) => {
+          const methodInputs = transform.inputs.map((key) => datum[key]);
+          transformedDatum[transform.key] = transform.method(methodInputs);
+        });
 
-      return transformedDatum;
-    });
+        return [key, transformedDatum];
+      }
+    );
 
-    category.data = transformedData as BioinformaticsDataArray;
+    category.data = Object.fromEntries(transformedData);
   });
 
   const dataJSX: Record<string, Array<JSX.Element>> = {
@@ -149,7 +176,8 @@ const Data: FunctionComponent = () => {
   // * using the data, but LineageFilter renders a child compnent that seems
   // * to reference the parent's props (?). Passing in only the lineages, or
   // * incomplete options causes the component to break
-  const sampleArr = viewName === "Samples" ? (category.data as Sample[]) : [];
+  const sampleArr =
+    viewName === "Samples" ? (category.data as SampleMapType) : [];
   const lineages = uniq(compact(sampleArr?.map((d) => d.lineage?.lineage)))
     .sort()
     .map((l) => {


### PR DESCRIPTION
### Summary
- **What:** 
  - Convert data from an array of sample/tree ids into an object who's keys are ids and whose values are the full sample/tree objects
  - Rename related instances of `checkedSamples` and `failedSamples` to `checkedSampleIds` and `failedSampleIds`, respectively
- **Why:** Deleting samples requires the `id` instead of `publicId` from a sample, so we need to pass down more info about the sample than just a public id. The two tables are more or less inseparable in terms of typing/data structuring at the moment, so both were modified to hold data in the new way.
- **Ticket:** [[sc-173844]](https://app.shortcut.com/genepi/story/173844)
- **Env:** https://[url]-frontend.dev.genepi.czi.technology

### Testing
Check various functionality of the tables: sorting, filtering, checking/unchecking checkboxes, making trees, downloading fasta files, everything

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)