### PR TITLE
HOTFIX -- Fix missing JSON download link for trees

### DIFF
--- a/src/frontend/src/views/Data/components/TreeActionMenu/components/TreeTableDownloadMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/components/TreeTableDownloadMenu/index.tsx
@@ -8,10 +8,9 @@ import { StyledIcon, StyledIconWrapper } from "../../style";
 
 interface Props {
   item: TableItem;
-  value: string;
 }
 
-const TreeTableDownloadMenu = ({ item, value }: Props): JSX.Element => {
+const TreeTableDownloadMenu = ({ item }: Props): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   const handleClick: MouseEventHandler = (event) => {
@@ -22,7 +21,7 @@ const TreeTableDownloadMenu = ({ item, value }: Props): JSX.Element => {
     setAnchorEl(null);
   };
 
-  const jsonLink = stringGuard(value);
+  const jsonLink = stringGuard(item["downloadLink"]);
   const tsvDownloadLink = stringGuard(item["accessionsLink"]);
   const disabled = item?.status !== TREE_STATUS.Completed;
   // TODO (mlila): This is necessary due to an sds bug -- MUI tooltips should not display

--- a/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
@@ -6,6 +6,20 @@ import TreeTableDownloadMenu from "./components/TreeTableDownloadMenu";
 import { StyledActionWrapper, StyledTreeActionMenu } from "./style";
 
 interface Props {
+  // FIXME kinda sorta, but really more of a REFACTOR ME (Vince)
+  // The `value` is necessary to keep TypeScript happy b/c of how the table
+  // renderers assume structure: they assume there's a single cell
+  // "attached" to a key name, and that key name in the overarching row object
+  // (`item`) should be presented to the cell renderer as a `value` to render.
+  // It also presents the entire `item` as a fallback. However, because
+  // TreeActionMenu sort of represents multiple cells at once, it's not
+  // reasonable to pass a single cell `value`, and it really only cares about
+  // the whole `item`, which then has its various constituent parts pulled out
+  // by the sub-components.
+  // HOWEVER, because of the fact that the renderer attempts to pass `value`
+  // no matter what, TypeScript gets angry if we just remove it from Props
+  // interface. Instead, we just don't pull the `value` from the passed props
+  // because it's not actually useful to us for this component.
   value: string;
   item: Tree;
   userInfo: UserResponse;
@@ -13,17 +27,18 @@ interface Props {
 }
 
 const TreeActionMenu = ({
+  // `value` unused, see wall of text above. TL;DR in Props to keep TS happy
+  // value,
   item,
   onDeleteTreeModalOpen,
   userInfo,
-  value,
 }: Props): JSX.Element => (
   <StyledTreeActionMenu>
     <StyledActionWrapper>
       <OpenInNextstrainButton item={item} />
     </StyledActionWrapper>
     <StyledActionWrapper>
-      <TreeTableDownloadMenu item={item} value={value} />
+      <TreeTableDownloadMenu item={item} />
     </StyledActionWrapper>
     <StyledActionWrapper>
       <MoreActionsMenu


### PR DESCRIPTION
### Summary:
- **What:** Allison Black brought this up [in Slack](https://czi-sci.slack.com/archives/C01HYJYA50W/p1640722279417900): going to Phylo Trees table and trying to download the JSON -- "Tree file (.json)" -- wasn't working. When you clicked the link, it just brought you back to the Samples table, but nothing was downloaded. This PR fixes that. See Notes below for what happened.
- **Ticket:** [sc<178847>](https://app.shortcut.com/genepi/story/178847/phylo-tree-table-json-download-broken) -- _Edit:_ I filed a ticket after writing up the PR
- **Env:** https://hotfix-jsontrees-frontend.dev.czgenepi.org/data/samples ... I think? I'm on vacation and have bad internet here, so I'm trying to push an rdev by using the branch naming approach, but I've never done this before and not sure I haven't screwed it up... **IMPORTANT** You can't actually verify this change on the rdev! (Also probably why this bug got through) Because the rdev data is not complete, the phylo tree links always fail when you try to download them. You can kinda verify by looking at the fact that the URL the link is pointing to is "real" though -- see the Demos below.


### Demos:

Before (current picture from Staging)
![image](https://user-images.githubusercontent.com/89553795/147615094-ebaadc45-36f0-4d8b-9d42-9a1aac2f902e.png)

Currently mousing over the "Tree file" link: note the `https://staging.czgenepi.org/data/-` URL it's pointing to in the bottom-left.

----
Now (picture from my local dev branch, what this PR is)
![image](https://user-images.githubusercontent.com/89553795/147615180-9c34042e-c0e1-4636-9eae-323e671bfe8d.png)

Now the link URL in bottom-left is pointing to a real thing.

### Notes:
The root cause of this bug was the restructuring of how the Phylo Tree table presents the various additional options for interaction as part of CRUD work -- the `TreeActionMenu` component. The table renderers assume a key name <--> table row item <--> cell/column identifier connection. This is used to pull the `value` prop for the specific cell renderer. With the restructuring to accomplish CRUD, the download aspect got moved a level down, and while it used to be keyed under the column id of `downloadLink`, that became `actionMenu`, so the `value` prop was now a pull of a non-existent table row value, so when that got sent down to the component actually making the link, it had nothing to target.

Additionally, because rdev and local aren't structured the same as Staging and Prod for the phylo run data, it was very hard to notice this during testing -- the download links already failed in rdev and local. It's just that after this bug, the JSON download started failing for a new reason, but that would have been a very subtle difference to see during testing. It wouldn't become clear it's a bug until after being merged and noticed in Staging/Prod.

That also means **it's very important to test this fix in Staging after it gets merged**, since that's the only place the fix can really be verified.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change -- Kinda, it's hard to verify because the phylo runs aren't the same in local and rdev. But the URL is being generated correctly now and is visible in the link, where it was not before, so I'm confident this will work. But has to be verified for realsies in Staging.
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- ~[ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)~ none needed