### PR TITLE
Support additional filetype uploads

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/index.tsx
@@ -27,7 +27,7 @@ export default function Instructions({ headers, rows }: Props): JSX.Element {
           <StyleDownloadTemplate headers={headers} rows={rows}>
             TSV template
           </StyleDownloadTemplate>
-          , but you can use your own TSV file as well.
+          , but you can use your own TSV or CSV file as well.
         </ListItem>
         <ListItem ordered fontSize="xs">
           Make sure your column headers match our naming convention.
@@ -36,12 +36,12 @@ export default function Instructions({ headers, rows }: Props): JSX.Element {
           Make sure your metadata values are in the correct format.
         </ListItem>
         <ListItem ordered fontSize="xs">
-          Upload your TSV file by clicking on the “Select Metadata File” button
-          below and selecting from your file browser. Only one file can be
-          imported at a time.
+          Upload your TSV or CSV file by clicking on the “Select Metadata File”
+          button below and selecting from your file browser. Only one file can
+          be imported at a time.
         </ListItem>
         <ListItem ordered fontSize="xs">
-          The metadata from your TSV will be imported into the table fields
+          The metadata from your file will be imported into the table fields
           below. If there are errors, please make the necessary changes.
         </ListItem>
       </List>

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -124,7 +124,7 @@ export default function ImportFile({
         <FilePicker
           handleFiles={handleFiles}
           text="Select Metadata File"
-          accept=".tsv"
+          accept=".tsv,.csv"
           shouldConfirm={hasImportedFile}
           confirmTitle="Are you sure you want to import new data?"
           confirmContent={

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -106,7 +106,7 @@ export default function ImportFile({
     <Wrapper>
       <IntroWrapper>
         <TitleWrapper>
-          <Title>Import Data from a TSV file</Title>
+          <Title>Import Data from a TSV or CSV file</Title>
           <Button color="primary" onClick={handleInstructionsClick}>
             {isInstructionsShown ? "HIDE" : "SHOW"} INSTRUCTIONS
           </Button>

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -121,7 +121,7 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
             text={isLoadingFile ? "Loading..." : "Select Fasta Files"}
             multiple
             handleFiles={handleFileChange}
-            accept=".fasta,.fa,.gz,.zip"
+            accept=".fasta,.fa,.txt,.gz,.zip"
             isDisabled={isLoadingFile}
           />
           {parseErrors && (

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -103,7 +103,7 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
             </span>,
             <span key="2">
               Accepted file formats: fasta (.fa or .fasta), fasta.gz (.fa.gz),
-              fasta.zip
+              fasta.zip, plain text (.txt)
             </span>,
             <span key="3">
               Sample names must be no longer than 120 characters and can only
@@ -118,7 +118,7 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
         />
         <ContentWrapper>
           <StyledFilePicker
-            text={isLoadingFile ? "Loading..." : "Select Fasta Files"}
+            text={isLoadingFile ? "Loading..." : "Select Sample Files"}
             multiple
             handleFiles={handleFileChange}
             accept=".fasta,.fa,.txt,.gz,.zip"

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -64,7 +64,12 @@ export async function handleFile(
     return handleGz(file, filename);
   }
 
-  if (filename.includes(".fasta") || filename.includes(".fa")) {
+  if (
+    filename.includes(".fasta") ||
+    filename.includes(".fa") ||
+    filename.includes(".txt")
+  ) {
+    // FASTA is not a special file encoding, just a way to format a text file.
     return handleFastaText(await strFromU8(file), filename);
   }
 


### PR DESCRIPTION
### Summary:
- **What:** Add support for uploading `.txt` Fasta sequences and `.csv` Metadata info
- **Ticket:** [sc<178059>](https://app.shortcut.com/genepi/story/<178059>)
- **Env:** No rdev, just verified it locally.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
~[ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)~ (none needed)