### PR TITLE
adding option to download tree with public identifiers

### DIFF
--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -53,7 +53,8 @@ interface Tree extends BioinformaticsType {
   startedDate: string;
   workflowId: string;
   status: TREE_STATUS;
-  downloadLink?: string;
+  downloadLinkIdStylePrivateIdentifiers?: string;
+  downloadLinkIdStylePublicIdentifiers?: string;
   user: {
     name: string;
     id: number;

--- a/src/frontend/src/views/Data/components/TreeActionMenu/components/TreeTableDownloadMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/components/TreeTableDownloadMenu/index.tsx
@@ -21,7 +21,12 @@ const TreeTableDownloadMenu = ({ item }: Props): JSX.Element => {
     setAnchorEl(null);
   };
 
-  const jsonLink = stringGuard(item["downloadLink"]);
+  const jsonLinkIdStylePrivateIdentifiers = stringGuard(
+    item["downloadLinkIdStylePrivateIdentifiers"]
+  );
+  const jsonLinkIdStylePublicIdentifiers = stringGuard(
+    item["downloadLinkIdStylePublicIdentifiers"]
+  );
   const tsvDownloadLink = stringGuard(item["accessionsLink"]);
   const disabled = item?.status !== TREE_STATUS.Completed;
   // TODO (mlila): This is necessary due to an sds bug -- MUI tooltips should not display
@@ -71,10 +76,17 @@ const TreeTableDownloadMenu = ({ item }: Props): JSX.Element => {
           onClose={handleClose}
           getContentAnchorEl={null}
         >
-          <NewTabLink href={jsonLink}>
+          <NewTabLink href={jsonLinkIdStylePrivateIdentifiers}>
             <MenuItemTooltip>
               <MenuItem disabled={disabled} onClick={handleClose}>
-                {"Tree file (.json)"}
+                {"Tree file with Private IDs (.json)"}
+              </MenuItem>
+            </MenuItemTooltip>
+          </NewTabLink>
+          <NewTabLink href={jsonLinkIdStylePublicIdentifiers}>
+            <MenuItemTooltip>
+              <MenuItem disabled={disabled} onClick={handleClose}>
+                {"Tree file with Public IDs (.json)"}
               </MenuItem>
             </MenuItemTooltip>
           </NewTabLink>

--- a/src/frontend/src/views/Data/transforms.tsx
+++ b/src/frontend/src/views/Data/transforms.tsx
@@ -5,13 +5,24 @@ const { API_URL } = ENV;
 export const TREE_TRANSFORMS: Transform[] = [
   {
     inputs: ["id"],
-    key: "downloadLink",
+    key: "downloadLinkIdStylePrivateIdentifiers",
     method: (inputs: number[]): string | undefined => {
       const id = inputs[0];
       if (typeof id !== "number") {
         return undefined;
       }
       return `${API_URL}/api/phylo_tree/${id}`;
+    },
+  },
+  {
+    inputs: ["id"],
+    key: "downloadLinkIdStylePublicIdentifiers",
+    method: (inputs: number[]): string | undefined => {
+      const id = inputs[0];
+      if (typeof id !== "number") {
+        return undefined;
+      }
+      return `${API_URL}/api/phylo_tree/${id}?id_style=public`;
     },
   },
   {


### PR DESCRIPTION
### Summary:
- **What:** adding option for users to download tree json with public identifiers
- **Ticket:** [sc185795](https://app.shortcut.com/genepi/story/185795)
- **Env:** https://pulic-identifier-tree-dl-frontend.dev.czgenepi.org

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)