### PR TITLE
Quickfix for phylo tree naming.

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -35,6 +35,8 @@ PHYLO_TREE_KEY = "phylo_trees"
 def humanize_tree_name(s3_key: str):
     json_filename = s3_key.split("/")[-1]
     basename = re.sub(r".json", "", json_filename)
+    if basename == "ncov_aspen":
+        return s3_key.split("/")[1]  # Return the directory name.
     title_case = basename.replace("_", " ").title()
     if "Ancestors" in title_case:
         title_case = title_case.replace("Ancestors", "Contextual")


### PR DESCRIPTION
### Summary:
- **What:** We changed the way we generate S3 key paths for phylo runs to make debugging easier. However, we have some code in our API endpoints that generate friendly human-readable names based on these s3 paths. The path changes caused the tree names to be displayed as "Ncov Aspen" for all trees generated with the new key structure. This adds backwards-compatible support for the new key structure. and it's a **stopgap** until we run migrations to populate all tree names in the DB directly.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)