### PR TITLE
Make it easier to build & push new dev db snapshots.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ prepare-new-db-snapshot:
 
 .PHONY: create_new_db_image
 create_new_db_image:
+	docker exec aspen_database_1 psql postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@$(LOCAL_DB_SERVER)/$(LOCAL_DB_NAME) -c VACUUM FULL
 	docker commit aspen_database_1 temp_db_image
 	export AWS_ACCOUNT_ID=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \
 	export DOCKER_REPO=$${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com; \

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,29 @@ local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login local-hostconf
 	docker-compose exec -T utility python scripts/setup_localdata.py
 	docker-compose exec -T utility pip install .
 
+.PHONY: prepare-new-db-snapshot
+prepare-new-db-snapshot:
+	docker-compose $(COMPOSE_OPTS) pull database
+	docker-compose $(COMPOSE_OPTS) up -d database
+	# Wait for psql to be up
+	while [ -z "$$(docker-compose exec -T database psql "postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@$(LOCAL_DB_SERVER)/$(LOCAL_DB_NAME)" -c 'select 1')" ]; do echo "waiting for db to start..."; sleep 1; done;
+	docker-compose exec -T utility alembic upgrade head
+	@echo
+	@echo "Ok, local db is prepared and ready to go -- make any additional changes you need to and then run:"
+	@echo "make create_new_db_image"
+
+.PHONY: create_new_db_image
+create_new_db_image:
+	docker commit aspen_database_1 temp_db_image
+	export AWS_ACCOUNT_ID=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \
+	export DOCKER_REPO=$${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com; \
+	export TAGGED_IMAGE="$${DOCKER_REPO}/genepi-devdb:build-$$(date +%F)"; \
+	echo docker build -t $${TAGGED_IMAGE} -f ./docker/Dockerfile.devdb ./docker; \
+	docker build -t $${TAGGED_IMAGE} -f ./docker/Dockerfile.devdb ./docker; \
+	docker rmi temp_db_image; \
+	echo "Tagged image is ready for testing/pushing:"; \
+	echo "  $${TAGGED_IMAGE}"
+
 .PHONY: check-images
 check-images: ## Spot-check the gisaid image
 	docker-compose $(COMPOSE_OPTS) run --no-deps --rm gisaid /usr/src/app/aspen/workflows/test-gisaid.sh

--- a/docker/Dockerfile.devdb
+++ b/docker/Dockerfile.devdb
@@ -1,0 +1,10 @@
+# Grab postgres fileystem from our previous container
+FROM temp_db_image as dumper
+
+# Move the snapshot's postgres data to a clean postgres image.
+# This isn't strictly required (we could just use the dumper image directly),
+# but it prevents us from accumulating undocumented config changes
+# from continually building new images on top of old ones
+FROM postgres:13.1-alpine
+
+COPY --from=dumper /var/lib/postgresql/data /var/lib/postgresql/data


### PR DESCRIPTION
### Summary:
- **What:** Generate some `make` targets that make it easier to update our dev DB snapshot

### Notes:
I generated & pushed a new version of the dev DB with the 'latest' tag that contains a full set of locations, and a small subset of gisaid metadata, so anyone that runs `make local-init` from here on out should have a more functional dataset.

The `make prepare-new-db-snapshot` puts the local dev db in a state where it's safe to apply any important changes to it- such as importing more data, running any manual migrations, etc ... once those changes are applied, run `make create_new_db_image` to build a clean db image with all the data imported from your current local dev db. That db image can then be tested and pushed to ECR for the rest of the team to use.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)