### PR TITLE
Allow running ARM oidc image in local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,6 @@ services:
   oidc:
     image: soluto/oidc-server-mock:0.3.0
     profiles: [ "backend", "web", "all" ]
-    platform: linux/amd64
     ports:
       - "4011:80"
       - "8443:8443"


### PR DESCRIPTION
### Summary:
- **What:** Our existing OIDC docker image doesn't run smoothly on ARM. This change will let docker-compose use the system default platform to run the OIDC docker container: ARM64 for M1 macs, and AMD64 for x86 macs. Long-term we probably need to work out a better solution (upgrading oidc? using a different tool?) but this should make my local dev function for now without breaking things for anyone else
