### PR TITLE
use a branch of chanzuckerberg/ncov

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -57,7 +57,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/chanzuckerberg/ncov.git && \
-    git fetch origin master && \
+    git fetch origin czgenepi && \
     git reset --hard FETCH_HEAD
 
 # Poetry: install app

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -39,7 +39,7 @@ RUN mkdir /ncov && \
     cd /ncov && \
     git init && \
     git remote add origin https://github.com/chanzuckerberg/ncov.git && \
-    git fetch origin master && \
+    git fetch origin czgenepi && \
     git reset --hard FETCH_HEAD
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs


### PR DESCRIPTION
### Summary:
- **What:** We've moved to use our forked version of `ncov` https://github.com/chanzuckerberg/czgenepi/pull/974. This PR makes it fetch the `czgenepi` branch instead of `master`.

### Demos:
The Docker image built without error. Current `czgenepi` is identical to `master` which had been extensively tested.

### Notes:
Now doing pushing and pulling among 3 repos, it reminds me, as a non-eng, of the upcoming Doctor Strange in the Multiverse of Madness [(trailer here)]( https://www.youtube.com/watch?v=Rt_UqUm38BI&ab_channel=MarvelEntertainment). That movie is tagged as `horror` 😆 

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)