### PR TITLE
remove autobuild language from overview tree tooltip

### DIFF
--- a/src/frontend/src/common/utils/featureFlags.tsx
+++ b/src/frontend/src/common/utils/featureFlags.tsx
@@ -21,6 +21,10 @@ export const FEATURE_FLAGS: FlagsObj = {
     isDisabled: true,
     key: "mayasFlag",
   },
+  overviewTrees: {
+    isDisabled: false,
+    key: "overviewTrees",
+  },
 };
 
 const allowedKeys = Object.keys(FEATURE_FLAGS) as string[];

--- a/src/frontend/src/views/Data/components/TreeTypeTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTypeTooltip/index.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from "czifui";
 import React from "react";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
+import { FEATURE_FLAGS, usesFeatureFlag } from "src/common/utils/featureFlags";
 
 interface Props {
   children: React.ReactElement;
@@ -17,7 +18,12 @@ export const TreeTypeTooltip = ({ children, value }: Props): JSX.Element => {
     case "Overview":
       content = `Best for viewing an overall picture of viral diversity within
       your jurisdiction, including genetically similar samples from outside of
-      your jurisdiction. Overview trees are automatically built by CZ GEN EPI every Monday.`;
+      your jurisdiction.`;
+
+      if (!usesFeatureFlag(FEATURE_FLAGS.overviewTrees)) {
+        content += ` Overview trees are automatically built by CZ GEN EPI every Monday.`;
+      }
+
       break;
     case "Non-Contextualized":
       content =


### PR DESCRIPTION
### Summary
- **What:**
  - Add feature flag for on demand overview trees
  - Update copy for tooltip on overview tree type in trees table
- **Why:** we're changing which tree type is automatically generated.
- **Ticket:** [[sc-177236]](https://app.shortcut.com/genepi/story/177236)

### Demos
#### Before: 
<img width="277" alt="Screen Shot 2022-01-10 at 2 39 11 PM" src="https://user-images.githubusercontent.com/7562933/148828604-f6b71fbf-50f5-4b4b-b961-78892054fa99.png">

#### After: 
<img width="286" alt="Screen Shot 2022-01-10 at 2 38 55 PM" src="https://user-images.githubusercontent.com/7562933/148828634-8e3a4ada-b802-4cd3-89b3-dbef15c7f5d7.png">

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)