### PR TITLE
Maya/184616 date range menu

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/style.ts
@@ -41,6 +41,12 @@ export const StyledFilterGroup = styled.div`
 export const StyledFilterGroupName = styled.p`
   ${fontHeaderXs}
   color: black;
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.xxs}px;
+    `;
+  }}
 `;
 
 export const StyledNewTabLink = styled(NewTabLink)`

--- a/src/frontend/src/common/types/dateFilter.d.ts
+++ b/src/frontend/src/common/types/dateFilter.d.ts
@@ -1,0 +1,15 @@
+type FormattedDateType = string | undefined;
+type DateType = FormattedDateType | Date;
+
+type UpdateDateFilterType = (
+  start: Date | undefined,
+  end: Date | undefined
+) => void;
+
+type DateMenuOption = {
+  name: string; // Must be UNIQUE because we assume can be used as key/id
+  // For both `numDays...` it's relative to now() when option is chosen.
+  // Assume start is guaranteed, but end cap is not.
+  numDaysEndOffset?: number; // How far back end of date interval is
+  numDaysStartOffset: number; // How far back start of date interval is
+};

--- a/src/frontend/src/common/utils/dateUtils.tsx
+++ b/src/frontend/src/common/utils/dateUtils.tsx
@@ -1,0 +1,21 @@
+interface Args {
+  currentLabel?: string;
+  startDate?: DateType;
+  endDate?: DateType;
+}
+
+export const getDateRangeLabel = ({
+  currentLabel,
+  startDate,
+  endDate,
+}: Args): string | null => {
+  // If a date menu option was selected, just use its specific name instead
+  if (currentLabel) return currentLabel;
+
+  // DateChip should only display if we have at least one of startDate/endDate
+  if (!startDate && !endDate) return null;
+
+  // Get the date chip message. Structure varies if only one of the two dates.
+  // Might be worth extracting date message to a common helper func elsewhere?
+  return `${startDate || "Prior"} to ${endDate || "Today"}`;
+};

--- a/src/frontend/src/components/DateField/index.tsx
+++ b/src/frontend/src/components/DateField/index.tsx
@@ -9,8 +9,6 @@ const INPUT_PROPS = {
   minLength: DATE_LENGTH,
 };
 
-export type FormattedDateType = string | undefined;
-
 interface Props {
   fieldKey: string;
   formik: FormikContextType<any>;

--- a/src/frontend/src/components/DateFilterMenu/constants.ts
+++ b/src/frontend/src/components/DateFilterMenu/constants.ts
@@ -1,0 +1,41 @@
+import { DateMenuOption } from "src/components/DateFilterMenu";
+
+export const MENU_OPTIONS_UPLOAD_DATE: DateMenuOption[] = [
+  {
+    name: "Today",
+    numDaysStartOffset: 0,
+  },
+  {
+    name: "Yesterday",
+    numDaysEndOffset: 1,
+    numDaysStartOffset: 1,
+  },
+  {
+    name: "Last 7 Days",
+    numDaysStartOffset: 7,
+  },
+];
+
+export const MENU_OPTIONS_COLLECTION_DATE: DateMenuOption[] = [
+  {
+    name: "Last 7 Days",
+    numDaysStartOffset: 7,
+  },
+  {
+    name: "Last 30 Days",
+    numDaysStartOffset: 30,
+  },
+  // Average month has ~30.4 days, so that's why the non-round numbers
+  {
+    name: "Last 3 Months",
+    numDaysStartOffset: 91,
+  },
+  {
+    name: "Last 6 Months",
+    numDaysStartOffset: 182,
+  },
+  {
+    name: "Last Year",
+    numDaysStartOffset: 365,
+  },
+];

--- a/src/frontend/src/components/DateFilterMenu/constants.ts
+++ b/src/frontend/src/components/DateFilterMenu/constants.ts
@@ -1,5 +1,3 @@
-import { DateMenuOption } from "src/components/DateFilterMenu";
-
 export const MENU_OPTIONS_UPLOAD_DATE: DateMenuOption[] = [
   {
     name: "Today",

--- a/src/frontend/src/components/DateFilterMenu/index.tsx
+++ b/src/frontend/src/components/DateFilterMenu/index.tsx
@@ -1,7 +1,7 @@
 import { Menu, MenuItem } from "czifui";
 import { useFormik } from "formik";
 import { noop } from "lodash";
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, { FC, useMemo } from "react";
 import DateField from "src/components/DateField";
 import {
   DATE_ERROR_MESSAGE,
@@ -33,9 +33,8 @@ interface Props {
   onClose(): void;
   onStartDateChange(date: FormattedDateType): void;
   onEndDateChange(date: FormattedDateType): void;
-  onDateLabelChange(label: string | null): void;
-  shouldClearFilter: boolean;
-  setShouldClearFilter(s: boolean): void;
+  selectedDateMenuOption: DateMenuOption | null;
+  setSelectedDateMenuOption(o: DateMenuOption | null): void;
 }
 
 export const DateFilterMenu: FC<Props> = ({
@@ -47,21 +46,9 @@ export const DateFilterMenu: FC<Props> = ({
   onClose,
   onStartDateChange,
   onEndDateChange,
-  onDateLabelChange,
-  shouldClearFilter,
-  setShouldClearFilter,
+  selectedDateMenuOption,
+  setSelectedDateMenuOption,
 }) => {
-  // What menu option is chosen. If none chosen, `null`.
-  const [selectedDateMenuOption, setSelectedDateMenuOption] =
-    useState<DateMenuOption | null>(null);
-
-  useEffect(() => {
-    if (shouldClearFilter) {
-      setSelectedDateMenuOption(null);
-      setShouldClearFilter(false);
-    }
-  }, [shouldClearFilter, setShouldClearFilter]);
-
   const validationSchema = useMemo(
     () =>
       yup.object({
@@ -109,7 +96,6 @@ export const DateFilterMenu: FC<Props> = ({
 
   const setDatesFromMenuOption = (dateOption: DateMenuOption) => {
     setSelectedDateMenuOption(dateOption);
-    onDateLabelChange(dateOption.name);
     // Selecting a menu option clears out anything entered in the fields.
     setFieldValue(fieldKeyStart, undefined);
     setFieldValue(fieldKeyEnd, undefined);
@@ -131,7 +117,6 @@ export const DateFilterMenu: FC<Props> = ({
     // Since using fields instead, clear out selected menu option
     setSelectedDateMenuOption(null);
     setDatesFromRange(start, end);
-    onDateLabelChange(null);
   };
 
   //TODO when it's available, use sds component for single select on preset date ranges

--- a/src/frontend/src/components/DateFilterMenu/index.tsx
+++ b/src/frontend/src/components/DateFilterMenu/index.tsx
@@ -2,13 +2,12 @@ import { Menu, MenuItem } from "czifui";
 import { useFormik } from "formik";
 import { noop } from "lodash";
 import React, { FC, useEffect, useMemo, useState } from "react";
-import DateField, { FormattedDateType } from "src/components/DateField";
+import DateField from "src/components/DateField";
 import {
   DATE_ERROR_MESSAGE,
   DATE_REGEX,
 } from "src/components/DateField/constants";
 import * as yup from "yup";
-import { UpdateDateFilterType } from "../FilterPanel";
 import {
   ErrorMessageHolder,
   StyledButton,
@@ -18,8 +17,6 @@ import {
   StyledText,
 } from "./style";
 
-export type DateType = FormattedDateType | Date;
-
 const formatDateForDisplay = (d: DateType) => {
   if (d === undefined) return d;
   if (typeof d === "string") return d;
@@ -27,16 +24,8 @@ const formatDateForDisplay = (d: DateType) => {
   return d.toISOString().substring(0, 10);
 };
 
-export interface DateMenuOption {
-  name: string; // Must be UNIQUE because we assume can be used as key/id
-  // For both `numDays...` it's relative to now() when option is chosen.
-  // Assume start is guaranteed, but end cap is not.
-  numDaysEndOffset?: number; // How far back end of date interval is
-  numDaysStartOffset: number; // How far back start of date interval is
-}
-
 interface Props {
-  anchorEl: HTMLElement | null;
+  anchorEl?: HTMLElement;
   fieldKeyEnd: string;
   fieldKeyStart: string;
   updateDateFilter: UpdateDateFilterType;
@@ -44,7 +33,7 @@ interface Props {
   onClose(): void;
   onStartDateChange(date: FormattedDateType): void;
   onEndDateChange(date: FormattedDateType): void;
-  onDateLabelChange(label: string): void;
+  onDateLabelChange(label: string | null): void;
   shouldClearFilter: boolean;
   setShouldClearFilter(s: boolean): void;
 }
@@ -142,7 +131,7 @@ export const DateFilterMenu: FC<Props> = ({
     // Since using fields instead, clear out selected menu option
     setSelectedDateMenuOption(null);
     setDatesFromRange(start, end);
-    onDateLabelChange(undefined);
+    onDateLabelChange(null);
   };
 
   //TODO when it's available, use sds component for single select on preset date ranges

--- a/src/frontend/src/components/DateFilterMenu/index.tsx
+++ b/src/frontend/src/components/DateFilterMenu/index.tsx
@@ -1,0 +1,204 @@
+import { Menu, MenuItem } from "czifui";
+import { useFormik } from "formik";
+import { noop } from "lodash";
+import React, { FC, useEffect, useMemo, useState } from "react";
+import DateField, { FormattedDateType } from "src/components/DateField";
+import {
+  DATE_ERROR_MESSAGE,
+  DATE_REGEX,
+} from "src/components/DateField/constants";
+import * as yup from "yup";
+import { UpdateDateFilterType } from "../FilterPanel";
+import {
+  ErrorMessageHolder,
+  StyledButton,
+  StyledDateRange,
+  StyledErrorMessage,
+  StyledManualDate,
+  StyledText,
+} from "./style";
+
+export type DateType = FormattedDateType | Date;
+
+const formatDateForDisplay = (d: DateType) => {
+  if (d === undefined) return d;
+  if (typeof d === "string") return d;
+
+  return d.toISOString().substring(0, 10);
+};
+
+export interface DateMenuOption {
+  name: string; // Must be UNIQUE because we assume can be used as key/id
+  // For both `numDays...` it's relative to now() when option is chosen.
+  // Assume start is guaranteed, but end cap is not.
+  numDaysEndOffset?: number; // How far back end of date interval is
+  numDaysStartOffset: number; // How far back start of date interval is
+}
+
+interface Props {
+  anchorEl: HTMLElement | null;
+  fieldKeyEnd: string;
+  fieldKeyStart: string;
+  updateDateFilter: UpdateDateFilterType;
+  menuOptions: DateMenuOption[];
+  onClose(): void;
+  onStartDateChange(date: FormattedDateType): void;
+  onEndDateChange(date: FormattedDateType): void;
+  onDateLabelChange(label: string): void;
+  shouldClearFilter: boolean;
+  setShouldClearFilter(s: boolean): void;
+}
+
+export const DateFilterMenu: FC<Props> = ({
+  anchorEl,
+  fieldKeyEnd,
+  fieldKeyStart,
+  updateDateFilter, // Don't directly call, use below `setDatesFromRange` instead
+  menuOptions,
+  onClose,
+  onStartDateChange,
+  onEndDateChange,
+  onDateLabelChange,
+  shouldClearFilter,
+  setShouldClearFilter,
+}) => {
+  // What menu option is chosen. If none chosen, `null`.
+  const [selectedDateMenuOption, setSelectedDateMenuOption] =
+    useState<DateMenuOption | null>(null);
+
+  useEffect(() => {
+    if (shouldClearFilter) {
+      setSelectedDateMenuOption(null);
+      setShouldClearFilter(false);
+    }
+  }, [shouldClearFilter, setShouldClearFilter]);
+
+  const validationSchema = useMemo(
+    () =>
+      yup.object({
+        [fieldKeyEnd]: yup
+          .string()
+          .matches(DATE_REGEX, DATE_ERROR_MESSAGE)
+          .min(10, DATE_ERROR_MESSAGE)
+          .max(10, DATE_ERROR_MESSAGE),
+        [fieldKeyStart]: yup
+          .string()
+          .matches(DATE_REGEX, DATE_ERROR_MESSAGE)
+          .min(10, DATE_ERROR_MESSAGE)
+          .max(10, DATE_ERROR_MESSAGE),
+      }),
+    [fieldKeyStart, fieldKeyEnd] // Should never actually change, but JIC
+  );
+
+  const formik = useFormik({
+    initialValues: {
+      [fieldKeyEnd]: undefined,
+      [fieldKeyStart]: undefined,
+    },
+    onSubmit: noop,
+    validationSchema,
+  });
+
+  // formik `isValid` actually gets set after `isValidating` goes back to false
+  // So we have to check both to avoid visual flicker in Apply button.
+  const { values, setFieldValue, isValid, isValidating, errors } = formik;
+
+  const errorMessageFieldKeyStart = errors[fieldKeyStart];
+  const errorMessageFieldKeyEnd = errors[fieldKeyEnd];
+
+  // Use this over directly using `updateDateFilter` prop so we track filter changes.
+  const setDatesFromRange: UpdateDateFilterType = (start, end) => {
+    const newStartDate = formatDateForDisplay(start);
+    const newEndDate = formatDateForDisplay(end);
+
+    onStartDateChange(newStartDate);
+    onEndDateChange(newEndDate);
+
+    updateDateFilter(start, end);
+    onClose();
+  };
+
+  const setDatesFromMenuOption = (dateOption: DateMenuOption) => {
+    setSelectedDateMenuOption(dateOption);
+    onDateLabelChange(dateOption.name);
+    // Selecting a menu option clears out anything entered in the fields.
+    setFieldValue(fieldKeyStart, undefined);
+    setFieldValue(fieldKeyEnd, undefined);
+
+    // We assume start of interval is always guaranteed, but not necessarily end
+    const start = new Date();
+    start.setDate(start.getDate() - dateOption.numDaysStartOffset);
+    start.setHours(0, 0, 0);
+    let end = undefined;
+    if (dateOption.numDaysEndOffset) {
+      end = new Date();
+      end.setDate(end.getDate() - dateOption.numDaysEndOffset);
+      end.setHours(23, 59, 59);
+    }
+    setDatesFromRange(start, end);
+  };
+
+  const setDatesFromFields: UpdateDateFilterType = (start, end) => {
+    // Since using fields instead, clear out selected menu option
+    setSelectedDateMenuOption(null);
+    setDatesFromRange(start, end);
+    onDateLabelChange(undefined);
+  };
+
+  //TODO when it's available, use sds component for single select on preset date ranges
+  return (
+    <Menu
+      anchorEl={anchorEl}
+      keepMounted
+      open={Boolean(anchorEl)}
+      onClose={onClose}
+      getContentAnchorEl={null}
+    >
+      <StyledManualDate>
+        <StyledDateRange>
+          <DateField fieldKey={fieldKeyStart} formik={formik} />
+          <StyledText>to</StyledText>
+          <DateField fieldKey={fieldKeyEnd} formik={formik} />
+        </StyledDateRange>
+        <ErrorMessageHolder>
+          {errorMessageFieldKeyStart ? (
+            <StyledErrorMessage>{errors[fieldKeyStart]}</StyledErrorMessage>
+          ) : (
+            <StyledErrorMessage />
+          )}
+          {errorMessageFieldKeyEnd ? (
+            <StyledErrorMessage>{errors[fieldKeyEnd]}</StyledErrorMessage>
+          ) : (
+            <StyledErrorMessage />
+          )}
+        </ErrorMessageHolder>
+        {(values[fieldKeyStart] || values[fieldKeyEnd]) && (
+          <StyledButton
+            sdsType="primary"
+            sdsStyle="square"
+            onClick={() => {
+              const startValue = values[fieldKeyStart];
+              const endValue = values[fieldKeyEnd];
+              const start = startValue ? new Date(startValue) : undefined;
+              const end = endValue ? new Date(endValue) : undefined;
+              return setDatesFromFields(start, end);
+            }}
+            disabled={isValidating || !isValid}
+          >
+            Apply
+          </StyledButton>
+        )}
+      </StyledManualDate>
+      {/* TODO (mlila): use a single select here instead */}
+      {menuOptions.map((dateOption: DateMenuOption) => (
+        <MenuItem
+          key={dateOption.name}
+          onClick={() => setDatesFromMenuOption(dateOption)}
+          selected={Boolean(selectedDateMenuOption?.name === dateOption.name)}
+        >
+          {dateOption.name}
+        </MenuItem>
+      ))}
+    </Menu>
+  );
+};

--- a/src/frontend/src/components/DateFilterMenu/style.ts
+++ b/src/frontend/src/components/DateFilterMenu/style.ts
@@ -1,0 +1,66 @@
+import styled from "@emotion/styled";
+import {
+  Button,
+  fontBodyXs,
+  fontBodyXxxs,
+  getColors,
+  getFontWeights,
+  getSpaces,
+} from "czifui";
+
+export const StyledDateRange = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const StyledManualDate = styled.div`
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+    return `
+      border-bottom: 1px solid ${colors?.gray[200]};
+      padding-bottom: ${(spaces?.xxs ?? 0) + (spaces?.m ?? 0)}px;
+      padding-top: ${spaces?.m}px;
+      padding-right: ${spaces?.xxs}px;
+      padding-left: ${spaces?.xxs}px;
+    `;
+  }}
+`;
+
+export const StyledText = styled.span`
+  ${fontBodyXs}
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    const spaces = getSpaces(props);
+    return `
+      font-weight: ${fontWeights?.semibold};
+      margin: 0 ${spaces?.xs}px;
+    `;
+  }}
+`;
+
+export const StyledButton = styled(Button)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.xs}px;
+    `;
+  }}
+`;
+
+export const ErrorMessageHolder = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const StyledErrorMessage = styled.span`
+  /* set max-width here so that there's space for both error messages to be present and be spaced appropriately */
+  max-width: 159px;
+  ${fontBodyXxxs}
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      color: ${colors?.error[600]};
+    `;
+  }}
+`;

--- a/src/frontend/src/components/FilterPanel/components/CollectionDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/CollectionDateFilter/index.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from "react";
 import { MENU_OPTIONS_COLLECTION_DATE } from "src/components/DateFilterMenu/constants";
-import { UpdateDateFilterType } from "../..";
 import { DateFilter } from "../DateFilter";
 
 interface Props {

--- a/src/frontend/src/components/FilterPanel/components/CollectionDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/CollectionDateFilter/index.tsx
@@ -1,30 +1,7 @@
 import React, { FC } from "react";
+import { MENU_OPTIONS_COLLECTION_DATE } from "src/components/DateFilterMenu/constants";
 import { UpdateDateFilterType } from "../..";
-import { DateFilter, DateMenuOption } from "../DateFilter";
-
-const MENU_OPTIONS_COLLECTION_DATE: DateMenuOption[] = [
-  {
-    name: "Last 7 Days",
-    numDaysStartOffset: 7,
-  },
-  {
-    name: "Last 30 Days",
-    numDaysStartOffset: 30,
-  },
-  // Average month has ~30.4 days, so that's why the non-round numbers
-  {
-    name: "Last 3 Months",
-    numDaysStartOffset: 91,
-  },
-  {
-    name: "Last 6 Months",
-    numDaysStartOffset: 182,
-  },
-  {
-    name: "Last Year",
-    numDaysStartOffset: 365,
-  },
-];
+import { DateFilter } from "../DateFilter";
 
 interface Props {
   updateCollectionDateFilter: UpdateDateFilterType;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/index.tsx
@@ -2,32 +2,20 @@ import React from "react";
 import { StyledChip } from "./style";
 
 interface DateChipProps {
-  startDate?: DateType;
-  endDate?: DateType;
   dateLabel: string | null;
   deleteDateFilterFunc: () => void;
 }
 
 const DateChip = ({
-  startDate,
-  endDate,
   dateLabel,
   deleteDateFilterFunc,
 }: DateChipProps): JSX.Element | null => {
-  // DateChip should only display if we have at least one of startDate/endDate
-  if (!startDate && !endDate) return null;
+  if (!dateLabel) return null;
 
-  // Get the date chip message. Structure varies if only one of the two dates.
-  // Might be worth extracting date message to a common helper func elsewhere?
-  let dateIntervalLabel = `${startDate || "Prior"} to ${endDate || "Today"}`;
-  // If a date menu option was selected, just use its specific name instead
-  if (dateLabel) {
-    dateIntervalLabel = dateLabel;
-  }
   return (
     <StyledChip
       size="medium"
-      label={dateIntervalLabel}
+      label={dateLabel}
       onDelete={deleteDateFilterFunc}
     />
   );

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { StyledChip } from "../../../../style";
+
+interface DateChipProps {
+  startDate?: DateType;
+  endDate?: DateType;
+  dateLabel: string | null;
+  deleteDateFilterFunc: () => void;
+}
+
+const DateChip = ({
+  startDate,
+  endDate,
+  dateLabel,
+  deleteDateFilterFunc,
+}: DateChipProps): JSX.Element | null => {
+  // DateChip should only display if we have at least one of startDate/endDate
+  if (!startDate && !endDate) return null;
+
+  // Get the date chip message. Structure varies if only one of the two dates.
+  // Might be worth extracting date message to a common helper func elsewhere?
+  let dateIntervalLabel = `${startDate || "Prior"} to ${endDate || "Today"}`;
+  // If a date menu option was selected, just use its specific name instead
+  if (dateLabel) {
+    dateIntervalLabel = dateLabel;
+  }
+  return (
+    <StyledChip
+      size="medium"
+      label={dateIntervalLabel}
+      onDelete={deleteDateFilterFunc}
+    />
+  );
+};
+
+export { DateChip };

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyledChip } from "../../../../style";
+import { StyledChip } from "./style";
 
 interface DateChipProps {
   startDate?: DateType;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/components/DateChip/style.ts
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+import { Chip, getSpaces } from "czifui";
+
+export const StyledChip = styled(Chip)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin: ${spaces?.xxs}px ${spaces?.xxs}px 0 0;
+    `;
+  }}
+`;

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -1,44 +1,7 @@
-import { Menu, MenuItem } from "czifui";
-import { useFormik } from "formik";
-import { noop } from "lodash";
-import React, { FC, useMemo, useState } from "react";
-import DateField, { FormattedDateType } from "src/components/DateField";
-import {
-  DATE_ERROR_MESSAGE,
-  DATE_REGEX,
-} from "src/components/DateField/constants";
-import * as yup from "yup";
-import { UpdateDateFilterType } from "../..";
-import {
-  StyledChip,
-  StyledFilterWrapper,
-  StyledInputDropdown,
-} from "../../style";
-import {
-  ErrorMessageHolder,
-  StyledButton,
-  StyledDateRange,
-  StyledErrorMessage,
-  StyledManualDate,
-  StyledText,
-} from "./style";
-
-export type DateType = FormattedDateType | Date;
-
-const formatDateForDisplay = (d: DateType) => {
-  if (d === undefined) return d;
-  if (typeof d === "string") return d;
-
-  return d.toISOString().substring(0, 10);
-};
-
-export interface DateMenuOption {
-  name: string; // Must be UNIQUE because we assume can be used as key/id
-  // For both `numDays...` it's relative to now() when option is chosen.
-  // Assume start is guaranteed, but end cap is not.
-  numDaysEndOffset?: number; // How far back end of date interval is
-  numDaysStartOffset: number; // How far back start of date interval is
-}
+import React, { useState } from "react";
+import { DateFilterMenu } from "src/components/DateFilterMenu";
+import { DateChip } from "./components/DateChip";
+import { StyledFilterWrapper, StyledInputDropdown } from "./style";
 
 interface Props {
   fieldKeyEnd: string;
@@ -48,20 +11,13 @@ interface Props {
   menuOptions: DateMenuOption[];
 }
 
-export const DateFilter: FC<Props> = ({
-  fieldKeyEnd,
-  fieldKeyStart,
-  inputLabel,
-  updateDateFilter, // Don't directly call, use below `setDatesFromRange` instead
-  menuOptions,
-}) => {
+const DateFilter = ({ inputLabel, ...props }: Props): JSX.Element => {
   // `startDate` and `endDate` represent the active filter dates. Update on filter change.
   const [startDate, setStartDate] = useState<FormattedDateType>();
   const [endDate, setEndDate] = useState<FormattedDateType>();
-  // What menu option is chosen. If none chosen, `null`.
-  const [selectedDateMenuOption, setSelectedDateMenuOption] =
-    useState<DateMenuOption | null>(null);
+  const [dateLabel, setDateLabel] = useState<string>("");
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+  const [shouldClearFilter, setShouldClearFilter] = useState<boolean>(false);
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
     setAnchorEl(event.currentTarget);
@@ -71,81 +27,12 @@ export const DateFilter: FC<Props> = ({
     setAnchorEl(undefined);
   };
 
-  const validationSchema = useMemo(
-    () =>
-      yup.object({
-        [fieldKeyEnd]: yup
-          .string()
-          .matches(DATE_REGEX, DATE_ERROR_MESSAGE)
-          .min(10, DATE_ERROR_MESSAGE)
-          .max(10, DATE_ERROR_MESSAGE),
-        [fieldKeyStart]: yup
-          .string()
-          .matches(DATE_REGEX, DATE_ERROR_MESSAGE)
-          .min(10, DATE_ERROR_MESSAGE)
-          .max(10, DATE_ERROR_MESSAGE),
-      }),
-    [fieldKeyStart, fieldKeyEnd] // Should never actually change, but JIC
-  );
-
-  const formik = useFormik({
-    initialValues: {
-      [fieldKeyEnd]: undefined,
-      [fieldKeyStart]: undefined,
-    },
-    onSubmit: noop,
-    validationSchema,
-  });
-
-  // formik `isValid` actually gets set after `isValidating` goes back to false
-  // So we have to check both to avoid visual flicker in Apply button.
-  const { values, setFieldValue, isValid, isValidating, errors } = formik;
-
-  const errorMessageFieldKeyStart = errors[fieldKeyStart];
-  const errorMessageFieldKeyEnd = errors[fieldKeyEnd];
-
-  // Use this over directly using `updateDateFilter` prop so we track filter changes.
-  const setDatesFromRange: UpdateDateFilterType = (start, end) => {
-    const newStartDate = formatDateForDisplay(start);
-    const newEndDate = formatDateForDisplay(end);
-    setStartDate(newStartDate);
-    setEndDate(newEndDate);
-
-    updateDateFilter(start, end);
-    handleClose();
-  };
-
-  const setDatesFromMenuOption = (dateOption: DateMenuOption) => {
-    setSelectedDateMenuOption(dateOption);
-    // Selecting a menu option clears out anything entered in the fields.
-    setFieldValue(fieldKeyStart, undefined);
-    setFieldValue(fieldKeyEnd, undefined);
-
-    // We assume start of interval is always guaranteed, but not necessarily end
-    const start = new Date();
-    start.setDate(start.getDate() - dateOption.numDaysStartOffset);
-    start.setHours(0, 0, 0);
-    let end = undefined;
-    if (dateOption.numDaysEndOffset) {
-      end = new Date();
-      end.setDate(end.getDate() - dateOption.numDaysEndOffset);
-      end.setHours(23, 59, 59);
-    }
-    setDatesFromRange(start, end);
-  };
-
-  const setDatesFromFields: UpdateDateFilterType = (start, end) => {
-    // Since using fields instead, clear out selected menu option
-    setSelectedDateMenuOption(null);
-    setDatesFromRange(start, end);
-  };
-
   const deleteDateFilter = () => {
-    setSelectedDateMenuOption(null);
-    setDatesFromRange(undefined, undefined);
+    setStartDate(undefined);
+    setEndDate(undefined);
+    setShouldClearFilter(true);
   };
 
-  //TODO when it's available, use sds component for single select on preset date ranges
   return (
     <StyledFilterWrapper>
       <StyledInputDropdown
@@ -155,100 +42,24 @@ export const DateFilter: FC<Props> = ({
         // @ts-expect-error remove line when inputdropdown types fixed in sds
         onClick={handleClick}
       />
-      <Menu
+      <DateFilterMenu
+        {...props}
         anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
         onClose={handleClose}
-        getContentAnchorEl={null}
-      >
-        <StyledManualDate>
-          <StyledDateRange>
-            <DateField fieldKey={fieldKeyStart} formik={formik} />
-            <StyledText>to</StyledText>
-            <DateField fieldKey={fieldKeyEnd} formik={formik} />
-          </StyledDateRange>
-          <ErrorMessageHolder>
-            {errorMessageFieldKeyStart ? (
-              <StyledErrorMessage>{errors[fieldKeyStart]}</StyledErrorMessage>
-            ) : (
-              <StyledErrorMessage />
-            )}
-            {errorMessageFieldKeyEnd ? (
-              <StyledErrorMessage>{errors[fieldKeyEnd]}</StyledErrorMessage>
-            ) : (
-              <StyledErrorMessage />
-            )}
-          </ErrorMessageHolder>
-          {(values[fieldKeyStart] || values[fieldKeyEnd]) && (
-            <StyledButton
-              sdsType="primary"
-              sdsStyle="square"
-              onClick={() => {
-                const startValue = values[fieldKeyStart];
-                const endValue = values[fieldKeyEnd];
-                const start = startValue ? new Date(startValue) : undefined;
-                const end = endValue ? new Date(endValue) : undefined;
-                return setDatesFromFields(start, end);
-              }}
-              disabled={isValidating || !isValid}
-            >
-              Apply
-            </StyledButton>
-          )}
-        </StyledManualDate>
-        {/* TODO (mlila): use a single select here instead */}
-        {menuOptions.map((dateOption: DateMenuOption) => (
-          <MenuItem
-            key={dateOption.name}
-            onClick={() => setDatesFromMenuOption(dateOption)}
-            selected={Boolean(
-              selectedDateMenuOption &&
-                selectedDateMenuOption.name === dateOption.name
-            )}
-          >
-            {dateOption.name}
-          </MenuItem>
-        ))}
-      </Menu>
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+        onDateLabelChange={setDateLabel}
+        shouldClearFilter={shouldClearFilter}
+        setShouldClearFilter={setShouldClearFilter}
+      />
       <DateChip
         startDate={startDate}
         endDate={endDate}
-        selectedDateMenuOption={selectedDateMenuOption}
-        deleteDateFilter={deleteDateFilter}
+        dateLabel={dateLabel}
+        deleteDateFilterFunc={deleteDateFilter}
       />
     </StyledFilterWrapper>
   );
 };
 
-interface DateChipProps {
-  startDate?: DateType;
-  endDate?: DateType;
-  selectedDateMenuOption: DateMenuOption | null;
-  deleteDateFilter: () => void;
-}
-
-function DateChip({
-  startDate,
-  endDate,
-  selectedDateMenuOption,
-  deleteDateFilter,
-}: DateChipProps): JSX.Element | null {
-  // DateChip should only display if we have at least one of startDate/endDate
-  if (!startDate && !endDate) return null;
-
-  // Get the date chip message. Structure varies if only one of the two dates.
-  // Might be worth extracting date message to a common helper func elsewhere?
-  let dateIntervalLabel = `${startDate || "Prior"} to ${endDate || "Today"}`;
-  // If a date menu option was selected, just use its specific name instead
-  if (selectedDateMenuOption) {
-    dateIntervalLabel = selectedDateMenuOption.name;
-  }
-  return (
-    <StyledChip
-      size="medium"
-      label={dateIntervalLabel}
-      onDelete={deleteDateFilter}
-    />
-  );
-}
+export { DateFilter };

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -15,8 +15,8 @@ const DateFilter = ({ inputLabel, ...props }: Props): JSX.Element => {
   // `startDate` and `endDate` represent the active filter dates. Update on filter change.
   const [startDate, setStartDate] = useState<FormattedDateType>();
   const [endDate, setEndDate] = useState<FormattedDateType>();
-  const [dateLabel, setDateLabel] = useState<string>("");
-  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+  const [dateLabel, setDateLabel] = useState<string | null>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>();
   const [shouldClearFilter, setShouldClearFilter] = useState<boolean>(false);
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { getDateRangeLabel } from "src/common/utils/dateUtils";
 import { DateFilterMenu } from "src/components/DateFilterMenu";
 import { DateChip } from "./components/DateChip";
 import { StyledFilterWrapper, StyledInputDropdown } from "./style";
@@ -11,13 +12,18 @@ interface Props {
   menuOptions: DateMenuOption[];
 }
 
-const DateFilter = ({ inputLabel, ...props }: Props): JSX.Element => {
+const DateFilter = ({
+  inputLabel,
+  updateDateFilter,
+  ...props
+}: Props): JSX.Element => {
   // `startDate` and `endDate` represent the active filter dates. Update on filter change.
   const [startDate, setStartDate] = useState<FormattedDateType>();
   const [endDate, setEndDate] = useState<FormattedDateType>();
-  const [dateLabel, setDateLabel] = useState<string | null>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>();
-  const [shouldClearFilter, setShouldClearFilter] = useState<boolean>(false);
+  // What menu option is chosen. If none chosen, `null`.
+  const [selectedDateMenuOption, setSelectedDateMenuOption] =
+    useState<DateMenuOption | null>(null);
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
     setAnchorEl(event.currentTarget);
@@ -30,8 +36,15 @@ const DateFilter = ({ inputLabel, ...props }: Props): JSX.Element => {
   const deleteDateFilter = () => {
     setStartDate(undefined);
     setEndDate(undefined);
-    setShouldClearFilter(true);
+    setSelectedDateMenuOption(null);
+    updateDateFilter(undefined, undefined);
   };
+
+  const dateLabel = getDateRangeLabel({
+    currentLabel: selectedDateMenuOption?.name,
+    startDate,
+    endDate,
+  });
 
   return (
     <StyledFilterWrapper>
@@ -48,16 +61,11 @@ const DateFilter = ({ inputLabel, ...props }: Props): JSX.Element => {
         onClose={handleClose}
         onStartDateChange={setStartDate}
         onEndDateChange={setEndDate}
-        onDateLabelChange={setDateLabel}
-        shouldClearFilter={shouldClearFilter}
-        setShouldClearFilter={setShouldClearFilter}
+        selectedDateMenuOption={selectedDateMenuOption}
+        setSelectedDateMenuOption={setSelectedDateMenuOption}
+        updateDateFilter={updateDateFilter}
       />
-      <DateChip
-        startDate={startDate}
-        endDate={endDate}
-        dateLabel={dateLabel}
-        deleteDateFilterFunc={deleteDateFilter}
-      />
+      <DateChip dateLabel={dateLabel} deleteDateFilterFunc={deleteDateFilter} />
     </StyledFilterWrapper>
   );
 };

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/index.tsx
@@ -56,7 +56,6 @@ const DateFilter = ({
         onClick={handleClick}
       />
       <DateFilterMenu
-        {...props}
         anchorEl={anchorEl}
         onClose={handleClose}
         onStartDateChange={setStartDate}
@@ -64,6 +63,7 @@ const DateFilter = ({
         selectedDateMenuOption={selectedDateMenuOption}
         setSelectedDateMenuOption={setSelectedDateMenuOption}
         updateDateFilter={updateDateFilter}
+        {...props}
       />
       <DateChip dateLabel={dateLabel} deleteDateFilterFunc={deleteDateFilter} />
     </StyledFilterWrapper>

--- a/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
+++ b/src/frontend/src/components/FilterPanel/components/DateFilter/style.ts
@@ -1,66 +1,21 @@
 import styled from "@emotion/styled";
-import {
-  Button,
-  fontBodyXs,
-  fontBodyXxxs,
-  getColors,
-  getFontWeights,
-  getSpaces,
-} from "czifui";
+import { fontCapsXxxs, getSpaces, InputDropdown } from "czifui";
 
-export const StyledDateRange = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-export const StyledManualDate = styled.div`
-  ${(props) => {
-    const colors = getColors(props);
-    const spaces = getSpaces(props);
-    return `
-      border-bottom: 1px solid ${colors?.gray[200]};
-      padding-bottom: ${(spaces?.xxs ?? 0) + (spaces?.m ?? 0)}px;
-      padding-top: ${spaces?.m}px;
-      padding-right: ${spaces?.xxs}px;
-      padding-left: ${spaces?.xxs}px;
-    `;
-  }}
-`;
-
-export const StyledText = styled.span`
-  ${fontBodyXs}
-  ${(props) => {
-    const fontWeights = getFontWeights(props);
-    const spaces = getSpaces(props);
-    return `
-      font-weight: ${fontWeights?.semibold};
-      margin: 0 ${spaces?.xs}px;
-    `;
-  }}
-`;
-
-export const StyledButton = styled(Button)`
+export const StyledFilterWrapper = styled.div`
   ${(props) => {
     const spaces = getSpaces(props);
     return `
-      margin-top: ${spaces?.xs}px;
+      margin: ${spaces?.l}px 0;
+
+      &:first-child {
+        margin: 0;
+      }
     `;
   }}
 `;
 
-export const ErrorMessageHolder = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
-export const StyledErrorMessage = styled.span`
-  /* set max-width here so that there's space for both error messages to be present and be spaced appropriately */
-  max-width: 159px;
-  ${fontBodyXxxs}
-  ${(props) => {
-    const colors = getColors(props);
-    return `
-      color: ${colors?.error[600]};
-    `;
-  }}
+export const StyledInputDropdown = styled(InputDropdown)`
+  ${fontCapsXxxs}
+  padding: 0;
+  text-align: left;
 `;

--- a/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
@@ -1,22 +1,7 @@
 import React, { FC } from "react";
+import { MENU_OPTIONS_UPLOAD_DATE } from "src/components/DateFilterMenu/constants";
 import { UpdateDateFilterType } from "../..";
-import { DateFilter, DateMenuOption } from "../DateFilter";
-
-const MENU_OPTIONS_UPLOAD_DATE: DateMenuOption[] = [
-  {
-    name: "Today",
-    numDaysStartOffset: 0,
-  },
-  {
-    name: "Yesterday",
-    numDaysEndOffset: 1,
-    numDaysStartOffset: 1,
-  },
-  {
-    name: "Last 7 Days",
-    numDaysStartOffset: 7,
-  },
-];
+import { DateFilter } from "../DateFilter";
 
 interface Props {
   updateUploadDateFilter: UpdateDateFilterType;

--- a/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
+++ b/src/frontend/src/components/FilterPanel/components/UploadDateFilter/index.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from "react";
 import { MENU_OPTIONS_UPLOAD_DATE } from "src/components/DateFilterMenu/constants";
-import { UpdateDateFilterType } from "../..";
 import { DateFilter } from "../DateFilter";
 
 interface Props {

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -47,11 +47,6 @@ interface FiltersType {
   [filterKey: string]: FilterType;
 }
 
-export type UpdateDateFilterType = (
-  start: Date | undefined,
-  end: Date | undefined
-) => void;
-
 // * (mlila): `key` should be the name of the column you are filtering on
 const DATA_FILTER_INIT = {
   CZBFailedGenomeRecovery: {

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -1,11 +1,5 @@
 import styled from "@emotion/styled";
-import {
-  Chip,
-  CommonThemeProps,
-  ComplexFilter,
-  getColors,
-  getSpaces,
-} from "czifui";
+import { CommonThemeProps, ComplexFilter, getColors, getSpaces } from "czifui";
 
 export interface ExtraProps extends CommonThemeProps {
   isOpen?: boolean;
@@ -26,15 +20,6 @@ export const StyledFilterPanel = styled("div", {
       display: ${isOpen ? "block" : "none"};
       padding: ${spaces?.xl}px;
       width: 240px;
-    `;
-  }}
-`;
-
-export const StyledChip = styled(Chip)`
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      margin: ${spaces?.xxs}px ${spaces?.xxs}px 0 0;
     `;
   }}
 `;

--- a/src/frontend/src/components/FilterPanel/style.ts
+++ b/src/frontend/src/components/FilterPanel/style.ts
@@ -3,10 +3,8 @@ import {
   Chip,
   CommonThemeProps,
   ComplexFilter,
-  fontCapsXxxs,
   getColors,
   getSpaces,
-  InputDropdown,
 } from "czifui";
 
 export interface ExtraProps extends CommonThemeProps {
@@ -28,25 +26,6 @@ export const StyledFilterPanel = styled("div", {
       display: ${isOpen ? "block" : "none"};
       padding: ${spaces?.xl}px;
       width: 240px;
-    `;
-  }}
-`;
-
-export const StyledInputDropdown = styled(InputDropdown)`
-  ${fontCapsXxxs}
-  padding: 0;
-  text-align: left;
-`;
-
-export const StyledFilterWrapper = styled.div`
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      margin: ${spaces?.l}px 0;
-
-      &:first-child {
-        margin: 0;
-      }
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Refactor of `DateFilter`
  - pull the menu out into its own component
  - pull out reusable functional code into util
  - pull constants out
  - pull types into their own file
- **Why:** This will facilitate the re-use of the filter logic for sample tree filtering
- **Ticket:** [[sc-184616]](https://app.shortcut.com/genepi/story/184616)
- **Env:** https://datefilter-frontend.dev.czgenepi.org/

### Testing
1. Ensure existing filters on the samples table still work
1. Ensure you can clear existing filters using chips

### Demos
No visual or functional changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)