### PR TITLE
fix tab counts

### DIFF
--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -142,7 +142,9 @@ const Data: FunctionComponent = () => {
               >
                 {category.text}
               </div>
-              <div className={style.count}>{category.data?.length}</div>
+              <div className={style.count}>
+                {Object.keys(category.data).length}
+              </div>
             </div>
           </Menu.Item>
         </a>


### PR DESCRIPTION
### Summary
- **What:** Fix counts for the Sample and Tree tabs
- **Why:** They got messed up when I changed the data structure of `data`

### Demos
#### Before: 
![Screen Shot 2021-12-13 at 5 17 52 PM](https://user-images.githubusercontent.com/7562933/145914885-50ea0e52-7cc2-4918-a601-2a87e76b2835.png)

#### After:
![Screen Shot 2021-12-13 at 5 17 08 PM](https://user-images.githubusercontent.com/7562933/145914800-09557e2f-d5f6-4c60-a4aa-68501ff875ef.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)