### PR TITLE
update ncov pin to the latest

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 983f79531d3f48e0d0ef04a58ae4acd1e668e9da && \
+    git fetch origin 44223bcd5249e53eb9a67fb2cc9f2efef77ff530 && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -38,7 +38,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/nextstrain/ncov.git && \
-    git fetch origin 983f79531d3f48e0d0ef04a58ae4acd1e668e9da && \
+    git fetch origin 44223bcd5249e53eb9a67fb2cc9f2efef77ff530 && \
     git reset --hard FETCH_HEAD
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs


### PR DESCRIPTION
### Summary:
- **What:** Brings in the change Sidney and Jess made to add Nextclade to QC sequences https://github.com/nextstrain/ncov/pull/842
- **Ticket:** [sc<179156>](https://app.shortcut.com/genepi/story/179156/use-nextclade-for-post-subsampling-alignment-in-the-ncov-workflow-nextstrain-issue-2)

### Demos:
I tested `7e00b75` in the PR above last night with the major changes in. Making this PR now so the run tonight at staging will have it for full testing.

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)