### PR TITLE
add ondemand overview tree

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
@@ -35,8 +35,9 @@ export const RadioLabelOverview = ({ selected }: Props): JSX.Element => {
             <ListItemText>
               <SmallText>
                 Best for seeing an overall picture of viral diversity within
-                your jurisdiction, in the context of genetically similar GISAID
-                samples from outside of your jurisdiction.
+                your jurisdiction in the past 12 weeks, in the context of
+                genetically similar GISAID samples from outside of your
+                jurisdiction.
               </SmallText>
             </ListItemText>
           </StyledListItem>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
@@ -4,7 +4,6 @@ import { List } from "czifui";
 import React from "react";
 import {
   Label,
-  LabelLight,
   LabelMain,
   SmallText,
   StyledIconCheckSmall,
@@ -17,16 +16,15 @@ interface Props {
   selected: boolean;
 }
 
-export const RadioLabelTargeted = ({ selected }: Props): JSX.Element => {
+export const RadioLabelOverview = ({ selected }: Props): JSX.Element => {
   return (
     <div>
       <Label>
-        <LabelMain>Targeted </LabelMain>
-        <LabelLight>— Recommended</LabelLight>
+        <LabelMain>Overview </LabelMain>
       </Label>
       <SmallText>
-        Includes additional publicly-available samples on GISAID from your
-        jurisdiction and other regions.
+        Includes samples from both within and outside of your jurisdiction, at a
+        ratio of roughly 2:1.
       </SmallText>
       {selected && (
         <List>
@@ -35,7 +33,11 @@ export const RadioLabelTargeted = ({ selected }: Props): JSX.Element => {
               <StyledIconCheckSmall />
             </StyledListItemIcon>
             <ListItemText>
-              <SmallText>Best for local outbreak investigation.</SmallText>
+              <SmallText>
+                Best for seeing an overall picture of viral diversity within
+                your jurisdiction, in the context of genetically similar GISAID
+                samples from outside of your jurisdiction.
+              </SmallText>
             </ListItemText>
           </StyledListItem>
           <StyledListItem button={false as any}>
@@ -44,9 +46,59 @@ export const RadioLabelTargeted = ({ selected }: Props): JSX.Element => {
             </StyledListItemIcon>
             <ListItemText>
               <SmallText>
-                Useful for seeing relationships between your selected samples,
-                other samples you have uploaded to CZ GEN EPI, and
-                publicly-available samples on GISAID.
+                Good for identifying possible local outbreaks.
+              </SmallText>
+            </ListItemText>
+          </StyledListItem>
+          <StyledListItem button={false as any}>
+            <StyledListItemIcon>
+              <StyledIconCheckSmall />
+            </StyledListItemIcon>
+            <ListItemText>
+              <SmallText>
+                Good for creating the same tree type as the CZ GEN EPI automatic
+                build, while ensuring that all selected samples will be included
+                in the tree.
+              </SmallText>
+            </ListItemText>
+          </StyledListItem>
+        </List>
+      )}
+    </div>
+  );
+};
+
+export const RadioLabelTargeted = ({ selected }: Props): JSX.Element => {
+  return (
+    <div>
+      <Label>
+        <LabelMain>Targeted </LabelMain>
+      </Label>
+      <SmallText>
+        Includes selected samples and samples that are closely related to the
+        selected samples, at a ratio of roughly 2:1.
+      </SmallText>
+      {selected && (
+        <List>
+          <StyledListItem button={false as any}>
+            <StyledListItemIcon>
+              <StyledIconCheckSmall />
+            </StyledListItemIcon>
+            <ListItemText>
+              <SmallText>
+                Best for investigating an identified outbreak.
+              </SmallText>
+            </ListItemText>
+          </StyledListItem>
+          <StyledListItem button={false as any}>
+            <StyledListItemIcon>
+              <StyledIconCheckSmall />
+            </StyledListItemIcon>
+            <ListItemText>
+              <SmallText>
+                Good for identifying samples most closely related to the
+                selected samples among all samples in GISAID and your CZ GEN EPI
+                samples.
               </SmallText>
             </ListItemText>
           </StyledListItem>
@@ -65,8 +117,8 @@ export const RadioLabelNonContextualized = ({
         <LabelMain>Non-Contextualized </LabelMain>
       </Label>
       <SmallText>
-        Includes additional publicly-available samples on GISAID from your
-        jurisdiction only.
+        Includes samples from only your jurisdiction from both CZ GEN EPI and
+        GISAID.
       </SmallText>
       {selected && (
         <List>
@@ -86,7 +138,7 @@ export const RadioLabelNonContextualized = ({
             </StyledListItemIcon>
             <ListItemText>
               <SmallText>
-                Useful for seeing viral diversity in your jurisdiction that may
+                Good for seeing viral diversity in your jurisdiction that may
                 not be captured by your own sampling effort.
               </SmallText>
             </ListItemText>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -16,6 +16,7 @@ import { CreateTreeButton } from "./components/CreateTreeButton";
 import { MissingSampleAlert } from "./components/MissingSampleAlert";
 import {
   RadioLabelNonContextualized,
+  RadioLabelOverview,
   RadioLabelTargeted,
 } from "./components/RadioLabel";
 import { SampleIdInput } from "./components/SampleIdInput";
@@ -48,6 +49,7 @@ interface Props {
 const TreeTypes = {
   Targeted: "TARGETED",
   NonContextualized: "NON_CONTEXTUALIZED",
+  Overview: "OVERVIEW",
 };
 type TreeType = typeof TreeTypes[keyof typeof TreeTypes];
 
@@ -216,6 +218,16 @@ export const CreateNSTreeModal = ({
               value={treeType}
               onChange={(e) => setTreeType(e.target.value as TreeType)}
             >
+              <StyledFormControlLabel
+                value={TreeTypes.Overview}
+                checked={treeType === TreeTypes.Overview}
+                control={<StyledRadio />}
+                label={
+                  <RadioLabelOverview
+                    selected={treeType === TreeTypes.Overview}
+                  />
+                }
+              />
               <StyledFormControlLabel
                 value={TreeTypes.Targeted}
                 checked={treeType === TreeTypes.Targeted}

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -62,7 +62,7 @@ export const CreateNSTreeModal = ({
   const [treeName, setTreeName] = useState<string>("");
   const [isInputInEditMode, setIsInputInEditMode] = useState<boolean>(false);
   const [shouldReset, setShouldReset] = useState<boolean>(false);
-  const [treeType, setTreeType] = useState<TreeType>(TreeTypes.Targeted);
+  const [treeType, setTreeType] = useState<TreeType>();
   const [missingInputSamples, setMissingInputSamples] = useState<string[]>([]);
   const [shouldShowErrorNotification, setShouldShowErrorNotification] =
     useState<boolean>(false);
@@ -81,7 +81,6 @@ export const CreateNSTreeModal = ({
   const clearState = function () {
     setShouldReset(true);
     setTreeName("");
-    setTreeType(TreeTypes.Targeted);
     setMissingInputSamples([]);
     setValidatedInputSamples([]);
   };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -62,7 +62,7 @@ export const CreateNSTreeModal = ({
   const [treeName, setTreeName] = useState<string>("");
   const [isInputInEditMode, setIsInputInEditMode] = useState<boolean>(false);
   const [shouldReset, setShouldReset] = useState<boolean>(false);
-  const [treeType, setTreeType] = useState<TreeType>();
+  const [treeType, setTreeType] = useState<TreeType | undefined>();
   const [missingInputSamples, setMissingInputSamples] = useState<string[]>([]);
   const [shouldShowErrorNotification, setShouldShowErrorNotification] =
     useState<boolean>(false);

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -73,14 +73,25 @@ export const CreateNSTreeModal = ({
   const [validatedInputSamples, setValidatedInputSamples] = useState<string[]>(
     []
   );
+  const [isValidTreeType, setValidTreeType] = useState<boolean>(false);
 
   useEffect(() => {
     if (shouldReset) setShouldReset(false);
   }, [shouldReset]);
 
+  useEffect(() => {
+    if (treeType !== undefined && Object.values(TreeTypes).includes(treeType)) {
+      setValidTreeType(true);
+    } else {
+      setValidTreeType(false);
+    }
+  }, [treeType]);
+
   const clearState = function () {
     setShouldReset(true);
     setTreeName("");
+    setTreeType(undefined);
+    setValidTreeType(false);
     setMissingInputSamples([]);
     setValidatedInputSamples([]);
   };
@@ -264,7 +275,7 @@ export const CreateNSTreeModal = ({
             hasValidName={hasValidName}
             hasSamples={allValidSamplesForTreeCreation.length > 0}
             isInEditMode={isInputInEditMode}
-            isValidTreeType={Object.values(TreeTypes).includes(treeType)}
+            isValidTreeType={isValidTreeType}
             onClick={handleSubmit}
           />
           <CreateTreeInfo>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -73,7 +73,7 @@ export const CreateNSTreeModal = ({
   const [validatedInputSamples, setValidatedInputSamples] = useState<string[]>(
     []
   );
-  const [isValidTreeType, setValidTreeType] = useState<boolean>(false);
+  const [isValidTreeType, setIsValidTreeType] = useState<boolean>(false);
 
   useEffect(() => {
     if (shouldReset) setShouldReset(false);
@@ -81,9 +81,9 @@ export const CreateNSTreeModal = ({
 
   useEffect(() => {
     if (treeType !== undefined && Object.values(TreeTypes).includes(treeType)) {
-      setValidTreeType(true);
+      setIsValidTreeType(true);
     } else {
-      setValidTreeType(false);
+      setIsValidTreeType(false);
     }
   }, [treeType]);
 
@@ -91,7 +91,7 @@ export const CreateNSTreeModal = ({
     setShouldReset(true);
     setTreeName("");
     setTreeType(undefined);
-    setValidTreeType(false);
+    setIsValidTreeType(false);
     setMissingInputSamples([]);
     setValidatedInputSamples([]);
   };

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -24,13 +24,13 @@ import { MutationCallbacks } from "./types";
 interface CreateTreePayload {
   name: string;
   samples: string[];
-  tree_type: string;
+  tree_type: string | undefined;
 }
 
 interface CreateTreeType {
   treeName: string;
   sampleIds: string[];
-  treeType: string;
+  treeType: string | undefined; // treeType can be undefined when user first opens the NSTreeCreate modal
 }
 
 type CreateTreeCallbacks = MutationCallbacks<void>;
@@ -42,7 +42,7 @@ async function createTree({
 }: {
   sampleIds: string[];
   treeName: string;
-  treeType: string;
+  treeType: string | undefined;
 }): Promise<unknown> {
   const payload: CreateTreePayload = {
     name: treeName,

--- a/src/frontend/src/common/utils/featureFlags.tsx
+++ b/src/frontend/src/common/utils/featureFlags.tsx
@@ -21,10 +21,6 @@ export const FEATURE_FLAGS: FlagsObj = {
     isDisabled: true,
     key: "mayasFlag",
   },
-  overviewTrees: {
-    isDisabled: false,
-    key: "overviewTrees",
-  },
 };
 
 const allowedKeys = Object.keys(FEATURE_FLAGS) as string[];

--- a/src/frontend/src/views/Data/components/TreeTypeTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeTypeTooltip/index.tsx
@@ -1,7 +1,6 @@
 import { Tooltip } from "czifui";
 import React from "react";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
-import { FEATURE_FLAGS, usesFeatureFlag } from "src/common/utils/featureFlags";
 
 interface Props {
   children: React.ReactElement;
@@ -19,11 +18,6 @@ export const TreeTypeTooltip = ({ children, value }: Props): JSX.Element => {
       content = `Best for viewing an overall picture of viral diversity within
       your jurisdiction, including genetically similar samples from outside of
       your jurisdiction.`;
-
-      if (!usesFeatureFlag(FEATURE_FLAGS.overviewTrees)) {
-        content += ` Overview trees are automatically built by CZ GEN EPI every Monday.`;
-      }
-
       break;
     case "Non-Contextualized":
       content =


### PR DESCRIPTION
### Summary:
- **What:** Add overview tree as a phylotree create option, also update other tree type copies.
- **Ticket:** [sc177170](https://app.shortcut.com/genepi/story/177170)
- **Env:** [rdev](https://overview-frontend.dev.czgenepi.org/)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)