### PR TITLE
Maya/188315 landing page header

### DIFF
--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -10,7 +10,6 @@ import style from "src/App.module.scss";
 import { ROUTES } from "src/common/routes";
 import { theme } from "src/common/styles/theme";
 import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
-import AcknowledgePolicyChanges from "src/components/AcknowledgePolicyChanges";
 import NavBarLoggedIn from "src/components/NavBar";
 import NavBarLanding from "src/components/NavBarV2";
 import SplitInitializer from "src/components/Split";
@@ -54,7 +53,6 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
               <EmotionThemeProvider theme={theme}>
                 <div className={style.app}>
                   <Nav />
-                  <AcknowledgePolicyChanges />
                   <Component {...pageProps} />
                 </div>
               </EmotionThemeProvider>

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -2,11 +2,12 @@ import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { StylesProvider, ThemeProvider } from "@material-ui/core/styles";
 import { AppProps } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import "semantic-ui-css/semantic.min.css";
 import style from "src/App.module.scss";
-import { useUserInfo } from "src/common/queries/auth";
+import { ROUTES } from "src/common/routes";
 import { theme } from "src/common/styles/theme";
 import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
 import AcknowledgePolicyChanges from "src/components/AcknowledgePolicyChanges";
@@ -18,14 +19,12 @@ const queryClient = new QueryClient();
 setFeatureFlagsFromQueryParams();
 
 function Nav(): JSX.Element {
-  // TODO: replace this with common nav
-  // this is a workaround while we figure out what the specs are of logged in vs. landing page navbar
-  const { data: userInfo } = useUserInfo();
-  if (userInfo) {
-    return <NavBarLoggedIn />;
-  } else {
-    return <NavBarLanding />;
-  }
+  const router = useRouter();
+  return router.asPath === ROUTES.HOMEPAGE ? (
+    <NavBarLanding />
+  ) : (
+    <NavBarLoggedIn />
+  );
 }
 
 const App = ({ Component, pageProps }: AppProps): JSX.Element => {

--- a/src/frontend/src/components/NavBarV2/index.tsx
+++ b/src/frontend/src/components/NavBarV2/index.tsx
@@ -1,15 +1,11 @@
 import React, { useState } from "react";
 import ENV from "src/common/constants/ENV";
-import Exclamation from "src/common/icons/IconExclamation.svg";
 import CloseIcon from "src/common/images/close-icon.svg";
 import HeaderLogo from "src/common/images/gen-epi-logo.svg";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
 import UserMenu from "./components/UserMenu";
 import {
-  AnnouncementBanner,
-  AnnouncementText,
-  AnnouncementTextBold,
   Bar,
   ButtonLink,
   HeaderContainer,
@@ -94,16 +90,6 @@ export default function NavBarLanding(): JSX.Element {
 
   return (
     <HeaderContainer data-test-id="navbar-landing">
-      {!user && (
-        <AnnouncementBanner>
-          <AnnouncementText>
-            <Exclamation />
-            <AnnouncementTextBold>Looking for Aspen?</AnnouncementTextBold>
-            &nbsp;You&apos;re in the right spot. As of December, our new name is
-            Chan Zuckerberg GEN EPI.
-          </AnnouncementText>
-        </AnnouncementBanner>
-      )}
       <HeaderMaxWidthContainer>
         <HeaderTopContainer>
           <HeaderLogoContainer href={data ? ROUTES.DATA : ROUTES.HOMEPAGE}>

--- a/src/frontend/src/components/NavBarV2/style.ts
+++ b/src/frontend/src/components/NavBarV2/style.ts
@@ -1,45 +1,5 @@
 import styled from "@emotion/styled";
 
-export const AnnouncementBanner = styled.div`
-  background: #511cc1;
-  color: white;
-  text-align: center;
-  font-size: 14px;
-  letter-spacing: 0.3px;
-  position: relative;
-  z-index: 2;
-
-  @media (max-width: 768px) {
-    font-size: 12px;
-    padding: 14px;
-  }
-`;
-
-export const AnnouncementText = styled.p`
-  padding: 14px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  @media (max-width: 768px) {
-    display: inline;
-    padding: initial;
-  }
-
-  svg {
-    margin-right: 10px;
-
-    @media (max-width: 768px) {
-      width: 14px;
-      transform: translateY(7px);
-    }
-  }
-`;
-
-export const AnnouncementTextBold = styled.span`
-  font-weight: 600;
-`;
-
 export const Bar = styled.div`
   width: 17px;
   height: 1px;


### PR DESCRIPTION
### Summary
- **What:** 
  - Remove banner for czge redirect from aspen
  - Remove banner to acknowledge Sept 30 policy changes
  - Change logic for showing the two page banners such that the landing page banner only shows on the landing page
- **Why:** 
  - The two banners give info that is months old at this point
  - Prevent UI jank associated with user login taking a second or two. Previously, we would should the landing page banner in-app if the login had not yet completed, which looked odd and jarring when the user was finally logged in.
- **Ticket:** [[sc-188315]](https://app.shortcut.com/genepi/story/188315)
- **Env:** https://navbar-frontend.dev.czgenepi.org/
- **Discussion:** 
  - https://czi-sci.slack.com/archives/C01HYJYA50W/p1646862771991459
  - https://czi-sci.slack.com/archives/C01HYJYA50W/p1649353862580309

### Testing
1. Landing page shows landing navbar
2. In-app shows in-app nav bar, even while login is happening
1. Banner on landing page removed
2. Banner in-app removed

### Demos
#### Before: 
![Screen Shot 2022-04-07 at 11 33 59 AM](https://user-images.githubusercontent.com/7562933/162272949-ca8cb316-4f91-4c3a-a178-42b1713e4333.png)
![Screen Shot 2022-04-07 at 11 33 43 AM](https://user-images.githubusercontent.com/7562933/162272899-7c21dbc0-c71b-4a86-add6-5be348676ce0.png)

#### After: 
![Screen Shot 2022-04-07 at 11 27 49 AM](https://user-images.githubusercontent.com/7562933/162272972-f861a8fb-76e6-46a0-8163-91cec5f11b37.png)
![Screen Shot 2022-04-07 at 11 29 18 AM](https://user-images.githubusercontent.com/7562933/162272992-f5fa4edb-7a1f-4e1e-b9b5-5ffe021e6ccc.png)

### Notes
Although we are not showing the policy changes banner anymore, I left the component in the repo in case we need to announce policy changes again.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)