### PR TITLE
Add distinct region, country level locations to location import script

### DIFF
--- a/src/backend/aspen/workflows/import_locations/save.py
+++ b/src/backend/aspen/workflows/import_locations/save.py
@@ -90,7 +90,7 @@ def save():
             session.execute(existing_country_level_loc_select).all()
         )
 
-        country_level_loc_select = sa.select(Location.region, Location.country).distinct()
+        country_level_loc_select = sa.select(GisaidMetadata.region, GisaidMetadata.country).distinct()
         country_level_locations = set(session.execute(country_level_loc_select).all())
 
         new_country_level_locations = country_level_locations - existing_country_level_locs

--- a/src/backend/aspen/workflows/import_locations/save.py
+++ b/src/backend/aspen/workflows/import_locations/save.py
@@ -90,10 +90,14 @@ def save():
             session.execute(existing_country_level_loc_select).all()
         )
 
-        country_level_loc_select = sa.select(GisaidMetadata.region, GisaidMetadata.country).distinct()
+        country_level_loc_select = sa.select(
+            GisaidMetadata.region, GisaidMetadata.country
+        ).distinct()
         country_level_locations = set(session.execute(country_level_loc_select).all())
 
-        new_country_level_locations = country_level_locations - existing_country_level_locs
+        new_country_level_locations = (
+            country_level_locations - existing_country_level_locs
+        )
         new_country_level_values = list(
             map(
                 lambda region_country_tuple: {

--- a/src/backend/aspen/workflows/import_locations/save.py
+++ b/src/backend/aspen/workflows/import_locations/save.py
@@ -80,6 +80,37 @@ def save():
             )
             session.execute(new_null_locations_insert)
 
+        # Insert country-level locations
+        existing_country_level_loc_select = (
+            sa.select(Location.region, Location.country)
+            .where(and_(Location.division == None, Location.location == None))
+            .distinct()
+        )
+        existing_country_level_locs = set(
+            session.execute(existing_country_level_loc_select).all()
+        )
+
+        country_level_loc_select = sa.select(Location.region, Location.country).distinct()
+        country_level_locations = set(session.execute(country_level_loc_select).all())
+
+        new_country_level_locations = country_level_locations - existing_country_level_locs
+        new_country_level_values = list(
+            map(
+                lambda region_country_tuple: {
+                    "region": region_country_tuple[0],
+                    "country": region_country_tuple[1],
+                    "division": None,
+                    "location": None,
+                },
+                new_country_level_locations,
+            )
+        )
+        if len(new_country_level_values) > 0:
+            new_country_level_locations_insert = Location.__table__.insert().values(
+                new_country_level_values
+            )
+            session.execute(new_country_level_locations_insert)
+
         session.commit()
 
     print("Successfully imported locations!")


### PR DESCRIPTION
### Summary:
- **What:** Adds distinct region, country level locations, where `division = NULL` and `location = NULL` to location import script.
- **Ticket:** [sc187549](https://app.shortcut.com/genepi/story/187549)
- **Env:** [https://countrylvl-frontend.dev.czgenepi.org/](https://countrylvl-frontend.dev.czgenepi.org/)

### Demos:
I ran the script locally to check. I had some older gisaid metadata lying around, and the locations table has entries for 2 extra  countries (Palau and Canary Islands) that are not in the metadata I had, hence the disparity. Tested again to make sure not duplicate entries were created.

<img width="989" alt="Screen Shot 2022-04-12 at 16 51 56" src="https://user-images.githubusercontent.com/24234461/163072756-633a09ca-c6c0-4fca-a967-b1c45b62c990.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)