### PR TITLE
Fix import_location script so it is idempotent

### DIFF
--- a/src/backend/aspen/workflows/import_locations/save.py
+++ b/src/backend/aspen/workflows/import_locations/save.py
@@ -45,26 +45,24 @@ def save():
             .where(Location.location == None)
             .distinct()
         )
-        existing_null_locations = session.execute(existing_null_location_select).all()
+        existing_null_locations = set(
+            session.execute(existing_null_location_select).all()
+        )
 
         gisaid_null_locations_select = sa.select(
             GisaidMetadata.region,
             GisaidMetadata.country,
             GisaidMetadata.division,
         ).distinct()
-        gisaid_null_locations = session.execute(gisaid_null_locations_select).all()
+        gisaid_null_locations = set(session.execute(gisaid_null_locations_select).all())
 
-        new_null_locations = {
-            region_country_division_tuple
-            for region_country_division_tuple in gisaid_null_locations
-            if region_country_division_tuple not in existing_null_locations
-        }
+        new_null_locations = gisaid_null_locations - existing_null_locations
         new_null_location_values = list(
             map(
-                lambda location: {
-                    "region": location[0],
-                    "country": location[1],
-                    "division": location[2],
+                lambda region_country_division_tuple: {
+                    "region": region_country_division_tuple[0],
+                    "country": region_country_division_tuple[1],
+                    "division": region_country_division_tuple[2],
                     "location": None,
                 },
                 new_null_locations,

--- a/src/backend/aspen/workflows/import_locations/save.py
+++ b/src/backend/aspen/workflows/import_locations/save.py
@@ -40,9 +40,11 @@ def save():
         session.execute(gisaid_locations_insert)
 
         # Insert an entry with a null location for every distinct Region/Country/Division combination
+        # Doing a double-equals comparison is critical for the statement to compile to the intended SQL,
+        # so we tell flake8 to ignore rule E711
         existing_null_location_select = (
             sa.select(Location.region, Location.country, Location.division)
-            .where(Location.location == None)
+            .where(Location.location == None)  # noqa: E711
             .distinct()
         )
         existing_null_locations = set(

--- a/src/backend/aspen/workflows/import_locations/save.py
+++ b/src/backend/aspen/workflows/import_locations/save.py
@@ -1,6 +1,12 @@
+# flake8: noqa: E711
+# Doing a double-equals comparison to None is critical for the statements
+# that use it to compile to the intended SQL, which is why tell flake8 to
+# ignore rule E711 at the top of this file
+
 import click
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.expression import and_
 
 from aspen.config.config import Config
 from aspen.database.connection import (
@@ -25,7 +31,7 @@ def save():
                 GisaidMetadata.division,
                 GisaidMetadata.location,
             )
-            .where(GisaidMetadata.location != "")
+            .where(and_(GisaidMetadata.location != "", GisaidMetadata.location != None))
             .distinct()
         )
         gisaid_locations_insert = (
@@ -40,11 +46,9 @@ def save():
         session.execute(gisaid_locations_insert)
 
         # Insert an entry with a null location for every distinct Region/Country/Division combination
-        # Doing a double-equals comparison is critical for the statement to compile to the intended SQL,
-        # so we tell flake8 to ignore rule E711
         existing_null_location_select = (
             sa.select(Location.region, Location.country, Location.division)
-            .where(Location.location == None)  # noqa: E711
+            .where(Location.location == None)
             .distinct()
         )
         existing_null_locations = set(


### PR DESCRIPTION
* Import all distinct region, country, division, location combinations from gisaid_metadata where location is not an empty string
* Separately, insert rows with null location for every distinct region, country, division combination
* Use Python set math to avoid massive join

### Summary:
- **What:** This PR fixes two major issues: one, a syntax error in the `save.py` script meant that the compiled SQL statement did not properly check for null values, so multiple `Location` entries with the same `region`/`country`/`division` and a `null` in the `location` column were created. Two, many entries in the Gisaid metadata table had an empty string (`""`) in the `location` column instead of a null value; these were directly imported and duplicated the above created entries in the locations table. Instead, we are only directly importing locations from Gisaid metadata that do not have an entry string in the location column; and creating an entry for every distinct region/country/division present (including the entries with empty strings) with a null location, checking for existing entries using Python's set logic.
- **Ticket:** [sc176244](https://app.shortcut.com/genepi/story/176244)
- **Env:** `<rdev link>`

### Demos:

https://user-images.githubusercontent.com/24234461/145464416-abde795a-f737-4c0b-98d9-cac8aa941f9e.mov

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)