### PR TITLE
Associate a bot user account with all automated tree builds.

### DIFF
--- a/src/backend/aspen/cli/db.py
+++ b/src/backend/aspen/cli/db.py
@@ -32,6 +32,7 @@ from aspen.database.models import (
     Sample,
     TreeType,
     UploadedPathogenGenome,
+    User,
     Workflow,
     WorkflowStatusType,
 )
@@ -188,6 +189,12 @@ def add_can_see(
     help="Name of tree being created",
 )
 @click.option(
+    "--user",
+    type=str,
+    required=False,
+    help="Email address of the user to associate with the build",
+)
+@click.option(
     "--group-name",
     type=str,
     required=True,
@@ -222,6 +229,7 @@ def add_can_see(
 def create_phylo_run(
     ctx,
     tree_name: str,
+    user: str,
     group_name: str,
     builds_template_args: str,
     git_refspec: str,
@@ -251,6 +259,8 @@ def create_phylo_run(
         workflow.template_args = json.loads(builds_template_args)
         if tree_name:
             workflow.name = tree_name
+        if user:
+            workflow.user = session.query(User).filter(User.email == user).one()
 
         session.add(workflow)
         session.flush()

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -36,6 +36,7 @@ WORKFLOW_ID=$(aspen-cli db create-phylo-run                                     
                   --group-name "${GROUP_NAME}"                                    \
                   --builds-template-args "${TEMPLATE_ARGS}"                       \
                   --tree-name "${S3_FILESTEM} Contextual Recency-Focused Build"   \
+                  --user hello@czgenepi.org                                       \
                   --tree-type "${TREE_TYPE}"
 )
 echo "${WORKFLOW_ID}" >| "/tmp/workflow_id"

--- a/src/backend/database_migrations/versions/20220114_192608_set_autoubuild_tree_user.py
+++ b/src/backend/database_migrations/versions/20220114_192608_set_autoubuild_tree_user.py
@@ -1,0 +1,43 @@
+"""set autoubuild tree user
+
+Create Date: 2022-01-14 19:26:10.048670
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220114_192608"
+down_revision = "20220103_132500"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Create a new bot group and add our bot user to it.
+    create_group_sql = sa.sql.text(
+        "INSERT INTO aspen.groups (name, address, prefix, default_tree_location_id) SELECT 'Bot Users', 'Bot Users', 'bot', id FROM locations WHERE division = 'California' AND location = 'San Mateo County'"
+    )
+    conn.execute(create_group_sql)
+
+    # There's a unique constraint on user.email, so we're not going to accidentally run into dupe users in the next query.
+    create_user_sql = sa.sql.text(
+        "INSERT INTO aspen.users (name, email, auth0_user_id, group_admin, system_admin, group_id, agreed_to_tos) SELECT 'Automatic Build', 'hello@czgenepi.org', 'bot_user', 'f', 'f', id, 'f' FROM groups WHERE prefix = 'bot'"
+    )
+    conn.execute(create_user_sql)
+
+    # All builds with the following properties will be updated to be associated with our new bot user:
+    #  - User ID is null: we don't want to overwrite any user data we already have in the workflows table
+    # AND:
+    #    - Tree name is null: All on-demand tree builds have the name field populated, and we only recently started populating this field for scheduled runs.
+    #    OR:
+    #    - The tree type is OVERVIEW. We don't currently support on-demand runs for OVERVIEW trees, so it's safe to update the user for overview runs with populated name fields.
+    update_trees_sql = sa.sql.text("UPDATE aspen.workflows SET user_id = ( SELECT id FROM users WHERE email = 'hello@czgenepi.org') WHERE id IN (SELECT pr.workflow_id FROM phylo_runs pr INNER JOIN workflows w ON pr.workflow_id = w.id WHERE w.user_id IS NULL AND (pr.name IS NULL OR pr.tree_type = 'OVERVIEW'))")
+    conn.execute(update_trees_sql)
+
+
+def downgrade():
+    raise NotImplementedError("don't downgrade")


### PR DESCRIPTION
### Summary:
- **What:** Associate all automatic builds in the DB with a bot user so the UI doesn't have to "figure out" what to do with empty user fields as much. After this migration is complete, we **will** still have some (though relatively few) tree builds in the db without user id's since we enabled on-demand runs **before** we started tracking which user initiated the run.
- **Ticket:** [sc177356](https://app.shortcut.com/genepi/story/177356)
- **Env:** https://botuser-frontend.dev.czgenepi.org/data/phylogenetic_trees

### Notes:

We're currently setting the user's name to **Automatic Build**, which is what will show up in the frontend. We can use some other name (or even update the name later) if there's a better option.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)