### PR TITLE
Allow division to be None in response schema

### DIFF
--- a/src/backend/aspen/api/schemas/locations.py
+++ b/src/backend/aspen/api/schemas/locations.py
@@ -7,7 +7,7 @@ class LocationResponse(BaseResponse):
     id: int
     region: str
     country: str
-    division: str
+    division: Optional[str]
     location: Optional[str]
 
 


### PR DESCRIPTION
### Summary:
- **What:** Fixes a bug that caused the API call for locations to fail. Divisions can now be null, but the response schema was not updated accordingly.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)