### PR TITLE
Change references to pangolin probability to "Confidence"

### DIFF
--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -22,7 +22,7 @@ class SampleGisaidResponseSchema(BaseResponse):
 class SampleLineageResponseSchema(BaseResponse):
     last_updated: Optional[datetime.datetime]
     lineage: Optional[str]
-    probability: Optional[float]
+    confidence: Optional[float]
     version: Optional[str]
 
 

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -29,14 +29,14 @@ def format_sample_lineage(sample: Sample) -> dict[str, Any]:
     if pathogen_genome:
         lineage = {
             "lineage": pathogen_genome.pangolin_lineage,
-            "probability": pathogen_genome.pangolin_probability,
+            "confidence": pathogen_genome.pangolin_probability,
             "version": pathogen_genome.pangolin_version,
             "last_updated": pathogen_genome.pangolin_last_updated,
         }
     else:
         lineage = {
             "lineage": None,
-            "probability": None,
+            "confidence": None,
             "version": None,
             "last_updated": None,
         }

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -77,7 +77,7 @@ async def test_samples_view(
                 "sequencing_date": str(uploaded_pathogen_genome.sequencing_date),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
+                    "confidence": uploaded_pathogen_genome.pangolin_probability,
                     "version": uploaded_pathogen_genome.pangolin_version,
                     "last_updated": convert_datetime_to_iso_8601(
                         uploaded_pathogen_genome.pangolin_last_updated
@@ -140,7 +140,7 @@ async def test_samples_view_gisaid_rejected(
                 "sequencing_date": str(uploaded_pathogen_genome.sequencing_date),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
+                    "confidence": uploaded_pathogen_genome.pangolin_probability,
                     "version": uploaded_pathogen_genome.pangolin_version,
                     "last_updated": convert_datetime_to_iso_8601(
                         uploaded_pathogen_genome.pangolin_last_updated
@@ -205,7 +205,7 @@ async def test_samples_view_gisaid_no_info(
                 "sequencing_date": str(uploaded_pathogen_genome.sequencing_date),
                 "lineage": {
                     "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                    "probability": uploaded_pathogen_genome.pangolin_probability,
+                    "confidence": uploaded_pathogen_genome.pangolin_probability,
                     "version": uploaded_pathogen_genome.pangolin_version,
                     "last_updated": convert_datetime_to_iso_8601(
                         uploaded_pathogen_genome.pangolin_last_updated
@@ -265,7 +265,7 @@ async def test_samples_view_gisaid_not_eligible(
                 "sequencing_date": None,
                 "lineage": {
                     "lineage": None,
-                    "probability": None,
+                    "confidence": None,
                     "version": None,
                     "last_updated": None,
                 },
@@ -462,7 +462,7 @@ async def test_samples_view_cansee_all(
             "sequencing_date": str(uploaded_pathogen_genome.sequencing_date),
             "lineage": {
                 "lineage": uploaded_pathogen_genome.pangolin_lineage,
-                "probability": uploaded_pathogen_genome.pangolin_probability,
+                "confidence": uploaded_pathogen_genome.pangolin_probability,
                 "version": uploaded_pathogen_genome.pangolin_version,
                 "last_updated": convert_datetime_to_iso_8601(
                     uploaded_pathogen_genome.pangolin_last_updated
@@ -531,7 +531,7 @@ async def test_samples_view_no_pangolin(
                 "sequencing_date": str(uploaded_pathogen_genome.sequencing_date),
                 "lineage": {
                     "lineage": None,
-                    "probability": None,
+                    "confidence": None,
                     "version": None,
                     "last_updated": None,
                 },

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -262,7 +262,7 @@ interface GisaidResponseType {
 interface LineageResponseType {
   last_updated: string;
   lineage: string;
-  probability: number;
+  confidence: number;
   version: string;
 }
 interface SubmittingGroupResponseType {

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -11,7 +11,7 @@ interface GISAID {
 interface Lineage {
   last_updated: unknown;
   lineage: unknown;
-  probability: unknown;
+  confidencde: unknown;
   version: unknown;
 }
 

--- a/src/frontend/src/views/Data/components/LineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/LineageTooltip/index.tsx
@@ -4,7 +4,7 @@ import { Label, Text, Wrapper } from "./style";
 export interface Lineage {
   last_updated: string;
   lineage: string;
-  probability: string;
+  confidence: string;
   version: string;
 }
 
@@ -14,7 +14,7 @@ interface Props {
 
 const DISPLAY_ORDER: Array<keyof Lineage> = [
   "lineage",
-  "probability",
+  "confidence",
   "version",
   "last_updated",
 ];
@@ -23,7 +23,10 @@ export const LineageTooltip = ({ lineage }: Props): JSX.Element => {
   return (
     <>
       {DISPLAY_ORDER.map((key) => {
-        const value = lineage[key];
+        let value = lineage[key];
+        if (key === "confidence") {
+          value = `${value}%`;
+        }
         return <Row key={key} label={key as keyof Lineage} text={value} />;
       })}
     </>
@@ -33,7 +36,7 @@ export const LineageTooltip = ({ lineage }: Props): JSX.Element => {
 const KEY_TO_LABELS = {
   last_updated: "Last Updated",
   lineage: "Lineage",
-  probability: "Probability",
+  confidence: "Confidence",
   version: "PangoLEARN Version",
 };
 

--- a/src/frontend/src/views/Data/headers.tsx
+++ b/src/frontend/src/views/Data/headers.tsx
@@ -100,8 +100,8 @@ export const SAMPLE_SUBHEADERS: Record<string, SubHeader[]> = {
       text: "Lineage",
     },
     {
-      key: "probability",
-      text: "Probability",
+      key: "confidence",
+      text: "Confidence",
     },
     {
       key: "last_updated",


### PR DESCRIPTION
### Summary:
- **What:** Changes v2 samples api to return "confidence" instead of "probability" for a pangolin lineage. Changes tooltip to use a `%` sign.
- **Ticket:** [sc143074](https://app.shortcut.com/genepi/story/143074)
- **Env:** `<rdev link>`

### Demos:
<img width="464" alt="Screen Shot 2022-03-03 at 09 40 51" src="https://user-images.githubusercontent.com/24234461/156621423-7a340dde-37c1-47a3-9cf6-cd068dfac52f.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)