### PR TITLE
fixing tree edit modal stylings

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/EditTreeConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditTreeConfirmationModal/index.tsx
@@ -3,10 +3,9 @@ import { Button } from "czifui";
 import React, { useEffect, useState } from "react";
 import { useEditTree } from "src/common/queries/trees";
 import BaseDialog from "src/components/BaseDialog";
-import { StyledIconButton } from "src/components/BaseDialog/style";
 import Notification from "src/components/Notification";
 import { TreeNameInput } from "src/components/TreeNameInput";
-import { StyledTitle } from "./style";
+import { StyledDiv, StyledIconButton, StyledTitle } from "./style";
 
 interface Props {
   onClose(): void;
@@ -31,7 +30,7 @@ export const EditTreeConfirmationModal = ({
   useEffect(() => {
     // this makes sure that the newTreeName defaults to the current tree name,
     //  and that the newTreeName state variable resets when we edit a new tree
-    if (tree) {
+    if (tree && tree.name) {
       setNewTreeName(tree.name);
     }
 
@@ -74,7 +73,7 @@ export const EditTreeConfirmationModal = ({
   const title = <StyledTitle>Edit Tree Name</StyledTitle>;
 
   const content = (
-    <>
+    <StyledDiv>
       <TreeNameInput
         setTreeName={setNewTreeName}
         treeName={newTreeName}
@@ -82,7 +81,7 @@ export const EditTreeConfirmationModal = ({
         textInputLabel={"Tree Name: "}
         isTextInputMultiLine={true}
       />
-    </>
+    </StyledDiv>
   );
 
   const confirmButton = (
@@ -110,7 +109,7 @@ export const EditTreeConfirmationModal = ({
           autoDismiss
           buttonOnClick={() => setShouldShowSuccessNotification(false)}
           buttonText="DISMISS"
-          dismissDirection="right"
+          dismissDirection="left"
           dismissed={!shouldShowSuccessNotification}
           intent="info"
         >
@@ -122,7 +121,7 @@ export const EditTreeConfirmationModal = ({
           autoDismiss
           buttonOnClick={() => setShouldShowErrorNotification(false)}
           buttonText="DISMISS"
-          dismissDirection="right"
+          dismissDirection="left"
           dismissed={!shouldShowErrorNotification}
           intent="error"
         >

--- a/src/frontend/src/common/components/library/data_subview/components/EditTreeConfirmationModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditTreeConfirmationModal/style.ts
@@ -1,14 +1,25 @@
 import styled from "@emotion/styled";
+import IconButton from "@material-ui/core/IconButton";
 import { fontHeaderXl, getSpaces } from "czifui";
 
 export const StyledTitle = styled.div`
   ${fontHeaderXl}
+`;
 
+export const StyledDiv = styled.div`
   ${(props) => {
     const spaces = getSpaces(props);
-
     return `
-      margin-bottom: ${spaces?.xl}px;
+      padding-top: ${spaces?.l}px;
     `;
   }}
+`;
+
+export const StyledIconButton = styled(IconButton)`
+  display: flex;
+  align-self: flex-end;
+  padding: 0;
+  &:hover {
+    background-color: transparent;
+  }
 `;

--- a/src/frontend/src/common/utils/featureFlags.tsx
+++ b/src/frontend/src/common/utils/featureFlags.tsx
@@ -21,10 +21,6 @@ export const FEATURE_FLAGS: FlagsObj = {
     isDisabled: true,
     key: "mayasFlag",
   },
-  editTrees: {
-    isDisabled: false,
-    key: "editTrees",
-  },
   editSamples: {
     isDisabled: false,
     key: "editSamples",

--- a/src/frontend/src/components/BaseDialog/index.tsx
+++ b/src/frontend/src/components/BaseDialog/index.tsx
@@ -37,8 +37,8 @@ export default function BaseDialog({
       open={open}
       onClose={onClose}
     >
-      <StyledDiv>{closeIcon}</StyledDiv>
       <DialogTitle narrow>
+        <StyledDiv>{closeIcon}</StyledDiv>
         <Title>{title}</Title>
       </DialogTitle>
       <DialogContent narrow>

--- a/src/frontend/src/components/BaseDialog/style.ts
+++ b/src/frontend/src/components/BaseDialog/style.ts
@@ -43,16 +43,12 @@ export const StyledFooter = styled.div`
 export const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      padding: ${spaces?.l}px;
-      padding-bottom: 0px;
-    `;
-  }}
+  padding-bottom: 0px;
 `;
 
 export const StyledIconButton = styled(IconButton)`
+  display: flex;
+  flex-direction: column;
   align-self: flex-end;
   padding: 0;
   &:hover {

--- a/src/frontend/src/components/TreeNameInput/style.ts
+++ b/src/frontend/src/components/TreeNameInput/style.ts
@@ -19,7 +19,7 @@ export const StyledInstructions = styled(Instructions)`
 
     return `
       border-radius: ${corners?.m}px;
-      padding:${spaces?.l}px;
+      padding:${spaces?.l}px ${spaces?.l}px ${spaces?.s}px ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Data/components/TreeActionMenu/components/MoreActionsMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/components/MoreActionsMenu/index.tsx
@@ -4,7 +4,6 @@ import { TREE_STATUS } from "src/common/constants/types";
 import MoreActionsIcon from "src/common/icons/IconDotsHorizontal3Large.svg";
 import { UserResponse } from "src/common/queries/auth";
 import { StyledEditIcon, StyledTrashIcon } from "src/common/styles/iconStyle";
-import { FEATURE_FLAGS, usesFeatureFlag } from "src/common/utils/featureFlags";
 import { StyledIcon, StyledIconWrapper } from "../../style";
 import { StyledText } from "./style";
 
@@ -82,12 +81,10 @@ const MoreActionsMenu = ({
           onClose={handleClose}
           getContentAnchorEl={null}
         >
-          {usesFeatureFlag(FEATURE_FLAGS.editTrees) && (
-            <MenuItem onClick={() => onEditTreeModalOpen(item)}>
-              <StyledEditIcon />
-              <StyledText>Edit Tree Name</StyledText>
-            </MenuItem>
-          )}
+          <MenuItem onClick={() => onEditTreeModalOpen(item)}>
+            <StyledEditIcon />
+            <StyledText>Edit Tree Name</StyledText>
+          </MenuItem>
           <MenuItem onClick={() => onDeleteTreeModalOpen(item)}>
             <StyledTrashIcon />
             <StyledText isWarning>Delete Tree</StyledText>


### PR DESCRIPTION
### Summary:
- **What:** addressing some design feedback tweaks for update tree modal. 
- **Ticket:** [sc185106](https://app.shortcut.com/genepi/story/185106)
- **Env:** https://update-trees-frontend.dev.czgenepi.org/data/phylogenetic_trees

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)