### PR TITLE
Danrlu/add color by qc

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
+++ b/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
@@ -47,9 +47,14 @@
       "type": "categorical"
     },
     {
-      "key": "country_exposure",
-      "title": "Country of exposure",
-      "type": "categorical"
+      "key": "reversion_mutations",
+      "title": "Reversion mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "potential_contaminants",
+      "title": "Potential contaminants",
+      "type": "continuous"
     },
     {
       "key": "author",

--- a/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
+++ b/src/backend/aspen/workflows/nextstrain_run/nextstrain_profile/aspen_auspice_config_v2.json
@@ -47,14 +47,24 @@
       "type": "categorical"
     },
     {
+      "key": "QC_missing_data",
+      "title": "Missing data",
+      "type": "categorical"
+    },
+    {
+      "key": "QC_mixed_sites",
+      "title": "Mixed sites",
+      "type": "categorical"
+    },
+    {
       "key": "reversion_mutations",
       "title": "Reversion mutations",
-      "type": "continuous"
+      "type": "categorical"
     },
     {
       "key": "potential_contaminants",
       "title": "Potential contaminants",
-      "type": "continuous"
+      "type": "categorical"
     },
     {
       "key": "author",


### PR DESCRIPTION
### Summary:
- **What:** Surface the QC stats Nextclade added to the tree as color by options.
- **Ticket:** https://app.shortcut.com/genepi/story/183268/add-bootstrap-values-to-trees-to-quantify-and-communicate-uncertainty

### Demos:
<img width="1911" alt="image" src="https://user-images.githubusercontent.com/20667188/153624270-eb2793cf-f6b9-4d99-8bff-bae6dfa75f0a.png">

### Notes:
Color by confidence estimated by bootstrap is too confusing b/c of low score (it's a diff tree from above)
<img width="991" alt="image" src="https://user-images.githubusercontent.com/20667188/153624643-ba9ade2d-d4e8-48a9-b6f3-54a85985fa1c.png">


### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)