### PR TITLE
Add subheaders for sample collection_location

### DIFF
--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -32,7 +32,7 @@ interface Sample extends BioinformaticsType {
     name: string;
   };
   collectionDate: string;
-  collectionLocation: string;
+  collectionLocation: GisaidLocation;
   sequencingDate: string;
   submittingGroup: {
     id: number;

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -112,6 +112,24 @@ export const SAMPLE_SUBHEADERS: Record<string, SubHeader[]> = {
       text: "Version",
     },
   ],
+  collectionLocation: [
+    {
+      key: "region",
+      text: "Region",
+    },
+    {
+      key: "country",
+      text: "Country",
+    },
+    {
+      key: "division",
+      text: "Division",
+    },
+    {
+      key: "location",
+      text: "Location",
+    },
+  ],
 };
 
 export const TREE_HEADERS: Header[] = [


### PR DESCRIPTION
### Summary:
- **What:** Adds proper parsing for a Sample's Collection Location in a user's metadata download.
- **Ticket:** [sc181535](https://app.shortcut.com/genepi/story/181535)
- **Env:** [https://mdta-fix-frontend.dev.czgenepi.org](https://mdta-fix-frontend.dev.czgenepi.org)

### Demos:
<img width="862" alt="Screen Shot 2022-01-24 at 16 27 39" src="https://user-images.githubusercontent.com/24234461/150887792-58ed3e12-b6ab-46ca-ab0c-7de9dadf5739.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)