### PR TITLE
set region to global for tree build

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -37,9 +37,11 @@ class BaseNextstrainConfigBuilder:
             self.tree_build_level = "country"
         elif not location.location:
             self.tree_build_level = "division"
-        # Fill out region/country/division/location fields if the group has them,
+        # The region field for tree build needs to be 'global' to avoid country names being converted to region
+        build["region"] = "global"
+        # Fill out country/division/location fields if the group has them,
         # or remove those fields if they don't.
-        location_fields = ["region", "country", "division", "location"]
+        location_fields = ["country", "division", "location"]
         location_values = []
         for field in location_fields:
             value = getattr(location, field)

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -37,8 +37,6 @@ class BaseNextstrainConfigBuilder:
             self.tree_build_level = "country"
         elif not location.location:
             self.tree_build_level = "division"
-        # The region field for tree build needs to be 'global' to avoid country names being converted to region
-        build["region"] = "global"
         # Fill out country/division/location fields if the group has them,
         # or remove those fields if they don't.
         location_fields = ["country", "division", "location"]

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -11,6 +11,7 @@ inputs:
 
 builds:
   aspen:
+    region: global
     country: {country}
     division: {division}
     location: {location}


### PR DESCRIPTION
### Summary:
- **What:** Adding this change #836 to yaml builder since we're having the same coloring issues 😉 

### Demos:
<img width="902" alt="image" src="https://user-images.githubusercontent.com/20667188/164286587-0b26c46b-7ceb-4616-9120-3f8bf9ccdcfe.png">
And tree run looks good. 

### Notes:
Will have some impact on Lucia and Jess's coloring by lat long work #1033 b/c all trees in 2022 don't really have functional color by country 😭 Very sorry!!

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)