### PR TITLE
skip diagnostics for tree build

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -30,6 +30,10 @@ files:
   auspice_config: "my_profiles/aspen/aspen_auspice_config_v2.json"   # this will work for all
 
 ## Parameters
+filter:
+  root_ref:
+    skip_diagnostics: True
+    
 refine:
   keep_polytomies: True
   clock_filter_iqd: 3


### PR DESCRIPTION
### Summary:
- **What:** Make sure the reference strain (the root of the tree) does not go through the diagnostic step and don't get filtered out. Snapshot below shows the added config parameters feeds into the correct script. 
(I added a section to the yaml template. @jgadling does anything on the yaml builder side needs to change?)
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/20667188/163847701-cc4fc157-ca8f-4f03-af63-e69bf9a4476b.png">


### Demos:
Tree run finished on Jess' docker container!

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)