### PR TITLE
Maya/warnings

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/index.tsx
@@ -1,54 +1,40 @@
-import { Collapse } from "@material-ui/core";
-import React, { useState } from "react";
+import React from "react";
 import { pluralize } from "src/common/utils/strUtils";
-import { SemiBold } from "../../../FailedSampleAlert/style";
-import {
-  ColumnFlexContainer,
-  RowFlexContainer,
-  StaticSizeDiv,
-  StyledArrowDownIcon,
-  StyledArrowUpIcon,
-  StyledCallout,
-  StyledList,
-  StyledListItem,
-} from "./style";
+import AlertAccordion from "src/components/AlertAccordion";
+import { SemiBold, StyledList, StyledListItem } from "./style";
 
 interface Props {
   missingSamples: string[];
 }
 
 const MissingSampleAlert = ({ missingSamples }: Props): JSX.Element | null => {
-  const [areMissingIdsShown, setMissingIdsShown] = useState<boolean>(false);
-
   const numMissingSamples = missingSamples.length;
   if (numMissingSamples <= 0) return null;
 
-  const toggleCollapse = () => {
-    setMissingIdsShown(!areMissingIdsShown);
-  };
+  const collapseContent = (
+    <StyledList>
+      {missingSamples.map((sample) => {
+        return <StyledListItem key={sample}>{sample}</StyledListItem>;
+      })}
+    </StyledList>
+  );
+
+  const title = (
+    <span>
+      <SemiBold>
+        {numMissingSamples} Sample {pluralize("ID", numMissingSamples)} couldn’t
+        be found
+      </SemiBold>{" "}
+      and will not appear on your tree.
+    </span>
+  );
 
   return (
-    <StyledCallout intent="warning" onClick={toggleCollapse}>
-      <RowFlexContainer>
-        <ColumnFlexContainer>
-          <StaticSizeDiv>
-            <SemiBold>
-              {numMissingSamples} Sample {pluralize("ID", numMissingSamples)}{" "}
-              couldn’t be found
-            </SemiBold>{" "}
-            and will not appear on your tree.
-          </StaticSizeDiv>
-          <Collapse in={areMissingIdsShown}>
-            <StyledList>
-              {missingSamples.map((sample) => {
-                return <StyledListItem key={sample}>{sample}</StyledListItem>;
-              })}
-            </StyledList>
-          </Collapse>
-        </ColumnFlexContainer>
-        {areMissingIdsShown ? <StyledArrowUpIcon /> : <StyledArrowDownIcon />}
-      </RowFlexContainer>
-    </StyledCallout>
+    <AlertAccordion
+      collapseContent={collapseContent}
+      intent="warning"
+      title={title}
+    />
   );
 };
 

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/MissingSampleAlert/style.ts
@@ -1,53 +1,9 @@
 import styled from "@emotion/styled";
-import { CommonThemeProps, fontBodyXs, getIconSizes, getSpaces } from "czifui";
-import ArrowDownIcon from "src/common/icons/IconArrowDownSmall.svg";
-import ArrowUpIcon from "src/common/icons/IconArrowUpSmall.svg";
-import { transparentScrollbars } from "src/common/styles/basicStyle";
-import { StyledCallout as Callout } from "../../../FailedSampleAlert/style";
-
-const smallIcon = (props: CommonThemeProps) => {
-  const iconSizes = getIconSizes(props);
-  return `
-    flex: 0 0 auto;
-    height: ${iconSizes?.s.height}px;
-    width: ${iconSizes?.s.width}px;
-  `;
-};
-
-export const StyledArrowDownIcon = styled(ArrowDownIcon)`
-  ${smallIcon}
-`;
-
-export const StyledArrowUpIcon = styled(ArrowUpIcon)`
-  ${smallIcon}
-`;
-
-export const RowFlexContainer = styled.div`
-  display: flex;
-  height: 100%;
-
-  .MuiCollapse-root {
-    overflow-y: auto;
-  }
-`;
-
-export const ColumnFlexContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
-  .MuiCollapse-root {
-    ${transparentScrollbars}
-  }
-`;
-
-export const StaticSizeDiv = styled.div`
-  flex: 0 0 auto;
-`;
+import { fontBodyXs, getFontWeights, getSpaces } from "czifui";
 
 export const StyledList = styled.ul`
   padding: 0;
 
-  /* TODO (mlila): this should be exported from SDS */
   li:nth-of-type(odd) {
     background-color: #f4eee4;
   }
@@ -66,9 +22,11 @@ export const StyledListItem = styled.li`
   }}
 `;
 
-export const StyledCallout = styled(Callout)`
-  max-height: 250px;
-  .MuiAlert-message {
-    width: 100%;
-  }
+export const SemiBold = styled.span`
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      font-weight: ${fontWeights?.semibold};
+    `;
+  }}
 `;

--- a/src/frontend/src/common/utils/strUtils.ts
+++ b/src/frontend/src/common/utils/strUtils.ts
@@ -1,3 +1,9 @@
+const WORDS_TO_PLURALIZE: Record<string, string> = {
+  was: "were",
+};
+
 export const pluralize = (str: string, count: number): string => {
-  return count === 1 ? str : `${str}s`;
+  if (count === 1) return str;
+  if (WORDS_TO_PLURALIZE[str]) return WORDS_TO_PLURALIZE[str];
+  return `${str}s`;
 };

--- a/src/frontend/src/components/AlertAccordion/index.tsx
+++ b/src/frontend/src/components/AlertAccordion/index.tsx
@@ -1,45 +1,40 @@
-import { IconButton } from "@material-ui/core";
-import { ExpandMore } from "@material-ui/icons";
-import { AlertTitle } from "@material-ui/lab";
-import { AlertProps } from "czifui";
+import { Collapse } from "@material-ui/core";
 import React, { useState } from "react";
-import { StyledAlert, Title } from "./style";
+import {
+  ColumnFlexContainer,
+  RowFlexContainer,
+  StaticSizeDiv,
+  StyledArrowDownIcon,
+  StyledArrowUpIcon,
+  StyledCallout,
+} from "./style";
 
 interface Props {
-  title?: string;
-  message: React.ReactNode;
-  severity: AlertProps["severity"];
-  className?: string;
+  collapseContent: React.ReactNode;
+  intent: "info" | "error" | "success" | "warning";
+  title: React.ReactNode;
 }
 
 export default function AlertAccordion({
+  collapseContent,
+  intent,
   title,
-  message,
-  severity,
-  className,
 }: Props): JSX.Element {
-  const [isShown, setIsShown] = useState(false);
+  const [isCollapseOpen, setCollapseOpen] = useState<boolean>(false);
 
-  function handleClick() {
-    setIsShown((prevState) => !prevState);
-  }
+  const toggleCollapse = () => {
+    setCollapseOpen(!isCollapseOpen);
+  };
 
   return (
-    <StyledAlert
-      className={className}
-      severity={severity}
-      action={
-        <IconButton aria-label="expand" color="inherit" onClick={handleClick}>
-          <ExpandMore fontSize="inherit" />
-        </IconButton>
-      }
-    >
-      {title && (
-        <AlertTitle>
-          <Title>{title}</Title>
-        </AlertTitle>
-      )}
-      {isShown && message}
-    </StyledAlert>
+    <StyledCallout intent={intent} onClick={toggleCollapse}>
+      <RowFlexContainer>
+        <ColumnFlexContainer>
+          <StaticSizeDiv>{title}</StaticSizeDiv>
+          <Collapse in={isCollapseOpen}>{collapseContent}</Collapse>
+        </ColumnFlexContainer>
+        {isCollapseOpen ? <StyledArrowUpIcon /> : <StyledArrowDownIcon />}
+      </RowFlexContainer>
+    </StyledCallout>
   );
 }

--- a/src/frontend/src/components/AlertAccordion/style.ts
+++ b/src/frontend/src/components/AlertAccordion/style.ts
@@ -1,12 +1,53 @@
 import styled from "@emotion/styled";
-import { Alert, fontHeaderS } from "czifui";
+import { Callout, CommonThemeProps, getIconSizes } from "czifui";
+import ArrowDownIcon from "src/common/icons/IconArrowDownSmall.svg";
+import ArrowUpIcon from "src/common/icons/IconArrowUpSmall.svg";
+import { transparentScrollbars } from "src/common/styles/basicStyle";
 
-export const StyledAlert = styled(Alert)`
-  .MuiAlert-action {
-    align-items: start;
+const smallIcon = (props: CommonThemeProps) => {
+  const iconSizes = getIconSizes(props);
+  return `
+    flex: 0 0 auto;
+    height: ${iconSizes?.s.height}px;
+    width: ${iconSizes?.s.width}px;
+  `;
+};
+
+export const StyledArrowDownIcon = styled(ArrowDownIcon)`
+  ${smallIcon}
+`;
+
+export const StyledArrowUpIcon = styled(ArrowUpIcon)`
+  ${smallIcon}
+`;
+
+export const RowFlexContainer = styled.div`
+  display: flex;
+  height: 100%;
+
+  .MuiCollapse-root {
+    overflow-y: auto;
   }
 `;
 
-export const Title = styled.span`
-  ${fontHeaderS}
+export const ColumnFlexContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  .MuiCollapse-root {
+    ${transparentScrollbars}
+  }
+`;
+
+export const StaticSizeDiv = styled.div`
+  flex: 0 0 auto;
+`;
+
+export const StyledCallout = styled(Callout)`
+  max-height: 250px;
+  width: 100%;
+
+  .MuiAlert-message {
+    width: 100%;
+  }
 `;

--- a/src/frontend/src/components/WebformTable/common/types.ts
+++ b/src/frontend/src/components/WebformTable/common/types.ts
@@ -24,10 +24,15 @@ export enum WARNING_CODE {
   ABSENT_SAMPLE,
   // A piece of data is present, but improperly formatted
   BAD_FORMAT_DATA,
+  // A column is present that isn't in our template
+  UNKNOWN_DATA_FIELDS,
+  // No exact location match found, so we choose the closest one we can find for them
+  BAD_LOCATION_FORMAT,
 }
 
 export enum ERROR_CODE {
   DEFAULT, // BAD FILE NAME
+  DUPLICATE_IDS,
   INVALID_NAME,
   MISSING_FIELD, // Missing required column entirely: no header field found
   OVER_MAX_SAMPLES,

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
@@ -19,6 +19,7 @@ const ERROR_CODE_TO_MESSAGE: Record<
   [ERROR_CODE.MISSING_FIELD]: MissingFieldMessage,
   [ERROR_CODE.OVER_MAX_SAMPLES]: "placeholder",
   [ERROR_CODE.DEFAULT]: DefaultMessage,
+  [ERROR_CODE.DUPLICATE_IDS]: "placeholder",
 };
 
 export default function Error({
@@ -38,6 +39,7 @@ export default function Error({
     [ERROR_CODE.OVER_MAX_SAMPLES]: "placeholder",
     [ERROR_CODE.DEFAULT]:
       "Something went wrong, please try again or contact us!",
+    [ERROR_CODE.DUPLICATE_IDS]: "placeholder",
   };
 
   const title = errorCodeToTitle[errorCode];

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
@@ -46,8 +46,8 @@ export default function Error({
   return (
     <AlertAccordion
       title={title}
-      message={<Message names={names} />}
-      severity="error"
+      collapseContent={<Message names={names} />}
+      intent="error"
     />
   );
 }

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { B } from "src/common/styles/basicStyle";
+import { pluralize } from "src/common/utils/strUtils";
 import AlertAccordion from "src/components/AlertAccordion";
 import { ERROR_CODE } from "src/components/WebformTable/common/types";
-import { maybePluralize } from "./common/pluralize";
 import { ProblemTable } from "./common/ProblemTable";
 import { Td, Th } from "./common/style";
 
@@ -30,7 +30,7 @@ export default function Error({
   const count = names.length;
 
   const errorCodeToTitle = {
-    [ERROR_CODE.INVALID_NAME]: `Please double check the following ${maybePluralize(
+    [ERROR_CODE.INVALID_NAME]: `Please double check the following ${pluralize(
       "sample",
       count
     )} to correct any errors before proceeding:`,

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/pluralize.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/pluralize.ts
@@ -1,9 +1,0 @@
-const WORDS_TO_PLURALIZE: Record<string, string> = {
-  Sample: "Samples",
-  sample: "samples",
-  was: "were",
-};
-
-export function maybePluralize(word: string, count: number): string {
-  return count > 1 ? WORDS_TO_PLURALIZE[word] : word;
-}

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/style.ts
@@ -6,7 +6,6 @@ import {
   getColors,
   getSpaces,
 } from "czifui";
-import AlertAccordion from "src/components/AlertAccordion";
 
 export const Th = styled.th`
   ${fontHeaderXs}
@@ -32,15 +31,6 @@ export const Td = styled.td`
 
 export const Title = styled.span`
   ${fontHeaderS}
-`;
-
-// To get the table to span the entire width of accordion, we must manipulate
-// MUI internal CSS to force its div that wraps content to use full width.
-// If this gets used regularly, might be better as prop on `AlertAccordion`.
-export const FullWidthAlertAccordion = styled(AlertAccordion)`
-  .MuiAlert-message {
-    width: 100%;
-  }
 `;
 
 export const FullWidthContainer = styled.div`

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -114,7 +114,9 @@ export function WarningAbsentSample({
   return (
     <AlertAccordion
       title={title}
-      collapseContent={<MessageAbsentSample absentSampleIds={absentSampleIds} />}
+      collapseContent={
+        <MessageAbsentSample absentSampleIds={absentSampleIds} />
+      }
       intent={WARNING_SEVERITY}
     />
   );

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -24,7 +24,7 @@ interface PropsAutoCorrect {
 }
 export function WarningAutoCorrect({
   autocorrectedSamplesCount,
-}: PropsAutoCorrect) {
+}: PropsAutoCorrect): JSX.Element {
   // "X samples were updated."
   const title = `${autocorrectedSamplesCount} ${pluralize(
     "Sample",
@@ -103,7 +103,9 @@ function MessageAbsentSample({ absentSampleIds }: PropsAbsentSample) {
     />
   );
 }
-export function WarningAbsentSample({ absentSampleIds }: PropsAbsentSample) {
+export function WarningAbsentSample({
+  absentSampleIds,
+}: PropsAbsentSample): JSX.Element {
   const count = absentSampleIds.length;
   // "X Samples were not found in metadata file."
   const title = `${count} ${pluralize("Sample", count)} ${pluralize(
@@ -221,7 +223,9 @@ function MessageBadFormatData({ badFormatData }: PropsBadFormatData) {
     />
   );
 }
-export function WarningBadFormatData({ badFormatData }: PropsBadFormatData) {
+export function WarningBadFormatData({
+  badFormatData,
+}: PropsBadFormatData): JSX.Element {
   const title =
     "Some of your data is not formatted correctly. " +
     "Please update before proceeding.";

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { B } from "src/common/styles/basicStyle";
+import { pluralize } from "src/common/utils/strUtils";
 import AlertAccordion from "src/components/AlertAccordion";
 import {
   OPTIONAL_HEADER_MARKER,
   SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
 } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleIdToWarningMessages } from "../../parseFile";
-import { maybePluralize } from "./common/pluralize";
 import { ProblemTable } from "./common/ProblemTable";
 import { FullWidthAlertAccordion } from "./common/style";
 
@@ -26,10 +26,10 @@ export function WarningAutoCorrect({
   autocorrectedSamplesCount,
 }: PropsAutoCorrect) {
   // "X samples were updated."
-  const title = `${autocorrectedSamplesCount} ${maybePluralize(
+  const title = `${autocorrectedSamplesCount} ${pluralize(
     "Sample",
     autocorrectedSamplesCount
-  )} ${maybePluralize("was", autocorrectedSamplesCount)} updated.`;
+  )} ${pluralize("was", autocorrectedSamplesCount)} updated.`;
   const message =
     "We encountered contradictory data in your upload that we have " +
     "automatically resolved. Please review the alerts below and correct " +
@@ -65,13 +65,13 @@ function MessageExtraneousEntry({ extraneousSampleIds }: PropsExtraneousEntry) {
 }
 export function WarningExtraneousEntry({
   extraneousSampleIds,
-}: PropsExtraneousEntry) {
+}: PropsExtraneousEntry): JSX.Element {
   const count = extraneousSampleIds.length;
   // "X Samples in metadata file were not used."
-  const title = `${count} ${maybePluralize(
+  const title = `${count} ${pluralize(
     "Sample",
     count
-  )} in metadata file ${maybePluralize("was", count)} not used.`;
+  )} in metadata file ${pluralize("was", count)} not used.`;
   return (
     <FullWidthAlertAccordion
       title={title}
@@ -106,7 +106,7 @@ function MessageAbsentSample({ absentSampleIds }: PropsAbsentSample) {
 export function WarningAbsentSample({ absentSampleIds }: PropsAbsentSample) {
   const count = absentSampleIds.length;
   // "X Samples were not found in metadata file."
-  const title = `${count} ${maybePluralize("Sample", count)} ${maybePluralize(
+  const title = `${count} ${pluralize("Sample", count)} ${pluralize(
     "was",
     count
   )} not found in metadata file.`;
@@ -150,10 +150,12 @@ function MessageMissingData({ missingData }: PropsMissingData) {
     />
   );
 }
-export function WarningMissingData({ missingData }: PropsMissingData) {
+export function WarningMissingData({
+  missingData,
+}: PropsMissingData): JSX.Element {
   const count = Object.keys(missingData).length;
   // "X Samples were missing data in required fields."
-  const title = `${count} ${maybePluralize("Sample", count)} ${maybePluralize(
+  const title = `${count} ${pluralize("Sample", count)} ${pluralize(
     "was",
     count
   )} missing data in required fields.`;

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -8,7 +8,6 @@ import {
 } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleIdToWarningMessages } from "../../parseFile";
 import { ProblemTable } from "./common/ProblemTable";
-import { FullWidthAlertAccordion } from "./common/style";
 
 const WARNING_SEVERITY = "warning";
 
@@ -37,8 +36,8 @@ export function WarningAutoCorrect({
   return (
     <AlertAccordion
       title={title}
-      message={message}
-      severity={WARNING_SEVERITY}
+      collapseContent={message}
+      intent={WARNING_SEVERITY}
     />
   );
 }
@@ -73,12 +72,12 @@ export function WarningExtraneousEntry({
     count
   )} in metadata file ${pluralize("was", count)} not used.`;
   return (
-    <FullWidthAlertAccordion
+    <AlertAccordion
       title={title}
-      message={
+      collapseContent={
         <MessageExtraneousEntry extraneousSampleIds={extraneousSampleIds} />
       }
-      severity={WARNING_SEVERITY}
+      intent={WARNING_SEVERITY}
     />
   );
 }
@@ -113,10 +112,10 @@ export function WarningAbsentSample({
     count
   )} not found in metadata file.`;
   return (
-    <FullWidthAlertAccordion
+    <AlertAccordion
       title={title}
-      message={<MessageAbsentSample absentSampleIds={absentSampleIds} />}
-      severity={WARNING_SEVERITY}
+      collapseContent={<MessageAbsentSample absentSampleIds={absentSampleIds} />}
+      intent={WARNING_SEVERITY}
     />
   );
 }
@@ -162,10 +161,10 @@ export function WarningMissingData({
     count
   )} missing data in required fields.`;
   return (
-    <FullWidthAlertAccordion
+    <AlertAccordion
       title={title}
-      message={<MessageMissingData missingData={missingData} />}
-      severity={WARNING_SEVERITY}
+      collapseContent={<MessageMissingData missingData={missingData} />}
+      intent={WARNING_SEVERITY}
     />
   );
 }
@@ -230,10 +229,10 @@ export function WarningBadFormatData({
     "Some of your data is not formatted correctly. " +
     "Please update before proceeding.";
   return (
-    <FullWidthAlertAccordion
+    <AlertAccordion
       title={title}
-      message={<MessageBadFormatData badFormatData={badFormatData} />}
-      severity={WARNING_SEVERITY}
+      collapseContent={<MessageBadFormatData badFormatData={badFormatData} />}
+      intent={WARNING_SEVERITY}
     />
   );
 }

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -168,15 +168,15 @@ export default function ImportFile({
         <Error errorCode={ERROR_CODE.MISSING_FIELD} names={missingFields} />
       )}
 
-      {autocorrectCount && (
+      {autocorrectCount > 0 && (
         <WarningAutoCorrect autocorrectedSamplesCount={autocorrectCount} />
       )}
 
-      {extraneousSampleIds.length && (
+      {extraneousSampleIds.length > 0 && (
         <WarningExtraneousEntry extraneousSampleIds={extraneousSampleIds} />
       )}
 
-      {absentSampleIds.length && (
+      {absentSampleIds.length > 0 && (
         <WarningAbsentSample absentSampleIds={absentSampleIds} />
       )}
 

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -159,52 +159,36 @@ export default function ImportFile({
         />
       </div>
 
-      <RenderOrNull
-        condition={
-          hasImportedFile &&
-          !getIsParseResultCompletelyUnused(extraneousSampleIds, parseResult)
-        }
-      >
-        <Success filename={filename} />
-      </RenderOrNull>
+      {hasImportedFile &&
+        !getIsParseResultCompletelyUnused(extraneousSampleIds, parseResult) && (
+          <Success filename={filename} />
+        )}
 
-      <RenderOrNull condition={missingFields}>
+      {missingFields && (
         <Error errorCode={ERROR_CODE.MISSING_FIELD} names={missingFields} />
-      </RenderOrNull>
+      )}
 
-      <RenderOrNull condition={autocorrectCount}>
+      {autocorrectCount && (
         <WarningAutoCorrect autocorrectedSamplesCount={autocorrectCount} />
-      </RenderOrNull>
+      )}
 
-      <RenderOrNull condition={extraneousSampleIds.length}>
+      {extraneousSampleIds.length && (
         <WarningExtraneousEntry extraneousSampleIds={extraneousSampleIds} />
-      </RenderOrNull>
+      )}
 
-      <RenderOrNull condition={absentSampleIds.length}>
+      {absentSampleIds.length && (
         <WarningAbsentSample absentSampleIds={absentSampleIds} />
-      </RenderOrNull>
+      )}
 
-      <RenderOrNull condition={!isEmpty(missingData)}>
+      {!isEmpty(missingData) && (
         <WarningMissingData missingData={missingData} />
-      </RenderOrNull>
+      )}
 
-      <RenderOrNull condition={!isEmpty(badFormatData)}>
+      {!isEmpty(badFormatData) && (
         <WarningBadFormatData badFormatData={badFormatData} />
-      </RenderOrNull>
+      )}
     </Wrapper>
   );
-}
-
-function RenderOrNull({
-  condition,
-  children,
-}: {
-  condition: unknown;
-  children: React.ReactNode;
-}): JSX.Element | null {
-  if (!condition) return null;
-
-  return <>{children}</>;
 }
 
 function getIsParseResultCompletelyUnused(

--- a/src/frontend/src/views/Upload/components/Review/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/index.tsx
@@ -6,6 +6,7 @@ import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
+import { pluralize } from "src/common/utils/strUtils";
 import Progress from "../common/Progress";
 import {
   ButtonWrapper,
@@ -15,7 +16,6 @@ import {
   Title,
 } from "../common/style";
 import { Props } from "../common/types";
-import { maybePluralize } from "../Metadata/components/ImportFile/components/Alerts/common/pluralize";
 import Table from "./components/Table";
 import Upload from "./components/Upload";
 import {
@@ -49,7 +49,7 @@ export default function Review({
         <div>
           <Title>Review</Title>
           <Subtitle>
-            Uploading {numOfSamples} {maybePluralize("Sample", numOfSamples)} to{" "}
+            Uploading {numOfSamples} {pluralize("Sample", numOfSamples)} to{" "}
             {group?.name}
           </Subtitle>
         </div>

--- a/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
@@ -19,6 +19,7 @@ const ERROR_CODE_MESSAGES: Record<ERROR_CODE, string> = {
   [ERROR_CODE.MISSING_FIELD]: "placeholder",
   [ERROR_CODE.OVER_MAX_SAMPLES]:
     "This file contains more than 500 samples, which exceeds the maximum for each upload process. Please limit the samples to 500 or less",
+  [ERROR_CODE.DUPLICATE_IDS]: "placeholder",
 };
 
 interface Props {

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -126,9 +126,9 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
           />
           {parseErrors && (
             <AlertAccordion
-              severity="error"
+              intent="error"
               title="Some of your files or samples could not be imported."
-              message={<AlertTable parseErrors={parseErrors} />}
+              collapseContent={<AlertTable parseErrors={parseErrors} />}
             />
           )}
           {samples && (


### PR DESCRIPTION
### Summary
- **What:** Prep work for adding new warning messages to the upload flow
  - Replace `AlertAccordion` implementation to make use of sds callout
  - Consolidate 2 pluralize functions into one
  - Resolve a few TS warnings
  - Simplify warning display logic
- **Why:** I need to add some warnings, and I want to get the correct styling for free. Plus I wanted to clean this stuff up a little because it's old code.
- **Ticket:**
  - [[sc-181275]](https://app.shortcut.com/genepi/story/181275)
  - [[sc-181269]](https://app.shortcut.com/genepi/story/181269)
  - [[sc-181281]](https://app.shortcut.com/genepi/story/181281)
- **Env:** https://warnings-frontend.dev.czgenepi.org/

### Demos
![Screen Shot 2022-04-13 at 10 50 56 PM](https://user-images.githubusercontent.com/7562933/163322732-83fd7b1e-085d-4ef4-b72a-49656669e1c8.png)
![Screen Shot 2022-04-13 at 10 51 07 PM](https://user-images.githubusercontent.com/7562933/163322739-fc8272f0-964b-4d9a-91fb-f3668b5508d5.png)
![Screen Shot 2022-04-13 at 10 50 32 PM](https://user-images.githubusercontent.com/7562933/163322754-5c70934b-86a7-40f2-9769-5d5f851aadea.png)

### Notes
- may be easiest to view each commit one at a time
- I also checked the existing collapsible callout (the one I originally built for this purpose in the NS tree create modal) to ensure no styling changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)