### PR TITLE
Update Makefile to use docker's built-in compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 ### DOCKER ENVIRONMENTAL VARS #################################################
 export DOCKER_BUILDKIT:=1
 export COMPOSE_DOCKER_CLI_BUILD:=1
-export docker_compose:=docker-compose --env-file .env.ecr
+export docker_compose:=docker compose --env-file .env.ecr
 export AWS_DEV_PROFILE=genepi-dev
 export AWS_PROD_PROFILE=genepi-prod
 export BACKEND_APP_ROOT=/usr/src/app
@@ -101,7 +101,7 @@ local-ecr-login:
 init-empty-db:
 	$(docker_compose) stop database
 	$(docker_compose) rm database
-	$(docker_compose) -f docker-compose.yml -f docker-compose-emptydb.yml up -d
+	$(docker_compose) --profile $(LOCALDEV_PROFILE) -f docker-compose.yml -f docker-compose-emptydb.yml up -d
 	sleep 10 # hack, let postgres start up cleanly.
 	-$(docker_compose) exec -T database psql "postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@$(LOCAL_DB_SERVER)/$(LOCAL_DB_NAME)" -c "ALTER USER $(LOCAL_DB_ADMIN_USERNAME) WITH PASSWORD '$(LOCAL_DB_ADMIN_PASSWORD)';"
 	-$(docker_compose) exec -T database psql "postgresql://$(LOCAL_DB_ADMIN_USERNAME):$(LOCAL_DB_ADMIN_PASSWORD)@$(LOCAL_DB_SERVER)/$(LOCAL_DB_NAME)" -c "CREATE USER $(LOCAL_DB_RW_USERNAME) WITH PASSWORD '$(LOCAL_DB_RW_PASSWORD)';"
@@ -187,7 +187,7 @@ local-start: .env.ecr ## Start a local dev environment that's been stopped.
 
 .PHONY: local-stop
 local-stop: ## Stop the local dev environment.
-	$(docker_compose) stop
+	$(docker_compose) --profile '*' stop
 
 .PHONY: local-clean
 local-clean: local-nohostconfig ## Remove everything related to the local dev environment (including db data!)


### PR DESCRIPTION
### Summary:
- **What:** Update our makefile to always use the docker CLI's built-in `compose` command

### Notes:
Docker desktop has a checkbox that allows us to switch between using compose v1 or v2 when we run the `docker-compose` command, however when we run `docker compose` we're always using compose v2.

These changes switch our Makefile to always use compose v2 via `docker compose` in alignment with our new `happy` cli. We also needed to update a few commands to make use of the profiles we have configured in `docker_compose.yml`. By default, any `docker compose up/down` commands will run any containers that *do not* have a profile specified. Since all of the containers in our `docker-compose.yml` file *do* have profiles defined, we need to specify which profiles (and * means everything) to use when bringing compose services up and down.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)