### PR TITLE
Remove unused Flask list samples view and related tests

### DIFF
--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -1,673 +1,17 @@
 import datetime
-import json
-from typing import Any, Optional, Sequence, Tuple
 
 from flask.testing import FlaskClient
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
 from aspen.app.views import api_utils
-from aspen.app.views.sample import SAMPLE_KEY
-from aspen.database.models import (
-    CanSee,
-    DataType,
-    PublicRepositoryType,
-    Sample,
-    SequencingReadsCollection,
-    UploadedPathogenGenome,
-)
-from aspen.test_infra.models.accession_workflow import AccessionWorkflowDirective
+from aspen.database.models import Sample, UploadedPathogenGenome
 from aspen.test_infra.models.gisaid_accession import gisaid_accession_factory
 from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
+from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
 from aspen.test_infra.models.usergroup import group_factory, user_factory
-
-
-def test_samples_view(
-    session,
-    app,
-    client,
-):
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user, private=True)
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(sample)
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {
-                    "status": "Accepted",
-                    "gisaid_id": uploaded_pathogen_genome.accessions()[
-                        0
-                    ].public_identifier,
-                },
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
-                    "version": uploaded_pathogen_genome.pangolin_version,
-                    "last_updated": api_utils.format_date(
-                        uploaded_pathogen_genome.pangolin_last_updated
-                    ),
-                },
-                "private": True,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def test_samples_view_gisaid_rejected(
-    session,
-    app,
-    client,
-):
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user)
-    # Test no GISAID accession logic
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-        sample,
-        accessions=(
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now() - datetime.timedelta(days=5),
-                None,
-                None,
-            ),
-        ),
-    )
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {"status": "Rejected", "gisaid_id": None},
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
-                    "version": uploaded_pathogen_genome.pangolin_version,
-                    "last_updated": api_utils.format_date(
-                        uploaded_pathogen_genome.pangolin_last_updated
-                    ),
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def test_samples_view_gisaid_no_info(
-    session,
-    app,
-    client,
-):
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user)
-    # Test no GISAID accession logic
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-        sample,
-        accessions=(),
-    )
-
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {"status": "Not Yet Submitted", "gisaid_id": None},
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
-                    "version": uploaded_pathogen_genome.pangolin_version,
-                    "last_updated": api_utils.format_date(
-                        uploaded_pathogen_genome.pangolin_last_updated
-                    ),
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def test_samples_view_gisaid_not_eligible(
-    session,
-    app,
-    client,
-):
-    group = group_factory()
-    user = user_factory(group)
-    # Mark the sample as failed
-    sample = sample_factory(group, user, czb_failed_genome_recovery=True)
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": True,
-                "gisaid": {"status": "Not Eligible", "gisaid_id": None},
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(None),
-                # In some cases, `sequencing_date` could actually still exist with a
-                # failed genome recovery, but for this test it's None because the sample
-                # has no underlying sequenced entity (no uploaded_pathogen_genome).
-                "sequencing_date": api_utils.format_date(None),
-                "lineage": {
-                    "lineage": None,
-                    "probability": None,
-                    "version": None,
-                    "last_updated": None,
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def test_samples_view_gisaid_submitted(
-    session,
-    app,
-    client,
-):
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user)
-    # create a sample with a gisaid workflow but no accession yet
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-        sample,
-        accessions=(
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now(),
-                None,
-                None,
-            ),
-        ),
-    )
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {"status": "Submitted", "gisaid_id": None},
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
-                    "version": uploaded_pathogen_genome.pangolin_version,
-                    "last_updated": api_utils.format_date(
-                        uploaded_pathogen_genome.pangolin_last_updated
-                    ),
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def _test_samples_view_cansee(
-    session,
-    client,
-    cansee_datatypes: Sequence[DataType],
-    user_factory_kwargs: Optional[dict] = None,
-) -> Tuple[Sample, SequencingReadsCollection, Any]:
-    user_factory_kwargs = user_factory_kwargs or {}
-    owner_group = group_factory()
-    viewer_group = group_factory(name="cdph")
-    user = user_factory(viewer_group, **user_factory_kwargs)
-    sample = sample_factory(owner_group, user)
-    # create a private sample as well to make sure it doesn't get shown unless admin
-    private_sample = sample_factory(
-        owner_group,
-        user,
-        private=True,
-        private_identifier="private_id",
-        public_identifier="public_id_2",
-    )
-    uploaded_pathogen_genome_factory(
-        private_sample,
-        accessions=(
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now(),
-                None,
-                None,
-            ),
-        ),
-    )
-
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(sample)
-    for cansee_datatype in cansee_datatypes:
-        CanSee(
-            viewer_group=viewer_group,
-            owner_group=owner_group,
-            data_type=cansee_datatype,
-        )
-    session.add_all((owner_group, viewer_group))
-    session.commit()
-
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    return (
-        sample,
-        uploaded_pathogen_genome,
-        json.loads(res.get_data(as_text=True))[SAMPLE_KEY],
-    )
-
-
-def test_samples_view_no_cansee(
-    session,
-    app,
-    client,
-):
-    _, _, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(),
-    )
-    assert samples == []
-
-
-def test_samples_view_system_admin(
-    session,
-    app,
-    client,
-):
-
-    sample, uploaded_pathogen_genome, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(),
-        user_factory_kwargs={
-            "system_admin": True,
-        },
-    )
-    # assert that we get both the public and private samples back
-    assert len(samples) == 2
-    private_ids = {sample["private_identifier"] for sample in samples}
-    private = {sample["private"] for sample in samples}
-    assert private_ids == {"private_identifer", "private_id"}
-    assert private == {True, False}
-
-
-def test_samples_view_cansee_trees(
-    session,
-    app,
-    client,
-):
-    _, _, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(DataType.TREES,),
-    )
-    assert samples == []
-
-
-def test_samples_view_cansee_sequences(
-    session,
-    app,
-    client,
-):
-    _, _, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(DataType.SEQUENCES,),
-    )
-    assert samples == []
-
-
-def test_samples_view_cansee_metadata(
-    session,
-    app,
-    client,
-):
-    sample, uploaded_pathogen_genome, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(DataType.METADATA,),
-    )
-
-    # no private identifier in the output.
-    assert samples == [
-        {
-            "collection_date": api_utils.format_date(sample.collection_date),
-            "collection_location": sample.location,
-            "czb_failed_genome_recovery": False,
-            "gisaid": {
-                "status": "Accepted",
-                "gisaid_id": uploaded_pathogen_genome.accessions()[0].public_identifier,
-            },
-            "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
-            "sequencing_date": api_utils.format_date(
-                uploaded_pathogen_genome.sequencing_date
-            ),
-            "lineage": {
-                "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                "probability": uploaded_pathogen_genome.pangolin_probability,
-                "version": uploaded_pathogen_genome.pangolin_version,
-                "last_updated": api_utils.format_date(
-                    uploaded_pathogen_genome.pangolin_last_updated
-                ),
-            },
-            "private": False,
-        }
-    ]
-
-
-def test_samples_view_cansee_private_identifiers(
-    session,
-    app,
-    client,
-):
-    """This state really makes no sense because why would you be able to see private
-    identifiers but not metadata??  But we'll ensure it still does the right thing."""
-    _, _, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(DataType.PRIVATE_IDENTIFIERS,),
-    )
-
-    # no private identifier in the output.
-    assert samples == []
-
-
-def test_samples_view_cansee_all(
-    session,
-    app,
-    client,
-):
-
-    sample, uploaded_pathogen_genome, samples = _test_samples_view_cansee(
-        session,
-        client,
-        cansee_datatypes=(DataType.METADATA, DataType.PRIVATE_IDENTIFIERS),
-    )
-
-    # no private identifier in the output.
-    assert samples == [
-        {
-            "collection_date": api_utils.format_date(sample.collection_date),
-            "collection_location": sample.location,
-            "czb_failed_genome_recovery": False,
-            "gisaid": {
-                "status": "Accepted",
-                "gisaid_id": uploaded_pathogen_genome.accessions()[0].public_identifier,
-            },
-            "private_identifier": sample.private_identifier,
-            "public_identifier": sample.public_identifier,
-            "upload_date": api_utils.format_date(uploaded_pathogen_genome.upload_date),
-            "sequencing_date": api_utils.format_date(
-                uploaded_pathogen_genome.sequencing_date
-            ),
-            "lineage": {
-                "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                "probability": uploaded_pathogen_genome.pangolin_probability,
-                "version": uploaded_pathogen_genome.pangolin_version,
-                "last_updated": api_utils.format_date(
-                    uploaded_pathogen_genome.pangolin_last_updated
-                ),
-            },
-            "private": False,
-        }
-    ]
-
-
-def test_samples_failed_accession(
-    session,
-    app,
-    client,
-):
-    """Add a sample with one successful and one failed accession attempt.  The samples
-    view should return the successful accession ID."""
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user)
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-        sample,
-        accessions=(
-            # failed accession.
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now() - datetime.timedelta(days=1, hours=2),
-                None,
-                None,
-            ),
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now() - datetime.timedelta(days=1, hours=1),
-                datetime.datetime.now() - datetime.timedelta(days=1),
-                "public_identifier_succeeded",
-            ),
-        ),
-    )
-
-    for accession in uploaded_pathogen_genome.accessions():
-        print(type(accession))
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {
-                    "status": "Accepted",
-                    "gisaid_id": "public_identifier_succeeded",
-                },
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
-                    "version": uploaded_pathogen_genome.pangolin_version,
-                    "last_updated": api_utils.format_date(
-                        uploaded_pathogen_genome.pangolin_last_updated
-                    ),
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def test_samples_multiple_accession(
-    session,
-    app,
-    client,
-):
-    """Add a sample with two successful accession attempts.  The samples view should
-    return the latest accession ID."""
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user)
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-        sample,
-        accessions=(
-            # failed accession.
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now() - datetime.timedelta(days=1, hours=2),
-                datetime.datetime.now() - datetime.timedelta(days=1, hours=1),
-                "public_identifier_earlier",
-            ),
-            AccessionWorkflowDirective(
-                PublicRepositoryType.GISAID,
-                datetime.datetime.now() - datetime.timedelta(days=1, hours=1),
-                datetime.datetime.now() - datetime.timedelta(days=1),
-                "public_identifier_later",
-            ),
-        ),
-    )
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {
-                    "status": "Accepted",
-                    "gisaid_id": "public_identifier_later",
-                },
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
-                    "version": uploaded_pathogen_genome.pangolin_version,
-                    "last_updated": api_utils.format_date(
-                        uploaded_pathogen_genome.pangolin_last_updated
-                    ),
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
-
-
-def test_samples_view_no_pangolin(
-    session,
-    app,
-    client,
-):
-    group = group_factory()
-    user = user_factory(group)
-    sample = sample_factory(group, user)
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
-        sample,
-        pangolin_lineage=None,
-        pangolin_probability=None,
-        pangolin_version=None,
-        pangolin_last_updated=None,
-    )
-    session.add(group)
-    session.commit()
-    with client.session_transaction() as sess:
-        sess["profile"] = {"name": user.name, "user_id": user.auth0_user_id}
-    res = client.get("/api/samples")
-    expected = {
-        SAMPLE_KEY: [
-            {
-                "collection_date": api_utils.format_date(sample.collection_date),
-                "collection_location": sample.location,
-                "czb_failed_genome_recovery": False,
-                "gisaid": {
-                    "status": "Accepted",
-                    "gisaid_id": uploaded_pathogen_genome.accessions()[
-                        0
-                    ].public_identifier,
-                },
-                "private_identifier": sample.private_identifier,
-                "public_identifier": sample.public_identifier,
-                "upload_date": api_utils.format_date(
-                    uploaded_pathogen_genome.upload_date
-                ),
-                "sequencing_date": api_utils.format_date(
-                    uploaded_pathogen_genome.sequencing_date
-                ),
-                "lineage": {
-                    "lineage": None,
-                    "probability": None,
-                    "version": None,
-                    "last_updated": "N/A",
-                },
-                "private": False,
-            }
-        ]
-    }
-    assert expected == json.loads(res.get_data(as_text=True))
 
 
 def test_samples_create_view_pass_no_public_id(
@@ -677,6 +21,7 @@ def test_samples_create_view_pass_no_public_id(
 ):
     group = group_factory()
     user = user_factory(group)
+    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -748,6 +93,7 @@ def test_samples_create_view_pass_no_sequencing_date(
 ):
     group = group_factory()
     user = user_factory(group)
+    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -821,6 +167,7 @@ def test_samples_create_view_invalid_sequence(
 ):
     group = group_factory()
     user = user_factory(group)
+    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -858,9 +205,10 @@ def test_samples_create_view_fail_duplicate_ids(
 ):
     group = group_factory()
     user = user_factory(group)
+    location = location_factory("Santa Barbara County")
     session.add(group)
     sample = sample_factory(
-        group, user, private_identifier="private", public_identifier="public"
+        group, user, location, private_identifier="private", public_identifier="public"
     )
     session.add(sample)
     session.commit()
@@ -912,9 +260,10 @@ def test_samples_create_view_fail_duplicate_ids_in_request_data(
 ):
     group = group_factory()
     user = user_factory(group)
+    location = location_factory("Santa Barbara County")
     session.add(group)
     sample = sample_factory(
-        group, user, private_identifier="private", public_identifier="public"
+        group, user, location, private_identifier="private", public_identifier="public"
     )
     session.add(sample)
     session.commit()
@@ -966,6 +315,7 @@ def test_samples_create_view_fail_missing_required_fields(
 ):
     group = group_factory()
     user = user_factory(group)
+    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -1009,6 +359,7 @@ def test_update_sample_public_ids(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
+    location = location_factory("Santa Barbara County")
     session.add(group)
 
     private_to_public = dict(
@@ -1022,6 +373,7 @@ def test_update_sample_public_ids(
         sample = sample_factory(
             group,
             user,
+            location,
             private_identifier=priv,
             public_identifier=pub.replace("_update", ""),
         )
@@ -1056,6 +408,7 @@ def test_update_sample_public_ids_duplicate_public_id(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
+    location = location_factory("Santa Barbara County")
     session.add(group)
     private_to_public = dict(
         zip(
@@ -1066,7 +419,7 @@ def test_update_sample_public_ids_duplicate_public_id(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group, user, private_identifier=priv, public_identifier=pub
+            group, user, location, private_identifier=priv, public_identifier=pub
         )
         session.add(sample)
 
@@ -1153,6 +506,7 @@ def test_update_sample_gisaid_isl(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
+    location = location_factory("Santa Barbara County")
     session.add(group)
 
     private_to_public = dict(
@@ -1164,7 +518,11 @@ def test_update_sample_gisaid_isl(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group, user, private_identifier=priv, public_identifier=f"{pub}_public"
+            group,
+            user,
+            location,
+            private_identifier=priv,
+            public_identifier=f"{pub}_public",
         )
         uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
             sample, sequence="ATGCAAAAAA", accessions=()
@@ -1209,6 +567,7 @@ def test_update_sample_new_gisaid_isl(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
+    location = location_factory("Santa Barbara County")
     session.add(group)
 
     private_to_public = dict(
@@ -1220,7 +579,11 @@ def test_update_sample_new_gisaid_isl(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group, user, private_identifier=priv, public_identifier=f"{pub}_public"
+            group,
+            user,
+            location,
+            private_identifier=priv,
+            public_identifier=f"{pub}_public",
         )
         uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA", accessions=())
         session.add(sample)
@@ -1258,7 +621,8 @@ def test_update_sample_new_gisaid_isl(
 def setup_validation_data(session: Session, client: FlaskClient):
     group = group_factory()
     user = user_factory(group)
-    sample = sample_factory(group, user)
+    location = location_factory("Santa Barbara County")
+    sample = sample_factory(group, user, location)
     gisaid_sample = gisaid_metadata_factory()
     session.add(group)
     session.add(sample)

--- a/src/backend/aspen/app/views/tests/test_samples_view.py
+++ b/src/backend/aspen/app/views/tests/test_samples_view.py
@@ -8,7 +8,6 @@ from aspen.app.views import api_utils
 from aspen.database.models import Sample, UploadedPathogenGenome
 from aspen.test_infra.models.gisaid_accession import gisaid_accession_factory
 from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
-from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
 from aspen.test_infra.models.usergroup import group_factory, user_factory
@@ -21,7 +20,6 @@ def test_samples_create_view_pass_no_public_id(
 ):
     group = group_factory()
     user = user_factory(group)
-    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -93,7 +91,6 @@ def test_samples_create_view_pass_no_sequencing_date(
 ):
     group = group_factory()
     user = user_factory(group)
-    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -167,7 +164,6 @@ def test_samples_create_view_invalid_sequence(
 ):
     group = group_factory()
     user = user_factory(group)
-    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -205,10 +201,9 @@ def test_samples_create_view_fail_duplicate_ids(
 ):
     group = group_factory()
     user = user_factory(group)
-    location = location_factory("Santa Barbara County")
     session.add(group)
     sample = sample_factory(
-        group, user, location, private_identifier="private", public_identifier="public"
+        group, user, private_identifier="private", public_identifier="public"
     )
     session.add(sample)
     session.commit()
@@ -260,10 +255,9 @@ def test_samples_create_view_fail_duplicate_ids_in_request_data(
 ):
     group = group_factory()
     user = user_factory(group)
-    location = location_factory("Santa Barbara County")
     session.add(group)
     sample = sample_factory(
-        group, user, location, private_identifier="private", public_identifier="public"
+        group, user, private_identifier="private", public_identifier="public"
     )
     session.add(sample)
     session.commit()
@@ -315,7 +309,6 @@ def test_samples_create_view_fail_missing_required_fields(
 ):
     group = group_factory()
     user = user_factory(group)
-    location_factory("Santa Barbara County")
     session.add(group)
     session.commit()
     with client.session_transaction() as sess:
@@ -359,7 +352,6 @@ def test_update_sample_public_ids(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
-    location = location_factory("Santa Barbara County")
     session.add(group)
 
     private_to_public = dict(
@@ -373,7 +365,6 @@ def test_update_sample_public_ids(
         sample = sample_factory(
             group,
             user,
-            location,
             private_identifier=priv,
             public_identifier=pub.replace("_update", ""),
         )
@@ -408,7 +399,6 @@ def test_update_sample_public_ids_duplicate_public_id(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
-    location = location_factory("Santa Barbara County")
     session.add(group)
     private_to_public = dict(
         zip(
@@ -419,7 +409,7 @@ def test_update_sample_public_ids_duplicate_public_id(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group, user, location, private_identifier=priv, public_identifier=pub
+            group, user, private_identifier=priv, public_identifier=pub
         )
         session.add(sample)
 
@@ -506,7 +496,6 @@ def test_update_sample_gisaid_isl(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
-    location = location_factory("Santa Barbara County")
     session.add(group)
 
     private_to_public = dict(
@@ -518,11 +507,7 @@ def test_update_sample_gisaid_isl(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group,
-            user,
-            location,
-            private_identifier=priv,
-            public_identifier=f"{pub}_public",
+            group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
         uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
             sample, sequence="ATGCAAAAAA", accessions=()
@@ -567,7 +552,6 @@ def test_update_sample_new_gisaid_isl(
 ):
     group = group_factory()
     user = user_factory(group, system_admin=True)
-    location = location_factory("Santa Barbara County")
     session.add(group)
 
     private_to_public = dict(
@@ -579,11 +563,7 @@ def test_update_sample_new_gisaid_isl(
 
     for priv, pub in private_to_public.items():
         sample = sample_factory(
-            group,
-            user,
-            location,
-            private_identifier=priv,
-            public_identifier=f"{pub}_public",
+            group, user, private_identifier=priv, public_identifier=f"{pub}_public"
         )
         uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA", accessions=())
         session.add(sample)
@@ -621,8 +601,7 @@ def test_update_sample_new_gisaid_isl(
 def setup_validation_data(session: Session, client: FlaskClient):
     group = group_factory()
     user = user_factory(group)
-    location = location_factory("Santa Barbara County")
-    sample = sample_factory(group, user, location)
+    sample = sample_factory(group, user)
     gisaid_sample = gisaid_metadata_factory()
     session.add(group)
     session.add(sample)

--- a/src/backend/aspen/main.py
+++ b/src/backend/aspen/main.py
@@ -5,6 +5,6 @@ from aspen.app.views.auth import callback_handling, login, logout  # noqa: F401
 from aspen.app.views.health import health  # noqa: F401
 from aspen.app.views.index import serve  # noqa: F401
 from aspen.app.views.phylo_trees import auspice_view, phylo_trees  # noqa: F401
-from aspen.app.views.sample import samples  # noqa: F401
+from aspen.app.views.sample import create_sample  # noqa: F401
 from aspen.app.views.usergroup import usergroup  # noqa: F401
 from aspen.app.views.usher import get_usher_tree_options  # noqa: F401


### PR DESCRIPTION
### Summary:
- **What:** The new location stuff breaks a lot of old code that isn't used any more, so rather than maintain it I'd like to just rip it out.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)