### PR TITLE
Quickfix for running CHI trees in staging.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -6,7 +6,7 @@ locals {
 
 module nextstrain_chicago_contextual_sfn_config {
   source   = "../sfn_config"
-  app_name = "nextstrain-chicago-contextual-sfn"
+  app_name = "nextstrain-chi-contextual-sfn"
   image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory


### PR DESCRIPTION
### Summary:
- **What:** Staging deploys are failing because our cloudwatch event names are too long. We probably need  to think harder about our resource naming, but this should improve things for now.

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)