### PR TITLE
[fix] Fix typing problem for v2 users endpoint.

### DIFF
--- a/src/backend/aspen/api/schemas/users.py
+++ b/src/backend/aspen/api/schemas/users.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+import datetime
 
 from aspen.api.schemas.base import BaseResponse
 
@@ -13,7 +14,7 @@ class UserBaseResponse(BaseResponse):
     name: str
     group: GroupResponse
     agreed_to_tos: bool = False
-    acknowledged_policy_version: Optional[str] = None
+    acknowledged_policy_version: Optional[datetime.date] = None
 
 
 # Only expose split id to the user it belongs to.

--- a/src/backend/aspen/api/schemas/users.py
+++ b/src/backend/aspen/api/schemas/users.py
@@ -1,5 +1,5 @@
-from typing import List, Optional
 import datetime
+from typing import List, Optional
 
 from aspen.api.schemas.base import BaseResponse
 


### PR DESCRIPTION
### Summary:
- **What:** The type spec for acknowledged_policy_version was incorrect, this fixes it.
- **Ticket:** [sc166024](https://app.shortcut.com/genepi/story/166024)
- **Env:** https://mev2-frontend.dev.czgenepi.org

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)