### PR TITLE
rename crowding penalty

### DIFF
--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -43,7 +43,7 @@ RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs
 
 ADD aspen/workflows/nextstrain_run/patches/crowding_penalty.patch /tmp/
-RUN patch /ncov/workflow/snakemake_rules/main_workflow.smk < /tmp/crowding_penalty.patch
+RUN (grep 'config\["priorities"\]\["crowding_penalty"\]' /ncov/workflow/snakemake_rules/main_workflow.smk || patch /ncov/workflow/snakemake_rules/main_workflow.smk < /tmp/crowding_penalty.patch)
 
 WORKDIR /usr/src/app
 

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -55,7 +55,7 @@ class BaseNextstrainConfigBuilder:
         config["files"]["description"] = config["files"]["description"].format(
             tree_type=self.subsampling_scheme.lower()
         )
-        config["crowding"]["crowding_penalty"] = self.crowding_penalty
+        config["priorities"]["crowding_penalty"] = self.crowding_penalty
 
     def update_subsampling(self, config):
         raise NotImplementedError()

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -34,7 +34,7 @@ refine:
   keep_polytomies: True
   clock_filter_iqd: 3
   
-crowding:
+priorities:
   crowding_penalty: {crowding_penalty_per_tree_type}
 
 ## Subsampling schemas

--- a/src/backend/aspen/workflows/nextstrain_run/patches/crowding_penalty.patch
+++ b/src/backend/aspen/workflows/nextstrain_run/patches/crowding_penalty.patch
@@ -5,7 +5,7 @@
          "benchmarks/priority_score_{build_name}_{focus}.txt"
      params:
 -        crowding = 0.1,
-+        crowding = config["crowding"]["crowding_penalty"],
++        crowding = config["priorities"]["crowding_penalty"],
          Nweight = 0.003
      conda: config["conda_environment"]
      shell:


### PR DESCRIPTION
### Summary:
- **What:** Rename the parameter section for crowding penalty per https://github.com/nextstrain/ncov/pull/828
- This should work w or w/o the upstream PR.
- I'm not sure how the [current patch](https://github.com/chanzuckerberg/aspen/blob/trunk/src/backend/Dockerfile.nextstrain#L46) will behave once the upstream PR merges. Will it error out or just skip and keep going? @jgadling If it will error, I'll pin the ncov until the upstream PR merges.


### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)