### PR TITLE
Remove code that bluntly tried to populate locations table and location_id

### DIFF
--- a/src/backend/database_migrations/versions/20211117_213611_add_locations_table.py
+++ b/src/backend/database_migrations/versions/20211117_213611_add_locations_table.py
@@ -44,13 +44,6 @@ def upgrade():
         referent_schema="aspen",
     )
     conn = op.get_bind()
-    insert_locations_sql = sa.sql.text(
-        "INSERT INTO aspen.locations (region, division, location, country) select distinct region, division, location, country from aspen.gisaid_metadata"
-    )
-    conn.execute(insert_locations_sql)
-    set_locations_sql = sa.sql.text(
-        "UPDATE aspen.samples SET location_id = locations.id FROM aspen.locations WHERE samples.location = locations.location and samples.division = locations.division and samples.region = locations.region and samples.country = locations.country"
-    )
     conn.execute(set_locations_sql)
 
 

--- a/src/backend/database_migrations/versions/20211117_213611_add_locations_table.py
+++ b/src/backend/database_migrations/versions/20211117_213611_add_locations_table.py
@@ -43,8 +43,6 @@ def upgrade():
         source_schema="aspen",
         referent_schema="aspen",
     )
-    conn = op.get_bind()
-    conn.execute(set_locations_sql)
 
 
 def downgrade():


### PR DESCRIPTION
### Summary:
- **What:** This code tried to bluntly import all distinct locations from gisaid metadata, but we ended up going with the more finer tuned approach in the `import_locations` workflow. Not the worst thing in the world, but creates messy data that needs to be cleaned up.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)