### PR TITLE
Support ondemand overview trees

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -2,7 +2,7 @@ locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
   nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 5 ? * MON-SAT *)"] : []
-  default_template_args = jsonencode({"group_sampling_weeks": 12})
+  default_template_args = jsonencode({"filter_start_date": "12 weeks ago", "filter_end_date": "now"})
 }
 
 module nextstrain_chicago_contextual_sfn_config {

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -2,6 +2,7 @@ locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
   nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 5 ? * MON-SAT *)"] : []
+  default_template_args = jsonencode({"group_sampling_weeks": 12})
 }
 
 module nextstrain_chicago_contextual_sfn_config {
@@ -25,7 +26,7 @@ module nextstrain_chicago_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Chicago Department of Public Health"
     s3_filestem              = "Chicago"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -51,7 +52,7 @@ module nextstrain_scc_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Santa Clara County Public Health"
     s3_filestem              = "Santa Clara"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -77,7 +78,7 @@ module nextstrain_alameda_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Alameda County Public Health Department"
     s3_filestem              = "Alameda"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -103,7 +104,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Contra Costa County Public Health Laboratories"
     s3_filestem              = "Contra Costa"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -129,7 +130,7 @@ module nextstrain_fresno_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Fresno County Public Health"
     s3_filestem              = "Fresno"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -155,7 +156,7 @@ module nextstrain_humboldt_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
     s3_filestem              = "Humboldt"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -181,7 +182,7 @@ module nextstrain_marin_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Marin County Department of Health & Human Services"
     s3_filestem              = "Marin"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -207,7 +208,7 @@ module nextstrain_monterey_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Monterey County Health Department"
     s3_filestem              = "Monterey"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -233,7 +234,7 @@ module nextstrain_orange_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Orange County Public Health Laboratory"
     s3_filestem              = "Orange"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -259,7 +260,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Bernardino County Public Health"
     s3_filestem              = "San Bernardino"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -285,7 +286,7 @@ module nextstrain_del_norte_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Del Norte Public Health Laboratory"
     s3_filestem              = "Del Norte"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -311,7 +312,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Joaquin County Public Health Services"
     s3_filestem              = "San Joaquin"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -337,7 +338,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Luis Obispo County Health Agency, Public Health Laboratories"
     s3_filestem              = "San Luis Obispo"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -363,7 +364,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Francisco Public Health Laboratory"
     s3_filestem              = "San Francisco"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -390,7 +391,7 @@ module nextstrain_tulare_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tulare County Public Health Lab"
     s3_filestem              = "Tulare"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -416,7 +417,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tuolumne County Public Health"
     s3_filestem              = "Tuolumne"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -442,7 +443,7 @@ module nextstrain_ventura_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Ventura County Public Health Laboratory"
     s3_filestem              = "Ventura"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -9,7 +9,7 @@ workflow nextstrain {
         String remote_dev_prefix = ""
         String group_name
         String s3_filestem
-        Map[String, String] template_args
+        String template_args
         String tree_type
     }
 
@@ -35,7 +35,7 @@ task nextstrain_workflow {
         String remote_dev_prefix
         String group_name
         String s3_filestem
-        Map[String, String] template_args
+        String template_args
         String tree_type
     }
 

--- a/.happy/terraform/modules/sfn_config/nextstrain.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain.wdl
@@ -9,7 +9,7 @@ workflow nextstrain {
         String remote_dev_prefix = ""
         String group_name
         String s3_filestem
-        Map[String, String] template_args
+        String template_args
         String tree_type
     }
 
@@ -35,7 +35,7 @@ task nextstrain_workflow {
         String remote_dev_prefix
         String group_name
         String s3_filestem
-        Map[String, String] template_args
+        String template_args
         String tree_type
     }
 
@@ -50,7 +50,7 @@ task nextstrain_workflow {
     export S3_FILESTEM="~{s3_filestem}"
     export GROUP_NAME="~{group_name}"
     # We aren't supposed to serialize Map inputs on the command line.
-    export TEMPLATE_ARGS_FILE="~{write_json(template_args)}"
+    export TEMPLATE_ARGS_FILE="~{write_lines([template_args])}"
     export TREE_TYPE="~{tree_type}"
 
     # Just in case the run script bails out before defining these vars

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -18,7 +18,7 @@ PHYLO_TREE_TYPES = [
 class TemplateArgsRequest(BaseRequest):
     filter_start_date: Optional[datetime.date]
     filter_end_date: Optional[datetime.date]
-    filter_pango_lineages: Optional[List[constr(regex=r"^[0-9A-Z.]+$")]]  # noqa
+    filter_pango_lineages: Optional[List[constr(regex=r"^[0-9A-Z.]+$")]]  # type: ignore # noqa
 
 
 class PhyloRunRequest(BaseRequest):

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -2,16 +2,21 @@ import datetime
 import re
 from typing import Dict, List, Optional
 
-from pydantic import constr, Field, root_validator, StrictStr, validator
+from pydantic import conint, constr, Field, root_validator, StrictStr, validator
 
 from aspen.api.schemas.base import BaseRequest, BaseResponse
 from aspen.database.models import TreeType
 
 # What kinds of ondemand nextstrain builds do we support?
-PHYLO_TREE_TYPES = {
-    TreeType.NON_CONTEXTUALIZED.value: "non_contextualized.yaml",
-    TreeType.TARGETED.value: "targeted.yaml",
-}
+PHYLO_TREE_TYPES = [
+    TreeType.OVERVIEW.value,
+    TreeType.NON_CONTEXTUALIZED.value,
+    TreeType.TARGETED.value,
+]
+
+
+class TemplateArgsRequest(BaseRequest):
+    group_sampling_weeks: Optional[conint(ge=1, le=52)]  # type: ignore
 
 
 class PhyloRunRequest(BaseRequest):
@@ -19,11 +24,12 @@ class PhyloRunRequest(BaseRequest):
     name: constr(min_length=1, max_length=128, strict=True)  # type: ignore
     samples: List[StrictStr]
     tree_type: StrictStr
+    template_args: Optional[TemplateArgsRequest]
 
     @validator("tree_type")
     def tree_type_must_be_supported(cls, value):
         uppercase_tree_type = value.upper()
-        assert PHYLO_TREE_TYPES.get(uppercase_tree_type)
+        assert uppercase_tree_type in PHYLO_TREE_TYPES
         return uppercase_tree_type
 
 

--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -2,7 +2,7 @@ import datetime
 import re
 from typing import Dict, List, Optional
 
-from pydantic import conint, constr, Field, root_validator, StrictStr, validator
+from pydantic import constr, Field, root_validator, StrictStr, validator
 
 from aspen.api.schemas.base import BaseRequest, BaseResponse
 from aspen.database.models import TreeType
@@ -16,7 +16,9 @@ PHYLO_TREE_TYPES = [
 
 
 class TemplateArgsRequest(BaseRequest):
-    group_sampling_weeks: Optional[conint(ge=1, le=52)]  # type: ignore
+    filter_start_date: Optional[datetime.date]
+    filter_end_date: Optional[datetime.date]
+    filter_pango_lineages: Optional[List[constr(regex=r"^[0-9A-Z.]+$")]]  # noqa
 
 
 class PhyloRunRequest(BaseRequest):

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -121,12 +121,20 @@ async def kick_off_phylo_run(
     # 4C build our PhyloRun object
     start_datetime = datetime.datetime.now()
 
+    template_args = {}
+    # Not all template_args keys are required, and we don't want to save empty fields.
+    if phylo_run_request.template_args:
+        template_args = {
+            k: v
+            for k, v in dict(phylo_run_request.template_args).items()
+            if v is not None
+        }
     workflow: PhyloRun = PhyloRun(
         start_datetime=start_datetime,
         workflow_status=WorkflowStatusType.STARTED,
         software_versions={},
         group=group,
-        template_args={},  # This field is currently unused, but we might reinstate it later.
+        template_args=template_args,
         name=phylo_run_request.name,
         gisaid_ids=list(gisaid_ids),
         tree_type=TreeType(phylo_run_request.tree_type),

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -124,11 +124,12 @@ async def kick_off_phylo_run(
     template_args = {}
     # Not all template_args keys are required, and we don't want to save empty fields.
     if phylo_run_request.template_args:
-        template_args = {
-            k: v
-            for k, v in dict(phylo_run_request.template_args).items()
-            if v is not None
-        }
+        for k, v in dict(phylo_run_request.template_args).items():
+            if not v:
+                continue  # Skip this field
+            if "date" in k:
+                v = v.strftime("%Y-%m-%d")
+            template_args[k] = v
     workflow: PhyloRun = PhyloRun(
         start_datetime=start_datetime,
         workflow_status=WorkflowStatusType.STARTED,

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -79,6 +79,56 @@ async def test_create_phylo_run_with_failed_sample(
     assert res.status_code == 400
 
 
+async def test_create_phylo_run_with_invalid_args(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    """
+    Test phylo tree creation that includes a reference to a GISAID sequence.
+    """
+    group = group_factory()
+    user = user_factory(group)
+    location = location_factory(
+        "North America", "USA", "California", "Santa Barbara County"
+    )
+    sample = sample_factory(group, user, location)
+    uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
+    gisaid_dump = aligned_gisaid_dump_factory()
+    gisaid_sample = gisaid_metadata_factory()
+    async_session.add(group)
+    async_session.add(gisaid_dump)
+    async_session.add(gisaid_sample)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    requests = [
+        {
+            "filter_start_date": "bob",
+        },
+        {
+            "filter_end_date": "01-01-01",
+        },
+        {
+            "filter_pango_lineages": "B.1",
+        },
+        {
+            "filter_pango_lineages": ["FOO_BAR"],
+        },
+    ]
+    request_body = {
+        "name": "test phylorun",
+        "tree_type": "overview",
+        "samples": [sample.public_identifier, gisaid_sample.strain],
+        "template_args": {},
+    }
+    for args in requests:
+        request_body["template_args"] = args
+        res = await http_client.post(
+            "/v2/phylo_runs/", json=request_body, headers=auth_headers
+        )
+        assert res.status_code == 422
+
+
 async def test_create_phylo_run_with_template_args(
     async_session: AsyncSession,
     http_client: AsyncClient,
@@ -101,19 +151,42 @@ async def test_create_phylo_run_with_template_args(
     await async_session.commit()
 
     auth_headers = {"user_id": user.auth0_user_id}
-    data = {
-        "name": "test phylorun",
-        "tree_type": "overview",
-        "samples": [sample.public_identifier, gisaid_sample.strain],
-        "template_args": {"group_sampling_weeks": 6},
-    }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
-    assert res.status_code == 200
-    response = res.json()
-    assert response["template_args"] == {"group_sampling_weeks": 6}
-    assert response["workflow_status"] == "STARTED"
-    assert response["group"]["name"] == group.name
-    assert "id" in response
+    requests = [
+        {
+            "name": "test phylorun",
+            "tree_type": "overview",
+            "samples": [sample.public_identifier, gisaid_sample.strain],
+            "template_args": {
+                "filter_start_date": "2021-01-20",
+                "filter_end_date": "2022-01-20",
+                "filter_pango_lineages": ["A", "B.1.166"],
+            },
+        },
+        {
+            "name": "test phylorun",
+            "tree_type": "overview",
+            "samples": [sample.public_identifier, gisaid_sample.strain],
+            "template_args": {
+                "filter_start_date": "2021-01-20",
+            },
+        },
+        {
+            "name": "test phylorun",
+            "tree_type": "overview",
+            "samples": [sample.public_identifier, gisaid_sample.strain],
+            "template_args": {
+                "filter_pango_lineages": ["FOO.BAR"],
+            },
+        },
+    ]
+    for data in requests:
+        res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+        assert res.status_code == 200
+        response = res.json()
+        assert response["template_args"] == data["template_args"]
+        assert response["workflow_status"] == "STARTED"
+        assert response["group"]["name"] == group.name
+        assert "id" in response
 
 
 async def test_create_phylo_run_with_gisaid_ids(

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -122,7 +122,7 @@ async def test_create_phylo_run_with_invalid_args(
         "template_args": {},
     }
     for args in requests:
-        request_body["template_args"] = args
+        request_body["template_args"] = args  # type: ignore
         res = await http_client.post(
             "/v2/phylo_runs/", json=request_body, headers=auth_headers
         )

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -29,9 +29,12 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
                 "query"
             ] = '''--query "((location == '{location}') & (division == '{division}')) | submitting_lab == 'RIPHL at Rush University Medical Center'"'''
 
+        # If we passed in a different time window, use it. Default to 12
+        cutoff_weeks = self.template_args.get("group_sampling_weeks", 12)
+
         # only keep group samples within the past 3 months
         today = datetime.date.today()
-        early_late_cutoff = today - datetime.timedelta(weeks=12)
+        early_late_cutoff = today - datetime.timedelta(weeks=cutoff_weeks)
 
         subsampling["group"][
             "min_date"

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -50,6 +50,11 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
             subsampling["country"]["max_sequences"] = 800
             subsampling["international"]["max_sequences"] = 200
 
+        # If there aren't any selected samples this is probably a scheduled run
+        # and we should, use the reference sequences
+        if config.num_included_samples == 0:
+            del config["files"]["include"]
+
 
 class NonContextualizedBuilder(BaseNextstrainConfigBuilder):
     subsampling_scheme = "NON_CONTEXTUALIZED"

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -51,8 +51,8 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
             subsampling["international"]["max_sequences"] = 200
 
         # If there aren't any selected samples this is probably a scheduled run
-        # and we should, use the reference sequences
-        if config.num_included_samples == 0:
+        # and we should use the reference sequences
+        if self.num_included_samples == 0:
             del config["files"]["include"]
 
 
@@ -78,8 +78,8 @@ class TargetedBuilder(BaseNextstrainConfigBuilder):
           self.subsampling_scheme : the value a few lines above
           self.crowding_penalty : the value a few lines above
           self.group : information about the group that this run is for (ex: self.group.name or self.group.default_tree_location)
-          config.num_sequences : the number of aspen samples written to our fasta input file
-          config.num_included_samples : the number of samples in include.txt (aspen + gisaid samples) for on-demand runs only
+          self.num_sequences : the number of aspen samples written to our fasta input file
+          self.num_included_samples : the number of samples in include.txt (aspen + gisaid samples) for on-demand runs only
 
         EXAMPLES SECTION:
           Delete a group from a subsampling scheme:

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -24,7 +24,6 @@ from aspen.database.models import (
     PhyloRun,
     PublicRepositoryType,
     Sample,
-    TreeType,
     UploadedPathogenGenome,
 )
 from aspen.database.models.workflow import Workflow

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -115,14 +115,12 @@ def export_run_config(
             session, county_samples, sequences_fh, metadata_fh
         )
 
-        # Write include.txt file(s) for targeted/non_contextualized builds.
-        if phylo_run.tree_type != TreeType.OVERVIEW:
-            selected_samples: List[PathogenGenome] = [
-                inp for inp in phylo_run.inputs if isinstance(inp, PathogenGenome)
-            ]
-            num_included_samples = write_includes_file(
-                session, phylo_run.gisaid_ids, selected_samples, selected_fh
-            )
+        selected_samples: List[PathogenGenome] = [
+            inp for inp in phylo_run.inputs if isinstance(inp, PathogenGenome)
+        ]
+        num_included_samples = write_includes_file(
+            session, phylo_run.gisaid_ids, selected_samples, selected_fh
+        )
 
         # Give the nexstrain config builder some info to make decisions
         context = {

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -61,10 +61,6 @@ aligned_gisaid_location=$(
            --builds-file /ncov/my_profiles/aspen/builds.yaml       \
 )
 
-# temporary fix for recency focused automatic build
-# even if the group has no samples in the past 3 months, the run will not fail
-sed -i '/include\.txt/d' /ncov/my_profiles/aspen/builds.yaml
-
 # Persist the build config we generated.
 $aws s3 cp /ncov/my_profiles/aspen/builds.yaml "${s3_prefix}/builds.yaml"
 

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -1,5 +1,5 @@
-from io import StringIO
 import datetime
+from io import StringIO
 from typing import List, Optional
 
 import yaml
@@ -140,7 +140,9 @@ def test_overview_config_scheduled(mocker, session, postgres_database):
         subsampling_scheme["group"]["query"]
         == "--query \"(location == '{location}') & (division == '{division}')\""
     )
-    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=12)).strftime("%Y-%m-%d")
+    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=12)).strftime(
+        "%Y-%m-%d"
+    )
     assert subsampling_scheme["group"]["min_date"] == f"--min-date {cutoff_date}"
     assert len(selected.splitlines()) == 0  # No selected sequences
     assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
@@ -158,7 +160,9 @@ def test_overview_config_ondemand(mocker, session, postgres_database):
 
     subsampling_scheme = nextstrain_config["subsampling"][tree_type.value]
 
-    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=5)).strftime("%Y-%m-%d")
+    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=5)).strftime(
+        "%Y-%m-%d"
+    )
     assert nextstrain_config["files"]["include"] == "data/include.txt"
     assert subsampling_scheme["group"]["min_date"] == f"--min-date {cutoff_date}"
     assert subsampling_scheme["group"]["max_sequences"] == 2000

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import datetime
 from typing import List, Optional
 
 import yaml
@@ -22,6 +23,7 @@ def create_test_data(
     group_name=None,  # Override group name
     group_location=None,  # Override group location
     group_division=None,  # Override group division
+    template_args=None,  # Send template args
 ):
     if group_name is None:
         group_name = f"testgroup-{tree_type.value}"
@@ -70,12 +72,14 @@ def create_test_data(
 
     inputs = selected_samples + [gisaid_dump]
     session.add_all(inputs)
+    if template_args is None:
+        template_args = {}
     phylo_run = phylorun_factory(
         group,
         inputs=inputs,
         gisaid_ids=gisaid_samples,
         tree_type=tree_type,
-        template_args={},
+        template_args=template_args,
         workflow_status=WorkflowStatusType.STARTED,
     )
     session.add(phylo_run)
@@ -120,7 +124,7 @@ def test_build_config(mocker, session, postgres_database):
 
 
 # Make sure that configs specific to an Overview tree are working.
-def test_overview_config(mocker, session, postgres_database):
+def test_overview_config_scheduled(mocker, session, postgres_database):
     mock_remote_db_uri(mocker, postgres_database.as_uri())
 
     tree_type = TreeType.OVERVIEW
@@ -130,12 +134,39 @@ def test_overview_config(mocker, session, postgres_database):
     subsampling_scheme = nextstrain_config["subsampling"][tree_type.value]
 
     # Just some placeholder sanity-checks
+    assert "include" not in nextstrain_config["files"]
     assert subsampling_scheme["group"]["max_sequences"] == 2000
     assert (
         subsampling_scheme["group"]["query"]
         == "--query \"(location == '{location}') & (division == '{division}')\""
     )
+    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=12)).strftime("%Y-%m-%d")
+    assert subsampling_scheme["group"]["min_date"] == f"--min-date {cutoff_date}"
     assert len(selected.splitlines()) == 0  # No selected sequences
+    assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
+    assert len(sequences.splitlines()) == 20  # 10 county samples, @2 lines each
+
+
+# Make sure that configs specific to an Overview tree are working.
+def test_overview_config_ondemand(mocker, session, postgres_database):
+    mock_remote_db_uri(mocker, postgres_database.as_uri())
+
+    tree_type = TreeType.OVERVIEW
+    query = {"group_sampling_weeks": 5}
+    phylo_run = create_test_data(session, tree_type, 10, 5, 5, template_args=query)
+    sequences, selected, metadata, nextstrain_config = generate_run(phylo_run.id)
+
+    subsampling_scheme = nextstrain_config["subsampling"][tree_type.value]
+
+    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=5)).strftime("%Y-%m-%d")
+    assert nextstrain_config["files"]["include"] == "data/include.txt"
+    assert subsampling_scheme["group"]["min_date"] == f"--min-date {cutoff_date}"
+    assert subsampling_scheme["group"]["max_sequences"] == 2000
+    assert (
+        subsampling_scheme["group"]["query"]
+        == "--query \"(location == '{location}') & (division == '{division}')\""
+    )
+    assert len(selected.splitlines()) == 10  # 5 gisaid samples + 5 selected samples
     assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
     assert len(sequences.splitlines()) == 20  # 10 county samples, @2 lines each
 

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -1,7 +1,7 @@
-import datetime
 from io import StringIO
 from typing import List, Optional
 
+import dateparser
 import yaml
 from sqlalchemy.sql.expression import and_
 
@@ -124,7 +124,7 @@ def test_build_config(mocker, session, postgres_database):
 
 
 # Make sure that configs specific to an Overview tree are working.
-def test_overview_config_scheduled(mocker, session, postgres_database):
+def test_overview_config_no_filters(mocker, session, postgres_database):
     mock_remote_db_uri(mocker, postgres_database.as_uri())
 
     tree_type = TreeType.OVERVIEW
@@ -140,10 +140,9 @@ def test_overview_config_scheduled(mocker, session, postgres_database):
         subsampling_scheme["group"]["query"]
         == "--query \"(location == '{location}') & (division == '{division}')\""
     )
-    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=12)).strftime(
-        "%Y-%m-%d"
-    )
-    assert subsampling_scheme["group"]["min_date"] == f"--min-date {cutoff_date}"
+    assert "min_date" not in subsampling_scheme["group"]
+    assert "max_date" not in subsampling_scheme["group"]
+    assert "pango_lineage" not in subsampling_scheme["group"]["query"]
     assert len(selected.splitlines()) == 0  # No selected sequences
     assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
     assert len(sequences.splitlines()) == 20  # 10 county samples, @2 lines each
@@ -154,21 +153,25 @@ def test_overview_config_ondemand(mocker, session, postgres_database):
     mock_remote_db_uri(mocker, postgres_database.as_uri())
 
     tree_type = TreeType.OVERVIEW
-    query = {"group_sampling_weeks": 5}
+    query = {
+        "filter_start_date": "2021-04-30",
+        "filter_end_date": "10 days ago",
+        "filter_pango_lineages": ["AY", "B.1.116"],
+    }
     phylo_run = create_test_data(session, tree_type, 10, 5, 5, template_args=query)
     sequences, selected, metadata, nextstrain_config = generate_run(phylo_run.id)
 
     subsampling_scheme = nextstrain_config["subsampling"][tree_type.value]
 
-    cutoff_date = (datetime.date.today() - datetime.timedelta(weeks=5)).strftime(
-        "%Y-%m-%d"
-    )
+    max_date = dateparser.parse("10 days ago").strftime("%Y-%m-%d")
     assert nextstrain_config["files"]["include"] == "data/include.txt"
-    assert subsampling_scheme["group"]["min_date"] == f"--min-date {cutoff_date}"
+    assert nextstrain_config["builds"]["aspen"]["pango_lineage"] == '["AY", "B.1.116"]'
+    assert subsampling_scheme["group"]["min_date"] == "--min-date 2021-04-30"
+    assert subsampling_scheme["group"]["max_date"] == f"--max-date {max_date}"
     assert subsampling_scheme["group"]["max_sequences"] == 2000
     assert (
         subsampling_scheme["group"]["query"]
-        == "--query \"(location == '{location}') & (division == '{division}')\""
+        == "--query \"(location == '{location}') & (division == '{division}') & (pango_lineage in {pango_lineage})\""
     )
     assert len(selected.splitlines()) == 10  # 5 gisaid samples + 5 selected samples
     assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line

--- a/src/backend/poetry.lock
+++ b/src/backend/poetry.lock
@@ -158,6 +158,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "backports.zoneinfo"
+version = "0.2.1"
+description = "Backport of the standard library zoneinfo module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+tzdata = ["tzdata"]
+
+[[package]]
 name = "black"
 version = "21.9b0"
 description = "The uncompromising code formatter."
@@ -286,6 +297,25 @@ pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+
+[[package]]
+name = "dateparser"
+version = "1.1.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = "*"
+regex = "<2019.02.19 || >2019.02.19,<2021.8.27 || >2021.8.27"
+tzlocal = "*"
+
+[package.extras]
+calendars = ["convertdate", "hijri-converter", "convertdate"]
+fasttext = ["fasttext"]
+langdetect = ["langdetect"]
 
 [[package]]
 name = "decorator"
@@ -1034,6 +1064,18 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pytz-deprecation-shim"
+version = "0.1.0.post0"
+description = "Shims to make deprecation of pytz easier"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+
+[package.dependencies]
+"backports.zoneinfo" = {version = "*", markers = "python_version >= \"3.6\" and python_version < \"3.9\""}
+tzdata = {version = "*", markers = "python_version >= \"3.6\""}
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -1045,7 +1087,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 name = "regex"
 version = "2021.9.30"
 description = "Alternative regular expression module, to replace re."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1371,6 +1413,31 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "tzdata"
+version = "2021.5"
+description = "Provider of IANA time zone data"
+category = "main"
+optional = false
+python-versions = ">=2"
+
+[[package]]
+name = "tzlocal"
+version = "4.1"
+description = "tzinfo object for the local timezone"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
+pytz-deprecation-shim = "*"
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["black", "pyroma", "pytest-cov", "zest.releaser"]
+test = ["pytest-mock (>=3.3)", "pytest (>=4.3)"]
+
+[[package]]
 name = "urllib3"
 version = "1.26.6"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1478,7 +1545,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4b8b6cc6ba8ab1cee90c65731aadfc55057befc30f1a8abc37b6e3e04a1748a8"
+content-hash = "767a5063cd9ab77bbfbf47307012704a480857720bfe37de575e076424e1dfd0"
 
 [metadata.files]
 alembic = [
@@ -1538,6 +1605,24 @@ awscli = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+"backports.zoneinfo" = [
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
+    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
 ]
 black = [
     {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
@@ -1632,6 +1717,10 @@ cryptography = [
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
+]
+dateparser = [
+    {file = "dateparser-1.1.0-py2.py3-none-any.whl", hash = "sha256:fec344db1f73d005182e214c0ff27313c748bbe0c1638ce9d48a809ddfdab2a0"},
+    {file = "dateparser-1.1.0.tar.gz", hash = "sha256:faa2b97f51f3b5ff1ba2f17be90de2b733fb6191f89b4058787473e8202f3044"},
 ]
 decorator = [
     {file = "decorator-5.1.0-py3-none-any.whl", hash = "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374"},
@@ -2110,6 +2199,10 @@ pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
+pytz-deprecation-shim = [
+    {file = "pytz_deprecation_shim-0.1.0.post0-py2.py3-none-any.whl", hash = "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6"},
+    {file = "pytz_deprecation_shim-0.1.0.post0.tar.gz", hash = "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"},
+]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
     {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
@@ -2329,6 +2422,14 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
     {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+]
+tzdata = [
+    {file = "tzdata-2021.5-py2.py3-none-any.whl", hash = "sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5"},
+    {file = "tzdata-2021.5.tar.gz", hash = "sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21"},
+]
+tzlocal = [
+    {file = "tzlocal-4.1-py3-none-any.whl", hash = "sha256:28ba8d9fcb6c9a782d6e0078b4f6627af1ea26aeaa32b4eab5324abc7df4149f"},
+    {file = "tzlocal-4.1.tar.gz", hash = "sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},

--- a/src/backend/poetry.lock
+++ b/src/backend/poetry.lock
@@ -1381,6 +1381,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-dateparser"
+version = "1.0.12"
+description = "Typing stubs for dateparser"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-pytz"
 version = "2021.1.2"
 description = "Typing stubs for pytz"
@@ -1545,7 +1553,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "767a5063cd9ab77bbfbf47307012704a480857720bfe37de575e076424e1dfd0"
+content-hash = "bfd151fbba10c74746f20d87f5b3d6982c15d01ec1e42431c1774df6a0df3558"
 
 [metadata.files]
 alembic = [
@@ -2405,6 +2413,10 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+types-dateparser = [
+    {file = "types-dateparser-1.0.12.tar.gz", hash = "sha256:5c00e12a6cf819aee1d50147c4274f44eabeb765015718336946df31efb8f70c"},
+    {file = "types_dateparser-1.0.12-py3-none-any.whl", hash = "sha256:98c796a19d4a2638ebc761bfb2f65e4183d379a69f5dc0942fd08ffb67669b0f"},
 ]
 types-pytz = [
     {file = "types-pytz-2021.1.2.tar.gz", hash = "sha256:448828a06f2aaa840e57364d866c661645a045e532f817e4f10c8c3ab2b66651"},

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -71,3 +71,6 @@ sqlalchemy-stubs = "^0.4"
 types-pytz = "^2021.1.2"
 types-requests = "^2.25.9"
 typing-extensions = "^3.10.0"
+
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::pytz_deprecation_shim.PytzUsageWarning"]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -54,6 +54,7 @@ autoflake = "^1.4"
 types-PyYAML = "^6.0.1"
 orjson = "^3.6.5"
 dateparser = "^1.1.0"
+types-dateparser = "^1.0.12"
 
 [tool.poetry.dev-dependencies]
 alembic = "^1.7.3"

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -53,6 +53,7 @@ pytest-asyncio = "^0.15.1"
 autoflake = "^1.4"
 types-PyYAML = "^6.0.1"
 orjson = "^3.6.5"
+dateparser = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 alembic = "^1.7.3"

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -29,7 +29,7 @@ from aspen.database.models import (
 from aspen.database.models.workflow import SoftwareNames
 
 
-def create_test_group(session, group_name, prefix):
+def create_test_group(session, group_name, prefix, default_tree_location):
     g = session.query(Group).filter(Group.name == group_name).one_or_none()
     if g:
         print("Group already exists")
@@ -39,6 +39,7 @@ def create_test_group(session, group_name, prefix):
         name=group_name,
         address="123 Example St, Redwood City CA",
         prefix=prefix,
+        default_tree_location=default_tree_location,
     )
     session.add(g)
     session.commit()
@@ -328,18 +329,18 @@ def create_test_data(engine):
     _ = create_gisaid(session)
 
     # Create db rows for our main test user
-    group = create_test_group(session, "CZI", "CZI")
-    user = create_test_user(session, group, "User1", "Test User")
     location = create_location(
         session, "North America", "USA", "California", "San Mateo County"
     )
+    group = create_test_group(session, "CZI", "CZI", location)
+    user = create_test_user(session, group, "User1", "Test User")
     create_samples(session, group, user, location, 10, 5)
     create_test_trees(session, group, user)
 
     # Create db rows for another group
-    group2 = create_test_group(session, "Timbuktu Dept of Public Health", "TBK")
-    user2 = create_test_user(session, group2, "tbktu", "Timbuktu User")
     location2 = create_location(session, "Africa", "Mali", "Timbuktu", None)
+    group2 = create_test_group(session, "Timbuktu Dept of Public Health", "TBK", location2)
+    user2 = create_test_user(session, group2, "tbktu", "Timbuktu User")
     create_samples(session, group2, user2, location2, 10, 10)
     create_test_trees(session, group2, user2)
 

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -339,7 +339,9 @@ def create_test_data(engine):
 
     # Create db rows for another group
     location2 = create_location(session, "Africa", "Mali", "Timbuktu", None)
-    group2 = create_test_group(session, "Timbuktu Dept of Public Health", "TBK", location2)
+    group2 = create_test_group(
+        session, "Timbuktu Dept of Public Health", "TBK", location2
+    )
     user2 = create_test_user(session, group2, "tbktu", "Timbuktu User")
     create_samples(session, group2, user2, location2, 10, 10)
     create_test_trees(session, group2, user2)

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -432,12 +432,16 @@ def phylo_runs():
 @phylo_runs.command(name="create")
 @click.option("-n","--name", required=True, type=str)
 @click.option("-t","--type", "tree_type", required=True, type=click.Choice(["OVERVIEW", "TARGETED", "NON_CONTEXTUALIZED"], case_sensitive=False))
+@click.option("-a","--template-args", "template_args", required=False, type=str)
 @click.option("-h", "--show-headers", is_flag=True)
 @click.argument("sample_ids", nargs=-1)
 @click.pass_context
-def start_phylo_run_v2(ctx, name, tree_type, sample_ids, show_headers):
+def start_phylo_run_v2(ctx, name, tree_type, template_args, sample_ids, show_headers):
     api_client = ctx.obj["api_client"]
     payload = { "name": name, "tree_type": tree_type, "samples": sample_ids }
+    if template_args:
+        payload["template_args"] = json.loads(template_args)
+    print(json.dumps(payload))
     resp = api_client.post("/v2/phylo_runs/", json=payload)
     if show_headers:
         print(resp.headers)


### PR DESCRIPTION
### Summary:
- **What:** Adding support for running on-demand overview trees with date range filters
- **Ticket:** [sc175560](https://app.shortcut.com/genepi/story/175560)
- **Env:** https://ondemand-frontend.dev.czgenepi.org

### Notes:
This adds support for running on-demand overview tree builds with selected samples *with configurable date filters.* 

Support for on-demand overview trees only consumes a few lines of this PR:
- Updating our API validation to allow tree_type=overview
- Make YAML builder aware of when to remove the files.include config for overview trees

Most of the rest of the changes re-add support for the `template_args` field in our phylo runs. This field has been unused for awhile, so there were a few codepoints that needed to be updated to read and write it properly.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)