### PR TITLE
add security txt instructions for security researchers to report issu…

### DIFF
--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -62,6 +62,16 @@ module.exports = ({
     ];
   },
 
+  async redirects() {
+    return [
+      {
+        source: "/security.txt",
+        destination: "/.well-known/security.txt",
+        permanent: true,
+      },
+    ];
+  },
+
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/src/frontend/public/.well-known/security.txt
+++ b/src/frontend/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@czgenepi.org
+Expires: 2023-03-01T17:00:00.000Z
+Preferred-Languages: en
+Canonical: https://czgenepi.org/.well-known/security.txt
+Hiring: https://chanzuckerberg.com/careers/career-opportunities/?team=engineering

--- a/src/frontend/public/security.txt
+++ b/src/frontend/public/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@czgenepi.org
+Expires: 2023-03-01T17:00:00.000Z
+Preferred-Languages: en
+Canonical: https://czgenepi.org/.well-known/security.txt
+Hiring: https://chanzuckerberg.com/careers/career-opportunities/?team=engineering

--- a/src/frontend/public/security.txt
+++ b/src/frontend/public/security.txt
@@ -1,5 +1,0 @@
-Contact: mailto:security@czgenepi.org
-Expires: 2023-03-01T17:00:00.000Z
-Preferred-Languages: en
-Canonical: https://czgenepi.org/.well-known/security.txt
-Hiring: https://chanzuckerberg.com/careers/career-opportunities/?team=engineering

--- a/src/frontend/tests/staticFiles/security.test.ts
+++ b/src/frontend/tests/staticFiles/security.test.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from "fs";
 
-const checkExpirationDate = (path) => {
+const checkExpirationDate = (path: string) => {
   const text = readFileSync(path).toString();
-  const expirationDateStr = text.match(/Expires: .*/g)[0].slice(9);
+  const expirationDateStr = text?.match(/Expires: .*/g)?.[0]?.slice(9);
+
+  if (!expirationDateStr) throw Error("security.txt missing expiry date");
+
   const expirationDate = new Date(expirationDateStr);
   const now = new Date();
 
@@ -17,4 +20,11 @@ test("ensure second security.txt file has not expired", () => {
   expect(() =>
     checkExpirationDate("public/.well-known/security.txt")
   ).not.toThrow();
+});
+
+test("ensure security files in sync", () => {
+  const file = readFileSync("public/security.txt").toString();
+  const file2 = readFileSync("public/.well-known/security.txt").toString();
+
+  expect(file == file2).toBeTruthy();
 });

--- a/src/frontend/tests/staticFiles/security.test.ts
+++ b/src/frontend/tests/staticFiles/security.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "fs";
+
+const checkExpirationDate = (path) => {
+  const text = readFileSync(path).toString();
+  const expirationDateStr = text.match(/Expires: .*/g)[0].slice(9);
+  const expirationDate = new Date(expirationDateStr);
+  const now = new Date();
+
+  if (expirationDate < now) throw Error("security.txt files need updating");
+};
+
+test("ensure first security.txt file has not expired", () => {
+  expect(() => checkExpirationDate("public/security.txt")).not.toThrow();
+});
+
+test("ensure second security.txt file has not expired", () => {
+  expect(() =>
+    checkExpirationDate("public/.well-known/security.txt")
+  ).not.toThrow();
+});

--- a/src/frontend/tests/staticFiles/security.test.ts
+++ b/src/frontend/tests/staticFiles/security.test.ts
@@ -12,7 +12,7 @@ const checkExpirationDate = (path: string) => {
   if (expirationDate < now) throw Error("security.txt files need updating");
 };
 
-test("ensure second security.txt file has not expired", () => {
+test("ensure security.txt file has not expired", () => {
   expect(() =>
     checkExpirationDate("public/.well-known/security.txt")
   ).not.toThrow();

--- a/src/frontend/tests/staticFiles/security.test.ts
+++ b/src/frontend/tests/staticFiles/security.test.ts
@@ -12,19 +12,8 @@ const checkExpirationDate = (path: string) => {
   if (expirationDate < now) throw Error("security.txt files need updating");
 };
 
-test("ensure first security.txt file has not expired", () => {
-  expect(() => checkExpirationDate("public/security.txt")).not.toThrow();
-});
-
 test("ensure second security.txt file has not expired", () => {
   expect(() =>
     checkExpirationDate("public/.well-known/security.txt")
   ).not.toThrow();
-});
-
-test("ensure security files in sync", () => {
-  const file = readFileSync("public/security.txt").toString();
-  const file2 = readFileSync("public/.well-known/security.txt").toString();
-
-  expect(file == file2).toBeTruthy();
 });


### PR DESCRIPTION
### Summary
- **What:** Add a `security.txt` to the website, following instructions from https://securitytxt.org/
- **Why:** So security researchers can report bugs easily and find jobs
- **Ticket:** [[sc-137545]](https://app.shortcut.com/genepi/story/137545)

### Demos
<img width="761" alt="Screen Shot 2022-03-01 at 9 50 56 AM" src="https://user-images.githubusercontent.com/7562933/156191144-5df1b337-961a-42f3-a6be-66d9cfd777f5.png">
<img width="676" alt="Screen Shot 2022-03-01 at 9 51 07 AM" src="https://user-images.githubusercontent.com/7562933/156191146-2bc5ae97-039c-4ffe-919a-aa2b68a364ae.png">

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)