### PR TITLE
Fix nonexistent var in aws envs.

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -17,7 +17,7 @@ start_time=$(date +%s)
 
 aws configure set region $AWS_REGION
 
-if [ ! -z "${BOTO_ENDPOINT_URL}" ]; then
+if [ -n "${BOTO_ENDPOINT_URL-}" ]; then
   export aws="aws --endpoint-url ${BOTO_ENDPOINT_URL}"
 else
   export aws="aws"

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -19,7 +19,7 @@ start_time=$(date +%s)
 
 aws configure set region $AWS_REGION
 
-if [ ! -z "${BOTO_ENDPOINT_URL}" ]; then
+if [ -n "${BOTO_ENDPOINT_URL-}" ]; then
   export aws="aws --endpoint-url ${BOTO_ENDPOINT_URL}"
 else
   export aws="aws"


### PR DESCRIPTION
### Summary:
- **What:** Fixes errors in case the BOTO_ENDPOINT_URL doesn't exist (for envs other than local dev)
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:
I'm testing this in staging (which has a recent gisaid dump) but with the docker image (+ script changes) in this pr here:
https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fgenepi$252Fgestaging$252Fgestagingstack$252Fswipe/log-events/genepi-gestaging-gestagingstack-swipe$252Fdefault$252F6b1f8ca71b7d417987ff2bc0409dbc2c

We already see files written to our new tree path here:
https://s3.console.aws.amazon.com/s3/buckets/aspen-data-staging?region=us-west-2&prefix=phylo_run/Orange+Contextual/13558/&showversions=false

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)