### PR TITLE
Danrlu/update ncov

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -1,8 +1,34 @@
 locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
-  nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 5 ? * MON-SAT *)"] : []
+  nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 11 ? * MON-SAT *)"] : []
   default_template_args = jsonencode({"filter_start_date": "12 weeks ago", "filter_end_date": "now"})
+}
+
+module nextstrain_marin_contextual_sfn_config {
+  source   = "../sfn_config"
+  app_name = "nextstrain-marin-contextual-sfn"
+  image    = local.nextstrain_image
+  vcpus    = local.nextstrain_sfn_vcpus
+  memory   = local.nextstrain_sfn_memory
+  wdl_path = "workflows/nextstrain.wdl"
+  custom_stack_name     = local.custom_stack_name
+  deployment_stage      = local.deployment_stage
+  remote_dev_prefix     = local.remote_dev_prefix
+  stack_resource_prefix = local.stack_resource_prefix
+  swipe_comms_bucket    = local.swipe_comms_bucket
+  swipe_wdl_bucket      = local.swipe_wdl_bucket
+  sfn_arn               = local.swipe_sfn_arn
+  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 11 ? * MON-SAT *)"] : []
+  event_role_arn        = local.event_role_arn
+  extra_args            =  {
+    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
+    remote_dev_prefix        = local.remote_dev_prefix
+    group_name               = "Marin County Department of Health & Human Services"
+    s3_filestem              = "Marin"
+    template_args            = local.default_template_args
+    tree_type                = "OVERVIEW"
+  }
 }
 
 module nextstrain_chicago_contextual_sfn_config {
@@ -156,32 +182,6 @@ module nextstrain_humboldt_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
     s3_filestem              = "Humboldt"
-    template_args            = local.default_template_args
-    tree_type                = "OVERVIEW"
-  }
-}
-
-module nextstrain_marin_contextual_sfn_config {
-  source   = "../sfn_config"
-  app_name = "nextstrain-marin-contextual-sfn"
-  image    = local.nextstrain_image
-  vcpus    = local.nextstrain_sfn_vcpus
-  memory   = local.nextstrain_sfn_memory
-  wdl_path = "workflows/nextstrain.wdl"
-  custom_stack_name     = local.custom_stack_name
-  deployment_stage      = local.deployment_stage
-  remote_dev_prefix     = local.remote_dev_prefix
-  stack_resource_prefix = local.stack_resource_prefix
-  swipe_comms_bucket    = local.swipe_comms_bucket
-  swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = local.swipe_sfn_arn
-  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
-  event_role_arn        = local.event_role_arn
-  extra_args            =  {
-    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
-    remote_dev_prefix        = local.remote_dev_prefix
-    group_name               = "Marin County Department of Health & Human Services"
-    s3_filestem              = "Marin"
     template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
@@ -368,7 +368,6 @@ module nextstrain_san_francisco_contextual_sfn_config {
     tree_type                = "OVERVIEW"
   }
 }
-
 
 module nextstrain_tulare_contextual_sfn_config {
   source   = "../sfn_config"

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -2,6 +2,7 @@ locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
   nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 5 ? * MON-SAT *)"] : []
+  default_template_args = jsonencode({"filter_start_date": "12 weeks ago", "filter_end_date": "now"})
 }
 
 module nextstrain_chicago_contextual_sfn_config {
@@ -17,7 +18,7 @@ module nextstrain_chicago_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -25,7 +26,7 @@ module nextstrain_chicago_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Chicago Department of Public Health"
     s3_filestem              = "Chicago"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -43,7 +44,7 @@ module nextstrain_scc_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -51,7 +52,7 @@ module nextstrain_scc_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Santa Clara County Public Health"
     s3_filestem              = "Santa Clara"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -69,7 +70,7 @@ module nextstrain_alameda_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -77,7 +78,7 @@ module nextstrain_alameda_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Alameda County Public Health Department"
     s3_filestem              = "Alameda"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -95,7 +96,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -103,7 +104,7 @@ module nextstrain_contra_costa_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Contra Costa County Public Health Laboratories"
     s3_filestem              = "Contra Costa"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -121,7 +122,7 @@ module nextstrain_fresno_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -129,7 +130,7 @@ module nextstrain_fresno_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Fresno County Public Health"
     s3_filestem              = "Fresno"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -147,7 +148,7 @@ module nextstrain_humboldt_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -155,7 +156,7 @@ module nextstrain_humboldt_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
     s3_filestem              = "Humboldt"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -173,7 +174,7 @@ module nextstrain_marin_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -181,7 +182,7 @@ module nextstrain_marin_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Marin County Department of Health & Human Services"
     s3_filestem              = "Marin"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -199,7 +200,7 @@ module nextstrain_monterey_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -207,7 +208,7 @@ module nextstrain_monterey_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Monterey County Health Department"
     s3_filestem              = "Monterey"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -225,7 +226,7 @@ module nextstrain_orange_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -233,7 +234,7 @@ module nextstrain_orange_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Orange County Public Health Laboratory"
     s3_filestem              = "Orange"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -251,7 +252,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -259,7 +260,7 @@ module nextstrain_san_bernardino_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Bernardino County Public Health"
     s3_filestem              = "San Bernardino"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -277,7 +278,7 @@ module nextstrain_del_norte_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -285,7 +286,7 @@ module nextstrain_del_norte_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Del Norte Public Health Laboratory"
     s3_filestem              = "Del Norte"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -303,7 +304,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -311,7 +312,7 @@ module nextstrain_san_joaquin_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Joaquin County Public Health Services"
     s3_filestem              = "San Joaquin"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -329,7 +330,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -337,7 +338,7 @@ module nextstrain_san_luis_obispo_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Luis Obispo County Health Agency, Public Health Laboratories"
     s3_filestem              = "San Luis Obispo"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -355,7 +356,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -363,7 +364,7 @@ module nextstrain_san_francisco_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "San Francisco Public Health Laboratory"
     s3_filestem              = "San Francisco"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -382,7 +383,7 @@ module nextstrain_tulare_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -390,7 +391,7 @@ module nextstrain_tulare_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tulare County Public Health Lab"
     s3_filestem              = "Tulare"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -408,7 +409,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -416,7 +417,7 @@ module nextstrain_tuolumne_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Tuolumne County Public Health"
     s3_filestem              = "Tuolumne"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }
@@ -434,7 +435,7 @@ module nextstrain_ventura_contextual_sfn_config {
   stack_resource_prefix = local.stack_resource_prefix
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
+  sfn_arn               = local.swipe_sfn_arn
   schedule_expressions  = local.nextstrain_cron_schedule
   event_role_arn        = local.event_role_arn
   extra_args            =  {
@@ -442,7 +443,7 @@ module nextstrain_ventura_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Ventura County Public Health Laboratory"
     s3_filestem              = "Ventura"
-    template_args            = {}
+    template_args            = local.default_template_args
     tree_type                = "OVERVIEW"
   }
 }

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -1,7 +1,33 @@
 locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
-  nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 5 ? * MON-SAT *)"] : []
+  nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 11 ? * MON-SAT *)"] : []
+}
+
+module nextstrain_marin_contextual_sfn_config {
+  source   = "../sfn_config"
+  app_name = "nextstrain-marin-contextual-sfn"
+  image    = local.nextstrain_image
+  vcpus    = local.nextstrain_sfn_vcpus
+  memory   = local.nextstrain_sfn_memory
+  wdl_path = "workflows/nextstrain.wdl"
+  custom_stack_name     = local.custom_stack_name
+  deployment_stage      = local.deployment_stage
+  remote_dev_prefix     = local.remote_dev_prefix
+  stack_resource_prefix = local.stack_resource_prefix
+  swipe_comms_bucket    = local.swipe_comms_bucket
+  swipe_wdl_bucket      = local.swipe_wdl_bucket
+  sfn_arn               = module.swipe_sfn.step_function_arn
+  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 11 ? * MON-SAT *)"] : []
+  event_role_arn        = local.event_role_arn
+  extra_args            =  {
+    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
+    remote_dev_prefix        = local.remote_dev_prefix
+    group_name               = "Marin County Department of Health & Human Services"
+    s3_filestem              = "Marin"
+    template_args            = {}
+    tree_type                = "OVERVIEW"
+  }
 }
 
 module nextstrain_chicago_contextual_sfn_config {
@@ -155,32 +181,6 @@ module nextstrain_humboldt_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
     s3_filestem              = "Humboldt"
-    template_args            = {}
-    tree_type                = "OVERVIEW"
-  }
-}
-
-module nextstrain_marin_contextual_sfn_config {
-  source   = "../sfn_config"
-  app_name = "nextstrain-marin-contextual-sfn"
-  image    = local.nextstrain_image
-  vcpus    = local.nextstrain_sfn_vcpus
-  memory   = local.nextstrain_sfn_memory
-  wdl_path = "workflows/nextstrain.wdl"
-  custom_stack_name     = local.custom_stack_name
-  deployment_stage      = local.deployment_stage
-  remote_dev_prefix     = local.remote_dev_prefix
-  stack_resource_prefix = local.stack_resource_prefix
-  swipe_comms_bucket    = local.swipe_comms_bucket
-  swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
-  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
-  event_role_arn        = local.event_role_arn
-  extra_args            =  {
-    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
-    remote_dev_prefix        = local.remote_dev_prefix
-    group_name               = "Marin County Department of Health & Human Services"
-    s3_filestem              = "Marin"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }

--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -1,33 +1,7 @@
 locals {
   nextstrain_sfn_memory = 64000
   nextstrain_sfn_vcpus = 10
-  nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 11 ? * MON-SAT *)"] : []
-}
-
-module nextstrain_marin_contextual_sfn_config {
-  source   = "../sfn_config"
-  app_name = "nextstrain-marin-contextual-sfn"
-  image    = local.nextstrain_image
-  vcpus    = local.nextstrain_sfn_vcpus
-  memory   = local.nextstrain_sfn_memory
-  wdl_path = "workflows/nextstrain.wdl"
-  custom_stack_name     = local.custom_stack_name
-  deployment_stage      = local.deployment_stage
-  remote_dev_prefix     = local.remote_dev_prefix
-  stack_resource_prefix = local.stack_resource_prefix
-  swipe_comms_bucket    = local.swipe_comms_bucket
-  swipe_wdl_bucket      = local.swipe_wdl_bucket
-  sfn_arn               = module.swipe_sfn.step_function_arn
-  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 11 ? * MON-SAT *)"] : []
-  event_role_arn        = local.event_role_arn
-  extra_args            =  {
-    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
-    remote_dev_prefix        = local.remote_dev_prefix
-    group_name               = "Marin County Department of Health & Human Services"
-    s3_filestem              = "Marin"
-    template_args            = {}
-    tree_type                = "OVERVIEW"
-  }
+  nextstrain_cron_schedule = local.deployment_stage == "geprod" ? ["cron(0 5 ? * MON-SAT *)"] : []
 }
 
 module nextstrain_chicago_contextual_sfn_config {
@@ -181,6 +155,32 @@ module nextstrain_humboldt_contextual_sfn_config {
     remote_dev_prefix        = local.remote_dev_prefix
     group_name               = "Humboldt County Dept Human and Health Sevices-Public Health"
     s3_filestem              = "Humboldt"
+    template_args            = {}
+    tree_type                = "OVERVIEW"
+  }
+}
+
+module nextstrain_marin_contextual_sfn_config {
+  source   = "../sfn_config"
+  app_name = "nextstrain-marin-contextual-sfn"
+  image    = local.nextstrain_image
+  vcpus    = local.nextstrain_sfn_vcpus
+  memory   = local.nextstrain_sfn_memory
+  wdl_path = "workflows/nextstrain.wdl"
+  custom_stack_name     = local.custom_stack_name
+  deployment_stage      = local.deployment_stage
+  remote_dev_prefix     = local.remote_dev_prefix
+  stack_resource_prefix = local.stack_resource_prefix
+  swipe_comms_bucket    = local.swipe_comms_bucket
+  swipe_wdl_bucket      = local.swipe_wdl_bucket
+  sfn_arn               = module.swipe_sfn.step_function_arn
+  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 5 ? * MON-SAT *)"] : []
+  event_role_arn        = local.event_role_arn
+  extra_args            =  {
+    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
+    remote_dev_prefix        = local.remote_dev_prefix
+    group_name               = "Marin County Department of Health & Human Services"
+    s3_filestem              = "Marin"
     template_args            = {}
     tree_type                = "OVERVIEW"
   }

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -305,7 +305,7 @@ task AlignGISAID {
     output {
         Array[File] snakemake_logs = glob("*.snakemake.log")
         File gisaid_metadata = "metadata.tsv"
-        File align_log = "filtered_gisaid.txt"
+        File align_log = "align_gisaid.txt"
         String entity_id = read_string("entity_id")
     }
 

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -261,7 +261,7 @@ task AlignGISAID {
     mkdir /ncov/my_profiles/align_gisaid/
     cp /usr/src/app/aspen/workflows/align_gisaid/{builds.yaml,config.yaml} /ncov/my_profiles/align_gisaid/
     # run snakemake, if run fails export the logs from snakemake and ncov to s3 
-    (cd /ncov && snakemake --printshellcmds results/aligned_gisaid.fasta.xz --profile my_profiles/align_gisaid) || { aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/snakemake/" --recursive ; aws s3 cp /ncov/logs/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/ncov/" --recursive ; }
+    (cd /ncov && snakemake --printshellcmds results/aligned_gisaid.fasta.xz results/sanitized_metadata_gisaid.tsv.xz --profile my_profiles/align_gisaid) || { aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/snakemake/" --recursive ; aws s3 cp /ncov/logs/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/ncov/" --recursive ; }
 
     mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/align_gisaid.txt .
     unxz -k /ncov/results/sanitized_metadata_gisaid.tsv.xz  # make an unzipped version for ImportGISAID. The zipped version goes to S3

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -261,16 +261,16 @@ task AlignGISAID {
     mkdir /ncov/my_profiles/align_gisaid/
     cp /usr/src/app/aspen/workflows/align_gisaid/{builds.yaml,config.yaml} /ncov/my_profiles/align_gisaid/
     # run snakemake, if run fails export the logs from snakemake and ncov to s3 
-    (cd /ncov && snakemake --printshellcmds results/filtered_gisaid.fasta.xz --profile my_profiles/align_gisaid) || { aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/snakemake/" --recursive ; aws s3 cp /ncov/logs/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/ncov/" --recursive ; }
+    (cd /ncov && snakemake --printshellcmds results/aligned_gisaid.fasta.xz --profile my_profiles/align_gisaid) || { aws s3 cp /ncov/.snakemake/log/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/snakemake/" --recursive ; aws s3 cp /ncov/logs/ "s3://${aspen_s3_db_bucket}/aligned_gisaid_dump/${build_id}/logs/ncov/" --recursive ; }
 
-    mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/filtered_gisaid.txt .
+    mv /ncov/.snakemake/log/*.snakemake.log /ncov/logs/align_gisaid.txt .
     unxz -k /ncov/results/sanitized_metadata_gisaid.tsv.xz  # make an unzipped version for ImportGISAID. The zipped version goes to S3
     mv /ncov/results/sanitized_metadata_gisaid.tsv metadata.tsv  # this is for wdl to pipe into ImportGISAID.
 
     # upload the files to S3
-    sequences_key="aligned_gisaid_dump/${build_id}/filtered_gisaid.fasta.xz"
+    sequences_key="aligned_gisaid_dump/${build_id}/aligned_gisaid.fasta.xz"
     metadata_key="aligned_gisaid_dump/${build_id}/sanitized_metadata_gisaid.tsv.xz"
-    aws s3 cp /ncov/results/filtered_gisaid.fasta.xz "s3://${aspen_s3_db_bucket}/${sequences_key}"
+    aws s3 cp /ncov/results/aligned_gisaid.fasta.xz "s3://${aspen_s3_db_bucket}/${sequences_key}"
     aws s3 cp /ncov/results/sanitized_metadata_gisaid.tsv.xz "s3://${aspen_s3_db_bucket}/${metadata_key}"
 
     # These are set by the Dockerfile and the Happy CLI

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -60,12 +60,9 @@ task nextstrain_workflow {
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 
-    # Recover tempalte args
-    parsed_template_args=$(jq -c . < "~{write_lines([template_args])}")
-
     workflow_id=$(aspen-cli db create-phylo-run                  \
                       --group-name "~{group_name}"               \
-                      --builds-template-args '~{parsed_template_args}'  \
+                      --builds-template-args '~{template_args}'  \
                       --tree-type "~{tree_type}"
     )
 

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -61,11 +61,12 @@ task nextstrain_workflow {
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 
     # Recover tempalte args
-    parsed_template_args=$(jq -c . < "~{write_lines([template_args])}")
+    export TEMPLATE_ARGS_FILE="~{write_lines([template_args])}"
+    TEMPLATE_ARGS=$(jq -c . < "${TEMPLATE_ARGS_FILE}")
 
     workflow_id=$(aspen-cli db create-phylo-run                  \
                       --group-name "~{group_name}"               \
-                      --builds-template-args '~{parsed_template_args}'  \
+                      --builds-template-args "${TEMPLATE_ARGS}"  \
                       --tree-type "~{tree_type}"
     )
 

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -60,9 +60,12 @@ task nextstrain_workflow {
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 
+    # Recover tempalte args
+    parsed_template_args=$(jq -c . < "~{write_lines([template_args])}")
+
     workflow_id=$(aspen-cli db create-phylo-run                  \
                       --group-name "~{group_name}"               \
-                      --builds-template-args '~{template_args}'  \
+                      --builds-template-args '~{parsed_template_args}'  \
                       --tree-type "~{tree_type}"
     )
 

--- a/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-dbg.wdl
@@ -61,12 +61,11 @@ task nextstrain_workflow {
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 
     # Recover tempalte args
-    export TEMPLATE_ARGS_FILE="~{write_lines([template_args])}"
-    TEMPLATE_ARGS=$(jq -c . < "${TEMPLATE_ARGS_FILE}")
+    parsed_template_args=$(jq -c . < "~{write_lines([template_args])}")
 
     workflow_id=$(aspen-cli db create-phylo-run                  \
                       --group-name "~{group_name}"               \
-                      --builds-template-args "${TEMPLATE_ARGS}"  \
+                      --builds-template-args '~{parsed_template_args}'  \
                       --tree-type "~{tree_type}"
     )
 

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 065eb54867a39a175ebce4181f43ddbd8c84b3b4 && \
+    git fetch origin 96894a882a6226e6d20b333df84ddffa6ffd4c2b && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 96894a882a6226e6d20b333df84ddffa6ffd4c2b && \
+    git fetch origin 983f79531d3f48e0d0ef04a58ae4acd1e668e9da && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -18,6 +18,7 @@ RUN apt-get -qq update && apt-get -qq -y install \
     locales \
     zstd \
     nano \
+    seqtk \
     && locale-gen en_US.UTF-8
 
 # Install poetry
@@ -37,13 +38,13 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 065eb54867a39a175ebce4181f43ddbd8c84b3b4 && \
+    git fetch origin 96894a882a6226e6d20b333df84ddffa6ffd4c2b && \
     git reset --hard FETCH_HEAD
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs
 
-ADD aspen/workflows/nextstrain_run/patches/crowding_penalty.patch /tmp/
-RUN (grep 'config\["priorities"\]\["crowding_penalty"\]' /ncov/workflow/snakemake_rules/main_workflow.smk || patch /ncov/workflow/snakemake_rules/main_workflow.smk < /tmp/crowding_penalty.patch)
+ADD aspen/workflows/nextstrain_run/patches/seqtk.patch /tmp/
+RUN patch /ncov/workflow/snakemake_rules/main_workflow.smk < /tmp/seqtk.patch
 
 WORKDIR /usr/src/app
 

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -38,7 +38,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 96894a882a6226e6d20b333df84ddffa6ffd4c2b && \
+    git fetch origin 983f79531d3f48e0d0ef04a58ae4acd1e668e9da && \
     git reset --hard FETCH_HEAD
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs

--- a/src/backend/aspen/workflows/nextstrain_run/patches/seqtk.patch
+++ b/src/backend/aspen/workflows/nextstrain_run/patches/seqtk.patch
@@ -1,0 +1,16 @@
+--- a/workflow/snakemake_rules/main_workflow.smk
++++ b/workflow/snakemake_rules/main_workflow.smk
+@@ -254,9 +254,10 @@ rule index_sequences:
+     conda: config["conda_environment"]
+     shell:
+         """
+-        augur index \
+-            --sequences {input.sequences} \
+-            --output {output.sequence_index} 2>&1 | tee {log}
++        unxz --stdout {input.sequences} \
++            | seqtk comp -u - \
++            | sed '1i strain\tlength\tA\tC\tG\tT\tmix2\tmix3\tN\tCpG\ttransversion\ttransition\tCpG_ts' \
++            | xz -c -2 > {output.sequence_index} 2>&1 | tee {log}
+         """
+ 
+ rule subsample:


### PR DESCRIPTION
### Summary:
- **What:** 
   - Pin to the latest ncov
   - Adjust how far GISAID job runs in response to upstream re-org https://github.com/nextstrain/ncov/pull/814. Note the tree build will automatically use the latest output from GISAID job [here](https://github.com/chanzuckerberg/aspen/blob/701f649c29f7b43081f62e0846f569b6fd9a22c0/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh#L65-L66) so no corresponding changes needed.
   - Replace `augur index` with `seqtk` to save us 1.5hr in each run.
   - Stack GISAID job (UTC 1a-9a) and tree job (UTC 11a) so tree run uses fresh new data.

### Demos:
GISAID job [test run](https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:473004499091:execution:genepi-gestaging-swipe-default-wdl:dan-gisaid-4-plus-1-time)

Tree run works in my EC2
![image](https://user-images.githubusercontent.com/20667188/150688830-e448ac58-ffc2-475e-a94b-bfe08046d903.png)

Sunday night staging run would be a combo final test. 

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)