### PR TITLE
Fix phylo run names.

### DIFF
--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -40,6 +40,20 @@ class UserResponse(BaseResponse):
     id: int
     name: str
 
+def humanize_tree_name(values):
+    json_filename = values["s3_key"].split("/")[-1]
+    basename = re.sub(r".json", "", json_filename)
+    if basename == "ncov_aspen":
+        return values["s3_key"].split("/")[1]  # Return the directory name.
+    title_case = basename.replace("_", " ").title()
+    if "Ancestors" in title_case:
+        title_case = title_case.replace("Ancestors", "Contextual")
+    if " Public" in title_case:
+        title_case = title_case.replace(" Public", "")
+    if " Private" in title_case:
+        title_case = title_case.replace(" Private", "")
+    return title_case
+
 
 class TreeResponse(BaseResponse):
     # A root validator gets us access to all fields in a model, so if
@@ -51,16 +65,7 @@ class TreeResponse(BaseResponse):
             return values
 
         # Generate a nice tree name if one doesn't exist
-        json_filename = values["s3_key"].split("/")[-1]
-        basename = re.sub(r".json", "", json_filename)
-        title_case = basename.replace("_", " ").title()
-        if "Ancestors" in title_case:
-            title_case = title_case.replace("Ancestors", "Contextual")
-        if " Public" in title_case:
-            title_case = title_case.replace(" Public", "")
-        if " Private" in title_case:
-            title_case = title_case.replace(" Private", "")
-        values["name"] = title_case
+        values["name"] = humanize_tree_name(values)
 
         # TODO, we need to include this field in the response model so we can interact
         # with it in this method, but ideally we don't want to return it at all.

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -40,6 +40,7 @@ class UserResponse(BaseResponse):
     id: int
     name: str
 
+
 def humanize_tree_name(values):
     json_filename = values["s3_key"].split("/")[-1]
     basename = re.sub(r".json", "", json_filename)


### PR DESCRIPTION
### Summary:
- **What:** When #874 was merged, that PR didn't include a parallel fix for the v2 api endpoint. This just ports the fix over to both apps.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)