### PR TITLE
strip hCoV-19 from gisaid ids for tree build

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -196,8 +196,8 @@ def write_includes_file(session, gisaid_ids, pathogen_genomes, selected_fh):
         selected_fh.write(f"{public_identifier}\n")
         num_includes += 1
     for gisaid_id in gisaid_ids:
-        if gisaid_id.lower().startswith("hcov-19"):
-            gisaid_id = gisaid_id[8:]
+        # remove leading hcov-19/ preceding characters, ignore case
+        gisaid_id = re.sub(r'^hcov-19\/', "", gisaid_id, flags=re.I)
         selected_fh.write(f"{gisaid_id}\n")
         num_includes += 1
     return num_includes

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import json
+import re
 from typing import Any, Iterable, List, Mapping, MutableMapping, Set, Tuple
 
 import click
@@ -191,12 +192,11 @@ def write_includes_file(session, gisaid_ids, pathogen_genomes, selected_fh):
     sample_query = session.query(Sample).filter(Sample.id.in_(sample_ids))
     for sample in sample_query:
         public_identifier = sample.public_identifier
-        if public_identifier.lower().startswith("hcov-19"):
-            public_identifier = public_identifier[8:]
+        # remove leading hcov-19/ preceding characters, ignore case
+        public_identifier = re.sub(r'^hcov-19\/', "", public_identifier, flags=re.I)
         selected_fh.write(f"{public_identifier}\n")
         num_includes += 1
     for gisaid_id in gisaid_ids:
-        # remove leading hcov-19/ preceding characters, ignore case
         gisaid_id = re.sub(r'^hcov-19\/', "", gisaid_id, flags=re.I)
         selected_fh.write(f"{gisaid_id}\n")
         num_includes += 1

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -196,6 +196,8 @@ def write_includes_file(session, gisaid_ids, pathogen_genomes, selected_fh):
         selected_fh.write(f"{public_identifier}\n")
         num_includes += 1
     for gisaid_id in gisaid_ids:
+        if gisaid_id.lower().startswith("hcov-19"):
+            gisaid_id = gisaid_id[8:]
         selected_fh.write(f"{gisaid_id}\n")
         num_includes += 1
     return num_includes

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -193,11 +193,11 @@ def write_includes_file(session, gisaid_ids, pathogen_genomes, selected_fh):
     for sample in sample_query:
         public_identifier = sample.public_identifier
         # remove leading hcov-19/ preceding characters, ignore case
-        public_identifier = re.sub(r'^hcov-19\/', "", public_identifier, flags=re.I)
+        public_identifier = re.sub(r"^hcov-19\/", "", public_identifier, flags=re.I)
         selected_fh.write(f"{public_identifier}\n")
         num_includes += 1
     for gisaid_id in gisaid_ids:
-        gisaid_id = re.sub(r'^hcov-19\/', "", gisaid_id, flags=re.I)
+        gisaid_id = re.sub(r"^hcov-19\/", "", gisaid_id, flags=re.I)
         selected_fh.write(f"{gisaid_id}\n")
         num_includes += 1
     return num_includes


### PR DESCRIPTION
**I don't have a set up to verify this change. I could only eyeball the code TnT**

### Summary:
- **What:** Current the GISAID ID box will allow IDs with "hCoV-19" during front end check, but doesn't strip "hCoV-19" in the backend for GISAID sequences. So add that stripping in to make front-back end consistent.

- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)