### PR TITLE
Revert to older ncov versions

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin master && \
+    git fetch origin 065eb54867a39a175ebce4181f43ddbd8c84b3b4 && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -37,7 +37,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin master && \
+    git fetch origin 065eb54867a39a175ebce4181f43ddbd8c84b3b4 && \
     git reset --hard FETCH_HEAD
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs


### PR DESCRIPTION
### Summary:
- **What:** Ncov broke something in this PR (https://github.com/nextstrain/ncov/pull/814/) that means it can't find our `ncov/results/filtered_gisaid.fasta.xz` file so we're reverting to an older version while we figure it out.

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)