### PR TITLE
Return group id and name with phylo tree

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -73,6 +73,7 @@ def phylo_trees():
         .options(
             joinedload(phylo_run_alias.outputs.of_type(PhyloTree)),
             joinedload(phylo_run_alias.user),
+            joinedload(phylo_run_alias.group),
         )
         .filter(
             or_(
@@ -95,6 +96,10 @@ def phylo_trees():
             "pathogen_genome_count": 0,  # TODO: do we still need this?,
             "tree_type": phylo_run.tree_type.value,
             "user": {},
+            "group": {
+                "id": phylo_run.group.id,
+                "name": phylo_run.group.name,
+            },
         }
         if phylo_run.user:
             result["user"] = {"id": phylo_run.user.id, "name": phylo_run.user.name}

--- a/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
@@ -103,6 +103,8 @@ def check_results(client, user: User, trees: Collection[PhyloTree]):
             raise ValueError(f"Could not find {tree} in results")
 
         assert result_tree["pathogen_genome_count"] == 0
+        assert result_tree["group"]["id"] is not None
+        assert result_tree["group"]["name"] is not None
 
 
 def test_phylo_tree_view(

--- a/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
+++ b/src/backend/aspen/app/views/tests/test_phylo_tree_view.py
@@ -90,7 +90,7 @@ def make_all_test_data(
 def check_results(client, user: User, trees: Collection[PhyloTree]):
     with client.session_transaction() as sess:
         sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    results: Mapping[str, List[Mapping[str, Union[str, int]]]] = json.loads(
+    results: Mapping[str, List[Mapping[str, Union[str, int, Mapping]]]] = json.loads(
         client.get("/api/phylo_trees").get_data(as_text=True)
     )
 
@@ -103,8 +103,11 @@ def check_results(client, user: User, trees: Collection[PhyloTree]):
             raise ValueError(f"Could not find {tree} in results")
 
         assert result_tree["pathogen_genome_count"] == 0
-        assert result_tree["group"]["id"] is not None
-        assert result_tree["group"]["name"] is not None
+        assert isinstance(result_tree["group"], dict)
+        group: Mapping[str, Union[str, int]] = result_tree["group"]
+        assert "id" in group and "name" in group
+        assert type(group["id"]) == int
+        assert type(group["name"]) == str
 
 
 def test_phylo_tree_view(


### PR DESCRIPTION
### Summary:
- **What:** Returns a `group` key with each phylo tree entry, an object with the group's id and name.
- **Ticket:** [sc177022](https://app.shortcut.com/genepi/story/177022)
- **Env:** `<rdev link>`

### Demos:
<img width="482" alt="Screen Shot 2021-12-15 at 11 16 10" src="https://user-images.githubusercontent.com/24234461/146251675-58f628b9-d646-47f1-93f9-fd5cdbddd164.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)