### PR TITLE
Improve perf for sample list endpoint

### DIFF
--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -42,32 +42,33 @@ class SampleUserResponseSchema(BaseResponse):
 
 
 class SampleGetterDict(GetterDict):
+    indirect_attributes = {
+        "sequencing_date": lambda obj: (
+            obj.uploaded_pathogen_genome.sequencing_date
+            if obj.uploaded_pathogen_genome
+            else None
+        ),
+        "upload_date": lambda obj: (
+            obj.uploaded_pathogen_genome.upload_date
+            if obj.uploaded_pathogen_genome
+            else None
+        ),
+        "lineage": format_sample_lineage,
+        "private_identifier": lambda obj: (
+            obj.private_identifier
+            if obj.show_private_identifier
+            else None
+        ),
+        "collection_location": lambda obj: (
+            obj.location
+            if obj.location != "" and obj.location != "NaN"
+            else obj.division
+        ),
+    }
+
     def get(self, key: Any, default: Any = None) -> Any:
-        indirect_attributes = {
-            "sequencing_date": (
-                self._obj.uploaded_pathogen_genome.sequencing_date
-                if self._obj.uploaded_pathogen_genome
-                else None
-            ),
-            "upload_date": (
-                self._obj.uploaded_pathogen_genome.upload_date
-                if self._obj.uploaded_pathogen_genome
-                else None
-            ),
-            "lineage": format_sample_lineage(self._obj),
-            "private_identifier": (
-                self._obj.private_identifier
-                if self._obj.show_private_identifier
-                else None
-            ),
-            "collection_location": (
-                self._obj.location
-                if self._obj.location != "" and self._obj.location != "NaN"
-                else self._obj.division
-            ),
-        }
-        if key in indirect_attributes:
-            return indirect_attributes[key]
+        if key in self.indirect_attributes:
+            return self.indirect_attributes[key](self._obj)
         default_response = getattr(self._obj, key, default)
         return default_response
 

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -55,9 +55,7 @@ class SampleGetterDict(GetterDict):
         ),
         "lineage": format_sample_lineage,
         "private_identifier": lambda obj: (
-            obj.private_identifier
-            if obj.show_private_identifier
-            else None
+            obj.private_identifier if obj.show_private_identifier else None
         ),
         "collection_location": lambda obj: (
             obj.location

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -5,6 +5,7 @@ from typing import Dict, List, NamedTuple, Optional, Set
 import orjson
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncResult, AsyncSession
 from sqlalchemy.orm import selectinload
@@ -162,7 +163,7 @@ async def list_samples(
             if not first:
                 yield ","
             first = False
-            yield orjson.dumps(item.dict())
+            yield orjson.dumps(jsonable_encoder(item))
         yield "]}"
 
     return StreamingResponse(_stream_json("samples", generate_row))

--- a/src/backend/poetry.lock
+++ b/src/backend/poetry.lock
@@ -725,6 +725,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "orjson"
+version = "3.6.5"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
@@ -1470,7 +1478,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "40678bcf29d919cb9bb9a933d88707ed55f9386054e97b2f328ed97505e22f21"
+content-hash = "4b8b6cc6ba8ab1cee90c65731aadfc55057befc30f1a8abc37b6e3e04a1748a8"
 
 [metadata.files]
 alembic = [
@@ -1902,6 +1910,32 @@ mypy = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+orjson = [
+    {file = "orjson-3.6.5-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:6c444edc073eb69cf85b28851a7a957807a41ce9bb3a9c14eefa8b33030cf050"},
+    {file = "orjson-3.6.5-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:432c6da3d8d4630739f5303dcc45e8029d357b7ff8e70b7239be7bd047df6b19"},
+    {file = "orjson-3.6.5-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:0fa32319072fadf0732d2c1746152f868a1b0f83c8cce2cad4996f5f3ca4e979"},
+    {file = "orjson-3.6.5-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:0d65cc67f2e358712e33bc53810022ef5181c2378a7603249cd0898aa6cd28d4"},
+    {file = "orjson-3.6.5-cp310-none-win_amd64.whl", hash = "sha256:fa8e3d0f0466b7d771a8f067bd8961bc17ca6ea4c89a91cd34d6648e6b1d1e47"},
+    {file = "orjson-3.6.5-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:470596fbe300a7350fd7bbcf94d2647156401ab6465decb672a00e201af1813a"},
+    {file = "orjson-3.6.5-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d2680d9edc98171b0c59e52c1ed964619be5cb9661289c0dd2e667773fa87f15"},
+    {file = "orjson-3.6.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:001962a334e1ab2162d2f695f2770d2383c7ffd2805cec6dbb63ea2ad96bf0ad"},
+    {file = "orjson-3.6.5-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:522c088679c69e0dd2c72f43cd26a9e73df4ccf9ed725ac73c151bbe816fe51a"},
+    {file = "orjson-3.6.5-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:d2b871a745a64f72631b633271577c99da628a9b63e10bd5c9c20706e19fe282"},
+    {file = "orjson-3.6.5-cp37-none-win_amd64.whl", hash = "sha256:51ab01fed3b3e21561f21386a2f86a0415338541938883b6ca095001a3014a3e"},
+    {file = "orjson-3.6.5-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:fc7e62edbc7ece95779a034d9e206d7ba9e2b638cc548fd3a82dc5225f656625"},
+    {file = "orjson-3.6.5-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:0720d60db3fa25956011a573274a269eb37de98070f3bc186582af1222a2d084"},
+    {file = "orjson-3.6.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e169a8876aed7a5bff413c53257ef1fa1d9b68c855eb05d658c4e73ed8dff508"},
+    {file = "orjson-3.6.5-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:331f9a3bdba30a6913ad1d149df08e4837581e3ce92bf614277d84efccaf796f"},
+    {file = "orjson-3.6.5-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:ece5dfe346b91b442590a41af7afe61df0af369195fed13a1b29b96b1ba82905"},
+    {file = "orjson-3.6.5-cp38-none-win_amd64.whl", hash = "sha256:6a5e9eb031b44b7a429c705ca48820371d25b9467c9323b6ae7a712daf15fbef"},
+    {file = "orjson-3.6.5-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:206237fa5e45164a678b12acc02aac7c5b50272f7f31116e1e08f8bcaf654f93"},
+    {file = "orjson-3.6.5-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d5aceeb226b060d11ccb5a84a4cfd760f8024289e3810ec446ef2993a85dbaca"},
+    {file = "orjson-3.6.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80dba3dbc0563c49719e8cc7d1568a5cf738accfcd1aa6ca5e8222b57436e75e"},
+    {file = "orjson-3.6.5-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:443f39bc5e7966880142430ce091e502aea068b38cb9db5f1ffdcfee682bc2d4"},
+    {file = "orjson-3.6.5-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:a06f2dd88323a480ac1b14d5829fb6cdd9b0d72d505fabbfbd394da2e2e07f6f"},
+    {file = "orjson-3.6.5-cp39-none-win_amd64.whl", hash = "sha256:82cb42dbd45a3856dbad0a22b54deb5e90b2567cdc2b8ea6708e0c4fe2e12be3"},
+    {file = "orjson-3.6.5.tar.gz", hash = "sha256:eb3a7d92d783c89df26951ef3e5aca9d96c9c6f2284c752aa3382c736f950597"},
 ]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -52,6 +52,7 @@ httpx = "^0.19.0"
 pytest-asyncio = "^0.15.1"
 autoflake = "^1.4"
 types-PyYAML = "^6.0.1"
+orjson = "^3.6.5"
 
 [tool.poetry.dev-dependencies]
 alembic = "^1.7.3"


### PR DESCRIPTION
### Summary:
The sample list endpoint is currently taking 20s to complete and returning a 13M json blob for some users. There's probably room for improvement in the way we're running our DB queries, but some quick profiling showed that most of the easy wins for this endpoint are related to json serialization. This PR updates the endpoint to stream out a json response rather than encoding it into a single string in memory and *then* returning it. In my testing in local dev, these changes reduced response time by 55-60% 

This has some tradeoffs though:
- Since we're no longer relying on FastAPI's built-in serialization, its auto-generated API docs won't include the response format for this API endpoint. There [are some workarounds for this](https://fastapi.tiangolo.com/advanced/additional-responses/) but since we're not currently relying on openapi functionality, I'm not sure whether we should work on that now.
- If we run into any exceptions while streaming a response, we'll be cutting off our JSON response mid-stream and users will get broken results instead of an HTTP error.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)