### PR TITLE
Danrlu/output folder

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -54,7 +54,7 @@ aligned_gisaid_location=$(
 )
 
 # Persist the build config we generated.
-aws s3 cp /ncov/my_profiles/aspen/builds.yaml "s3://${aspen_s3_db_bucket}/phylo_run/${build_id}/builds.yaml"
+aws s3 cp /ncov/my_profiles/aspen/builds.yaml "s3://${aspen_s3_db_bucket}/phylo_run/${build_id}/${S3_FILESTEM}_builds.yaml"
 
 aligned_gisaid_s3_bucket=$(echo "${aligned_gisaid_location}" | jq -r .bucket)
 aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .sequences_key)

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -54,7 +54,7 @@ aligned_gisaid_location=$(
 )
 
 # Persist the build config we generated.
-aws s3 cp /ncov/my_profiles/aspen/builds.yaml "s3://${aspen_s3_db_bucket}/phylo_run/${build_date}/${S3_FILESTEM}/${WORKFLOW_ID}/builds.yaml"
+aws s3 cp /ncov/my_profiles/aspen/builds.yaml "s3://${aspen_s3_db_bucket}/phylo_run/${build_id}/builds.yaml"
 
 aligned_gisaid_s3_bucket=$(echo "${aligned_gisaid_location}" | jq -r .bucket)
 aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .sequences_key)


### PR DESCRIPTION
### Summary:
- **What:** Automatic tree builds had this error: 
![image](https://user-images.githubusercontent.com/20667188/146224740-e0602548-f590-487f-a7b9-c4d0f5a0667f.png)

Our on-demand trees get written to:
![image](https://user-images.githubusercontent.com/20667188/146225024-8ccf2434-4b7b-4f32-a0b9-1d61e8090c13.png)

The scheduled trees has a diff path pattern (so there is no `build_date` defined):
![image](https://user-images.githubusercontent.com/20667188/146224951-38c3a84e-567c-4af8-bf0c-965744abb7b9.png)

This PR modifies the builds.yaml location for scheduled trees to be the same as tree JSON location. 

- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:
Not sure how to test. I'm thinking to resurrect a scheduled tree run in staging for future testing.

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)