### PR TITLE
sds vars in homepage

### DIFF
--- a/src/frontend/src/views/LandingPageV2/components/Footer/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/Footer/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { getColors, getSpaces } from "czifui";
 
 export const CZBiohubLogo = styled.a`
   max-width: 120px;
@@ -26,8 +27,13 @@ export const CZLogoContainer = styled.div`
 `;
 
 export const CZILogo = styled.a`
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      border-right: 1px solid ${colors?.gray[500]};
+    `;
+  }}
   margin-left: 32px;
-  border-right: 1px solid #767676;
   padding-right: 20px;
   max-width: 100px;
 `;
@@ -53,14 +59,30 @@ export const FooterBottomLinks = styled.div``;
 export const FooterBottomSeparator = styled.div`
   display: none;
 
-  @media (max-width: 768px) {
-    display: block;
-    width: 100%;
-    margin: 23px auto;
-    height: 1px;
-    background: #545454;
-  }
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      @media (max-width: 768px) {
+        display: block;
+        width: 100%;
+        margin: ${spaces?.l}px auto;
+        height: 1px;
+        background: ${colors?.gray[600]};
+      }
+    `;
+  }}
 `;
+
+const footerText = () => {
+  return `
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: 0.3px;
+  `;
+};
 
 export const FooterContainer = styled.div`
   background: black;
@@ -73,10 +95,7 @@ export const FooterContainer = styled.div`
 
   & a {
     color: white;
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 24px;
-    letter-spacing: 0.3px;
+    ${footerText}
   }
 `;
 
@@ -86,13 +105,11 @@ export const FooterLogoContainer = styled.a`
 `;
 
 export const FooterPartnerships = styled.div`
+  ${footerText}
+
   display: flex;
   align-items: center;
-  font-size: 14px;
-  font-weight: 400;
   font-style: italic;
-  line-height: 24px;
-  letter-spacing: 0.3px;
 
   @media (max-width: 768px) {
     flex-direction: column;

--- a/src/frontend/src/views/LandingPageV2/components/Hero/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/Hero/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { fontBodyM } from "czifui";
 
 export const G = styled.g``;
 
@@ -232,11 +233,9 @@ export const PartnershipText = styled.span`
 `;
 
 export const Tagline = styled.p`
+  ${fontBodyM}
+
   color: white;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 26px;
-  letter-spacing: 0.3px;
   margin-bottom: 0;
   margin-top: 22px;
 

--- a/src/frontend/src/views/LandingPageV2/components/IntroSection/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/IntroSection/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { getSpaces } from "czifui";
 
 export const IntroContainer = styled.div`
   display: flex;
@@ -7,14 +8,20 @@ export const IntroContainer = styled.div`
   max-width: 1440px;
   margin: 0 auto;
 
-  @media (max-width: 1440px) {
-    padding: 0 22px 0 0;
-  }
+  ${(props) => {
+    const spaces = getSpaces(props);
 
-  @media (max-width: 768px) {
-    flex-direction: column;
-    padding: 0 22px;
-  }
+    return `
+      @media (max-width: 1440px) {
+        padding: 0 ${spaces?.l}px 0 0;
+      }
+
+      @media (max-width: 768px) {
+        flex-direction: column;
+        padding: 0 ${spaces?.l}px;
+      }
+    `;
+  }}
 `;
 
 export const IntroDescription = styled.p`

--- a/src/frontend/src/views/LandingPageV2/components/PartnersSection/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/PartnersSection/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { getColors } from "czifui";
 
 const centeredFlex = () => {
   return `
@@ -28,8 +29,6 @@ export const PartnerLink = styled.a`
   width: 100%;
   max-width: 242px;
   height: 118px;
-  border: 1px solid #d3d3d3;
-  outline: 5px solid transparent;
   cursor: pointer;
 
   &:nth-of-type(2) {
@@ -40,9 +39,16 @@ export const PartnerLink = styled.a`
     }
   }
 
-  &:hover {
-    border: 2px solid #535353;
-  }
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      border: 1px solid ${colors?.gray[300]};
+
+      &:hover {
+        border: 2px solid ${colors?.gray[600]};
+      }
+    `;
+  }}
 `;
 
 export const PartnerLinkRow = styled.div`

--- a/src/frontend/src/views/LandingPageV2/components/QuoteSlider/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/QuoteSlider/style.ts
@@ -1,9 +1,17 @@
 import styled from "@emotion/styled";
+import { getColors } from "czifui";
 
 export const QuoteSliderContainer = styled.div`
   padding-bottom: 100px;
   text-align: center;
-  background: #511cc1;
+
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      background: ${colors?.primary[400]};
+    `;
+  }}
 
   & .slick-dots {
     bottom: -22%;


### PR DESCRIPTION
### Summary
- **What:** Use sds vars in homepage styling
- **Why:** To keep things consistent, and to get updates when styles change across the site
- **Ticket:** [[sc-188023]](https://app.shortcut.com/genepi/story/188023)
- **Env:** https://sdsvars-frontend.dev.czgenepi.org/

### Testing
1. Load the homepage
1. Ensure nothing is offensively janky, styling-wise

### Demos
No visual changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)