### PR TITLE
Add auto-trees for UT Austin and UCSC

### DIFF
--- a/.happy/terraform/modules/ecs-stack/county_runs.tf
+++ b/.happy/terraform/modules/ecs-stack/county_runs.tf
@@ -446,3 +446,55 @@ module nextstrain_ventura_contextual_sfn_config {
     tree_type                = "OVERVIEW"
   }
 }
+
+module nextstrain_ut_austin_contextual_sfn_config {
+  source   = "../sfn_config"
+  app_name = "nextstrain-ut-austin-contextual-sfn"
+  image    = local.nextstrain_image
+  vcpus    = local.nextstrain_sfn_vcpus
+  memory   = local.nextstrain_sfn_memory
+  wdl_path = "workflows/nextstrain.wdl"
+  custom_stack_name     = local.custom_stack_name
+  deployment_stage      = local.deployment_stage
+  remote_dev_prefix     = local.remote_dev_prefix
+  stack_resource_prefix = local.stack_resource_prefix
+  swipe_comms_bucket    = local.swipe_comms_bucket
+  swipe_wdl_bucket      = local.swipe_wdl_bucket
+  sfn_arn               = local.swipe_sfn_arn
+  schedule_expressions  = local.nextstrain_cron_schedule
+  event_role_arn        = local.event_role_arn
+  extra_args            =  {
+    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
+    remote_dev_prefix        = local.remote_dev_prefix
+    group_name               = "University of Texas at Austin"
+    s3_filestem              = "UTAustin"
+    template_args            = local.default_template_args
+    tree_type                = "OVERVIEW"
+  }
+}
+
+module nextstrain_ucsc_contextual_sfn_config {
+  source   = "../sfn_config"
+  app_name = "nextstrain-ucsc-contextual-sfn"
+  image    = local.nextstrain_image
+  vcpus    = local.nextstrain_sfn_vcpus
+  memory   = local.nextstrain_sfn_memory
+  wdl_path = "workflows/nextstrain.wdl"
+  custom_stack_name     = local.custom_stack_name
+  deployment_stage      = local.deployment_stage
+  remote_dev_prefix     = local.remote_dev_prefix
+  stack_resource_prefix = local.stack_resource_prefix
+  swipe_comms_bucket    = local.swipe_comms_bucket
+  swipe_wdl_bucket      = local.swipe_wdl_bucket
+  sfn_arn               = local.swipe_sfn_arn
+  schedule_expressions  = local.nextstrain_cron_schedule
+  event_role_arn        = local.event_role_arn
+  extra_args            =  {
+    genepi_config_secret_name = "${local.deployment_stage}/genepi-config"
+    remote_dev_prefix        = local.remote_dev_prefix
+    group_name               = "UCSC Pathogen Genomics"
+    s3_filestem              = "UCSC"
+    template_args            = local.default_template_args
+    tree_type                = "OVERVIEW"
+  }
+}


### PR DESCRIPTION
### Summary:
- **What:** Adds auto-generated contextual overview trees for groups of UT Austin and UCSC
- **Ticket:** No ticket
- **Env:** No rdev

### Checklist:
- [x] I merged latest `trunk`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)