### PR TITLE
name the new overview tree differently on the tree table

### DIFF
--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -37,6 +37,8 @@ def humanize_tree_name(s3_key: str):
     basename = re.sub(r".json", "", json_filename)
     if basename == "ncov_aspen":
         return s3_key.split("/")[1]  # Return the directory name.
+    if basename == "ncov_aspen_3m":
+        return s3_key.split("/")[1] + " recency-focused build"  # Name it differently from overview tree.
     title_case = basename.replace("_", " ").title()
     if "Ancestors" in title_case:
         title_case = title_case.replace("Ancestors", "Contextual")

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -82,7 +82,7 @@ $aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_meta
 (cd /ncov && snakemake --printshellcmds auspice/ncov_aspen.json --profile my_profiles/aspen/ --resources=mem_mb=312320) || { $aws s3 cp /ncov/.snakemake/log/ "${s3_prefix}/logs/snakemake/" --recursive ; $aws s3 cp /ncov/logs/ "${s3_prefix}/logs/ncov/" --recursive ; }
 
 # upload the tree to S3
-key="${key_prefix}/ncov_aspen.json"
+key="${key_prefix}/ncov_aspen_3m.json"
 $aws s3 cp /ncov/auspice/ncov_aspen.json "s3://${aspen_s3_db_bucket}/${key}"
 
 # update aspen


### PR DESCRIPTION
I'm not confident in the solution here, just leaving this as a note. But not sure how robust it is to put a stopgap on a [stopgap](https://github.com/chanzuckerberg/aspen/pull/874) for tree names on the tree table.

Not sure what is the usage of this argument: https://github.com/chanzuckerberg/aspen/blob/4d75b11391f45ab09acdeb85d16bc4841bba5fce/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh#L104