### PR TITLE
Fix local db snapshot creation tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ prepare-new-db-snapshot: local-start
 	@echo "Ok, local db is prepared and ready to go -- make any additional changes you need to and then run:"
 	@echo "make create_new_db_image"
 
-.PHONY: create_new_db_image
+.PHONY: create-new-db-image
 create-new-db-image:
 	docker compose exec database psql $(LOCAL_DB_CONN_STRING) -c VACUUM FULL
 	docker commit czgenepi-database-1 temp_db_image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   database:
-    image: "${DOCKER_REPO}genepi-devdb:latest"
+    image: "${DOCKER_REPO}genepi-devdb:czge-2022-04-04"
     profiles: [ "backend", "web", "all" ]
     platform: linux/amd64
     ports:
@@ -11,6 +11,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password_postgres
       - POSTGRES_DB=aspen_db
+      - PGDATA=/var/lib/czge/data # Avoid using the pgsql image's default volume.
     command: [ "postgres" ]
     networks:
       genepinet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   database:
-    image: "${DOCKER_REPO}genepi-devdb:czge-2022-04-04"
+    image: "${DOCKER_REPO}genepi-devdb:latest"
     profiles: [ "backend", "web", "all" ]
     platform: linux/amd64
     ports:
@@ -11,7 +11,12 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password_postgres
       - POSTGRES_DB=aspen_db
-      - PGDATA=/var/lib/czge/data # Avoid using the pgsql image's default volume.
+      # The postgres image declares a mounted volume at /var/lib/postgresql/data
+      # by default, which means that the data in that directory is difficult to
+      # snapshot and export. Here, we're telling Postgres to use this (non-mounted)
+      # directory as its storage location instead so it works with our db snapshot
+      # workflow.
+      - PGDATA=/var/lib/czge/data
     command: [ "postgres" ]
     networks:
       genepinet:

--- a/docker/Dockerfile.devdb
+++ b/docker/Dockerfile.devdb
@@ -7,4 +7,6 @@ FROM temp_db_image as dumper
 # from continually building new images on top of old ones
 FROM postgres:13.1-alpine
 
+# This path needs to be the same as the path in the PGDATA environment
+# variable in docker-compose.yml
 COPY --from=dumper /var/lib/czge/data /var/lib/czge/data

--- a/docker/Dockerfile.devdb
+++ b/docker/Dockerfile.devdb
@@ -7,4 +7,4 @@ FROM temp_db_image as dumper
 # from continually building new images on top of old ones
 FROM postgres:13.1-alpine
 
-COPY --from=dumper /var/lib/postgresql/data /var/lib/postgresql/data
+COPY --from=dumper /var/lib/czge/data /var/lib/czge/data


### PR DESCRIPTION
### Summary:
- **What:** Fix the `make` targets we use to generate local db snapshots

# Important! #
- Once this PR is merged, everyone should run `make local-init` to repopulate their local databases with sample data!
- Also, to use these targets, your repo checkout directory should be named `czgenepi`

### Notes:
@vincent-czi discovered that our local db snapshot targets weren't persisting the changes he made to his local database. After some investigation, we discovered that the `postgresql` docker image we're using declares a `volume` in its dockerfile, causing the default PostgreSQL data directory to always be created as a mounted volume, instead of peristing data normally inside the container. This isn't a problem in normal usage, but when we use `docker commit` to snapshot the state of a running container to a temporary docker image, any mounted volumes are omitted from the snapshot!

This change forces our database to write its db data to `/var/lib/czge/data` which isn't mounted as a volume, so our snapshot flows work properly.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)