### PR TITLE
Work around some docker-compose interface changes.

### DIFF
--- a/scripts/happy
+++ b/scripts/happy
@@ -886,11 +886,6 @@ class ArtifactBuilder:
 
     def build(self, artifacts=None):
         env = self.get_env()
-        compose_args = self.get_compose_args()
-        cmd = ["docker-compose"] + compose_args + ["build"]
-        if artifacts:
-            cmd += artifacts
-        subprocess.check_call(cmd, env=env)
 
         images = {}
         for service_name, service in self.get_compose_services().items():
@@ -898,6 +893,13 @@ class ArtifactBuilder:
                 if artifacts and service_name not in artifacts:
                     continue
                 images[service_name] = service["image"]
+
+        compose_args = self.get_compose_args()
+        cmd = ["docker-compose"] + compose_args + ["build"] + list(images.keys())
+        if artifacts:
+            cmd += artifacts
+        subprocess.check_call(cmd, env=env)
+
         return images
 
     def get_compose_args(self):


### PR DESCRIPTION
### Summary:
- **What:** For "reasons" I have yet to understand, the `docker-compose build` interface has changed so that it doesn't build all images by default. This PR sends an explict list of which services to build images for.

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)