### PR TITLE
reconfigure auto build overview tree

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -18,7 +18,7 @@ module nextstrain_chicago_contextual_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = module.swipe_sfn.step_function_arn
-  schedule_expressions  = local.nextstrain_cron_schedule
+  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
   event_role_arn        = local.event_role_arn
   extra_args            =  {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -24,7 +24,7 @@ module nextstrain_chicago_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Chicago Department of Public Health"
-    s3_filestem              = "Chicago Contextual"
+    s3_filestem              = "Chicago"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -50,7 +50,7 @@ module nextstrain_scc_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Santa Clara County Public Health"
-    s3_filestem              = "Santa Clara Contextual"
+    s3_filestem              = "Santa Clara"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -76,7 +76,7 @@ module nextstrain_alameda_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Alameda County Public Health Department"
-    s3_filestem              = "Alameda Contextual"
+    s3_filestem              = "Alameda"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -102,7 +102,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Contra Costa County Public Health Laboratories"
-    s3_filestem              = "Contra Costa Contextual"
+    s3_filestem              = "Contra Costa"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -128,7 +128,7 @@ module nextstrain_fresno_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Fresno County Public Health"
-    s3_filestem              = "Fresno Contextual"
+    s3_filestem              = "Fresno"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -154,7 +154,7 @@ module nextstrain_humboldt_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
-    s3_filestem              = "Humboldt Contextual"
+    s3_filestem              = "Humboldt"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -180,7 +180,7 @@ module nextstrain_marin_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Marin County Department of Health & Human Services"
-    s3_filestem              = "Marin Contextual"
+    s3_filestem              = "Marin"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -206,7 +206,7 @@ module nextstrain_monterey_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Monterey County Health Department"
-    s3_filestem              = "Monterey Contextual"
+    s3_filestem              = "Monterey"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -232,7 +232,7 @@ module nextstrain_orange_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Orange County Public Health Laboratory"
-    s3_filestem              = "Orange Contextual"
+    s3_filestem              = "Orange"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -258,7 +258,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Bernardino County Public Health"
-    s3_filestem              = "San Bernardino Contextual"
+    s3_filestem              = "San Bernardino"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -284,7 +284,7 @@ module nextstrain_del_norte_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Del Norte Public Health Laboratory"
-    s3_filestem              = "Del Norte Contextual"
+    s3_filestem              = "Del Norte"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -310,7 +310,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Joaquin County Public Health Services"
-    s3_filestem              = "San Joaquin Contextual"
+    s3_filestem              = "San Joaquin"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -336,7 +336,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Luis Obispo County Health Agency, Public Health Laboratories"
-    s3_filestem              = "San Luis Obispo Contextual"
+    s3_filestem              = "San Luis Obispo"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -362,7 +362,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Francisco Public Health Laboratory"
-    s3_filestem              = "San Francisco Contextual"
+    s3_filestem              = "San Francisco"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -389,7 +389,7 @@ module nextstrain_tulare_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tulare County Public Health Lab"
-    s3_filestem              = "Tulare Contextual"
+    s3_filestem              = "Tulare"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -415,7 +415,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tuolumne County Public Health"
-    s3_filestem              = "Tuolumne Contextual"
+    s3_filestem              = "Tuolumne"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }
@@ -441,7 +441,7 @@ module nextstrain_ventura_contextual_sfn_config {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Ventura County Public Health Laboratory"
-    s3_filestem              = "Ventura Contextual"
+    s3_filestem              = "Ventura"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }

--- a/src/backend/aspen/cli/db.py
+++ b/src/backend/aspen/cli/db.py
@@ -182,6 +182,12 @@ def add_can_see(
 
 @db.command("create-phylo-run")
 @click.option(
+    "--tree-name",
+    type=str,
+    required=False,
+    help="Name of tree being created",
+)
+@click.option(
     "--group-name",
     type=str,
     required=True,
@@ -215,6 +221,7 @@ def add_can_see(
 @click.pass_context
 def create_phylo_run(
     ctx,
+    tree_name: str,
     group_name: str,
     builds_template_args: str,
     git_refspec: str,
@@ -242,6 +249,8 @@ def create_phylo_run(
         )
         workflow.inputs = [aligned_gisaid_dump]
         workflow.template_args = json.loads(builds_template_args)
+        if tree_name:
+            workflow.name = tree_name
 
         session.add(workflow)
         session.flush()

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -34,7 +34,7 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
         early_late_cutoff = today - datetime.timedelta(weeks=12)
 
         subsampling["group"][
-                "min-date"
+                "min_date"
             ] = f"--min-date {early_late_cutoff.strftime('%Y-%m-%d')}"
 
         # Update our sampling for state/country level builds if necessary

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -3,6 +3,7 @@ from math import ceil
 from aspen.database.models import TreeType
 from aspen.workflows.nextstrain_run.builder_base import BaseNextstrainConfigBuilder
 
+import datetime
 
 def builder_factory(tree_type: TreeType, group, template_args, **kwargs):
     # This is basically a router -- We'll switch between which build types
@@ -27,6 +28,14 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
             subsampling["group"][
                 "query"
             ] = '''--query "((location == '{location}') & (division == '{division}')) | submitting_lab == 'RIPHL at Rush University Medical Center'"'''
+
+        # only keep group samples within the past 3 months
+        today = datetime.date.today()
+        early_late_cutoff = today - datetime.timedelta(weeks=2)
+
+        subsampling["group"][
+                "min-date"
+            ] = f"--min-date {early_late_cutoff.strftime('%Y-%m-%d')}"
 
         # Update our sampling for state/country level builds if necessary
         update_subsampling_for_location(self.tree_build_level, subsampling)

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -1,9 +1,9 @@
+import datetime
 from math import ceil
 
 from aspen.database.models import TreeType
 from aspen.workflows.nextstrain_run.builder_base import BaseNextstrainConfigBuilder
 
-import datetime
 
 def builder_factory(tree_type: TreeType, group, template_args, **kwargs):
     # This is basically a router -- We'll switch between which build types
@@ -34,8 +34,8 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
         early_late_cutoff = today - datetime.timedelta(weeks=12)
 
         subsampling["group"][
-                "min_date"
-            ] = f"--min-date {early_late_cutoff.strftime('%Y-%m-%d')}"
+            "min_date"
+        ] = f"--min-date {early_late_cutoff.strftime('%Y-%m-%d')}"
 
         # Update our sampling for state/country level builds if necessary
         update_subsampling_for_location(self.tree_build_level, subsampling)

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -31,7 +31,7 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
 
         # only keep group samples within the past 3 months
         today = datetime.date.today()
-        early_late_cutoff = today - datetime.timedelta(weeks=2)
+        early_late_cutoff = today - datetime.timedelta(weeks=12)
 
         subsampling["group"][
                 "min-date"

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -57,9 +57,9 @@ class BaseNextstrainConfigBuilder:
 
         # Update the tree's title with build type & location.
         if self.subsampling_scheme == "OVERVIEW":
-            title_template = "{tree_type} tree for samples collected in {location}"
-        else:
             title_template = "Contextualized tree for samples collected in {location} in the last 3 months"
+        else:
+            title_template = "{tree_type} tree for samples collected in {location}"
         build["title"] = title_template.format(
             tree_type=self.subsampling_scheme.title(),
             location=", ".join(location_values),

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -56,7 +56,10 @@ class BaseNextstrainConfigBuilder:
         build["subsampling_scheme"] = self.subsampling_scheme
 
         # Update the tree's title with build type & location.
-        title_template = "{tree_type} tree for samples collected in {location}"
+        if self.subsampling_scheme == "OVERVIEW":
+            title_template = "{tree_type} tree for samples collected in {location}"
+        else:
+            title_template = "Contextualized tree for samples collected in {location} in the last 3 months"
         build["title"] = title_template.format(
             tree_type=self.subsampling_scheme.title(),
             location=", ".join(location_values),

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -73,6 +73,12 @@ subsampling:
           type: "proximity"
           focus: "group"
 
+    international_serial_sampling:
+      group_by: "region year month"
+      seq_per_group: 2
+      query: --query "(country != '{country}')"
+
+
 
   TARGETED:
     root:

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -32,14 +32,16 @@ aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 TEMPLATE_ARGS=$(jq -c . < "${TEMPLATE_ARGS_FILE}")
 
 # Create a workflow run
-WORKFLOW_ID=$(aspen-cli db create-phylo-run                                                                           \
-                  --group-name "${GROUP_NAME}"                                                                               \
-                  --builds-template-args "${TEMPLATE_ARGS}"                                                                  \
+WORKFLOW_ID=$(aspen-cli db create-phylo-run                                       \
+                  --group-name "${GROUP_NAME}"                                    \
+                  --builds-template-args "${TEMPLATE_ARGS}"                       \
+                  --tree-name "${S3_FILESTEM} Contextual Recency-Focused Build"   \
                   --tree-type "${TREE_TYPE}"
 )
 echo "${WORKFLOW_ID}" >| "/tmp/workflow_id"
 
-key_prefix="phylo_run/${S3_FILESTEM}/${WORKFLOW_ID}"
+type_titlecase="$(tr '[:lower:]' '[:upper:]' <<< ${TREE_TYPE:0:1})$(tr '[:upper:]' '[:lower:]' <<< ${TREE_TYPE:1})"
+key_prefix="phylo_run/${S3_FILESTEM}/${type_titlecase}/${WORKFLOW_ID}"
 s3_prefix="s3://${aspen_s3_db_bucket}/${key_prefix}"
 
 # set up ncov

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -61,6 +61,9 @@ aligned_gisaid_location=$(
            --builds-file /ncov/my_profiles/aspen/builds.yaml       \
 )
 
+# temporary fix for recency focused automatic build
+# even if the group has no samples in the past 3 months, the run will not fail
+sed -i '/include\.txt/d' /ncov/my_profiles/aspen/builds.yaml
 
 # Persist the build config we generated.
 $aws s3 cp /ncov/my_profiles/aspen/builds.yaml "${s3_prefix}/builds.yaml"

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -82,7 +82,10 @@ def test_build_config(mocker, session, postgres_database):
         sequences, selected, metadata, nextstrain_config = generate_run(phylo_run.id)
         build = nextstrain_config["builds"]["aspen"]
         assert build["subsampling_scheme"] == tree_type.value
-        assert build["title"].startswith(tree_type.value.title())
+        if tree_type.value == "OVERVIEW":
+            assert build["title"].startswith("Contextualized tree for samples")
+        else:
+            assert build["title"].startswith(tree_type.value.title())
         assert phylo_run.group.default_tree_location.location in build["title"]
         assert phylo_run.group.default_tree_location.division in build["title"]
         assert build["division"] == phylo_run.group.default_tree_location.division


### PR DESCRIPTION
### Summary:
- **What:** Make the overview trees to focus on samples collected in the past 3 months. 

   - Pass a min date (12 weeks from now) to the nextstrain yaml 

   - Change the title shown on the tree to include "3 months"

   - Append "Recency-Focused Build" to the tree names in Aspen tree table. Implemented in https://github.com/chanzuckerberg/aspen/pull/894 Thanks Jess!

   - All runs should work regardless of whether the county has samples in the past 3 months.


### Demos:
Only samples from the last 3 months from Marin are on the tree (blue), together w other contextual samples

![image](https://user-images.githubusercontent.com/20667188/147360949-ba2853f4-4c7f-4f91-9cfb-806c8601d381.png)


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)