### PR TITLE
Fix pangolin image build.

### DIFF
--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -13,7 +13,7 @@ RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetr
 
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y make wget git jq
+RUN apt-get update && apt-get install -y make wget git jq gcc
 
 # install miniconda
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh


### PR DESCRIPTION
### Summary:
- **What:** As it turns out, our pangolin image build has just been working due to our build cache. This updates our pangolin docker image so that it can be rebuilt from scratch

### Demos:
```
czgenepi/src/backend]% docker build -t pangotest --no-cache -f Dockerfile.pangolin .
[+] Building 602.1s (19/21)
 => [internal] load build definition from Dockerfile.pangolin                                                                0.1s
 => => transferring dockerfile: 1.29kB                                                                                       0.0s
 => [internal] load .dockerignore                                                                                            0.1s
 => => transferring context: 176B                                                                                            0.0s
 => [internal] load metadata for docker.io/library/python:3.9.1-slim                                                         1.2s
 => [ 1/17] FROM docker.io/library/python:3.9.1-slim@sha256:bf3ec573c0ae0d0c619c3f3e0e9490878432bf7a5c63a643b6c39c9878b5119  0.0s
 => [internal] load build context                                                                                            7.1s
 => => transferring context: 48.55MB                                                                                         7.0s
 => CACHED [ 4/17] WORKDIR /usr/src/app                                                                                      0.0s
 => [ 5/16] RUN apt-get update && apt-get install -y make wget git jq gcc                                                   29.5s
 => [ 6/16] RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh                                   4.5s
 => [ 7/16] RUN chmod +x Miniconda3-latest-Linux-x86_64.sh                                                                   0.8s
 => [ 8/16] RUN ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda                                                   32.0s
 => [ 9/16] RUN eval "$($HOME/miniconda/bin/conda shell.bash hook)" && conda init                                            1.9s
 => [10/16] COPY aspen/workflows/pangolin/install_pangolin.sh .                                                              0.1s
 => [11/16] RUN bash install_pangolin.sh                                                                                   427.9s
 => [12/16] COPY pyproject.toml poetry.lock environment.yaml ./                                                              0.1s
 => [13/16] COPY third-party ./third-party                                                                                   0.0s
 => [14/16] RUN /opt/poetry/bin/poetry config virtualenvs.create false &&     /opt/poetry/bin/poetry install                52.2s
 => [15/16] COPY . .                                                                                                         1.9s
 => [16/16] RUN /opt/poetry/bin/poetry install                                                                               5.1s
 => exporting to image                                                                                                      43.8s
 => => exporting layers                                                                                                     43.8s
 => => writing image sha256:35d72c4bec9cd1ba8679993a30621325480819a7eb17bfef508e167d5e3b5af2                                 0.0s
 => => naming to docker.io/library/pangotest  
```

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)