### PR TITLE
Remove forbidden "location" field from create_sample API request

### DIFF
--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -147,10 +147,6 @@ export async function createSamples({
         [METADATA_KEYS_TO_API_KEYS.collectionLocation]: collectionLocation!.id,
         [METADATA_KEYS_TO_API_KEYS.keepPrivate]: keepPrivate,
         [METADATA_KEYS_TO_API_KEYS.publicId]: publicId,
-        // The "location" field here will be unused since we are passing a
-        // location_id, but is currently required. This must be removed
-        // when the old location data and methods are cleaned up.
-        location: collectionLocation!.name,
         private_identifier: sampleId,
       },
     };


### PR DESCRIPTION
### Summary:
- **What:** Removes the now forbidden "location" field from the payload in the create sample POST request
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)