### PR TITLE
remove automatic rename of alameda county

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -172,6 +172,7 @@ task TransformGISAID {
     sed -i -e 's/Southern San Joaquin Valley\tNorth America\/USA\/California\//Southern San Joaquin Valley\tNorth America\/USA\/California\/Tulare County/' \
     -e 's/Orange County CA/Orange County/' \
     -e 's/Monterey County CA/Monterey County/' \
+    -e 's/Alameda County CA/Alameda County/' \
     -e '/Illinois\/Chicago\tNorth America/d' \
     /ncov-ingest/source-data/gisaid_geoLocationRules.tsv
 


### PR DESCRIPTION
### Summary:
- **What:** ncov-ingest is renaming`Alameda County` to `Alameda County CA` b/c of `Alameda County AZ`. We're suppressing it in this PR.

### Demos:
Tested the code in bash.

### Notes:
All regular users are on this list now. I need to think about how to do this more pre-emptively.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)