### PR TITLE
make entire logo and name clickable

### DIFF
--- a/src/frontend/src/components/NavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/index.tsx
@@ -40,9 +40,9 @@ const NavBarLoggedIn = (): JSX.Element => {
         <Link href={route} passHref>
           <LogoAnchor href="passHref">
             <Logo data-test-id="logo" />
+            {orgSplash}
           </LogoAnchor>
         </Link>
-        {orgSplash}
       </div>
 
       <div className={style.right}>

--- a/src/frontend/src/components/NavBar/style.ts
+++ b/src/frontend/src/components/NavBar/style.ts
@@ -18,4 +18,5 @@ export const LogoAnchor = styled.a`
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 100%;
 `;


### PR DESCRIPTION
### Summary
- **What:** Make county name in cz genepi header clickable, in addition to the logo
- **Why:** feels like a more consistent interaction pattern
- **Ticket:** [[sc-137423]](https://app.shortcut.com/genepi/story/137423)

### Demos
![after](https://user-images.githubusercontent.com/7562933/156101133-0e1885de-858a-4f4c-8ba7-6e1d3b1fa8d0.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)