### PR TITLE
Specify pip install directory in local-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login local-hostconf
 	$(docker_compose) exec -T backend $(BACKEND_APP_ROOT)/scripts/setup_dev_data.sh
 	$(docker_compose) exec -T backend alembic upgrade head
 	$(docker_compose) exec -T backend python scripts/setup_localdata.py
-	$(docker_compose) exec -T backend pip install .
+	$(docker_compose) exec -T backend pip install ./aspen
 
 .PHONY: prepare-new-db-snapshot
 prepare-new-db-snapshot:


### PR DESCRIPTION
### Summary:
- **What:** `make local-init` is broken because we don't pass enough information to `pip` to let it know what we want to install on the final command. This breaks a couple tests as well. This PR specifies the package in the aspen directory.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)