### PR TITLE
Maya/177246 use phylo runs v2

### DIFF
--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -6,10 +6,9 @@ export enum API {
   SAMPLES = "/v2/samples/",
   LOG_IN = "/login",
   LOG_OUT = "/logout",
-  PHYLO_TREES = "/api/phylo_trees",
   SAMPLES_CREATE = "/api/samples/create",
   SAMPLES_FASTA_DOWNLOAD = "/api/sequences",
-  PHYLO_TREES_V2 = "/v2/phylo_runs/", // TODO (mlila): convert entire frontend to use new endpoint
+  PHYLO_TREES = "/v2/phylo_runs/",
   GET_FASTA_URL = "/api/sequences/getfastaurl",
   USHER_TREE_OPTIONS = "/api/usher/tree_options",
   SAMPLES_VALIDATE_IDS = "/api/samples/validate-ids",
@@ -47,7 +46,7 @@ export const DEFAULT_DELETE_OPTIONS: RequestInit = {
 
 const API_KEY_TO_TYPE: Record<string, string> = {
   group: "Group",
-  phylo_trees: "Tree",
+  phylo_runs: "Tree",
   samples: "Sample",
   user: "User",
 };
@@ -116,7 +115,7 @@ export const fetchSamples = (): Promise<SampleResponse> =>
   apiResponse<SampleResponse>(["samples"], [SAMPLE_MAP], API.SAMPLES);
 
 export interface TreeResponse extends APIResponse {
-  phylo_trees: Tree[];
+  phylo_runs: Tree[];
 }
 const TREE_MAP = new Map<string, keyof Tree>([
   ["phylo_tree_id", "id"],
@@ -127,4 +126,4 @@ const TREE_MAP = new Map<string, keyof Tree>([
   ["workflow_id", "workflowId"],
 ]);
 export const fetchTrees = (): Promise<TreeResponse> =>
-  apiResponse<TreeResponse>(["phylo_trees"], [TREE_MAP], API.PHYLO_TREES);
+  apiResponse<TreeResponse>(["phylo_runs"], [TREE_MAP], API.PHYLO_TREES);

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -118,12 +118,10 @@ export interface TreeResponse extends APIResponse {
   phylo_runs: Tree[];
 }
 const TREE_MAP = new Map<string, keyof Tree>([
-  ["phylo_tree_id", "id"],
-  ["pathogen_genome_count", "pathogenGenomeCount"],
-  ["completed_date", "creationDate"],
+  ["end_datetime", "creationDate"],
   ["tree_type", "treeType"],
-  ["started_date", "startedDate"],
-  ["workflow_id", "workflowId"],
+  ["start_datetime", "startedDate"],
+  ["workflow_status", "status"],
 ]);
 export const fetchTrees = (): Promise<TreeResponse> =>
   apiResponse<TreeResponse>(["phylo_runs"], [TREE_MAP], API.PHYLO_TREES);

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteTreeConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteTreeConfirmationModal/index.tsx
@@ -30,11 +30,11 @@ const DeleteTreeConfirmationModal = ({
 
   if (!tree) return null;
 
-  const { workflowId, name } = tree;
+  const { id, name } = tree;
 
   const onDelete = () => {
     deleteTreeMutation.mutate({
-      treeIdToDelete: workflowId,
+      treeIdToDelete: id,
     });
     onClose();
   };

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -164,7 +164,7 @@ export function useTreeInfo(): UseQueryResult<TreeResponse, unknown> {
 
 type TreeDeleteCallbacks = MutationCallbacks<TreeDeleteResponseType>;
 interface TreeDeleteRequestType {
-  treeIdToDelete: string;
+  treeIdToDelete: number;
 }
 
 interface TreeDeleteResponseType {

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -49,7 +49,7 @@ async function createTree({
     samples: sampleIds,
     tree_type: treeType,
   };
-  const response = await fetch(API_URL + API.PHYLO_TREES_V2, {
+  const response = await fetch(API_URL + API.PHYLO_TREES, {
     ...DEFAULT_POST_OPTIONS,
     body: JSON.stringify(payload),
   });
@@ -174,7 +174,7 @@ interface TreeDeleteResponseType {
 export async function deleteTree({
   treeIdToDelete,
 }: TreeDeleteRequestType): Promise<TreeDeleteResponseType> {
-  const response = await fetch(API_URL + API.PHYLO_TREES_V2 + treeIdToDelete, {
+  const response = await fetch(API_URL + API.PHYLO_TREES + treeIdToDelete, {
     ...DEFAULT_DELETE_OPTIONS,
   });
 

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -46,12 +46,10 @@ interface Sample extends BioinformaticsType {
 
 interface Tree extends BioinformaticsType {
   type: "Tree";
-  id?: number;
+  id: number;
   name: string;
-  pathogenGenomeCount: number;
   creationDate: string;
   startedDate: string;
-  workflowId: string;
   status: TREE_STATUS;
   downloadLink?: string;
   user: {

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -162,7 +162,7 @@ const TREE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   },
   name: TreeTableNameCell,
   startedDate: ({ value, header }): JSX.Element => {
-    const dateNoTime = value.split(" ")[0];
+    const dateNoTime = datetimeWithTzToLocalDate(value);
     return (
       <TreeRowContent header={header}>
         <div data-test-id={`row-${header.key}`}>{dateNoTime}</div>

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -84,7 +84,7 @@ const Data: FunctionComponent = () => {
       samples: transformData(sampleData?.samples ?? [], "publicId"),
       // use workflowID as key (failed and started phylotrees do not have an associated PhyloTree ID since they are technically only PhyloRun objects)
       trees: transformData(
-        treeData?.phylo_trees ?? [],
+        treeData?.phylo_runs ?? [],
         "workflowId",
         TREE_TRANSFORMS
       ),

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -82,12 +82,7 @@ const Data: FunctionComponent = () => {
   const { samples, trees } = useMemo(
     () => ({
       samples: transformData(sampleData?.samples ?? [], "publicId"),
-      // use workflowID as key (failed and started phylotrees do not have an associated PhyloTree ID since they are technically only PhyloRun objects)
-      trees: transformData(
-        treeData?.phylo_runs ?? [],
-        "workflowId",
-        TREE_TRANSFORMS
-      ),
+      trees: transformData(treeData?.phylo_runs ?? [], "id", TREE_TRANSFORMS),
     }),
     [sampleData, treeData]
   );


### PR DESCRIPTION
### Summary
- **What:** Use v2 phylo runs api endpoint across entire front end
- **Why:** So we can get rid of the old endpoint
- **Ticket:** [[sc-177246]](https://app.shortcut.com/genepi/story/177246)
- **Env:** https://phyloruns-frontend.dev.czgenepi.org

### Testing
1. Ensure trees still show in trees table as expected
2. Ensure dates in the tree table are formatted properly
1. Ensure action related to tree still perform as expected (ie: deleting, etc)

### Demos
No visual changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)