### PR TITLE
Maya/184616 date range menu

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/index.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+import { getDateRangeLabel } from "src/common/utils/dateUtils";
+import { MENU_OPTION_ALL_TIME } from "src/components/DateFilterMenu/constants";
+import { StyledDateFilterMenu, StyledInputDropdown } from "./style";
+
+interface Props {
+  fieldKeyEnd: string;
+  fieldKeyStart: string;
+  menuOptions: DateMenuOption[];
+  updateDateFilter: UpdateDateFilterType;
+}
+
+const CollectionDateFilter = ({
+  updateDateFilter,
+  ...props
+}: Props): JSX.Element => {
+  // `startDate` and `endDate` represent the active filter dates. Update on filter change.
+  const [startDate, setStartDate] = useState<FormattedDateType>();
+  const [endDate, setEndDate] = useState<FormattedDateType>();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>();
+  // What menu option is chosen. If none chosen, `null`.
+  const [selectedDateMenuOption, setSelectedDateMenuOption] =
+    useState<DateMenuOption | null>(MENU_OPTION_ALL_TIME);
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(undefined);
+  };
+
+  const dateLabel = getDateRangeLabel({
+    currentLabel: selectedDateMenuOption?.name,
+    startDate,
+    endDate,
+  });
+
+  return (
+    <>
+      <StyledInputDropdown
+        sdsStyle="square"
+        sdsType="singleSelect"
+        label={dateLabel}
+        // @ts-expect-error remove line when inputdropdown types fixed in sds
+        onClick={handleClick}
+      />
+      <StyledDateFilterMenu
+        {...props}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+        selectedDateMenuOption={selectedDateMenuOption}
+        setSelectedDateMenuOption={setSelectedDateMenuOption}
+        updateDateFilter={updateDateFilter}
+      />
+    </>
+  );
+};
+
+export { CollectionDateFilter };

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/style.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/style.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { InputDropdown } from "czifui";
+import { DateFilterMenu } from "src/components/DateFilterMenu";
+
+export const StyledInputDropdown = styled(InputDropdown)`
+  width: 224px;
+`;
+
+export const StyledDateFilterMenu = styled(DateFilterMenu)`
+  max-height: 290px;
+  min-width: 270px;
+`;

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { noop } from "src/common/constants/empty";
+import {
+  MENU_OPTIONS_COLLECTION_DATE,
+  MENU_OPTION_ALL_TIME,
+} from "src/components/DateFilterMenu/constants";
 import { StyledInfoOutlinedIcon, StyledTooltip } from "../../style";
+import { CollectionDateFilter } from "./components/CollectionDateFilter";
 import {
   StyledContainer,
   StyledExplainerTitle,
@@ -37,7 +42,7 @@ const SAMPLE_FILTERING_TOOLTIP_TEXT = (
  * our designs to what's current available. Those are just there to get
  * a version of this out the door, nothing longterm at all there.
  */
-export function SampleFiltering() {
+export function SampleFiltering(): JSX.Element {
   return (
     <StyledContainer>
       <StyledExplainerTitle>
@@ -65,12 +70,14 @@ export function SampleFiltering() {
         </StyledFilterGroup>
         <StyledFilterGroup>
           <StyledFilterGroupName>Collection Date</StyledFilterGroupName>
-          <StyledInputDropdown
-            disabled={false}
-            label="Dummy placeholder"
-            onClick={noop}
-            sdsStage="userInput"
-            sdsStyle="square"
+          <CollectionDateFilter
+            fieldKeyEnd="collectionDateEnd"
+            fieldKeyStart="collectionDateStart"
+            updateDateFilter={noop}
+            menuOptions={[
+              ...MENU_OPTIONS_COLLECTION_DATE,
+              MENU_OPTION_ALL_TIME,
+            ]}
           />
         </StyledFilterGroup>
       </StyledFiltersSection>

--- a/src/frontend/src/common/types/dateFilter.d.ts
+++ b/src/frontend/src/common/types/dateFilter.d.ts
@@ -11,5 +11,5 @@ type DateMenuOption = {
   // For both `numDays...` it's relative to now() when option is chosen.
   // Assume start is guaranteed, but end cap is not.
   numDaysEndOffset?: number; // How far back end of date interval is
-  numDaysStartOffset: number; // How far back start of date interval is
+  numDaysStartOffset?: number; // How far back start of date interval is
 };

--- a/src/frontend/src/common/utils/dateUtils.tsx
+++ b/src/frontend/src/common/utils/dateUtils.tsx
@@ -8,12 +8,12 @@ export const getDateRangeLabel = ({
   currentLabel,
   startDate,
   endDate,
-}: Args): string | null => {
+}: Args): string => {
   // If a date menu option was selected, just use its specific name instead
   if (currentLabel) return currentLabel;
 
   // DateChip should only display if we have at least one of startDate/endDate
-  if (!startDate && !endDate) return null;
+  if (!startDate && !endDate) return "";
 
   // Get the date chip message. Structure varies if only one of the two dates.
   // Might be worth extracting date message to a common helper func elsewhere?

--- a/src/frontend/src/components/DateFilterMenu/constants.ts
+++ b/src/frontend/src/components/DateFilterMenu/constants.ts
@@ -39,5 +39,5 @@ export const MENU_OPTIONS_COLLECTION_DATE: DateMenuOption[] = [
 ];
 
 export const MENU_OPTION_ALL_TIME: DateMenuOption = {
-  name: "All time",
+  name: "All Time",
 };

--- a/src/frontend/src/components/DateFilterMenu/constants.ts
+++ b/src/frontend/src/components/DateFilterMenu/constants.ts
@@ -37,3 +37,7 @@ export const MENU_OPTIONS_COLLECTION_DATE: DateMenuOption[] = [
     numDaysStartOffset: 365,
   },
 ];
+
+export const MENU_OPTION_ALL_TIME: DateMenuOption = {
+  name: "All time",
+};

--- a/src/frontend/src/components/DateFilterMenu/index.tsx
+++ b/src/frontend/src/components/DateFilterMenu/index.tsx
@@ -96,14 +96,18 @@ export const DateFilterMenu: FC<Props> = ({
 
   const setDatesFromMenuOption = (dateOption: DateMenuOption) => {
     setSelectedDateMenuOption(dateOption);
+
     // Selecting a menu option clears out anything entered in the fields.
     setFieldValue(fieldKeyStart, undefined);
     setFieldValue(fieldKeyEnd, undefined);
 
-    // We assume start of interval is always guaranteed, but not necessarily end
-    const start = new Date();
-    start.setDate(start.getDate() - dateOption.numDaysStartOffset);
-    start.setHours(0, 0, 0);
+    let start = undefined;
+    if (dateOption.numDaysStartOffset) {
+      start = new Date();
+      start.setDate(start.getDate() - dateOption.numDaysStartOffset);
+      start.setHours(0, 0, 0);
+    }
+
     let end = undefined;
     if (dateOption.numDaysEndOffset) {
       end = new Date();


### PR DESCRIPTION
### Summary
- **What:** Add a collection date range filter to the ns tree modal
- **Ticket:** [[sc-184616]](https://app.shortcut.com/genepi/story/184616)
- **Env:** https://daterange-frontend.dev.czgenepi.org/
- **Design:** https://www.figma.com/file/nGRxk2lhJoWoiPSnM0GY8g/Self-Serve-Tree-V4---Sample-Filtering?node-id=2664%3A179344

### Demos
#### Before: 
![Screen Shot 2022-04-21 at 10 46 43 AM](https://user-images.githubusercontent.com/7562933/164520053-dba8e1ae-d914-4785-8f39-fb3af4b2a782.png)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/164520012-97f3ea37-423a-4f14-8185-8537a6465aec.gif)

### Notes
- Further styling required
- Still need to have this filter impact the resulting tree

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)