### PR TITLE
HOTFIX: handle brittle TSV upload bug

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/index.tsx
@@ -56,7 +56,9 @@ export default function LocationField({
   // Original line below
   // const errorMessage = touched[fieldKey] && errors[fieldKey];
   const hasErrorInLocation = touched[fieldKey] && errors[fieldKey];
-  const errorMessage = hasErrorInLocation ? "Location was not recognized." : undefined;
+  const errorMessage = hasErrorInLocation
+    ? "Location was not recognized."
+    : undefined;
   /**
    * END HOTFIX
    */

--- a/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/Table/components/Row/components/LocationField/index.tsx
@@ -39,7 +39,27 @@ export default function LocationField({
     value = values[fieldKey] as NamedGisaidLocation;
   }
 
-  const errorMessage = touched[fieldKey] && errors[fieldKey];
+  /**
+   * TODO REMOVE in near term
+   * HOTFIX somewhat hacky code
+   * Will reevaluate in a few days
+   *
+   * Issue is that because collectionLocation is now an object rather than a
+   * simple string, the `errors[fieldKey]` results in an object rather than a simple
+   * string. When that gets injected into React, boooom.
+   * We avoid by checking for existence of an error object for the fieldKey, then
+   * just use a hardcoded error message.
+   *
+   * This should only be an issue for TSV upload, since it's impossible to choose an
+   * unrecognized location during interaction with the dropdown.
+   */
+  // Original line below
+  // const errorMessage = touched[fieldKey] && errors[fieldKey];
+  const hasErrorInLocation = touched[fieldKey] && errors[fieldKey];
+  const errorMessage = hasErrorInLocation ? "Location was not recognized." : undefined;
+  /**
+   * END HOTFIX
+   */
 
   const filter = (
     options: NamedGisaidLocation[],


### PR DESCRIPTION
### Summary:
- **What:** Hotfix for brittle TSV upload issue

### Notes:
Changes to currentLocation with the new location dropdown approach causes the app to crash hard if user sends up a malformed TSV. Because currentLocation is now an object, an error that used to be a simple string comes back as an object. But we inject that error directly into the React, and React is cool with rendering strings and will eat your heart if you try to render an object.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)