### PR TITLE
Fix git commands in batch jobs

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -165,7 +165,7 @@ task TransformGISAID {
     raw_gisaid_s3_bucket=$(echo "${raw_gisaid_location}" | jq -r .bucket)
     raw_gisaid_s3_key=$(echo "${raw_gisaid_location}" | jq -r .key)
 
-    git clone --depth 1 git://github.com/nextstrain/ncov-ingest /ncov-ingest
+    git clone --depth 1 https://github.com/nextstrain/ncov-ingest /ncov-ingest
     ncov_ingest_git_rev=$(git -C /ncov-ingest rev-parse HEAD)
 
     # modify location rules from ncov-ingest. Southern San Joaquin Valley would be left blank in the default version
@@ -252,7 +252,7 @@ task AlignGISAID {
     build_id=$(date +%Y%m%d-%H%M)
     
     # We're pinning to a specific git hash in the Dockerfile so we're not cloning this here.
-    # git clone --depth 1 git://github.com/nextstrain/ncov /ncov
+    # git clone --depth 1 https://github.com/nextstrain/ncov /ncov
     ncov_git_rev=$(git -C /ncov rev-parse HEAD)
 
     # fetch the gisaid dataset

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -70,7 +70,7 @@ task nextstrain_workflow {
     mkdir -p /ncov/my_profiles/aspen /ncov/results
 #    (cd /ncov &&
 #     git init &&
-#     git fetch --depth 1 git://github.com/nextstrain/ncov.git df90b457f48ef3d7500927656536cacb16c9a83f &&
+#     git fetch --depth 1 https://github.com/nextstrain/ncov.git df90b457f48ef3d7500927656536cacb16c9a83f &&
 #     git checkout FETCH_HEAD
 #    )
     ncov_git_rev=$(cd /ncov && git rev-parse HEAD)

--- a/src/backend/aspen/workflows/pangolin/install_pangolin.sh
+++ b/src/backend/aspen/workflows/pangolin/install_pangolin.sh
@@ -4,7 +4,7 @@ eval "$($HOME/miniconda/bin/conda shell.bash hook)"
 conda init
 mkdir /pangolin
 cd /pangolin
-git clone git://github.com/cov-lineages/pangolin.git --depth 1 .
+git clone https://github.com/cov-lineages/pangolin.git --depth 1 .
 conda env create -f environment.yml
 conda activate pangolin
 pip install .


### PR DESCRIPTION
GitHub is about to deprecate `git://` URL's, and they've disabled this functionality for the day, breaking some of our batch jobs.

This fixes the `git clone` commands in our jobs by switching to using `https://` protocol instead of `git://`
https://github.blog/2021-09-01-improving-git-protocol-security-github/

### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)