### PR TITLE
use workflowId instead of phyloTree Id

### DIFF
--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -52,7 +52,6 @@ const transformData = (
       const methodInputs = transform.inputs.map((key: string) => datum[key]);
       transformedDatum[transform.key] = transform.method(methodInputs);
     });
-
     return transformedDatum;
   }) as BioinformaticsDataArray;
 
@@ -83,7 +82,12 @@ const Data: FunctionComponent = () => {
   const { samples, trees } = useMemo(
     () => ({
       samples: transformData(sampleData?.samples ?? [], "publicId"),
-      trees: transformData(treeData?.phylo_trees ?? [], "id", TREE_TRANSFORMS),
+      // use workflowID as key (failed and started phylotrees do not have an associated PhyloTree ID since they are technically only PhyloRun objects)
+      trees: transformData(
+        treeData?.phylo_trees ?? [],
+        "workflowId",
+        TREE_TRANSFORMS
+      ),
     }),
     [sampleData, treeData]
   );


### PR DESCRIPTION
### Summary:
- **What:** switch trees key to use workflowID instead of phyloTreeID (started and failed phyloTrees have no associated phyloTree Ids)
- **Ticket:** [sc176694](https://app.shortcut.com/genepi/story/176694)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)