### PR TITLE
Rely on Poetry for aspen install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ remote-dbconsole: .env.ecr # Get a python console on a remote db (from OSX only!
 	export DB_URI=$$(jq -r '"postgresql://\(.DB_admin_username):\(.DB_admin_password)@'$${OSX_IP}':5555/$(DB)"' <<< $$config); \
 	echo Connecting to $$(jq -r .DB_address <<< $$config)/$(DB) via $$(jq -r .bastion_host <<< $$config); \
 	ssh -f -o ExitOnForwardFailure=yes -L $${OSX_IP}:5555:$$(jq -r .DB_address <<< $$config):5432 $$(jq -r .bastion_host <<< $$config) sleep 20; \
-	$(docker_compose) run -e DB_URI backend sh -c 'pip install . && aspen-cli db --remote interact --connect'
+	$(docker_compose) run -e DB_URI backend sh -c 'aspen-cli db --remote interact --connect'
 
 ### DOCKER LOCAL DEV #########################################
 .PHONY: local-hostconfig
@@ -120,7 +120,6 @@ local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login local-hostconf
 	$(docker_compose) exec -T backend $(BACKEND_APP_ROOT)/scripts/setup_dev_data.sh
 	$(docker_compose) exec -T backend alembic upgrade head
 	$(docker_compose) exec -T backend python scripts/setup_localdata.py
-	$(docker_compose) exec -T backend pip install ./aspen
 
 # Assumes you've already run `make local-init` to configure localstack resources!
 .PHONY: prepare-new-db-snapshot

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -57,5 +57,6 @@ COPY --from=build \
 ENV PYTHONPATH=.
 
 COPY . .
+# By default, Poetry installs deps, dev deps, and the project package (aspen)
 RUN cd aspen && /opt/poetry/bin/poetry install
 CMD ["/usr/local/bin/supervisord", "-c", "/usr/src/app/etc/supervisord.conf"]


### PR DESCRIPTION
### Summary:
- **What:** `aspen` package install is wonky with `make local-init`
- **Ticket:** None
- **Env:** https://vince-aspen-install-frontend.dev.czgenepi.org/ [**NOTE:** Not working as of right now -- Not sure what's going on, don't think it's related to my code change, I think it was a hiccup with Happy?]

### Demos:
Before fix

<img width="700" alt="Screen Shot 2022-04-05 at 4 33 11 PM" src="https://user-images.githubusercontent.com/89553795/161871412-845332da-2793-4a80-b7bf-6c1e870fcf76.png">

---

After fix

<img width="695" alt="Screen Shot 2022-04-05 at 4 52 26 PM" src="https://user-images.githubusercontent.com/89553795/161871443-f76f5e19-dccd-49d5-b1ff-b08a227ef41d.png">


### Notes:
I'm still not really clear on what's _causing_ the issue, other than vague hand-waving at some kind of conflict between installing the project package with Poetry **and** via `pip install`. Apparently Poetry defaults to installing the project package ("root" package), so the Docker build for backend image is already installing `aspen` during build. Then when we run `make local-init` the `pip install` attempts to do it again, and things break for importing the project package.

I think we might have managed to dodge noticing this sooner because our deployed environments don't run `make local-init` and for everything that does run `make local-init`, it's still safe to import `aspen` so long as Python is being started from the `/usr/src/app` default starting dir because `aspen` is a sub-dir it's being imported by path as opposed to being an installed package.

I'm pretty sure this is the only change that's necessary, but I do see a similar project package install happening in `docker/aspen-batch/Dockerfile` -- do we still use that at all? Pretty sure that's just unused at this point, but if I'm wrong and it still matters, should look into that too.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change (locally, still need to figure out why rdev didn't take)
- [x] I added labels to my PR
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)