### PR TITLE
add new warnings and error for upload flow

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/DuplicateIdsError/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/DuplicateIdsError/index.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { B } from "src/common/styles/basicStyle";
+import { pluralize } from "src/common/utils/strUtils";
+import AlertAccordion from "src/components/AlertAccordion";
+import { StyledTable } from "./style";
+
+interface Props {
+  duplicatePrivateIds?: string[];
+  duplicatePublicIds?: string[];
+}
+
+const DuplicateIdsMessage = ({
+  duplicatePrivateIds = [],
+  duplicatePublicIds = [],
+}: Props): JSX.Element | null => {
+  const hasDupPrivate = duplicatePrivateIds.length > 0;
+  const hasDupPublic = duplicatePublicIds.length > 0;
+
+  return (
+    <div>
+      You can update the duplicate IDs in the table below, or update your file
+      and re-import.
+      {(hasDupPrivate || hasDupPublic) && (
+        <StyledTable>
+          {hasDupPrivate && (
+            <tbody>
+              <span>
+                <B>Duplicate Private IDs: </B> {duplicatePrivateIds.join(", ")}
+              </span>
+            </tbody>
+          )}
+          {hasDupPublic && (
+            <tbody>
+              <span>
+                <B>Duplicate Public IDs: </B> {duplicatePublicIds.join(", ")}
+              </span>
+            </tbody>
+          )}
+        </StyledTable>
+      )}
+    </div>
+  );
+};
+
+const DuplicateIdsError = ({
+  duplicatePrivateIds = [],
+  duplicatePublicIds = [],
+}: Props): JSX.Element => {
+  const totalErrorCount =
+    duplicatePrivateIds.length + duplicatePublicIds.length;
+
+  const title = (
+    <span>
+      <B>
+        {totalErrorCount} {pluralize("Sample", totalErrorCount)}{" "}
+        {pluralize("has", totalErrorCount)} duplicate Private or Public IDs.
+      </B>{" "}
+      Please review and correct before proceeding.
+    </span>
+  );
+
+  return (
+    <AlertAccordion
+      intent="error"
+      title={title}
+      collapseContent={
+        <DuplicateIdsMessage
+          duplicatePrivateIds={duplicatePrivateIds}
+          duplicatePublicIds={duplicatePublicIds}
+        />
+      }
+    />
+  );
+};
+
+export { DuplicateIdsError };

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/DuplicateIdsError/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/DuplicateIdsError/style.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+import { getSpaces } from "czifui";
+
+export const StyledTable = styled.table`
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    // TODO (mlila): overlay colors not yet available from sds,
+    // TODO          so hardcoding this for now.
+    return `
+      background-color: #F6EAEA;
+      margin-top: ${spaces?.m}px;
+      padding: ${spaces?.l}px;
+      width: 100%;
+    `;
+  }}
+`;

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/WarningBadLocationFormat/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/WarningBadLocationFormat/index.tsx
@@ -1,0 +1,66 @@
+import { map } from "lodash";
+import React from "react";
+import { B } from "src/common/styles/basicStyle";
+import AlertAccordion from "src/components/AlertAccordion";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { ProblemTable } from "src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/ProblemTable";
+
+/**
+ * WARNING_CODE.BAD_LOCATION_FORMAT
+ */
+interface BadLocationFormatProps {
+  badSamples: {
+    id: string;
+    originalValue: string;
+    updatedValue: string;
+  }[];
+}
+
+const MessageBadLocationFormat = ({ badSamples }: BadLocationFormatProps) => {
+  const tablePreamble =
+    "You can update the data in the table below, or update your file and re-import.";
+
+  const columnHeaders = [
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
+    "Data Column",
+    "Imported Value",
+    "Updated Value",
+  ];
+
+  const rows = map(badSamples, (sample) => {
+    const { id, originalValue, updatedValue } = sample;
+    return [id, "Collection Location", originalValue, updatedValue];
+  });
+
+  return (
+    <ProblemTable
+      tablePreamble={tablePreamble}
+      columnHeaders={columnHeaders}
+      rows={rows}
+    />
+  );
+};
+
+const WarningBadLocationFormat = ({
+  badSamples,
+}: BadLocationFormatProps): JSX.Element => {
+  const title = (
+    <span>
+      <B>
+        Some metadata was automatically updated in the fields below to match
+        required formatting.
+      </B>{" "}
+      Please double check and correct any errors.
+    </span>
+  );
+
+  return (
+    <AlertAccordion
+      title={title}
+      collapseContent={<MessageBadLocationFormat badSamples={badSamples} />}
+      intent="warning"
+    />
+  );
+};
+
+export { WarningBadLocationFormat };

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/WarningUnknownDataFields/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/components/WarningUnknownDataFields/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { B } from "src/common/styles/basicStyle";
+import AlertAccordion from "src/components/AlertAccordion";
+
+/**
+ * WARNING_CODE.UNKNOWN_DATA_FIELDS
+ */
+const WarningUnknownDataFields = (): JSX.Element => {
+  const title = <B>Unknown data fields in metadata file weren’t imported.</B>;
+  const message =
+    "We encountered some unknown data fields in your file that we did not import. If you " +
+    "are missing data, please double check that your column headers match our naming convention.";
+
+  return (
+    <AlertAccordion title={title} collapseContent={message} intent="warning" />
+  );
+};
+
+export { WarningUnknownDataFields };

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ErrorsAndWarnings/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { DuplicateIdsError } from "./components/DuplicateIdsError";
+import { WarningBadLocationFormat } from "./components/WarningBadLocationFormat";
+import { WarningUnknownDataFields } from "./components/WarningUnknownDataFields";
+
+interface Props {
+  errorData?: any; // placeholder
+}
+
+// TODO (mlila): error data needs to be passed through this component to display messages. This state
+// TODO          should be calculated and managed by the parent because we also need to add in the
+// TODO          row input warning/error styles which will be based on the same data.
+const ErrorsAndWarnings = ({ errorData }: Props): JSX.Element | null => {
+  if (!errorData) return null;
+
+  // TODO (mlila): some errors and warnings from upload flow need to be copied here
+  return (
+    <>
+      <DuplicateIdsError />
+      <WarningBadLocationFormat badSamples={[]} />
+      <WarningUnknownDataFields />
+    </>
+  );
+};
+
+export { ErrorsAndWarnings };

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -23,6 +23,7 @@ import {
   SampleIdToEditMetadataWebform,
 } from "src/components/WebformTable/common/types";
 import { ContinueButton } from "src/views/Upload/components/common/style";
+import { ErrorsAndWarnings } from "./components/ErrorsAndWarnings";
 import {
   StyledButton,
   StyledDiv,
@@ -176,6 +177,7 @@ const EditSamplesConfirmationModal = ({
               InstructionsTitleMarginBottom="xxs"
               listItemFontSize="xs"
             />
+            <ErrorsAndWarnings />
             <WebformTable
               setIsValid={setIsValid}
               metadata={metadata}

--- a/src/frontend/src/common/utils/strUtils.ts
+++ b/src/frontend/src/common/utils/strUtils.ts
@@ -1,4 +1,5 @@
 const WORDS_TO_PLURALIZE: Record<string, string> = {
+  has: "have",
   was: "were",
 };
 

--- a/src/frontend/src/components/WebformTable/common/types.ts
+++ b/src/frontend/src/components/WebformTable/common/types.ts
@@ -32,7 +32,6 @@ export enum WARNING_CODE {
 
 export enum ERROR_CODE {
   DEFAULT, // BAD FILE NAME
-  DUPLICATE_IDS,
   INVALID_NAME,
   MISSING_FIELD, // Missing required column entirely: no header field found
   OVER_MAX_SAMPLES,

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
@@ -19,7 +19,6 @@ const ERROR_CODE_TO_MESSAGE: Record<
   [ERROR_CODE.MISSING_FIELD]: MissingFieldMessage,
   [ERROR_CODE.OVER_MAX_SAMPLES]: "placeholder",
   [ERROR_CODE.DEFAULT]: DefaultMessage,
-  [ERROR_CODE.DUPLICATE_IDS]: "placeholder",
 };
 
 export default function Error({
@@ -31,15 +30,19 @@ export default function Error({
   const count = names.length;
 
   const errorCodeToTitle = {
-    [ERROR_CODE.INVALID_NAME]: `Please double check the following ${pluralize(
-      "sample",
-      count
-    )} to correct any errors before proceeding:`,
-    [ERROR_CODE.MISSING_FIELD]: "Import Failed, file missing required field.",
+    [ERROR_CODE.INVALID_NAME]: (
+      <B>
+        Please double check the following {pluralize("sample", count)} to
+        correct any errors before proceeding:
+      </B>
+    ),
+    [ERROR_CODE.MISSING_FIELD]: (
+      <B>Import Failed, file missing required field.</B>
+    ),
     [ERROR_CODE.OVER_MAX_SAMPLES]: "placeholder",
-    [ERROR_CODE.DEFAULT]:
-      "Something went wrong, please try again or contact us!",
-    [ERROR_CODE.DUPLICATE_IDS]: "placeholder",
+    [ERROR_CODE.DEFAULT]: (
+      <B>Something went wrong, please try again or contact us!</B>
+    ),
   };
 
   const title = errorCodeToTitle[errorCode];

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/ProblemTable.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/ProblemTable.tsx
@@ -42,7 +42,11 @@ interface Props {
  * within a row, each entry should be unique and each column header should be
  * unique as well. For its current usage, this will always be true.
  */
-export function ProblemTable({ tablePreamble, columnHeaders, rows }: Props) {
+export function ProblemTable({
+  tablePreamble,
+  columnHeaders,
+  rows,
+}: Props): JSX.Element {
   return (
     <FullWidthContainer>
       {tablePreamble || null}

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/style.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/style.ts
@@ -1,32 +1,27 @@
 import styled from "@emotion/styled";
 import {
+  CommonThemeProps,
   fontBodyXs,
   fontHeaderS,
   fontHeaderXs,
-  getColors,
   getSpaces,
 } from "czifui";
 
+const mPadding = (props: CommonThemeProps) => {
+  const spaces = getSpaces(props);
+  return `
+    padding: ${spaces?.m}px;
+  `;
+};
+
 export const Th = styled.th`
   ${fontHeaderXs}
-  ${(props) => {
-    const spaces = getSpaces(props);
-    const colors = getColors(props);
-    return `
-      padding: ${spaces?.m}px;
-      border-bottom: ${spaces?.xxxs}px solid ${colors?.gray[200]};
-    `;
-  }}
+  ${mPadding}
 `;
 
 export const Td = styled.td`
   ${fontBodyXs}
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      padding: ${spaces?.m}px;
-    `;
-  }}
+  ${mPadding}
 `;
 
 export const Title = styled.span`

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -224,6 +224,7 @@ function MessageBadFormatData({ badFormatData }: PropsBadFormatData) {
     />
   );
 }
+
 export function WarningBadFormatData({
   badFormatData,
 }: PropsBadFormatData): JSX.Element {

--- a/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
@@ -19,7 +19,6 @@ const ERROR_CODE_MESSAGES: Record<ERROR_CODE, string> = {
   [ERROR_CODE.MISSING_FIELD]: "placeholder",
   [ERROR_CODE.OVER_MAX_SAMPLES]:
     "This file contains more than 500 samples, which exceeds the maximum for each upload process. Please limit the samples to 500 or less",
-  [ERROR_CODE.DUPLICATE_IDS]: "placeholder",
 };
 
 interface Props {


### PR DESCRIPTION
### Summary
- **What:** Add warning and error messages for editing samples metadata upload
- **Ticket:**
  - [[sc-181275]](https://app.shortcut.com/genepi/story/181275)
  - [[sc-181269]](https://app.shortcut.com/genepi/story/181269)
  - [[sc-181281]](https://app.shortcut.com/genepi/story/181281)
- **Env:** https://warn-frontend.dev.czgenepi.org/?editSamples=true
- **Design:** https://www.figma.com/file/Glop15AdcM56MOM9WKRZJj/CRUD-V1?node-id=443%3A155711

### Demos
![Screen Shot 2022-04-18 at 8 47 16 PM](https://user-images.githubusercontent.com/7562933/163927463-c7082258-9746-4968-9ab5-c7fdf00f1408.png)
![Screen Shot 2022-04-18 at 8 47 25 PM](https://user-images.githubusercontent.com/7562933/163927466-8c35a9ee-8396-4c94-9260-7a37077a06e8.png)
![Screen Shot 2022-04-18 at 9 54 54 PM](https://user-images.githubusercontent.com/7562933/163927467-ec4d5019-921a-4cbb-8daf-d2553e92ada9.png)

### Notes
These warnings aren't hooked up to anything real yet because there does not seem to be a metadata tsv import flow yet.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)