### PR TITLE
State/Country level builds

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -25,11 +25,7 @@ module nextstrain_chicago_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Chicago Department of Public Health"
     s3_filestem              = "Chicago Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "Illinois"
-      location = "Chicago"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -55,11 +51,7 @@ module nextstrain_scc_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Santa Clara County Public Health"
     s3_filestem              = "Santa Clara Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Santa Clara County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -85,11 +77,7 @@ module nextstrain_alameda_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Alameda County Public Health Department"
     s3_filestem              = "Alameda Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Alameda County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -115,11 +103,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Contra Costa County Public Health Laboratories"
     s3_filestem              = "Contra Costa Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Contra Costa County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -145,11 +129,7 @@ module nextstrain_fresno_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Fresno County Public Health"
     s3_filestem              = "Fresno Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Fresno County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -175,11 +155,7 @@ module nextstrain_humboldt_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
     s3_filestem              = "Humboldt Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Humboldt County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -205,11 +181,7 @@ module nextstrain_marin_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Marin County Department of Health & Human Services"
     s3_filestem              = "Marin Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Marin County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -235,11 +207,7 @@ module nextstrain_monterey_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Monterey County Health Department"
     s3_filestem              = "Monterey Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Monterey County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -265,11 +233,7 @@ module nextstrain_orange_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Orange County Public Health Laboratory"
     s3_filestem              = "Orange Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Orange County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -295,11 +259,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Bernardino County Public Health"
     s3_filestem              = "San Bernardino Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "San Bernardino County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -325,11 +285,7 @@ module nextstrain_del_norte_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Del Norte Public Health Laboratory"
     s3_filestem              = "Del Norte Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Del Norte County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -355,11 +311,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Joaquin County Public Health Services"
     s3_filestem              = "San Joaquin Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "San Joaquin County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -385,11 +337,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Luis Obispo County Health Agency, Public Health Laboratories"
     s3_filestem              = "San Luis Obispo Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "San Luis Obispo County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -415,11 +363,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Francisco Public Health Laboratory"
     s3_filestem              = "San Francisco Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "San Francisco County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -446,11 +390,7 @@ module nextstrain_tulare_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tulare County Public Health Lab"
     s3_filestem              = "Tulare Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Tulare County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -476,11 +416,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tuolumne County Public Health"
     s3_filestem              = "Tuolumne Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Tuolumne County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }
@@ -506,11 +442,7 @@ module nextstrain_ventura_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Ventura County Public Health Laboratory"
     s3_filestem              = "Ventura Contextual"
-    template_filename        = "group_plus_context.yaml"
-    template_args            = {
-      division = "California"
-      location = "Ventura County"
-    }
+    template_args            = {}
     tree_type                = "OVERVIEW"
   }
 }

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -60,9 +60,8 @@ task nextstrain_workflow {
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 
-    workflow_id=$(aspen-cli db create-phylo-run                                                                                  \
-                      --group-name "~{group_name}"                                                                               \
-                      --all-group-sequences                                                                                      \
+    workflow_id=$(aspen-cli db create-phylo-run                  \
+                      --group-name "~{group_name}"               \
                       --builds-template-args '~{template_args}'  \
                       --tree-type "~{tree_type}"
     )
@@ -82,9 +81,10 @@ task nextstrain_workflow {
     aligned_gisaid_location=$(
         python3 /usr/src/app/aspen/workflows/nextstrain_run/export.py \
                --phylo-run-id "${workflow_id}"                        \
-               --sequences /ncov/data/sequences_aspen.fasta            \
-               --metadata /ncov/data/metadata_aspen.tsv                \
-               --builds-file /ncov/my_profiles/aspen/builds.yaml       \
+               --sequences /ncov/data/sequences_aspen.fasta           \
+               --metadata /ncov/data/metadata_aspen.tsv               \
+               --selected /ncov/data/include.txt                      \
+               --builds-file /ncov/my_profiles/aspen/builds.yaml      \
     )
     aligned_gisaid_s3_bucket=$(echo "${aligned_gisaid_location}" | jq -r .bucket)
     aligned_gisaid_sequences_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .sequences_key)

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -9,7 +9,6 @@ workflow nextstrain {
         String remote_dev_prefix = ""
         String group_name
         String s3_filestem
-        String template_filename
         Map[String, String] template_args
         String tree_type
     }
@@ -22,7 +21,6 @@ workflow nextstrain {
         remote_dev_prefix = remote_dev_prefix,
         group_name = group_name,
         s3_filestem = s3_filestem,
-        template_filename = template_filename,
         template_args = template_args,
         tree_type = tree_type
     }
@@ -37,7 +35,6 @@ task nextstrain_workflow {
         String remote_dev_prefix
         String group_name
         String s3_filestem
-        String template_filename
         Map[String, String] template_args
         String tree_type
     }
@@ -66,7 +63,6 @@ task nextstrain_workflow {
     workflow_id=$(aspen-cli db create-phylo-run                                                                                  \
                       --group-name "~{group_name}"                                                                               \
                       --all-group-sequences                                                                                      \
-                      --builds-template-file /usr/src/app/aspen/workflows/nextstrain_run/builds_templates/~{template_filename}   \
                       --builds-template-args '~{template_args}'  \
                       --tree-type "~{tree_type}"
     )

--- a/.happy/terraform/modules/sfn_config/nextstrain.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain.wdl
@@ -9,7 +9,6 @@ workflow nextstrain {
         String remote_dev_prefix = ""
         String group_name
         String s3_filestem
-        String template_filename
         Map[String, String] template_args
         String tree_type
     }
@@ -22,7 +21,6 @@ workflow nextstrain {
         remote_dev_prefix = remote_dev_prefix,
         group_name = group_name,
         s3_filestem = s3_filestem,
-        template_filename = template_filename,
         template_args = template_args,
         tree_type = tree_type
     }
@@ -37,7 +35,6 @@ task nextstrain_workflow {
         String remote_dev_prefix
         String group_name
         String s3_filestem
-        String template_filename
         Map[String, String] template_args
         String tree_type
     }
@@ -52,7 +49,6 @@ task nextstrain_workflow {
     fi
     export S3_FILESTEM="~{s3_filestem}"
     export GROUP_NAME="~{group_name}"
-    export TEMPLATE_FILENAME="~{template_filename}"
     # We aren't supposed to serialize Map inputs on the command line.
     export TEMPLATE_ARGS_FILE="~{write_json(template_args)}"
     export TREE_TYPE="~{tree_type}"

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -120,16 +120,6 @@ async def kick_off_phylo_run(
         raise ex.ServerException("No gisaid dump for run")
 
     # 4C build our PhyloRun object
-    template_path_prefix = (
-        "/usr/src/app/aspen/workflows/nextstrain_run/builds_templates"
-    )
-    builds_template_file = (
-        f"{template_path_prefix}/{PHYLO_TREE_TYPES[phylo_run_request.tree_type]}"
-    )
-    builds_template_args = {
-        "division": group.division,
-        "location": group.location,
-    }
     start_datetime = datetime.datetime.now()
 
     workflow: PhyloRun = PhyloRun(
@@ -137,8 +127,7 @@ async def kick_off_phylo_run(
         workflow_status=WorkflowStatusType.STARTED,
         software_versions={},
         group=group,
-        template_file_path=builds_template_file,
-        template_args=builds_template_args,
+        template_args={},  # This field is currently unused, but we might reinstate it later.
         name=phylo_run_request.name,
         gisaid_ids=list(gisaid_ids),
         tree_type=TreeType(phylo_run_request.tree_type),

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -18,7 +18,6 @@ from aspen.api.auth import get_auth_user
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.phylo_runs import (
-    PHYLO_TREE_TYPES,
     PhyloRunDeleteResponse,
     PhyloRunRequest,
     PhyloRunResponse,

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -37,7 +37,6 @@ async def test_create_phylo_run(
     res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
     assert res.status_code == 200
     response = res.json()
-    template_args = response["template_args"]
     assert response["template_args"] == {}
     assert response["workflow_status"] == "STARTED"
     assert response["group"]["name"] == group.name
@@ -100,7 +99,6 @@ async def test_create_phylo_run_with_gisaid_ids(
     res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
     assert res.status_code == 200
     response = res.json()
-    template_args = response["template_args"]
     assert response["template_args"] == {}
     assert response["workflow_status"] == "STARTED"
     assert response["group"]["name"] == group.name

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -38,9 +38,7 @@ async def test_create_phylo_run(
     assert res.status_code == 200
     response = res.json()
     template_args = response["template_args"]
-    assert template_args["division"] == group.division
-    assert template_args["location"] == group.location
-    assert "targeted.yaml" in response["template_file_path"]
+    assert response["template_args"] == {}
     assert response["workflow_status"] == "STARTED"
     assert response["group"]["name"] == group.name
     assert response["user"]["name"] == user.name
@@ -103,9 +101,7 @@ async def test_create_phylo_run_with_gisaid_ids(
     assert res.status_code == 200
     response = res.json()
     template_args = response["template_args"]
-    assert template_args["division"] == group.division
-    assert template_args["location"] == group.location
-    assert "non_contextualized.yaml" in response["template_file_path"]
+    assert response["template_args"] == {}
     assert response["workflow_status"] == "STARTED"
     assert response["group"]["name"] == group.name
     assert "id" in response

--- a/src/backend/aspen/app/serializers.py
+++ b/src/backend/aspen/app/serializers.py
@@ -44,7 +44,6 @@ class PhyloRunResponseSchema(Schema):
     end_datetime = fields.DateTime()
     workflow_status = fields.Pluck(WorkflowStatusSchema, "name")
     group = fields.Nested(GroupResponseSchema, only=("id", "name"))
-    template_file_path = fields.String()
     template_args = fields.Nested(GroupResponseSchema, only=("division", "location"))
 
 

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -7,6 +7,7 @@ from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String
 from sqlalchemy.orm import backref, relationship
 
 from aspen.database.models.base import idbase
+from aspen.database.models.locations import Location
 from aspen.database.models.mixins import DictMixin
 
 if TYPE_CHECKING:
@@ -28,6 +29,14 @@ class Group(idbase, DictMixin):  # type: ignore
     )
     division = Column(String, nullable=True)
     location = Column(String, nullable=True)
+
+    # Default location context (int'l or division or location level)
+    default_tree_location_id = Column(
+        Integer,
+        ForeignKey(Location.id),
+        nullable=True,
+    )
+    default_tree_location = relationship("Location")  # type: ignore
 
     can_see: MutableSequence[CanSee]
     can_be_seen_by: MutableSequence[CanSee]

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -6,13 +6,16 @@ def group_factory(
     address="123 Main St",
     prefix=None,
     location=None,
-    division="West",
+    division=None,
 ) -> Group:
     # shortcut so we don't need to specify prefix
     if not prefix:
         prefix = name
-    if not location:
+    # Note - the None checks are to allow explicitly empty location/division strings
+    if location == None:
         location = f"{name} city"
+    if division == None:
+        division = f"{name} state"
     tree_loc = Location(region="North America", country="USA", location=location, division=division)
     return Group(
         name=name,

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -12,9 +12,9 @@ def group_factory(
     if not prefix:
         prefix = name
     # Note - the None checks are to allow explicitly empty location/division strings
-    if location == None:
+    if location is None:
         location = f"{name} city"
-    if division == None:
+    if division is None:
         division = f"{name} state"
     tree_loc = Location(
         region="North America", country="USA", location=location, division=division

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -1,22 +1,26 @@
-from aspen.database.models import Group, User
+from aspen.database.models import Group, User, Location
 
 
 def group_factory(
     name="groupname",
     address="123 Main St",
     prefix=None,
-    location="Metropolis",
+    location=None,
     division="West",
 ) -> Group:
     # shortcut so we don't need to specify prefix
     if not prefix:
         prefix = name
+    if not location:
+        location = f"{name} city"
+    tree_loc = Location(region="North America", country="USA", location=location, division=division)
     return Group(
         name=name,
         address=address,
         prefix=prefix,
         location=location,
         division=division,
+        default_tree_location=tree_loc,
     )
 
 

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -1,4 +1,4 @@
-from aspen.database.models import Group, User, Location
+from aspen.database.models import Group, Location, User
 
 
 def group_factory(
@@ -16,7 +16,9 @@ def group_factory(
         location = f"{name} city"
     if division == None:
         division = f"{name} state"
-    tree_loc = Location(region="North America", country="USA", location=location, division=division)
+    tree_loc = Location(
+        region="North America", country="USA", location=location, division=division
+    )
     return Group(
         name=name,
         address=address,

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -108,7 +108,7 @@ def update_subsampling_for_country(subsampling):
     subsampling["group"]["max_sequences"] = 200
     subsampling["group"]["query"] = '''--query "(country == '{country}')"'''
 
-def update_subsampling_for_state(subsampling):
+def update_subsampling_for_division(subsampling):
     # State isn't useful
     del subsampling["state"]
     # Update our local group query

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -52,7 +52,7 @@ class TargetedBuilder(BaseNextstrainConfigBuilder):
           subsampling : the subsampling scheme for *this build type only* (ex: mega_template["subsampling"]["TARGETED"])
           self.subsampling_scheme : the value a few lines above
           self.crowding_penalty : the value a few lines above
-          self.group : information about the group that this run is for (ex: self.group.name or self.group.division)
+          self.group : information about the group that this run is for (ex: self.group.name or self.group.default_tree_location)
           config.num_sequences : the number of aspen samples written to our fasta input file
           config.num_included_samples : the number of samples in include.txt (aspen + gisaid samples) for on-demand runs only
 

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -92,6 +92,7 @@ class TargetedBuilder(BaseNextstrainConfigBuilder):
         # Update our sampling for state/country level builds if necessary
         update_subsampling_for_location(self.group.default_tree_location, subsampling)
 
+
 def update_subsampling_for_location(location, subsampling):
     # If we don't have a division, this is a country-level build
     if not location.division:
@@ -99,6 +100,7 @@ def update_subsampling_for_location(location, subsampling):
     # If we have a division but not a location, this is a state-level build
     elif not location.location:
         update_subsampling_for_division(subsampling)
+
 
 def update_subsampling_for_country(subsampling):
     # State and country aren't useful
@@ -108,8 +110,11 @@ def update_subsampling_for_country(subsampling):
     subsampling["group"]["max_sequences"] = 200
     subsampling["group"]["query"] = '''--query "(country == '{country}')"'''
 
+
 def update_subsampling_for_division(subsampling):
     # State isn't useful
     del subsampling["state"]
     # Update our local group query
-    subsampling["group"]["query"] = '''--query "(division == '{division}') & (country == '{country}')"'''
+    subsampling["group"][
+        "query"
+    ] = '''--query "(division == '{division}') & (country == '{country}')"'''

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -44,15 +44,8 @@ class NonContextualizedBuilder(BaseNextstrainConfigBuilder):
     crowding_penalty = 0.1
 
     def update_subsampling(self, config, subsampling):
-        # Update our query to be division or country level.
-        if self.tree_build_level == "division":
-            subsampling["same_county"][
-                "query"
-            ] = '''--query "(division == '{division}')"'''
-        if self.tree_build_level == "country":
-            subsampling["same_county"][
-                "query"
-            ] = '''--query "(country == '{country}')"'''
+        # Update our sampling for state/country level builds if necessary
+        update_subsampling_for_location(self.tree_build_level, subsampling)
 
 
 # Set max_sequences for targeted builds.
@@ -126,14 +119,19 @@ def update_subsampling_for_location(tree_build_level, subsampling):
 
 def update_subsampling_for_country(subsampling):
     # State and country aren't useful
-    del subsampling["state"]
-    del subsampling["country"]
+    if "state" in subsampling:
+        del subsampling["state"]
+    if "country" in subsampling:
+        del subsampling["country"]
     # Update our local group query
     subsampling["group"]["query"] = '''--query "(country == '{country}')"'''
 
 
 def update_subsampling_for_division(subsampling):
     # State isn't useful
-    del subsampling["state"]
+    if "state" in subsampling:
+        del subsampling["state"]
     # Update our local group query
-    subsampling["group"]["query"] = '''--query "(division == '{division}')"'''
+    subsampling["group"][
+        "query"
+    ] = '''--query "(division == '{division}') & (country == '{country}')"'''  # Keep the country filter in case of multiple divisions worldwide

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -32,7 +32,7 @@ class BaseNextstrainConfigBuilder:
         build = config["builds"]["aspen"]
 
         location = self.group.default_tree_location
-        # Make a shortcut to decide whether this is a location vs divsision vs country level build
+        # Make a shortcut to decide whether this is a location vs division vs country level build
         if not location.division:
             self.tree_build_level = "country"
         elif not location.location:

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -74,7 +74,7 @@ class BaseNextstrainConfigBuilder:
         self.update_build(config)
         self.update_subsampling(config, config["subsampling"][self.subsampling_scheme])
 
-        # Remote unused subsampling schemes from our output file
+        # Remove unused subsampling schemes from our output file
         subsampling = config["subsampling"][self.subsampling_scheme]
         config["subsampling"] = {self.subsampling_scheme: subsampling}
 

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -43,13 +43,15 @@ class BaseNextstrainConfigBuilder:
             else:
                 del build[field]
 
-
         # NOTE: <BuilderClass>.subsampling_scheme is used in 3 places:
         #   - Its lowercase'd name is used to find a markdown file with an "about this tree" description
         #   - It refers to a subsampling_scheme key in the mega nextstrain template
         #   - It's title-case'd and included in the tree title as human-readable text
         build["subsampling_scheme"] = self.subsampling_scheme
-        build["title"] = build["title"].format(tree_type=self.subsampling_scheme.title(), location=", ".join(location_values))
+        build["title"] = build["title"].format(
+            tree_type=self.subsampling_scheme.title(),
+            location=", ".join(location_values),
+        )
         config["files"]["description"] = config["files"]["description"].format(
             tree_type=self.subsampling_scheme.lower()
         )

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -50,7 +50,7 @@ class BaseNextstrainConfigBuilder:
         build["subsampling_scheme"] = self.subsampling_scheme
 
         # Update the tree's title with build type & location.
-        title_template = '{tree_type} tree for samples collected in {location}'
+        title_template = "{tree_type} tree for samples collected in {location}"
         build["title"] = title_template.format(
             tree_type=self.subsampling_scheme.title(),
             location=", ".join(location_values),

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -48,7 +48,9 @@ class BaseNextstrainConfigBuilder:
         #   - It refers to a subsampling_scheme key in the mega nextstrain template
         #   - It's title-case'd and included in the tree title as human-readable text
         build["subsampling_scheme"] = self.subsampling_scheme
-        build["title"] = build["title"].format(
+        # Update the tree's title with build type & location.
+        title_template = '{tree_type} tree for samples collected in {location}'
+        build["title"] = title_template.format(
             tree_type=self.subsampling_scheme.title(),
             location=", ".join(location_values),
         )

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -17,6 +17,7 @@ class BaseNextstrainConfigBuilder:
         self.group = group
         self.template_args = template_args
         self.template = None
+        self.tree_build_level = "location"
         # Set self.num_county_sequences, self.num_sequences, etc.
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -31,6 +32,11 @@ class BaseNextstrainConfigBuilder:
         build = config["builds"]["aspen"]
 
         location = self.group.default_tree_location
+        # Make a shortcut to decide whether this is a location vs divsision vs country level build
+        if not location.division:
+            self.tree_build_level = "country"
+        elif not location.location:
+            self.tree_build_level = "division"
         # Fill out region/country/division/location fields if the group has them,
         # or remove those fields if they don't.
         location_fields = ["region", "country", "division", "location"]

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -29,17 +29,19 @@ class BaseNextstrainConfigBuilder:
 
     def update_build(self, config):
         build = config["builds"]["aspen"]
-        # TODO - We'll add region/country info to groups soon, but it's not there yet.
-        # region = self.group.region
-        # country = self.group.country
-        # build["region"] = region
-        # build["title"] = build["title"].format(division=division, location=location, country=country, region=region)
-        country = "USA"
-        division = self.group.division
-        location = self.group.location
-        build["country"] = country
-        build["division"] = division
-        build["location"] = location
+        if group.default_tree_location:
+            location = group.default_tree_location
+            location_args = {
+                "region": location.region,
+                "division": location.division,
+                "country": location.country,
+                "location": location.location,
+            }
+        build["title"] = build["title"].format(**location_args)
+
+        build["country"] = location_args["country"]
+        build["division"] = location_args["division"]
+        build["location"] = location_args["location"]
 
         # NOTE: <BuilderClass>.subsampling_scheme is used in 3 places:
         #   - Its lowercase'd name is used to find a markdown file with an "about this tree" description

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -43,19 +43,13 @@ class BaseNextstrainConfigBuilder:
             else:
                 del build[field]
 
-        build["title"] = build["title"].format(location=", ".join(location_values))
 
         # NOTE: <BuilderClass>.subsampling_scheme is used in 3 places:
         #   - Its lowercase'd name is used to find a markdown file with an "about this tree" description
         #   - It refers to a subsampling_scheme key in the mega nextstrain template
         #   - It's title-case'd and included in the tree title as human-readable text
         build["subsampling_scheme"] = self.subsampling_scheme
-        build["title"] = build["title"].format(
-            tree_type=self.subsampling_scheme.title(),
-            division=division,
-            location=location,
-            country=country,
-        )
+        build["title"] = build["title"].format(tree_type=self.subsampling_scheme.title(), location=", ".join(location_values))
         config["files"]["description"] = config["files"]["description"].format(
             tree_type=self.subsampling_scheme.lower()
         )

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -48,6 +48,7 @@ class BaseNextstrainConfigBuilder:
         #   - It refers to a subsampling_scheme key in the mega nextstrain template
         #   - It's title-case'd and included in the tree title as human-readable text
         build["subsampling_scheme"] = self.subsampling_scheme
+
         # Update the tree's title with build type & location.
         title_template = '{tree_type} tree for samples collected in {location}'
         build["title"] = title_template.format(

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -29,19 +29,21 @@ class BaseNextstrainConfigBuilder:
 
     def update_build(self, config):
         build = config["builds"]["aspen"]
-        if group.default_tree_location:
-            location = group.default_tree_location
-            location_args = {
-                "region": location.region,
-                "division": location.division,
-                "country": location.country,
-                "location": location.location,
-            }
-        build["title"] = build["title"].format(**location_args)
 
-        build["country"] = location_args["country"]
-        build["division"] = location_args["division"]
-        build["location"] = location_args["location"]
+        location = self.group.default_tree_location
+        # Fill out region/country/division/location fields if the group has them,
+        # or remove those fields if they don't.
+        location_fields = ["region", "country", "division", "location"]
+        location_values = []
+        for field in location_fields:
+            value = getattr(location, field)
+            if value:
+                build[field] = value
+                location_values.append(value)
+            else:
+                del build[field]
+
+        build["title"] = build["title"].format(location=", ".join(location_values))
 
         # NOTE: <BuilderClass>.subsampling_scheme is used in 3 places:
         #   - Its lowercase'd name is used to find a markdown file with an "about this tree" description

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -129,7 +129,7 @@ subsampling:
     root:
       exclude: "--exclude-where 'root_ref!=yes'"
 
-    same_county:
+    group:
       group_by: "year month"
       max_sequences: 2000
       query: --query "(location == '{location}') & (division == '{division}')"

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -15,7 +15,7 @@ builds:
     division: {division}
     location: {location}
     subsampling_scheme: {tree_type}
-    title: '{tree_type} tree for samples collected in {location}'  # not sure how this works w country-level builds
+    title: Aspen Tree  # This gets replaced with a more specific title in builder_base.py
 
 ## custom rules
 custom_rules:

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -15,7 +15,7 @@ builds:
     division: {division}
     location: {location}
     subsampling_scheme: {tree_type}
-    title: '{tree_type} tree for samples collected in {location}, {division}, {country}'  # not sure how this works w country-level builds
+    title: '{tree_type} tree for samples collected in {location}'  # not sure how this works w country-level builds
 
 ## custom rules
 custom_rules:

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -15,7 +15,7 @@ builds:
     division: {division}
     location: {location}
     subsampling_scheme: {tree_type}
-    title: Aspen Tree  # This gets replaced with a more specific title in builder_base.py
+    title: CZ Gen Epi Tree  # This gets replaced with a more specific title in builder_base.py
 
 ## custom rules
 custom_rules:

--- a/src/backend/aspen/workflows/nextstrain_run/export_test.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export_test.py
@@ -66,7 +66,7 @@ def cli(
     selected: int,
     gisaid: int,
     group_name: str,
-    location: int,
+    location: str,
 ):
     tree_types = {
         "overview": TreeType.OVERVIEW,
@@ -106,6 +106,8 @@ def cli(
             group = session.query(Group).filter(Group.name == group_name).first()
         else:
             group = session.query(Group).first()
+        if not group:
+            raise Exception("No group found")
         if location:
             (region, country, div, loc) = location.split("/")
             tree_location = Location(

--- a/src/backend/aspen/workflows/nextstrain_run/export_test.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export_test.py
@@ -28,11 +28,15 @@ from aspen.workflows.nextstrain_run.export import (
 @click.option("--sequences", type=int, required=False, default=10)
 @click.option("--selected", type=int, required=False, default=10)
 @click.option("--gisaid", type=int, required=False, default=10)
+@click.option("--group-name", type=str, required=False, default=None)
+@click.option("--location-id", type=int, required=False, default=None)
 def cli(
     tree_type: str,
     sequences: int,
     selected: int,
     gisaid: int,
+    group_name: str,
+    location_id: int,
 ):
     tree_types = {
         "overview": TreeType.OVERVIEW,
@@ -68,7 +72,10 @@ def cli(
             "num_sequences": num_sequences,
             "num_included_samples": num_included_samples,
         }
-        group = session.query(Group).first()
+        if group_name:
+            group = session.query(Group).filter(Group.name == group_name).first()
+        else:
+            group = session.query(Group).first()
         builder = builder_factory(build_type, group, template_args, **context)
         builder.write_file(builds_file_fh)
 

--- a/src/backend/aspen/workflows/nextstrain_run/export_test.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export_test.py
@@ -11,7 +11,7 @@ from aspen.database.connection import (
     session_scope,
     SqlAlchemyInterface,
 )
-from aspen.database.models import Group, PathogenGenome, Sample, TreeType
+from aspen.database.models import Group, Location, PathogenGenome, Sample, TreeType
 from aspen.workflows.nextstrain_run.build_config import builder_factory
 from aspen.workflows.nextstrain_run.export import (
     write_includes_file,
@@ -25,18 +25,48 @@ from aspen.workflows.nextstrain_run.export import (
     type=click.Choice(["overview", "targeted", "non_contextualized"]),
     required=True,
 )
-@click.option("--sequences", type=int, required=False, default=10)
-@click.option("--selected", type=int, required=False, default=10)
-@click.option("--gisaid", type=int, required=False, default=10)
-@click.option("--group-name", type=str, required=False, default=None)
-@click.option("--location-id", type=int, required=False, default=None)
+@click.option(
+    "--sequences",
+    type=int,
+    required=False,
+    default=10,
+    help="How many overall group sequences in this build",
+)
+@click.option(
+    "--selected",
+    type=int,
+    required=False,
+    default=10,
+    help="How many of the overall group sequences should be selected in include.txt",
+)
+@click.option(
+    "--gisaid",
+    type=int,
+    required=False,
+    default=10,
+    help="How many GISAID ID's to include in the build",
+)
+@click.option(
+    "--group-name",
+    type=str,
+    required=False,
+    default=None,
+    help="Which existing group to use for this build?",
+)
+@click.option(
+    "--location",
+    type=str,
+    required=False,
+    default=None,
+    help="Location for tree build in region/country/div/loc format. Country example: 'North America/Mexico//'",
+)
 def cli(
     tree_type: str,
     sequences: int,
     selected: int,
     gisaid: int,
     group_name: str,
-    location_id: int,
+    location: int,
 ):
     tree_types = {
         "overview": TreeType.OVERVIEW,
@@ -76,11 +106,18 @@ def cli(
             group = session.query(Group).filter(Group.name == group_name).first()
         else:
             group = session.query(Group).first()
+        if location:
+            (region, country, div, loc) = location.split("/")
+            tree_location = Location(
+                region=region, country=country, division=div, location=loc
+            )
+            group.default_tree_location = tree_location
         builder = builder_factory(build_type, group, template_args, **context)
         builder.write_file(builds_file_fh)
 
         print("Wrote output files!")
         print(json.dumps(context))
+        session.rollback()  # Don't save any changes to the DB.
 
 
 def get_random_pathogen_genomes(session, max_genomes):

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -6,7 +6,6 @@
 # REMOTE_DEV_PREFIX (if set)
 # S3_FILESTEM
 # GROUP_NAME
-# TEMPLATE_ARGS_FILE
 # TREE_TYPE
 
 set -Eeuxo pipefail

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -78,10 +78,10 @@ def test_build_config(mocker, session, postgres_database):
         build = nextstrain_config["builds"]["aspen"]
         assert build["subsampling_scheme"] == tree_type.value
         assert build["title"].startswith(tree_type.value.title())
-        assert phylo_run.group.location in build["title"]
-        assert phylo_run.group.division in build["title"]
-        assert build["division"] == phylo_run.group.division
-        assert build["location"] == phylo_run.group.location
+        assert phylo_run.group.default_tree_location.location in build["title"]
+        assert phylo_run.group.default_tree_location.division in build["title"]
+        assert build["division"] == phylo_run.group.default_tree_location.division
+        assert build["location"] == phylo_run.group.default_tree_location.location
         assert tree_type.value.lower() in nextstrain_config["files"]["description"]
         assert nextstrain_config["files"]["description"].endswith(".md")
         assert len(sequences.splitlines()) == 20  # 10 county samples @2 lines each

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -208,6 +208,7 @@ def generate_run(phylo_run_id):
         yaml.load(builds_file_fh.getvalue(), Loader=yaml.FullLoader),
     )
 
+
 # Make sure that state-level builds are working
 def test_overview_config_division(mocker, session, postgres_database):
     mock_remote_db_uri(mocker, postgres_database.as_uri())
@@ -221,7 +222,11 @@ def test_overview_config_division(mocker, session, postgres_database):
 
     # Make sure our query got updated properly
     assert "state" not in subsampling_scheme.keys()
-    assert subsampling_scheme["group"]["query"] == '''--query "(division == '{division}') & (country == '{country}')"'''
+    assert (
+        subsampling_scheme["group"]["query"]
+        == '''--query "(division == '{division}') & (country == '{country}')"'''
+    )
+
 
 # Make sure that country-level builds are working.
 def test_overview_config_country(mocker, session, postgres_database):
@@ -229,7 +234,14 @@ def test_overview_config_country(mocker, session, postgres_database):
 
     tree_type = TreeType.OVERVIEW
     phylo_run = create_test_data(
-        session, tree_type, 10, 0, 0, group_name="Group Without Location or Country", location="", division=""
+        session,
+        tree_type,
+        10,
+        0,
+        0,
+        group_name="Group Without Location or Country",
+        location="",
+        division="",
     )
     sequences, selected, metadata, nextstrain_config = generate_run(phylo_run.id)
     subsampling_scheme = nextstrain_config["subsampling"][tree_type.value]
@@ -238,4 +250,6 @@ def test_overview_config_country(mocker, session, postgres_database):
     assert "state" not in subsampling_scheme.keys()
     assert "country" not in subsampling_scheme.keys()
     assert subsampling_scheme["group"]["max_sequences"] == 200
-    assert subsampling_scheme["group"]["query"] == '''--query "(country == '{country}')"'''
+    assert (
+        subsampling_scheme["group"]["query"] == '''--query "(country == '{country}')"'''
+    )

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -148,7 +148,7 @@ def test_non_contextualized_config(mocker, session, postgres_database):
     subsampling_scheme = nextstrain_config["subsampling"][tree_type.value]
 
     # Just some placeholder sanity-checks
-    assert subsampling_scheme["same_county"]["max_sequences"] == 2000
+    assert subsampling_scheme["group"]["max_sequences"] == 2000
     assert len(selected.splitlines()) == 10  # 5 gisaid samples + 5 selected samples
     assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
     assert len(sequences.splitlines()) == 20  # 10 county samples, @2 lines each
@@ -182,17 +182,17 @@ def test_non_contextualized_regions(mocker, session, postgres_database):
 
         if run_type == "state":
             assert (
-                subsampling_scheme["same_county"]["query"]
-                == '''--query "(division == '{division}')"'''
+                subsampling_scheme["group"]["query"]
+                == '''--query "(division == '{division}') & (country == '{country}')"'''
             )
         else:
             assert (
-                subsampling_scheme["same_county"]["query"]
+                subsampling_scheme["group"]["query"]
                 == '''--query "(country == '{country}')"'''
             )
 
         # Just some placeholder sanity-checks
-        assert subsampling_scheme["same_county"]["max_sequences"] == 2000
+        assert subsampling_scheme["group"]["max_sequences"] == 2000
         assert len(selected.splitlines()) == 10  # 5 gisaid samples + 5 selected samples
         assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
         assert len(sequences.splitlines()) == 20  # 10 county samples, @2 lines each
@@ -249,7 +249,7 @@ def test_targeted_config_regions(mocker, session, postgres_database):
             assert "state" not in subsampling_scheme.keys()
             assert (
                 subsampling_scheme["group"]["query"]
-                == '''--query "(division == '{division}')"'''
+                == '''--query "(division == '{division}') & (country == '{country}')"'''
             )
         else:
             assert "state" not in subsampling_scheme.keys()
@@ -322,7 +322,7 @@ def test_overview_config_division(mocker, session, postgres_database):
     assert "state" not in subsampling_scheme.keys()
     assert (
         subsampling_scheme["group"]["query"]
-        == '''--query "(division == '{division}')"'''
+        == '''--query "(division == '{division}') & (country == '{country}')"'''
     )
 
 

--- a/src/backend/database_migrations/versions/20211214_003923_add_location_to_groups.py
+++ b/src/backend/database_migrations/versions/20211214_003923_add_location_to_groups.py
@@ -1,0 +1,47 @@
+"""Add Location to Groups
+
+Create Date: 2021-12-14 00:39:25.682465
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20211214_003923"
+down_revision = "20211117_213611"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "groups",
+        sa.Column("location_id", sa.Integer(), nullable=True),
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        op.f("fk_groups_locations"),
+        "groups",
+        "locations",
+        ["location_id"],
+        ["id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+
+    conn = op.get_bind()
+
+    non_null_locations = sa.sql.text("""
+            update groups g set location_id = (select id from locations l where l.location = g.location and l.division = g.division and l.country = 'USA' and l.region = 'North America') where g.location is not null and g.location != 'NaN'
+            """)
+    null_locations = sa.sql.text("""
+update groups g set location_id = (select id from locations l where l.location is null and l.division = g.division and l.country = 'USA' and l.region = 'North America') where g.location is null or g.location = 'NaN'
+            """)
+    conn.execute(non_null_locations)
+    conn.execute(null_locations)
+
+
+def downgrade():
+    # Don't downgrade.
+    pass

--- a/src/backend/database_migrations/versions/20211214_003923_add_location_to_groups.py
+++ b/src/backend/database_migrations/versions/20211214_003923_add_location_to_groups.py
@@ -7,7 +7,6 @@ import enumtables  # noqa: F401
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
 revision = "20211214_003923"
 down_revision = "20211117_213611"
 branch_labels = None


### PR DESCRIPTION
### Summary:
- **What:** Add support for state & country-level builds
- **Ticket:** [sc173906](https://app.shortcut.com/genepi/story/173906)

### Notes:
This PR makes a few important changes:
- Adds a `default_tree_location` to each group as a reference to the locations table.
- If the `divsision` and/or `location` fields for a group's `default_tree_location` are empty, update the nextstrain YAML to do a division- or country-centered build
- Removes all references to `phylo_runs.template_file_path` - we're currently figuring out which template to use based on the `tree_type` field
- Empties out the `phylo_runs.template_args` field for all new runs. We're not currently using it, but I *think* we might have some uses for it in the near future, if we allow users to pass additional config to tree builds.
- I'm leaving the old `group.division` and `group.location` fields where they are for the time being. Those fields are being used to generate some s3 filenames, and I think we'll learn more about how to work with groups & locations soon (maybe we'll want separate tree build locations and default sample locations) so we can refine that later.

TODO - I still need to update our export_test.py script to handle state/country runs.


### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)