### PR TITLE
Add bulk samples update endpoint

### DIFF
--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -106,12 +106,11 @@ class SampleDeleteResponse(BaseResponse):
 
 class UpdateSamplesBaseRequest(BaseRequest):
     id: int
-    collection_date: datetime.date
-    collection_location: str
-    gisaid: SampleGisaidResponseSchema
-    private: bool
+    collection_date: Optional[datetime.date]
+    collection_location: Optional[str]
+    private: Optional[bool]
     private_identifier: Optional[str]
-    public_identifier: str
+    public_identifier: Optional[str]
     sequencing_date: Optional[datetime.date]
 
 

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -102,3 +102,22 @@ class SampleBulkDeleteResponse(BaseResponse):
 
 class SampleDeleteResponse(BaseResponse):
     id: int
+
+
+class UpdateSamplesBaseRequest(BaseRequest):
+    id: int
+    collection_date: datetime.date
+    collection_location: str
+    gisaid: SampleGisaidResponseSchema
+    private: bool
+    private_identifier: Optional[str]
+    public_identifier: str
+    sequencing_date: Optional[datetime.date]
+
+
+class UpdateSamplesRequest(BaseRequest):
+    samples: List[UpdateSamplesBaseRequest]
+
+
+class UpdateSamplesResponse(BaseResponse):
+    ids: List[int]

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -107,7 +107,7 @@ class SampleDeleteResponse(BaseResponse):
 class UpdateSamplesBaseRequest(BaseRequest):
     id: int
     collection_date: Optional[datetime.date]
-    collection_location: Optional[str]
+    collection_location: Optional[int]
     private: Optional[bool]
     private_identifier: Optional[str]
     public_identifier: Optional[str]

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -109,8 +109,8 @@ class UpdateSamplesBaseRequest(BaseRequest):
     collection_date: Optional[datetime.date]
     collection_location: Optional[int]
     private: Optional[bool]
-    private_identifier: Optional[str]
-    public_identifier: Optional[str]
+    private_identifier: Optional[constr(min_length=1, max_length=128, strict=True)]  # type: ignore
+    public_identifier: Optional[constr(min_length=1, max_length=128, strict=True)]  # type: ignore
     sequencing_date: Optional[datetime.date]
 
 

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -77,8 +77,8 @@ class SampleResponseSchema(BaseResponse):
     collection_date: datetime.date
     collection_location: LocationResponse
     czb_failed_genome_recovery: bool
-    gisaid: SampleGisaidResponseSchema
-    lineage: SampleLineageResponseSchema
+    gisaid: Optional[SampleGisaidResponseSchema]
+    lineage: Optional[SampleLineageResponseSchema]
     private: bool
     private_identifier: Optional[str]
     public_identifier: str
@@ -116,7 +116,3 @@ class UpdateSamplesBaseRequest(BaseRequest):
 
 class UpdateSamplesRequest(BaseRequest):
     samples: List[UpdateSamplesBaseRequest]
-
-
-class UpdateSamplesResponse(BaseResponse):
-    ids: List[int]

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -224,8 +224,10 @@ async def _get_accessible_phylo_runs(db, user, run_id=None, editable=False):
     results = await db.execute(query)
     return results.unique().scalars().all()
 
+
 async def get_editable_phylo_runs(db, user, run_id=None):
     return await _get_accessible_phylo_runs(db, user, run_id, editable=True)
+
 
 async def get_readable_phylo_runs(db, user, run_id=None):
     return await _get_accessible_phylo_runs(db, user, run_id, editable=True)
@@ -239,9 +241,7 @@ async def list_runs(
     user: User = Depends(get_auth_user),
 ) -> PhyloRunsListResponse:
 
-    phylo_runs: Iterable[PhyloRun] = await get_readable_phylo_runs(
-        db, user
-    )
+    phylo_runs: Iterable[PhyloRun] = await get_readable_phylo_runs(db, user)
 
     # filter for only information we need in sample table view
     results: List[PhyloRunResponse] = []

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -230,7 +230,7 @@ async def get_editable_phylo_runs(db, user, run_id=None):
 
 
 async def get_readable_phylo_runs(db, user, run_id=None):
-    return await _get_accessible_phylo_runs(db, user, run_id, editable=True)
+    return await _get_accessible_phylo_runs(db, user, run_id, editable=False)
 
 
 @router.get("/")

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -225,7 +225,8 @@ async def update_samples(
 
     # Make sure these samples exist and are delete-able by the current user.
     sample_db_res = await get_owned_samples_by_ids(db, [sample_id], user)
-
+    print("stop")
+    print("stop")
     # return error message if any samples sumitted for update are not editable by user
 
     # update fields

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -17,8 +17,7 @@ from aspen.api.schemas.samples import (
     SampleDeleteResponse,
     SampleResponseSchema,
     SamplesResponseSchema,
-    UpdateSamplesRequest,
-    UpdateSamplesResponse
+    UpdateSamplesRequest
 )
 from aspen.api.settings import Settings
 from aspen.api.utils import authz_samples_cansee, determine_gisaid_status
@@ -225,7 +224,7 @@ async def update_samples(
     db: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
-) -> UpdateSamplesResponse:
+) -> SamplesResponseSchema:
 
     # reorganize request data to make it easier to update
     reorganized_request_data = {
@@ -233,37 +232,28 @@ async def update_samples(
         for s in update_samples_request.samples
     }
     sample_ids_to_update = reorganized_request_data.keys()
+
     # Make sure these samples exist and are delete-able by the current user.
     sample_db_res = await get_owned_samples_by_ids(db, sample_ids_to_update, user)
     editable_samples = sample_db_res.all()
-
-    # # load the samples.
-    # all_samples_query = sa.select(Sample).options(  # type: ignore
-    #     selectinload(Sample.uploaded_pathogen_genome),
-    #     selectinload(Sample.submitting_group),
-    #     selectinload(Sample.uploaded_by),
-    #     selectinload(Sample.collection_location),
-    # )
-    # user_visible_samples_query = authz_samples_cansee(all_samples_query, None, user)
-    # user_visible_samples_result = await db.execute(user_visible_samples_query)
-    # editable_samples: List[Sample] = (
-    #     user_visible_samples_result.unique().scalars().all()
-    # )
 
     # are there any samples that can't be updated?
     uneditable_samples = [s for s in sample_ids_to_update if s not in [i.id for i in editable_samples]]
     if uneditable_samples:
         raise ex.NotFoundException("some samples cannot be updated")
 
-    # async with db as session:
+    res = SamplesResponseSchema(samples=[])
     for sample in editable_samples:
         update_data = reorganized_request_data[sample.id]
         for key, value in update_data:
-            if value:
+            if value != None:  # We need to be able to set private to False!
                 setattr(sample, key, value)
-
-        db.add(sample)
+        # Sequencing date is handled specially
+        if update_data.sequencing_date:
+            sample.uploaded_pathogen_genome.sequencing_date = update_data.sequencing_date
+        sample.show_private_identifier = True
+        res.samples.append(SampleResponseSchema.from_orm(sample))
 
     await db.commit()
 
-    return UpdateSamplesResponse(ids=[i for i in sample_ids_to_update])
+    return res

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -248,9 +248,6 @@ async def update_samples(
     ]
     if uneditable_samples:
         raise ex.NotFoundException("some samples cannot be updated")
-    # Check that we don't have dupe public/private ID's
-    [sample.private_identifier for sample in editable_samples]
-    [sample.public_identifier for sample in editable_samples]
 
     res = SamplesResponseSchema(samples=[])
     for sample in editable_samples:

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -17,6 +17,8 @@ from aspen.api.schemas.samples import (
     SampleDeleteResponse,
     SampleResponseSchema,
     SamplesResponseSchema,
+    UpdateSamplesRequest,
+    UpdateSamplesResponse
 )
 from aspen.api.settings import Settings
 from aspen.api.utils import authz_samples_cansee, determine_gisaid_status
@@ -211,3 +213,21 @@ async def delete_sample(
     await db.delete(sample)
     await db.commit()
     return SampleDeleteResponse(id=sample_db_id)
+
+
+@router.put("/")
+async def update_samples(
+    update_samples_request: UpdateSamplesRequest,
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+    user: User = Depends(get_auth_user),
+) -> UpdateSamplesResponse:
+
+    # Make sure these samples exist and are delete-able by the current user.
+    sample_db_res = await get_owned_samples_by_ids(db, [sample_id], user)
+
+    # return error message if any samples sumitted for update are not editable by user
+
+    # update fields
+
+    # return response

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -933,3 +933,62 @@ async def test_delete_sample_failures(
         headers=auth_headers,
     )
     assert res.status_code == 200
+
+
+async def test_update_samples_success(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    """
+    Test successful sample deletion by ID
+    """
+    group = group_factory()
+    user = user_factory(group)
+    samples = [
+        sample_factory(
+            group,
+            user,
+            public_identifier="path/to/sample_id1",
+            private_identifier="i_dont_have_spaces1",
+        ),
+        sample_factory(
+            group,
+            user,
+            public_identifier="path/to/sample id2",
+            private_identifier="i have spaces2",
+        ),
+        sample_factory(
+            group,
+            user,
+            public_identifier="path/to/sample_id3",
+            private_identifier="i have spaces3",
+        ),
+    ]
+    for sample in samples:
+        upg = uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+        async_session.add(upg)
+    async_session.add(group)
+    await async_session.commit()
+
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    data = {"samples": [
+        {
+            "id": samples[0].id,
+            "private_identifier": "new_private_identifier",
+        },
+        {
+            "id": samples[1].id,
+            "public_identifier": "new_public_identifier"
+        }
+    ]
+    }
+    res = await http_client.put(
+        f"/v2/samples/",
+        data=data,
+        headers=auth_headers,
+    )
+    #assert res.status_code == 200
+    response = res.json()
+    print("stop ")
+

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -943,7 +943,7 @@ async def test_update_samples_success(
     http_client: AsyncClient,
 ):
     """
-    Test successful sample deletion by ID
+    Test successful sample update
     """
     group = group_factory()
     user = user_factory(group)

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -947,22 +947,28 @@ async def test_update_samples_success(
     """
     group = group_factory()
     user = user_factory(group)
+    location = location_factory(
+        "North America", "USA", "California", "Santa Barbara County"
+    )
     samples = [
         sample_factory(
             group,
             user,
+            location,
             public_identifier="path/to/sample_id1",
             private_identifier="i_dont_have_spaces1",
         ),
         sample_factory(
             group,
             user,
+            location,
             public_identifier="path/to/sample id2",
             private_identifier="i have spaces2",
         ),
         sample_factory(
             group,
             user,
+            location,
             public_identifier="path/to/sample_id3",
             private_identifier="i have spaces3",
         ),

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -362,8 +362,9 @@ def delete_samples(ctx, sample_ids):
 @click.option("--collection-date", required=False, type=str, help="Update the sample collection date")
 @click.option("--sequencing-date", required=False, type=str, help="Update the sample sequencing date")
 @click.option("--private", required=False, type=bool, help="Set whether the sample is private")
+@click.option("--location", required=False, type=int, help="Set the sample's collection location")
 @click.pass_context
-def update_samples(ctx, sample_id, private_id, public_id, collection_date, sequencing_date, private):
+def update_samples(ctx, sample_id, private_id, public_id, collection_date, sequencing_date, private, location):
     api_client = ctx.obj["api_client"]
     if collection_date:
         collection_date = dateparser.parse(collection_date).strftime('%Y-%m-%d')
@@ -375,6 +376,7 @@ def update_samples(ctx, sample_id, private_id, public_id, collection_date, seque
         "private_identifier": private_id,
         "collection_date": collection_date,
         "sequencing_date": sequencing_date,
+        "collection_location": location,
         "private": private,
     }
     # Remove None fields

--- a/src/cli/requirements.txt
+++ b/src/cli/requirements.txt
@@ -1,3 +1,4 @@
 keyring==23.0.1
 click==7.1.2
 auth0-python==3.16.2
+dateparser==1.1.0


### PR DESCRIPTION
### Summary:
- **What:** Add an API endpoint to update sample metadata.
- **Ticket:** [sc171783](https://app.shortcut.com/genepi/story/171783)

### Notes:
This adds an endpoint that accepts a list of samples with metadata fields to update. Any empty or missing metadata fields will be ignored, and only non-empty fields will be modified. 

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)