### PR TITLE
Fix bug where GISAID ISLs were not included in metadata downloads

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -79,14 +79,12 @@ function tsvDataMap(
     sortKey: ["CZBFailedGenomeRecovery"],
     text: "Genome Recovery",
   });
-  console.log(headers);
   if (tableData) {
     const filteredTableData = tableData.filter((entry) =>
       checkedSampleIds.includes(String(entry["publicId"]))
     );
     const tsvData = filteredTableData.map((entry) => {
       return headersDownload.flatMap((header) => {
-        console.log("TSV Header:", header);
         if (
           typeof entry[header.key] === "object" &&
           Object.prototype.hasOwnProperty.call(subheaders, header.key)

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -74,17 +74,19 @@ function tsvDataMap(
   subheaders: Record<string, SubHeader[]>
 ): [string[], string[][]] | undefined {
   const headersDownload = [...headers];
-  headersDownload[7] = {
+  headersDownload.push({
     key: "CZBFailedGenomeRecovery",
     sortKey: ["CZBFailedGenomeRecovery"],
     text: "Genome Recovery",
-  };
+  });
+  console.log(headers);
   if (tableData) {
     const filteredTableData = tableData.filter((entry) =>
       checkedSampleIds.includes(String(entry["publicId"]))
     );
     const tsvData = filteredTableData.map((entry) => {
       return headersDownload.flatMap((header) => {
+        console.log("TSV Header:", header);
         if (
           typeof entry[header.key] === "object" &&
           Object.prototype.hasOwnProperty.call(subheaders, header.key)


### PR DESCRIPTION
### Summary:
- **What:** In parsing table headers for creating a metadata TSV file, an extra `CZBFailedGenomeRecovery` column is added. However instead of being pushed into the array it was added using subscript notation at the index where the `GISAID` header existed, thus overwriting that header.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)