### PR TITLE
add more threads to pangolin job

### DIFF
--- a/src/backend/aspen/workflows/pangolin/run_pangolin.sh
+++ b/src/backend/aspen/workflows/pangolin/run_pangolin.sh
@@ -28,7 +28,7 @@ cd /usr/src/app/aspen/workflows/pangolin
 
 # call pangolin on the exported sequences
 lineage_report="lineage_report.csv"
-pangolin $sequences_output --outfile "$lineage_report"
+pangolin --threads 16 $sequences_output --outfile "$lineage_report"
 
 last_updated=$(date +'%m-%d-%Y')
 # save the pangolin results back to the db:


### PR DESCRIPTION
### Summary:
- **What:** UShER's speed comes from efficient multi threading. Add that to pangolin job which uses UShER behind the curtain. 

### Demos:
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/20667188/163027770-be185d7e-20a7-4426-9f18-86389591c97e.png">

### Notes:
Not sure how to test otherwise. Hoping to send it to staging scheduled run this afternoon and see what happens. 

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)