### PR TITLE
Reset status for ondemand runs when swipe retries.

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -44,6 +44,7 @@ aligned_gisaid_location=$(
            --metadata /ncov/data/metadata_aspen.tsv         \
            --selected /ncov/data/include.txt                       \
            --builds-file /ncov/my_profiles/aspen/builds.yaml       \
+           --reset-status \
 )
 
 


### PR DESCRIPTION
### Summary:
- **What:** Improve workflow status handling when swipe retries jobs on spot instances
- **Ticket:** [sc185732](https://app.shortcut.com/genepi/story/185732)

### Notes:
This is one small part of the fixes necessary to make sure we're reflecting workflow statuses in our db properly. This ensures that for *on-demand* phylo runs, we reset job status to `STARTED` when a job fails on SPOT instances and gets restarted on on-demand instances.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)