### PR TITLE
Add CLI command to create new users

### DIFF
--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -293,6 +293,39 @@ def me(ctx):
     print(resp.text)
 
 
+@user.command(name="create")
+@click.argument("email")
+@click.option("--name", required=True, type=str, help="The user's name.")
+@click.option("--group_id", required=True, type=str, help="The id of the group to create the user in.")
+@click.option("--auth0_user_id", required=True, type=str, help="The auth0 identifier attached to the user's auth0 account.")
+@click.option("--group_admin", is_flag=True, default=False)
+@click.option("--system_admin", is_flag=True, default=False)
+@click.pass_context
+def create(
+    ctx,
+    email,
+    name,
+    group_id,
+    auth0_user_id,
+    group_admin,
+    system_admin,
+):
+    api_client = ctx.obj["api_client"]
+    user = {
+        "name": name,
+        "email": email,
+        "group_id": group_id,
+        "group_admin": group_admin,
+        "system_admin": system_admin,
+    }
+    if auth0_user_id:
+        user["auth0_user_id"] = auth0_user_id
+    # Remove None fields
+    print(user)
+    resp = api_client.post("/api/usergroup", json=user)
+    print(resp.text)
+
+
 @cli.group()
 def userinfo():
     pass


### PR DESCRIPTION
### Summary:
- **What:** Adds a cli command to create users.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

<img width="1099" alt="Screen Shot 2022-03-25 at 17 34 17" src="https://user-images.githubusercontent.com/24234461/160217444-a75c58f3-9179-4d6c-a229-e2b9f5457e91.png">

### Notes:

The current code to automagically create Auth0 user accounts doesn't seem to be working, so `--auth0_user_id` is a required flag until that changes.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)