### PR TITLE
173844 delete some samples

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { noop } from "src/common/constants/empty";
 import { useUserInfo } from "src/common/queries/auth";
 import { useDeleteSamples } from "src/common/queries/samples";
+import { B } from "src/common/styles/support/style";
 import { pluralize } from "src/common/utils/strUtils";
 import { DeleteDialog } from "src/components/DeleteDialog";
+import { StyledCallout } from "./style";
 
 interface Props {
   checkedSamples: Sample[];
@@ -46,8 +48,25 @@ const DeleteSamplesConfirmationModal = ({
     numSamples
   )}?`;
 
-  const content =
-    "Deleted samples will be removed from Aspen. If these samples were included in previously generated trees, they will be shown with their public IDs only. You will not be able to undo this action.";
+  const numSamplesCantDelete = checkedSamples.length - samplesToDelete.length;
+  const content = (
+    <div>
+      <span>
+        Deleted samples will be removed from Aspen. If these samples were
+        included in previously generated trees, they will be shown with their
+        public IDs only. You will not be able to undo this action.
+      </span>
+      {numSamplesCantDelete > 0 && (
+        <StyledCallout intent="warning">
+          <B>
+            {numSamplesCantDelete} Selected{" "}
+            {pluralize("Sample", numSamplesCantDelete)} can’t be deleted
+          </B>{" "}
+          because they are managed by another jurisdiction.
+        </StyledCallout>
+      )}
+    </div>
+  );
 
   return (
     <DeleteDialog

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -13,7 +13,6 @@ interface Props {
   open: boolean;
 }
 
-// TODO need to cleared checkedsamples state in parent or else the checked sample counter is wrong
 const DeleteSamplesConfirmationModal = ({
   checkedSamples,
   onClose,

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -1,20 +1,29 @@
 import React from "react";
 import { noop } from "src/common/constants/empty";
+import { useUserInfo } from "src/common/queries/auth";
 import { useDeleteSamples } from "src/common/queries/samples";
 import { pluralize } from "src/common/utils/strUtils";
 import { DeleteDialog } from "src/components/DeleteDialog";
 
 interface Props {
-  checkedSamples: string[];
+  checkedSamples: Sample[];
   onClose(): void;
   open: boolean;
 }
 
+// TODO need to cleared checkedsamples state in parent or else the checked sample counter is wrong
 const DeleteSamplesConfirmationModal = ({
   checkedSamples,
   onClose,
   open,
 }: Props): JSX.Element | null => {
+  const { data } = useUserInfo();
+  const { group: userGroup } = data ?? {};
+
+  const samplesToDelete = checkedSamples
+    .filter((sample) => sample.submittingGroup?.name === userGroup?.name)
+    .map((sample) => sample.id);
+
   // TODO (mlila): update these callbacks to display notifications
   // TODO          as part of #173849
   const deleteSampleMutation = useDeleteSamples({
@@ -24,9 +33,7 @@ const DeleteSamplesConfirmationModal = ({
 
   const onDelete = () => {
     deleteSampleMutation.mutate({
-      // TODO (mlila): this should be an array of db unique ids
-      // TODO          this requires a refactor
-      samplesToDelete: checkedSamples,
+      samplesToDelete,
     });
     onClose();
   };

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { Callout, getSpaces } from "czifui";
+
+export const StyledCallout = styled(Callout)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.l}px;
+      margin-bottom: ${spaces?.xl}px;
+      max-width: 100%;
+    `;
+  }}
+`;

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -336,7 +336,7 @@ const DataSubview: FunctionComponent<Props> = ({
               shouldStartUsherFlow={shouldStartUsherFlow}
             />
             <DeleteSamplesConfirmationModal
-              checkedSamples={checkedSampleIds}
+              checkedSamples={checkedSamples}
               onClose={() => setDeleteConfirmationOpen(false)}
               open={isDeleteConfirmationOpen}
             />

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -1,4 +1,4 @@
-import { escapeRegExp, filter } from "lodash";
+import { compact, escapeRegExp, filter } from "lodash";
 import NextLink from "next/link";
 import React, {
   FunctionComponent,
@@ -300,6 +300,10 @@ const DataSubview: FunctionComponent<Props> = ({
         </DownloadWrapper>
       );
     }
+
+    const checkedSamples = compact(
+      checkedSampleIds.map((id) => data?.[id]) as Sample[]
+    );
 
     return (
       <>

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -306,6 +306,7 @@ const DataSubview: FunctionComponent<Props> = ({
       );
     }
 
+    // convert array of sample ids into a list of sample objects
     const checkedSamples = compact(
       checkedSampleIds.map((id) => data?.[id]) as Sample[]
     );

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -217,6 +217,11 @@ const DataSubview: FunctionComponent<Props> = ({
     setCreateTreeStarted(false);
   }
 
+  const handleDeleteSampleModalClose = () => {
+    setDeleteConfirmationOpen(false);
+    setCheckedSampleIds([]);
+  };
+
   const onChange = (
     _event: React.ChangeEvent<HTMLInputElement>,
     fieldInput: InputOnChangeData
@@ -337,7 +342,7 @@ const DataSubview: FunctionComponent<Props> = ({
             />
             <DeleteSamplesConfirmationModal
               checkedSamples={checkedSamples}
-              onClose={() => setDeleteConfirmationOpen(false)}
+              onClose={handleDeleteSampleModalClose}
               open={isDeleteConfirmationOpen}
             />
           </>

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -186,7 +186,7 @@ export function useSampleInfo(): UseQueryResult<SampleResponse, unknown> {
  * delete samples
  */
 interface DeleteSamplesPayload {
-  ids: string[];
+  ids: number[];
 }
 
 export async function deleteSamples({
@@ -207,7 +207,7 @@ export async function deleteSamples({
 }
 
 interface SampleDeleteRequestType {
-  samplesToDelete: string[];
+  samplesToDelete: number[];
 }
 
 export interface SampleDeleteResponseType {

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -22,6 +22,7 @@ enum TREE_STATUS {
 }
 
 interface Sample extends BioinformaticsType {
+  id: number;
   type: "Sample";
   privateId: string;
   publicId: string;


### PR DESCRIPTION
### Summary
- **What:** 
  - Delete samples when 
  - Add a callout to the Delete confirmation modal when the user tries to delete a sample they don't have permission to delete
- **Ticket:** [[sc-173844]](https://app.shortcut.com/genepi/story/173844)
- **Design:** https://www.figma.com/proto/QuQtuWj8iU7nqI6AREd0RE/CRUD-V0?node-id=205%3A74347&scaling=min-zoom&page-id=88%3A64261&starting-point-node-id=111%3A80433
- **Env:** https://deletesamples-frontend.dev.genepi.czi.technology/?crudV0=true [pending]

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)