### PR TITLE
Populate most empty phylo tree / run names.

### DIFF
--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import Dict, List, Optional
 
 from pydantic import constr, Field, root_validator, StrictStr, validator
@@ -41,42 +40,9 @@ class UserResponse(BaseResponse):
     name: str
 
 
-def humanize_tree_name(values):
-    json_filename = values["s3_key"].split("/")[-1]
-    basename = re.sub(r".json", "", json_filename)
-    if basename == "ncov_aspen":
-        return values["s3_key"].split("/")[1]  # Return the directory name.
-    title_case = basename.replace("_", " ").title()
-    if "Ancestors" in title_case:
-        title_case = title_case.replace("Ancestors", "Contextual")
-    if " Public" in title_case:
-        title_case = title_case.replace(" Public", "")
-    if " Private" in title_case:
-        title_case = title_case.replace(" Private", "")
-    return title_case
-
-
 class TreeResponse(BaseResponse):
-    # A root validator gets us access to all fields in a model, so if
-    # we need to generate a field as a composite of other fields, this
-    # is how we do it.
-    @root_validator(pre=False)
-    def _set_fields(cls, values: dict) -> dict:
-        if values["name"]:
-            return values
-
-        # Generate a nice tree name if one doesn't exist
-        values["name"] = humanize_tree_name(values)
-
-        # TODO, we need to include this field in the response model so we can interact
-        # with it in this method, but ideally we don't want to return it at all.
-        values["s3_key"] = None
-
-        return values
-
     id: int
     name: Optional[str]
-    s3_key: Optional[str]
 
 
 class PhyloRunResponse(BaseResponse):

--- a/src/backend/aspen/app/views/phylo_trees.py
+++ b/src/backend/aspen/app/views/phylo_trees.py
@@ -32,21 +32,6 @@ from aspen.phylo_tree.identifiers import rename_nodes_on_tree
 PHYLO_TREE_KEY = "phylo_trees"
 
 
-def humanize_tree_name(s3_key: str):
-    json_filename = s3_key.split("/")[-1]
-    basename = re.sub(r".json", "", json_filename)
-    if basename == "ncov_aspen":
-        return s3_key.split("/")[1]  # Return the directory name.
-    title_case = basename.replace("_", " ").title()
-    if "Ancestors" in title_case:
-        title_case = title_case.replace("Ancestors", "Contextual")
-    if " Public" in title_case:
-        title_case = title_case.replace(" Public", "")
-    if " Private" in title_case:
-        title_case = title_case.replace(" Private", "")
-    return title_case
-
-
 def generate_tree_name_from_template(phylo_run: PhyloRun) -> str:
     # template_args should be transparently deserialized into a python dict.
     # but if something is wrong with the data in the column (i.e. the json is
@@ -110,7 +95,7 @@ def phylo_trees():
                 phylo_tree = output
                 result = result | {
                     "phylo_tree_id": phylo_tree.entity_id,
-                    "name": phylo_tree.name or humanize_tree_name(phylo_tree.s3_key),
+                    "name": phylo_tree.name,
                 }
         if not phylo_tree:
             result = result | {

--- a/src/backend/aspen/cli/db.py
+++ b/src/backend/aspen/cli/db.py
@@ -32,6 +32,7 @@ from aspen.database.models import (
     Sample,
     TreeType,
     UploadedPathogenGenome,
+    User,
     Workflow,
     WorkflowStatusType,
 )
@@ -188,6 +189,12 @@ def add_can_see(
     help="Name of tree being created",
 )
 @click.option(
+    "--user",
+    type=str,
+    required=False,
+    help="Email address of the user to associate with the build",
+)
+@click.option(
     "--group-name",
     type=str,
     required=True,
@@ -222,6 +229,7 @@ def add_can_see(
 def create_phylo_run(
     ctx,
     tree_name: str,
+    user: str,
     group_name: str,
     builds_template_args: str,
     git_refspec: str,
@@ -251,6 +259,8 @@ def create_phylo_run(
         workflow.template_args = json.loads(builds_template_args)
         if tree_name:
             workflow.name = tree_name
+        if user:
+            workflow.user = session.query(User).filter(User.email == user).one()
 
         session.add(workflow)
         session.flush()

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -36,6 +36,7 @@ WORKFLOW_ID=$(aspen-cli db create-phylo-run                                     
                   --group-name "${GROUP_NAME}"                                    \
                   --builds-template-args "${TEMPLATE_ARGS}"                       \
                   --tree-name "${S3_FILESTEM} Contextual Recency-Focused Build"   \
+                  --user hello@czgenepi.org                                       \
                   --tree-type "${TREE_TYPE}"
 )
 echo "${WORKFLOW_ID}" >| "/tmp/workflow_id"

--- a/src/backend/database_migrations/versions/20220114_192608_set_autoubuild_tree_user.py
+++ b/src/backend/database_migrations/versions/20220114_192608_set_autoubuild_tree_user.py
@@ -1,0 +1,43 @@
+"""set autoubuild tree user
+
+Create Date: 2022-01-14 19:26:10.048670
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220114_192608"
+down_revision = "20220103_132500"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Create a new bot group and add our bot user to it.
+    create_group_sql = sa.sql.text(
+        "INSERT INTO aspen.groups (name, address, prefix, default_tree_location_id) SELECT 'Bot Users', 'Bot Users', 'bot', id FROM locations WHERE division = 'California' AND location = 'San Mateo County'"
+    )
+    conn.execute(create_group_sql)
+
+    # There's a unique constraint on user.email, so we're not going to accidentally run into dupe users in the next query.
+    create_user_sql = sa.sql.text(
+        "INSERT INTO aspen.users (name, email, auth0_user_id, group_admin, system_admin, group_id, agreed_to_tos) SELECT 'Automatic Build', 'hello@czgenepi.org', 'bot_user', 'f', 'f', id, 'f' FROM groups WHERE prefix = 'bot'"
+    )
+    conn.execute(create_user_sql)
+
+    # All builds with the following properties will be updated to be associated with our new bot user:
+    #  - User ID is null: we don't want to overwrite any user data we already have in the workflows table
+    # AND:
+    #    - Tree name is null: All on-demand tree builds have the name field populated, and we only recently started populating this field for scheduled runs.
+    #    OR:
+    #    - The tree type is OVERVIEW. We don't currently support on-demand runs for OVERVIEW trees, so it's safe to update the user for overview runs with populated name fields.
+    update_trees_sql = sa.sql.text("UPDATE aspen.workflows SET user_id = ( SELECT id FROM users WHERE email = 'hello@czgenepi.org') WHERE id IN (SELECT pr.workflow_id FROM phylo_runs pr INNER JOIN workflows w ON pr.workflow_id = w.id WHERE w.user_id IS NULL AND (pr.name IS NULL OR pr.tree_type = 'OVERVIEW'))")
+    conn.execute(update_trees_sql)
+
+
+def downgrade():
+    raise NotImplementedError("don't downgrade")

--- a/src/backend/database_migrations/versions/20220115_011524_set_tree_build_names.py
+++ b/src/backend/database_migrations/versions/20220115_011524_set_tree_build_names.py
@@ -1,0 +1,54 @@
+"""set tree build names
+
+Create Date: 2022-01-15 01:15:26.068245
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220115_011524"
+down_revision = "20220114_192608"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    old_filenames = sa.sql.text("""
+      UPDATE aspen.phylo_trees SET name =
+        INITCAP( /* title case */
+          REPLACE( /* public */
+          REPLACE( /* private */
+          REPLACE( /* ancestors */
+            REPLACE( /* underscores */
+              REPLACE( /* .json */
+                RIGHT(s3_key, POSITION('/' in REVERSE(s3_key)) - 1) /* Just the filename */
+              , '.json', '') /* Strip .json extension */
+            , '_', ' ') /* Underscores to spaces */
+          , 'ancestors', 'contextual') /* Ancestors -> Contextual */
+          , ' public', '') /* Strip public */
+          , ' private', '') /* Strip private */
+        ) /* title case */
+      WHERE name IS NULL AND s3_key NOT LIKE '%ncov_aspen.json';
+    """)
+    conn.execute(old_filenames)
+
+    new_filenames = sa.sql.text("""
+      UPDATE aspen.phylo_trees SET name =
+        REGEXP_REPLACE(
+            SUBSTRING(s3_key, POSITION('/' in s3_key) + 1) /* strip the first path segment */
+        , '/.*', '')
+      WHERE name IS NULL AND s3_key LIKE '%ncov_aspen.json';
+    """)
+    conn.execute(new_filenames)
+
+    # Copy over the name info we populated in the trees table above to the runs table.
+    update_runs = sa.sql.text("""
+      UPDATE aspen.phylo_runs SET name = (SELECT pt.name FROM aspen.phylo_trees pt INNER JOIN aspen.entities e ON e.id = pt.entity_id WHERE e.producing_workflow_id = aspen.phylo_runs.workflow_id) WHERE name IS NULL
+    """)
+    conn.execute(update_runs)
+
+def downgrade():
+    raise NotImplementedError("don't downgrade")


### PR DESCRIPTION
### Summary:
- **What:** Populate tree names in the DB.
- **Ticket:** [sc177367](https://app.shortcut.com/genepi/story/177367)
- **Env:** https://treenames-frontend.dev.czgenepi.org

### Notes:
This populates the `name` column for all phylo trees that were built before we supported giving trees explicit names. It  misses updating the `name` field for old failed phylo runs, but I'll address that in a separate PR.

This migration needs to run **after** the user population migration because the previous migration depends on having empty name fields for old phylo runs.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)