### PR TITLE
fix: enable auto_run_migrations for rdev

### DIFF
--- a/.happy/config.json
+++ b/.happy/config.json
@@ -62,7 +62,8 @@
             "secret_arn": "happy/env-dev-config",
             "terraform_directory": ".happy/terraform/envs/dev",
             "log_group_prefix": "/genepi/dev",
-            "task_launch_type": "fargate"
+            "task_launch_type": "fargate",
+            "auto_run_migrations": true
         },
         "staging": {
             "aws_profile": "genepi-dev",


### PR DESCRIPTION
### Summary:
- **What:** Explicitly enable auto_run_migrations for rdev env. This should be compatible with both python + go clis.
- **Ticket:** NA
- **Env:** NA

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)