### PR TITLE
Fix gisaid samples in tsv download

### DIFF
--- a/src/backend/aspen/api/utils/tsv_streamer.py
+++ b/src/backend/aspen/api/utils/tsv_streamer.py
@@ -50,11 +50,11 @@ class MetadataTSVStreamer(TSVStreamer):
 
     def __init__(self, filename: str, data: Iterable, selected: Iterable):
         super().__init__(filename, data)
-        self.selected = selected
+        self.selected = [item.lower() for item in selected]
 
     def generate_row(self, item):
         data: Mapping[str, Any] = {
             "Sample Identifier": item,
-            "Selected": "yes" if item in self.selected else "no",
+            "Selected": "yes" if item.lower() in self.selected else "no",
         }
         return data

--- a/src/backend/aspen/api/views/phylo_trees.py
+++ b/src/backend/aspen/api/views/phylo_trees.py
@@ -1,4 +1,5 @@
 import re
+
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -231,7 +231,7 @@ async def validate_ids(
 ) -> ValidateIDsResponse:
 
     """
-    take in a list of identifiers and checks if all idenitifiers exist as either Sample public or private identifiers, or GisaidMetadata strain names
+    take in a list of identifiers and checks if all identifiers exist as either Sample public or private identifiers, or GisaidMetadata strain names
 
     returns a response with list of missing identifiers if any, otherwise will return an empty list
     """

--- a/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
+++ b/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
@@ -69,18 +69,19 @@ async def create_phylotree_with_inputs(
     )
     input_entity = uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
 
-    gisaid_samples = ["gisaid_identifier"]
+    db_gisaid_samples = ["gisaid_identifier", "hCoV-19/gisaid_identifier2"]
     phylo_run = phylorun_factory(
         owner_group,
         inputs=[input_entity],
-        gisaid_ids=gisaid_samples,
+        gisaid_ids=db_gisaid_samples,
     )
     samples = [sample]
     phylo_tree = phylotree_factory(
         phylo_run,
         samples,
     )
-    upload_s3_file(mock_s3_resource, phylo_tree, samples, gisaid_samples)
+    tree_gisaid_samples = ["gisaid_identifier", "GISAID_identifier2"]
+    upload_s3_file(mock_s3_resource, phylo_tree, samples, tree_gisaid_samples)
 
     async_session.add_all([phylo_tree])
     await async_session.commit()
@@ -205,6 +206,7 @@ async def test_private_id_matrix(
                 f"root_identifier_1	no\r\n"
                 f"{samples[0].public_identifier}	yes\r\n"
                 f"gisaid_identifier	yes\r\n"
+                f"GISAID_identifier2	yes\r\n"
             ),
         },
         {
@@ -215,6 +217,7 @@ async def test_private_id_matrix(
                 f"root_identifier_1	no\r\n"
                 f"{samples[0].private_identifier}	yes\r\n"
                 f"gisaid_identifier	yes\r\n"
+                f"GISAID_identifier2	yes\r\n"
             ),
         },
     ]

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -296,8 +296,18 @@ def me(ctx):
 @user.command(name="create")
 @click.argument("email")
 @click.option("--name", required=True, type=str, help="The user's name.")
-@click.option("--group_id", required=True, type=str, help="The id of the group to create the user in.")
-@click.option("--auth0_user_id", required=True, type=str, help="The auth0 identifier attached to the user's auth0 account.")
+@click.option(
+    "--group_id",
+    required=True,
+    type=str,
+    help="The id of the group to create the user in.",
+)
+@click.option(
+    "--auth0_user_id",
+    required=True,
+    type=str,
+    help="The auth0 identifier attached to the user's auth0 account.",
+)
 @click.option("--group_admin", is_flag=True, default=False)
 @click.option("--system_admin", is_flag=True, default=False)
 @click.pass_context
@@ -370,7 +380,7 @@ def get_tree_sample_ids(ctx, tree_id, public_ids):
         params["id_style"] = "public"
     else:
         params["id_style"] = "private"
-    resp = api_client.get(f"/api/phylo_tree/sample_ids/{tree_id}", params=params)
+    resp = api_client.get(f"/v2/phylo_trees/{tree_id}/sample_ids", params=params)
     print(resp.text)
 
 


### PR DESCRIPTION
### Summary:
- **What:** Make sure gisaid samples are marked as selected in the tsv download file
- **Ticket:** [sc193207](https://app.shortcut.com/genepi/story/193207)
- **Env:** `<rdev link>`

### Notes:
If GISAID samples were added to a phylo tree with an `hCoV-19/` prefix, our filtering code wasn't stripping the prefix before checking whether samples in a tree (which don't have the prefix) match the samples input by the user.

This PR will force samples to match whether or not they have a `hCoV-19/` prefix on either side of the comparison, and also makes sure all matching is case-insensitive.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)