### PR TITLE
Update GitHub actions to build & push genepi images

### DIFF
--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -20,19 +20,19 @@ jobs:
         image:
           - dockerfile: src/backend/Dockerfile.gisaid
             context: ./src/backend/
-            name: aspen-gisaid
+            name: genepi-gisaid
           - dockerfile: src/backend/Dockerfile.nextstrain
             context: ./src/backend/
-            name: aspen-nextstrain
+            name: genepi-nextstrain
           - dockerfile: src/backend/Dockerfile.pangolin
             context: ./src/backend/
-            name: aspen-pangolin
+            name: genepi-pangolin
           - dockerfile: src/backend/Dockerfile
             context: ./src/backend/
-            name: aspen-backend
+            name: genepi-backend
           - dockerfile: src/frontend/Dockerfile
             context: ./src/frontend/
-            name: aspen-frontend
+            name: genepi-frontend
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           # Build frontend image
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-frontend:latest src/frontend
           make frontend-check-style
   ts-test:
     runs-on: ubuntu-20.04
@@ -80,7 +80,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           # Build frontend
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-frontend:latest src/frontend
           make frontend-tests
   ts-test-build:
     runs-on: ubuntu-20.04
@@ -104,7 +104,7 @@ jobs:
           mkdir src/frontend/build
           chmod -R a+w src/frontend/build
           # Build frontend
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-frontend:latest src/frontend
           make frontend-test-build
   py-lint:
     runs-on: ubuntu-20.04
@@ -126,7 +126,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           # Build backend
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-backend:latest src/backend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-backend:latest src/backend
           make backend-check-style
   py-test:
     runs-on: ubuntu-20.04
@@ -148,9 +148,9 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           # Build backend image
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-backend:latest src/backend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-backend:latest src/backend
           # Build frontend
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/aspen-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/aspen-frontend:latest src/frontend
+          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-frontend:latest src/frontend
           make local-init
           make backend-test
   build-push-images:
@@ -168,19 +168,19 @@ jobs:
         image:
           - dockerfile: src/backend/Dockerfile.gisaid
             context: ./src/backend/
-            name: aspen-gisaid
+            name: genepi-gisaid
           - dockerfile: src/backend/Dockerfile.nextstrain
             context: ./src/backend/
-            name: aspen-nextstrain
+            name: genepi-nextstrain
           - dockerfile: src/backend/Dockerfile.pangolin
             context: ./src/backend/
-            name: aspen-pangolin
+            name: genepi-pangolin
           - dockerfile: src/backend/Dockerfile
             context: ./src/backend/
-            name: aspen-backend
+            name: genepi-backend
           - dockerfile: src/frontend/Dockerfile
             context: ./src/frontend/
-            name: aspen-frontend
+            name: genepi-frontend
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ rm-pycache: ## remove all __pycache__ files (run if encountering issues with pyc
 remote-pgconsole: # Get a psql console on a remote db (from OSX only!)
 	export ENV=$${ENV:=rdev}; \
 	export AWS_PROFILE=$(shell [ $(ENV) = prod ] && echo $(AWS_PROD_PROFILE) || echo $(AWS_DEV_PROFILE)); \
-	export config=$$(aws secretsmanager get-secret-value --secret-id $${ENV}/genepi-config | jq -r .SecretString ); \
+	export HAPPY_ENV=$(shell [ $(ENV) != dev ] && echo ge$(ENV) || echo $(ENV)); \
+	export config=$$(aws secretsmanager get-secret-value --secret-id $${HAPPY_ENV}/genepi-config | jq -r .SecretString ); \
 	export DB_URI=$$(jq -r '"postgresql://\(.DB_admin_username):\(.DB_admin_password)@127.0.0.1:5556/$(DB)"' <<< $$config); \
 	echo Connecting to $$(jq -r .DB_address <<< $$config)/$(DB) via $$(jq -r .bastion_host <<< $$config); \
 	ssh -f -o ExitOnForwardFailure=yes -L 5556:$$(jq -r .DB_address <<< $$config):5432 $$(jq -r .bastion_host <<< $$config) sleep 10; \
@@ -43,7 +44,8 @@ remote-pgconsole: # Get a psql console on a remote db (from OSX only!)
 remote-dbconsole: .env.ecr # Get a python console on a remote db (from OSX only!)
 	export ENV=$${ENV:=rdev}; \
 	export AWS_PROFILE=$(shell [ $(ENV) = prod ] && echo $(AWS_PROD_PROFILE) || echo $(AWS_DEV_PROFILE)); \
-	export config=$$(aws secretsmanager get-secret-value --secret-id $${ENV}/genepi-config | jq -r .SecretString ); \
+	export HAPPY_ENV=$(shell [ $(ENV) != dev ] && echo ge$(ENV) || echo $(ENV)); \
+	export config=$$(aws secretsmanager get-secret-value --secret-id $${HAPPY_ENV}/genepi-config | jq -r .SecretString ); \
 	export OSX_IP=$$(ipconfig getifaddr en0 || ipconfig getifaddr en1); \
 	export DB_URI=$$(jq -r '"postgresql://\(.DB_admin_username):\(.DB_admin_password)@'$${OSX_IP}':5555/$(DB)"' <<< $$config); \
 	echo Connecting to $$(jq -r .DB_address <<< $$config)/$(DB) via $$(jq -r .bastion_host <<< $$config); \


### PR DESCRIPTION
### Summary:
- **What:** Update GitHub Actions to use images repositories with a 'genepi-' prefix instead of an 'aspen-' prefix
- **Ticket:** [sc175714](https://app.shortcut.com/genepi/story/175714)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)