### PR TITLE
add another bullet back in

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
@@ -12,7 +12,7 @@ const InputInstructions = (): JSX.Element => {
     FEATURE_FLAGS.sample_filtering_tree_creation
   );
 
-  if (isSampleFilteringEnabled) {
+  if (!isSampleFilteringEnabled) {
     return (
       <StyledWrapper>
         <CollapsibleInstructions
@@ -69,6 +69,10 @@ const InputInstructions = (): JSX.Element => {
           </div>,
           <div key={2}>
             IDs must be separated by tabs, commas, or enter one ID per row.
+          </div>,
+          <div key={3}>
+            Adding more than 2000 samples will increase the tree building run
+            time.
           </div>,
         ]}
       />


### PR DESCRIPTION
### Summary
- **What:** Add in bullet point again per Janeece and Dan. Also I noticed the logic was toggled on when to show which directions. Whoops!
- **Ticket:** [[sc-184608]](https://app.shortcut.com/genepi/story/184608)
- **Discussion:** https://github.com/chanzuckerberg/czgenepi/pull/1026#discussion_r852270643
- 
### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)