### PR TITLE
Remove unnecessary env filter.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -46,7 +46,7 @@ locals {
   batch_role_arn = local.secret["batch_queues"]["genepi"]["role_arn"]
   ec2_queue_arn  = local.secret["batch_envs"]["genepi"]["envs"]["EC2"]["queue_arn"]
   spot_queue_arn = local.secret["batch_envs"]["genepi"]["envs"]["SPOT"]["queue_arn"]
-  swipe_sfn_arn  = local.deployment_stage == "prod" ? module.swipe_sfn[0].step_function_arn : local.secret["swipe_sfn_arns"]["genepi"]["default"]
+  swipe_sfn_arn  = local.secret["swipe_sfn_arns"]["genepi"]["default"]
   external_dns   = local.secret["external_zone_name"]
   internal_dns   = local.secret["internal_zone_name"]
 


### PR DESCRIPTION
### Summary:
- **What:** Prod is now configured to use swipe, no exceptions!
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Notes:
This was supposed to configure prod to continue using the old infra until we flipped the switch. But it should have filtered for the name "geprod" instead of "prod" so we're using swipe now anyway!

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)