### PR TITLE
Trim off a leading 'hcov-19/' before trying to match gisaid samples.

### DIFF
--- a/src/backend/aspen/workflows/import_gisaid_isls/save.py
+++ b/src/backend/aspen/workflows/import_gisaid_isls/save.py
@@ -5,6 +5,7 @@
 
 import click
 import sqlalchemy as sa
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.expression import literal_column
 
@@ -36,7 +37,11 @@ def save():
                 GisaidMetadata.gisaid_epi_isl,
             )
             .select_from(Sample)
-            .join(GisaidMetadata, Sample.public_identifier == GisaidMetadata.strain)
+            .join(
+                GisaidMetadata,
+                func.regexp_replace(Sample.public_identifier, "^hcov-19/", "", "i")
+                == GisaidMetadata.strain,
+            )
             .subquery()
         )
 


### PR DESCRIPTION
### Summary:
- **What:** This PR strips off a leading (case-insensitive) 'hcov-19/' prefix from sample public identifiers before trying to match identifiers to the strains in the gisaid database. It means what we're more permissive about matching ISL's.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)