### PR TITLE
remove depreciated backdrop click prop

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -194,14 +194,11 @@ export const CreateNSTreeModal = ({
       </Notification>
       <StyledDialog
         disableEscapeKeyDown
+        disableBackdropClick
         open={open}
-        onClose={(_event, reason) => {
-          if (reason !== "backdropClick") {
-            handleClose();
-          }
-        }}
         fullWidth={true}
         maxWidth={"sm"}
+        onClose={handleClose}
       >
         <StyledDialogTitle>
           <StyledIconButton onClick={handleClose}>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -193,10 +193,13 @@ export const CreateNSTreeModal = ({
         </NextLink>
       </Notification>
       <StyledDialog
-        disableBackdropClick
         disableEscapeKeyDown
         open={open}
-        onClose={handleClose}
+        onClose={(_event, reason) => {
+          if (reason !== "backdropClick") {
+            handleClose();
+          }
+        }}
         fullWidth={true}
         maxWidth={"sm"}
       >

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Dialog, FormControlLabel, Radio, TextField } from "@material-ui/core";
+import { FormControlLabel, Radio, TextField } from "@material-ui/core";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import {
   Button,
@@ -16,8 +16,9 @@ import {
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import { transparentScrollbars } from "src/common/styles/support/style";
+import DialogNoDepreciation from "src/components/DialogNoDepreciation";
 
-export const StyledDialog = styled(Dialog)`
+export const StyledDialog = styled(DialogNoDepreciation)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -16,9 +16,9 @@ import {
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import { transparentScrollbars } from "src/common/styles/support/style";
-import DialogNoDepreciation from "src/components/DialogNoDepreciation";
+import Dialog from "src/components/Dialog";
 
-export const StyledDialog = styled(DialogNoDepreciation)`
+export const StyledDialog = styled(Dialog)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -1,4 +1,3 @@
-import { Dialog } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import { Alert, Tooltip } from "czifui";
 import { isEqual } from "lodash";
@@ -12,6 +11,7 @@ import { useUserInfo } from "src/common/queries/auth";
 import { downloadSamplesFasta } from "src/common/queries/samples";
 import { B } from "src/common/styles/support/style";
 import { pluralize } from "src/common/utils/strUtils";
+import DialogNoDepreciation from "src/components/DialogNoDepreciation";
 import Notification from "src/components/Notification";
 import { TooltipDescriptionText, TooltipHeaderText } from "../../style";
 import { ContactUsLink } from "../ContactUsLink";
@@ -136,14 +136,11 @@ const DownloadModal = ({
         </B>{" "}
         <ContactUsLink />
       </Notification>
-      <Dialog
+      <DialogNoDepreciation
         disableEscapeKeyDown
+        disableBackdropClick
         open={open}
-        onClose={(_event, reason) => {
-          if (reason !== "backdropClick") {
-            handleCloseModal();
-          }
-        }}
+        onClose={handleCloseModal}
       >
         <DialogTitle>
           <StyledIconButton onClick={handleCloseModal}>
@@ -224,7 +221,7 @@ const DownloadModal = ({
           </Content>
         </DialogContent>
         <DialogActions></DialogActions>
-      </Dialog>
+      </DialogNoDepreciation>
     </>
   );
 

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -11,7 +11,7 @@ import { useUserInfo } from "src/common/queries/auth";
 import { downloadSamplesFasta } from "src/common/queries/samples";
 import { B } from "src/common/styles/support/style";
 import { pluralize } from "src/common/utils/strUtils";
-import DialogNoDepreciation from "src/components/DialogNoDepreciation";
+import Dialog from "src/components/Dialog";
 import Notification from "src/components/Notification";
 import { TooltipDescriptionText, TooltipHeaderText } from "../../style";
 import { ContactUsLink } from "../ContactUsLink";
@@ -136,7 +136,7 @@ const DownloadModal = ({
         </B>{" "}
         <ContactUsLink />
       </Notification>
-      <DialogNoDepreciation
+      <Dialog
         disableEscapeKeyDown
         disableBackdropClick
         open={open}
@@ -221,7 +221,7 @@ const DownloadModal = ({
           </Content>
         </DialogContent>
         <DialogActions></DialogActions>
-      </DialogNoDepreciation>
+      </Dialog>
     </>
   );
 

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -137,10 +137,8 @@ const DownloadModal = ({
         <ContactUsLink />
       </Notification>
       <Dialog
-        // disableBackdropClick
         disableEscapeKeyDown
         open={open}
-        // onClose={handleCloseModal}
         onClose={(_event, reason) => {
           if (reason !== "backdropClick") {
             handleCloseModal();

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -137,10 +137,15 @@ const DownloadModal = ({
         <ContactUsLink />
       </Notification>
       <Dialog
-        disableBackdropClick
+        // disableBackdropClick
         disableEscapeKeyDown
         open={open}
-        onClose={handleCloseModal}
+        // onClose={handleCloseModal}
+        onClose={(_event, reason) => {
+          if (reason !== "backdropClick") {
+            handleCloseModal();
+          }
+        }}
       >
         <DialogTitle>
           <StyledIconButton onClick={handleCloseModal}>

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -1,4 +1,4 @@
-import { Dialog, TextField } from "@material-ui/core";
+import { TextField } from "@material-ui/core";
 import { DefaultMenuSelectOption, Dropdown, InputDropdown } from "czifui";
 import { cloneDeep, debounce } from "lodash";
 import React, { SyntheticEvent, useEffect, useState } from "react";
@@ -9,6 +9,7 @@ import {
   useFastaFetch,
 } from "src/common/queries/trees";
 import { pluralize } from "src/common/utils/strUtils";
+import DialogNoDepreciation from "src/components/DialogNoDepreciation";
 import {
   StyledDialogTitle,
   StyledTooltip,
@@ -183,15 +184,11 @@ export const UsherPlacementModal = ({
   );
 
   return (
-    <Dialog
+    <DialogNoDepreciation
       disableEnforceFocus
       disableEscapeKeyDown
       open={open}
-      onClose={(_event, reason) => {
-        if (reason !== "backdropClick") {
-          onClose();
-        }
-      }}
+      onClose={onClose}
       fullWidth
       maxWidth={"sm"}
     >
@@ -309,6 +306,6 @@ export const UsherPlacementModal = ({
           </form>
         </Content>
       </StyledDialogContent>
-    </Dialog>
+    </DialogNoDepreciation>
   );
 };

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -9,7 +9,7 @@ import {
   useFastaFetch,
 } from "src/common/queries/trees";
 import { pluralize } from "src/common/utils/strUtils";
-import DialogNoDepreciation from "src/components/DialogNoDepreciation";
+import Dialog from "src/components/Dialog";
 import {
   StyledDialogTitle,
   StyledTooltip,
@@ -184,7 +184,7 @@ export const UsherPlacementModal = ({
   );
 
   return (
-    <DialogNoDepreciation
+    <Dialog
       disableBackdropClick
       disableEnforceFocus
       disableEscapeKeyDown
@@ -307,6 +307,6 @@ export const UsherPlacementModal = ({
           </form>
         </Content>
       </StyledDialogContent>
-    </DialogNoDepreciation>
+    </Dialog>
   );
 };

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -184,11 +184,14 @@ export const UsherPlacementModal = ({
 
   return (
     <Dialog
-      disableBackdropClick
       disableEnforceFocus
       disableEscapeKeyDown
       open={open}
-      onClose={onClose}
+      onClose={(_event, reason) => {
+        if (reason !== "backdropClick") {
+          onClose();
+        }
+      }}
       fullWidth
       maxWidth={"sm"}
     >

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -185,6 +185,7 @@ export const UsherPlacementModal = ({
 
   return (
     <DialogNoDepreciation
+      disableBackdropClick
       disableEnforceFocus
       disableEscapeKeyDown
       open={open}

--- a/src/frontend/src/components/ConfirmDialog/index.tsx
+++ b/src/frontend/src/components/ConfirmDialog/index.tsx
@@ -1,9 +1,9 @@
-import { Dialog } from "@material-ui/core";
 import { Button } from "czifui";
 import React from "react";
 import DialogActions from "src/common/components/library/Dialog/components/DialogActions";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
+import DialogNoDepreciation from "src/components/DialogNoDepreciation";
 import { Content, StyledFooter, Title } from "./style";
 
 export interface ConfirmDialogProps {
@@ -32,14 +32,11 @@ export default function ConfirmDialog({
   );
 
   return (
-    <Dialog
+    <DialogNoDepreciation
       disableEscapeKeyDown
+      disableBackdropClick
       open={open}
-      onClose={(_event, reason) => {
-        if (reason !== "backdropClick") {
-          onClose();
-        }
-      }}
+      onClose={onClose}
     >
       <DialogTitle narrow>
         <Title>{title}</Title>
@@ -54,6 +51,6 @@ export default function ConfirmDialog({
         </Button>
       </DialogActions>
       {footer && <StyledFooter narrow>{footer}</StyledFooter>}
-    </Dialog>
+    </DialogNoDepreciation>
   );
 }

--- a/src/frontend/src/components/ConfirmDialog/index.tsx
+++ b/src/frontend/src/components/ConfirmDialog/index.tsx
@@ -33,10 +33,13 @@ export default function ConfirmDialog({
 
   return (
     <Dialog
-      disableBackdropClick
       disableEscapeKeyDown
       open={open}
-      onClose={onClose}
+      onClose={(_event, reason) => {
+        if (reason !== "backdropClick") {
+          onClose();
+        }
+      }}
     >
       <DialogTitle narrow>
         <Title>{title}</Title>

--- a/src/frontend/src/components/ConfirmDialog/index.tsx
+++ b/src/frontend/src/components/ConfirmDialog/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import DialogActions from "src/common/components/library/Dialog/components/DialogActions";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
-import DialogNoDepreciation from "src/components/DialogNoDepreciation";
+import Dialog from "src/components/Dialog";
 import { Content, StyledFooter, Title } from "./style";
 
 export interface ConfirmDialogProps {
@@ -32,7 +32,7 @@ export default function ConfirmDialog({
   );
 
   return (
-    <DialogNoDepreciation
+    <Dialog
       disableEscapeKeyDown
       disableBackdropClick
       open={open}
@@ -51,6 +51,6 @@ export default function ConfirmDialog({
         </Button>
       </DialogActions>
       {footer && <StyledFooter narrow>{footer}</StyledFooter>}
-    </DialogNoDepreciation>
+    </Dialog>
   );
 }

--- a/src/frontend/src/components/Dialog/index.tsx
+++ b/src/frontend/src/components/Dialog/index.tsx
@@ -1,4 +1,7 @@
-import { Dialog, DialogProps as MuiDialogProps } from "@material-ui/core";
+import {
+  Dialog as MuiDialog,
+  DialogProps as MuiDialogProps,
+} from "@material-ui/core";
 import React from "react";
 
 interface Props extends MuiDialogProps {
@@ -6,8 +9,9 @@ interface Props extends MuiDialogProps {
   onClose(): void;
 }
 
-// This component wraps Dialog and handles the backdropClick prop which is now depreciated
-export default function DialogNoDepreciation({
+// This component wraps Dialog and handles `Failed prop type: The prop disableBackdropClick of ForwardRef(Dialog) is deprecated`
+
+export default function Dialog({
   disableBackdropClick = false,
   onClose,
   ...props
@@ -19,5 +23,5 @@ export default function DialogNoDepreciation({
     onClose();
   };
 
-  return <Dialog onClose={handleClose} {...props} />;
+  return <MuiDialog onClose={handleClose} {...props} />;
 }

--- a/src/frontend/src/components/DialogNoDepreciation/index.tsx
+++ b/src/frontend/src/components/DialogNoDepreciation/index.tsx
@@ -1,0 +1,24 @@
+// import Dialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
+import { Dialog, DialogProps as MuiDialogProps } from "@material-ui/core";
+import React from "react";
+
+interface Props extends MuiDialogProps {
+  disableBackdropClick?: boolean;
+  onClose(): void;
+}
+
+// This component wraps Dialog and handles the backdropClick prop which is now depreciated
+export default function DialogNoDepreciation({
+  disableBackdropClick = false,
+  onClose,
+  ...props
+}: Props): JSX.Element {
+  const handleClose = (_event: any, reason: string) => {
+    if (disableBackdropClick && reason === "backdropClick") {
+      return false;
+    }
+    onClose();
+  };
+
+  return <Dialog onClose={handleClose} {...props} />;
+}

--- a/src/frontend/src/components/DialogNoDepreciation/index.tsx
+++ b/src/frontend/src/components/DialogNoDepreciation/index.tsx
@@ -1,4 +1,3 @@
-// import Dialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
 import { Dialog, DialogProps as MuiDialogProps } from "@material-ui/core";
 import React from "react";
 

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
@@ -1,4 +1,3 @@
-import { Dialog } from "@material-ui/core";
 import { AlertTitle } from "@material-ui/lab";
 import { Alert, Button } from "czifui";
 import NextLink from "next/link";
@@ -7,6 +6,7 @@ import { useMutation } from "react-query";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { createSamples } from "src/common/queries/samples";
 import { ROUTES } from "src/common/routes";
+import DialogNoDepreciation from "src/components/DialogNoDepreciation";
 import { ContinueButton } from "../../../common/style";
 import { SampleIdToMetadata, Samples } from "../../../common/types";
 import {
@@ -45,14 +45,11 @@ export default function Upload({
 
   return (
     <>
-      <Dialog
+      <DialogNoDepreciation
+        disableBackdropClick
         disableEscapeKeyDown
         open={isOpen}
-        onClose={(_event, reason) => {
-          if (reason !== "backdropClick") {
-            handleClose();
-          }
-        }}
+        onClose={handleClose}
       >
         <StyledDialogContent>
           <ImageWrapper>{getImage()}</ImageWrapper>
@@ -86,7 +83,7 @@ export default function Upload({
             </NextLink>
           )}
         </StyledDialogActions>
-      </Dialog>
+      </DialogNoDepreciation>
 
       <ContinueButton
         disabled={isDisabled}

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
@@ -46,10 +46,13 @@ export default function Upload({
   return (
     <>
       <Dialog
-        disableBackdropClick
         disableEscapeKeyDown
         open={isOpen}
-        onClose={handleClose}
+        onClose={(_event, reason) => {
+          if (reason !== "backdropClick") {
+            handleClose();
+          }
+        }}
       >
         <StyledDialogContent>
           <ImageWrapper>{getImage()}</ImageWrapper>

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
@@ -6,7 +6,7 @@ import { useMutation } from "react-query";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { createSamples } from "src/common/queries/samples";
 import { ROUTES } from "src/common/routes";
-import DialogNoDepreciation from "src/components/DialogNoDepreciation";
+import Dialog from "src/components/Dialog";
 import { ContinueButton } from "../../../common/style";
 import { SampleIdToMetadata, Samples } from "../../../common/types";
 import {
@@ -45,7 +45,7 @@ export default function Upload({
 
   return (
     <>
-      <DialogNoDepreciation
+      <Dialog
         disableBackdropClick
         disableEscapeKeyDown
         open={isOpen}
@@ -83,7 +83,7 @@ export default function Upload({
             </NextLink>
           )}
         </StyledDialogActions>
-      </DialogNoDepreciation>
+      </Dialog>
 
       <ContinueButton
         disabled={isDisabled}


### PR DESCRIPTION
### Summary:
- **What:** removes
```
Failed prop type: The prop disableBackdropClick of ForwardRef(Dialog) is deprecated. Use the onClose prop with the reason argument to filter the backdropClick events.
```
warnings from the console

- **Ticket:** no ticket
- **Env:** no rdev

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)