### PR TITLE
Branding changes to CZ Gen Epi

### DIFF
--- a/docker/aspen-batch/Dockerfile
+++ b/docker/aspen-batch/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /aspen
 RUN mkdir /tmp/aspen-tmp
 RUN cd /tmp/aspen-tmp
 RUN git init
-RUN git fetch --depth 1 git://github.com/chanzuckerberg/aspen $REVSPEC
+RUN git fetch --depth 1 git://github.com/chanzuckerberg/czgenepi $REVSPEC
 RUN git checkout FETCH_HEAD
 RUN python3.7 -m venv /aspen/.venv
 RUN /aspen/.venv/bin/pip install -U pip

--- a/docker/aspen-batch/docker-entrypoint.sh
+++ b/docker/aspen-batch/docker-entrypoint.sh
@@ -17,7 +17,7 @@ else
     export ASPEN_GIT_REVSPEC="$1"
 
     git init
-    git fetch --depth 1 git://github.com/chanzuckerberg/aspen "$ASPEN_GIT_REVSPEC"
+    git fetch --depth 1 git://github.com/chanzuckerberg/czgenepi "$ASPEN_GIT_REVSPEC"
     git checkout FETCH_HEAD
 
     /aspen/.venv/bin/pip install -U pip

--- a/docs/REMOTE_DEV.md
+++ b/docs/REMOTE_DEV.md
@@ -34,7 +34,7 @@ If you forget which stacks you've created, just run `./scripts/happy list` at an
 If you need to reset your remote dev stack DB run `./scripts/happy migrate <your-stack-name> --reset`.
 
 ### Slices
-If you're only working on a subset of the Aspen application, there's no need to build and push all docker images to test your changes in remote-dev. Both `happy create` and `happy update` commands support a `--slice` option that uses the latest `trunk` build of all docker images except the ones you're working on. For example, if you're only making changes to the frontend/backend images, you don't care to build & push the gisaid image. The following command will create an rdev with your changes reflected in only the `frontend` and `backend` images:
+If you're only working on a subset of the CZ Gen Epi application, there's no need to build and push all docker images to test your changes in remote-dev. Both `happy create` and `happy update` commands support a `--slice` option that uses the latest `trunk` build of all docker images except the ones you're working on. For example, if you're only making changes to the frontend/backend images, you don't care to build & push the gisaid image. The following command will create an rdev with your changes reflected in only the `frontend` and `backend` images:
 
 ```
 ./scripts/happy create mynewrdev --slice fullstack
@@ -74,7 +74,7 @@ Options:
 ```
 
 ### Remote Dev Database management
-There are two commands in the Aspen CLI that exist specifically to enable management of remote dev environments: `aspen-cli db --remote setup` and `aspen-cli db --remote drop`. The `setup` command is responsible for creating a new database in our Aurora database, and importing a db snapshot into the new database. The `drop` command drops a database when a remote dev stack is deleted.
+There are two commands in the CZ Gen Epi CLI that exist specifically to enable management of remote dev environments: `aspen-cli db --remote setup` and `aspen-cli db --remote drop`. The `setup` command is responsible for creating a new database in our Aurora database, and importing a db snapshot into the new database. The `drop` command drops a database when a remote dev stack is deleted.
 
 ### GitHub Action Integration
 A new stack can also be deployed to remote development environment through GitHub Action integration. Pushing any branch prefixed with "rdev-" will trigger the GH Action workflow to create or update a dev stack, with the stack name equals the part of branch name following the prefix, e.g. pushing branch "rdev-my-dev-branch" will deploy the stack "my-dev-branch" in the remote dev enviroment. This is useful in situation where local connections is slow.

--- a/docs/backend/workflows.md
+++ b/docs/backend/workflows.md
@@ -1,6 +1,6 @@
 ## Workflows
 
-Aspen has a number of long-lived workflows that are run through [miniwdl](https://github.com/chanzuckerberg/miniwdl/)/[Swipe](https://github.com/chanzuckerberg/swipe)/AWS Batch.  This document explains each of these workflows.
+CZ Gen Epi has a number of long-lived workflows that are run through [miniwdl](https://github.com/chanzuckerberg/miniwdl/)/[Swipe](https://github.com/chanzuckerberg/swipe)/AWS Batch.  This document explains each of these workflows.
 
 ### GISAID Workflow
 
@@ -8,20 +8,20 @@ This workflow encompasses three processing steps to ingest a GISAID data dump in
 
 #### Ingest
 
-This workflow downloads a [GISAID hCov-19 data dump](https://www.gisaid.org/) and records a [`RawGisaidDump`](https://github.com/chanzuckerberg/aspen/search?q=%22class+RawGisaidDump%22) object referencing the dump.
+This workflow downloads a [GISAID hCov-19 data dump](https://www.gisaid.org/) and records a [`RawGisaidDump`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+RawGisaidDump%22) object referencing the dump.
 
 #### Transform
 
-This workflow applies the [transform-gisaid script](https://github.com/nextstrain/ncov-ingest/blob/master/bin/transform-gisaid) to transform the metadata into the format expected by the nextstrain pipeline.  The input for this workflow is a [`RawGisaidDump`](https://github.com/chanzuckerberg/aspen/search?q=%22class+RawGisaidDump%22) object and records a [`ProcessedGisaidDump`](https://github.com/chanzuckerberg/aspen/search?q=%22class+ProcessedGisaidDump%22) object referencing the processed dump.  A [`GisaidDumpWorkflow`](https://github.com/chanzuckerberg/aspen/search?q=%22class+GisaidDumpWorkflow%22) is used to link the input to the output.
+This workflow applies the [transform-gisaid script](https://github.com/nextstrain/ncov-ingest/blob/master/bin/transform-gisaid) to transform the metadata into the format expected by the nextstrain pipeline.  The input for this workflow is a [`RawGisaidDump`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+RawGisaidDump%22) object and records a [`ProcessedGisaidDump`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+ProcessedGisaidDump%22) object referencing the processed dump.  A [`GisaidDumpWorkflow`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+GisaidDumpWorkflow%22) is used to link the input to the output.
 
 #### Align
 
-This workflow aligns the sequences downloaded from gisaid to a reference sequence, using the align step in the [nextstrain workflow](https://github.com/nextstrain/ncov/blob/master/workflow/snakemake_rules/main_workflow.smk).  The input for this workflow is a [`ProcessedGisaidDump`](https://github.com/chanzuckerberg/aspen/search?q=%22class+ProcessedGisaidDump%22) object and records an [`AlignedGisaidDump`](https://github.com/chanzuckerberg/aspen/search?q=%22class+AlignedGisaidDump%22) object referencing the aligned dump.  A [`GisaidAlignmentWorkflow`](https://github.com/chanzuckerberg/aspen/search?q=%22class+GisaidAlignmentWorkflow%22) is used to link the input to the output.
+This workflow aligns the sequences downloaded from gisaid to a reference sequence, using the align step in the [nextstrain workflow](https://github.com/nextstrain/ncov/blob/master/workflow/snakemake_rules/main_workflow.smk).  The input for this workflow is a [`ProcessedGisaidDump`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+ProcessedGisaidDump%22) object and records an [`AlignedGisaidDump`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+AlignedGisaidDump%22) object referencing the aligned dump.  A [`GisaidAlignmentWorkflow`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+GisaidAlignmentWorkflow%22) is used to link the input to the output.
 
 ### Nextstrain Workflow
 
-This workflow pulls the inputs for a [`PhyloRun`](https://github.com/chanzuckerberg/aspen/search?q=%22class+PhyloRun%22), which consists of [`UploadedPathogenGenome`](https://github.com/chanzuckerberg/aspen/search?q=%22class+UploadedPathogenGenome%22), [`CalledPathogenGenome`](https://github.com/chanzuckerberg/aspen/search?q=%22class+CalledPathogenGenome%22), and [`AlignedGisaidDump`](https://github.com/chanzuckerberg/aspen/search?q=%22class+AlignedGisaidDump%22).  It creates a builds file based on templates in [build_templates](../../src/backend/aspen/workflows/nextstrain_run/builds_templates/), and then kicks off a nextstrain run.
+This workflow pulls the inputs for a [`PhyloRun`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+PhyloRun%22), which consists of [`UploadedPathogenGenome`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+UploadedPathogenGenome%22), [`CalledPathogenGenome`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+CalledPathogenGenome%22), and [`AlignedGisaidDump`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+AlignedGisaidDump%22).  It creates a builds file based on templates in [build_templates](../../src/backend/czgenepi/workflows/nextstrain_run/builds_templates/), and then kicks off a nextstrain run.
 
 Normally, the Nextstrain pipeline takes unaligned data and builds a tree from that data.  Repeatedly aligning the GISAID data, however, is wasteful.  Instead, we [cache the aligned data](#align) and inject it into the working directory of the Nextstrain pipeline.  Snakemake assumes the alignment has been done by a prior run, and does not attempt to do it.
 
-The input for this workflow is a [`PhyloRun`](https://github.com/chanzuckerberg/aspen/search?q=%22class+PhyloRun%22), and the output is a [`PhyloTree`](https://github.com/chanzuckerberg/aspen/search?q=%22class+PhyloTree%22) object.
+The input for this workflow is a [`PhyloRun`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+PhyloRun%22), and the output is a [`PhyloTree`](https://github.com/chanzuckerberg/czgenepi/search?q=%22class+PhyloTree%22) object.

--- a/docs/general/how-to-upgrade-dependencies.md
+++ b/docs/general/how-to-upgrade-dependencies.md
@@ -7,7 +7,7 @@ As a general rule please do not directly import the latest version of the downst
 
 If we run into a case where an immediate upstream dependency does not address the vulnerability in a timely manner (i.e. package `C` becomes abandonware), please file an issue noting the problem and start tracking the likely resolution (i.e. migrate to a new dependency, wait, safely ignore, etc.). Please bring the issue to attention for triage during the next issue refinement meeting.
 
-Please check the repos' Dependabot Alerts to ensure that all alerts have been addressed. Please do not clear the alerts unless they are either addressed (via a fully merged PR) or they are not relevant. This means that if one of our dependency packages is unable to be updated because of no available upgrade, leave the alert open so we know to update the package later once an update is available. The dependabot alerts can be found [here](https://github.com/chanzuckerberg/aspen/security/dependabot).
+Please check the repos' Dependabot Alerts to ensure that all alerts have been addressed. Please do not clear the alerts unless they are either addressed (via a fully merged PR) or they are not relevant. This means that if one of our dependency packages is unable to be updated because of no available upgrade, leave the alert open so we know to update the package later once an update is available. The dependabot alerts can be found [here](https://github.com/chanzuckerberg/czgenepi/security/dependabot).
 
 
 ### Upgrading CZ Gen Epi frontend

--- a/scripts/happy-deploy.py
+++ b/scripts/happy-deploy.py
@@ -8,9 +8,9 @@ import click
 import requests
 
 github_org = "chanzuckerberg"
-github_repo = "aspen"
+github_repo = "czgenepi"
 github_graphql_endpoint = "https://api.github.com/graphql"
-github_deployment_endpoint = "https://api.github.com/repos/chanzuckerberg/aspen/deployments"
+github_deployment_endpoint = "https://api.github.com/repos/chanzuckerberg/czgenepi/deployments"
 
 
 def get_latest_successful_deployment(github_api_token, stage):

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -1,8 +1,8 @@
 FROM nextstrain/base
 ARG DEBIAN_FRONTEND=noninteractive
 
-LABEL maintainer = "Aspen"
-LABEL description = "Image for Aspen ingest-gisaid workflow"
+LABEL maintainer = "CZ Gen Epi"
+LABEL description = "Image for CZ Gen Epi ingest-gisaid workflow"
 
 RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sources.list; \
     echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/98idseq; \

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -4,8 +4,8 @@
 FROM nextstrain/base
 ARG DEBIAN_FRONTEND=noninteractive
 
-LABEL maintainer = "Aspen"
-LABEL description = "Image for Aspen nextstrain workflow"
+LABEL maintainer = "CZ Gen Epi"
+LABEL description = "Image for CZ Gen Epi nextstrain workflow"
 
 RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sources.list; \
     echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/98idseq; \

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "aspen"
 version = "0.1.0"
-description = "ASPEN.  Covid Tracking 2.0"
+description = "CZ Gen Epi. Covid Tracking 2.0"
 authors = ["CZ Gen Epi Team <info@chanzuckerberg.com>"]
 
 [tool.poetry.scripts]

--- a/src/frontend/src/common/routes.ts
+++ b/src/frontend/src/common/routes.ts
@@ -4,7 +4,7 @@ export enum ROUTES {
   CAREERS = "https://chanzuckerberg.com/careers/career-opportunities/?initiative=science",
   CZI = "https://chanzuckerberg.com/",
   DATA = "/data",
-  GITHUB = "https://github.com/chanzuckerberg/aspen/",
+  GITHUB = "https://github.com/chanzuckerberg/czgenepi/",
   LOGIN = "/login",
   NEXTSTRAIN = "https://nextstrain.org/",
   TERMS = "/terms",


### PR DESCRIPTION
### Summary:
- **What:** Updates some public-facing resources to use the name "CZ Gen Epi" instead of "Aspen", and changes Github links to use `https://github.com/chanzuckerberg/czgenepi/`. Once we merge this, we should be able to rename the repository.
- **Ticket:** [sc179332](https://app.shortcut.com/genepi/story/179332)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)