### PR TITLE
Disable flaky test until we have time to investigate

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -128,6 +128,8 @@ jobs:
           # Build backend
           docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-backend:latest src/backend
           make backend-check-style
+# Test has been flaky for a couple months (~April 2022). Commenting out until we have
+# some test engineering support to suss out the issue and clean things up.
 #  e2e-test:
 #    runs-on: ubuntu-20.04
 #    steps:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -128,38 +128,38 @@ jobs:
           # Build backend
           docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-backend:latest src/backend
           make backend-check-style
-  e2e-test:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Configure AWS prod Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-      - name: Login to ECR
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - uses: actions/checkout@v2
-      - name: Playwright tests
-        run: |
-          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
-          # Build backend image
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-backend:latest src/backend
-          # Build frontend
-          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-frontend:latest src/frontend
-          mkdir -p src/frontend/build
-          chmod a+rwx src/frontend/build # TODO temp hack - need a better plan for the build dir.
-          make local-init
-          echo "Init complete - testing web service"
-          # docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
-          echo "Webserver up, running tests!"
-          docker-compose logs -f frontend &
-          export S3_PREFIX=${{ secrets.CI_SCREENSHOT_PREFIX }}/${{ github.run_id }}/
-          make frontend-e2e-ci
+#  e2e-test:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Configure AWS prod Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-west-2
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          role-duration-seconds: 900
+#      - name: Login to ECR
+#        uses: docker/login-action@v1
+#        with:
+#          registry: ${{ secrets.ECR_REPO }}
+#      - uses: actions/checkout@v2
+#      - name: Playwright tests
+#        run: |
+#          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+#          # Build backend image
+#          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-backend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-backend:latest src/backend
+#          # Build frontend
+#          docker buildx build --cache-from=type=registry,ref=${{ secrets.ECR_REPO }}/genepi-frontend:branch-trunk -t ${{ secrets.ECR_REPO }}/genepi-frontend:latest src/frontend
+#          mkdir -p src/frontend/build
+#          chmod a+rwx src/frontend/build # TODO temp hack - need a better plan for the build dir.
+#          make local-init
+#          echo "Init complete - testing web service"
+#          # docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
+#          echo "Webserver up, running tests!"
+#          docker-compose logs -f frontend &
+#          export S3_PREFIX=${{ secrets.CI_SCREENSHOT_PREFIX }}/${{ github.run_id }}/
+#          make frontend-e2e-ci
   py-test:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
### Summary:
- **What:** These tests have been failing intermittently and are low-value. We don't have time to investigate right now, let's disable them until we do.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)