### PR TITLE
use marin for staging run

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -6,7 +6,7 @@ locals {
 
 module nextstrain_chicago_contextual_sfn_config {
   source   = "../sfn_config"
-  app_name = "nextstrain-chi-contextual-sfn"
+  app_name = "nextstrain-chicago-contextual-sfn"
   image    = local.nextstrain_image
   vcpus    = local.nextstrain_sfn_vcpus
   memory   = local.nextstrain_sfn_memory
@@ -18,7 +18,7 @@ module nextstrain_chicago_contextual_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = module.swipe_sfn.step_function_arn
-  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
+  schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
@@ -174,7 +174,7 @@ module nextstrain_marin_contextual_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = module.swipe_sfn.step_function_arn
-  schedule_expressions  = local.nextstrain_cron_schedule
+  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
   event_role_arn        = local.event_role_arn
   extra_args            =  {
     genepi_config_secret_name = "${local.deployment_stage}/genepi-config"


### PR DESCRIPTION
### Summary:
- **What:** Add scheduled tree run in staging and use Marin as county

`genepi-gestaging-gestagingstack-nextstrain-marin-contextual-sfn` would be 63 char sharp XD

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)