### PR TITLE
Support scorpio call/score.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,12 +190,20 @@ services:
       - BOTO_ENDPOINT_URL=http://localstack.genepinet.localdev:4566
       - AWS_ACCESS_KEY_ID=dev_access_key_id
       - AWS_SECRET_ACCESS_KEY=dev_secret_access_key
+      - FLASK_ENV=development
+      - PYTHONUNBUFFERED=1
+      - DB=docker
+      - ENV=local
+      - DEPLOYMENT_STAGE=local
+      - PYTHONPATH=.
     command: [ "true" ]
     restart: "no"
     networks:
       genepinet:
         aliases:
           - pangolin.genepinet.localdev
+    volumes:
+      - ./src/backend:/usr/src/app
   nextstrain:
     image: "${DOCKER_REPO}genepi-nextstrain"
     profiles: [ "nextstrain", "jobs", "all" ]

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -28,6 +28,7 @@ class SampleLineageResponse(BaseResponse):
     version: Optional[str]
     scorpio_call: Optional[str]
     scorpio_support: Optional[float]
+    qc_status: Optional[str]
 
 
 class SampleGroupResponse(BaseResponse):

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -26,6 +26,8 @@ class SampleLineageResponse(BaseResponse):
     lineage: Optional[str]
     confidence: Optional[float]
     version: Optional[str]
+    scorpio_call: Optional[str]
+    scorpio_support: Optional[float]
 
 
 class SampleGroupResponse(BaseResponse):

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -119,7 +119,7 @@ def determine_gisaid_status(
 
 def format_sample_lineage(sample: Sample) -> Dict[str, Any]:
     pathogen_genome = sample.uploaded_pathogen_genome
-    lineage = {
+    lineage: Dict[str, Any] = {
         "lineage": None,
         "confidence": None,
         "version": None,
@@ -134,9 +134,9 @@ def format_sample_lineage(sample: Sample) -> Dict[str, Any]:
         lineage["last_updated"] = pathogen_genome.pangolin_last_updated
 
         # Support looking at pango csv output.
-        pango_output = pathogen_genome.pangolin_output
+        pango_output: Dict[str, Any] = pathogen_genome.pangolin_output  # type: ignore
         lineage["scorpio_call"] = pango_output.get("scorpio_call")
         if pango_output.get("scorpio_support"):
-            lineage["scorpio_support"] = float(pango_output.get("scorpio_support"))
+            lineage["scorpio_support"] = float(pango_output.get("scorpio_support"))  # type: ignore
 
     return lineage

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -126,6 +126,7 @@ def format_sample_lineage(sample: Sample) -> Dict[str, Any]:
         "last_updated": None,
         "scorpio_call": None,
         "scorpio_support": None,
+        "qc_status": None,
     }
     if pathogen_genome:
         lineage["lineage"] = pathogen_genome.pangolin_lineage

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -119,19 +119,24 @@ def determine_gisaid_status(
 
 def format_sample_lineage(sample: Sample) -> Dict[str, Any]:
     pathogen_genome = sample.uploaded_pathogen_genome
+    lineage = {
+        "lineage": None,
+        "confidence": None,
+        "version": None,
+        "last_updated": None,
+        "scorpio_call": None,
+        "scorpio_support": None,
+    }
     if pathogen_genome:
-        lineage = {
-            "lineage": pathogen_genome.pangolin_lineage,
-            "confidence": pathogen_genome.pangolin_probability,
-            "version": pathogen_genome.pangolin_version,
-            "last_updated": pathogen_genome.pangolin_last_updated,
-        }
-    else:
-        lineage = {
-            "lineage": None,
-            "confidence": None,
-            "version": None,
-            "last_updated": None,
-        }
+        lineage["lineage"] = pathogen_genome.pangolin_lineage
+        lineage["confidence"] = pathogen_genome.pangolin_probability
+        lineage["version"] = pathogen_genome.pangolin_version
+        lineage["last_updated"] = pathogen_genome.pangolin_last_updated
+
+        # Support looking at pango csv output.
+        pango_output = pathogen_genome.pangolin_output
+        lineage["scorpio_call"] = pango_output.get("scorpio_call")
+        if pango_output.get("scorpio_support"):
+            lineage["scorpio_support"] = float(pango_output.get("scorpio_support"))
 
     return lineage

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -136,6 +136,7 @@ def format_sample_lineage(sample: Sample) -> Dict[str, Any]:
         # Support looking at pango csv output.
         pango_output: Dict[str, Any] = pathogen_genome.pangolin_output  # type: ignore
         lineage["scorpio_call"] = pango_output.get("scorpio_call")
+        lineage["qc_status"] = pango_output.get("qc_status")
         if pango_output.get("scorpio_support"):
             lineage["scorpio_support"] = float(pango_output.get("scorpio_support"))  # type: ignore
 

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -42,7 +42,14 @@ async def test_samples_view(
         "North America", "USA", "California", "Santa Barbara County"
     )
     sample = sample_factory(group, user, location, private=True)
-    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(sample)
+    pangolin_output = {
+        "scorpio_call": "B.1.167",
+        "scorpio_support": "0.775",
+        "qc_status": "pass",
+    }
+    uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
+        sample, pangolin_output=pangolin_output
+    )
     async_session.add(group)
     await async_session.commit()
 
@@ -82,6 +89,9 @@ async def test_samples_view(
                     "last_updated": convert_datetime_to_iso_8601(
                         uploaded_pathogen_genome.pangolin_last_updated
                     ),
+                    "scorpio_call": pangolin_output["scorpio_call"],
+                    "scorpio_support": float(pangolin_output["scorpio_support"]),
+                    "qc_status": pangolin_output["qc_status"],
                 },
                 "private": True,
                 "submitting_group": {
@@ -145,6 +155,9 @@ async def test_samples_view_gisaid_rejected(
                     "last_updated": convert_datetime_to_iso_8601(
                         uploaded_pathogen_genome.pangolin_last_updated
                     ),
+                    "scorpio_call": None,
+                    "scorpio_support": None,
+                    "qc_status": None,
                 },
                 "private": False,
                 "submitting_group": {
@@ -210,6 +223,9 @@ async def test_samples_view_gisaid_no_info(
                     "last_updated": convert_datetime_to_iso_8601(
                         uploaded_pathogen_genome.pangolin_last_updated
                     ),
+                    "scorpio_call": None,
+                    "scorpio_support": None,
+                    "qc_status": None,
                 },
                 "private": False,
                 "submitting_group": {
@@ -268,6 +284,9 @@ async def test_samples_view_gisaid_not_eligible(
                     "confidence": None,
                     "version": None,
                     "last_updated": None,
+                    "scorpio_call": None,
+                    "scorpio_support": None,
+                    "qc_status": None,
                 },
                 "private": False,
                 "submitting_group": {
@@ -467,6 +486,9 @@ async def test_samples_view_cansee_all(
                 "last_updated": convert_datetime_to_iso_8601(
                     uploaded_pathogen_genome.pangolin_last_updated
                 ),
+                "scorpio_call": None,
+                "scorpio_support": None,
+                "qc_status": None,
             },
             "private": False,
             "submitting_group": {
@@ -534,6 +556,9 @@ async def test_samples_view_no_pangolin(
                     "confidence": None,
                     "version": None,
                     "last_updated": None,
+                    "scorpio_call": None,
+                    "scorpio_support": None,
+                    "qc_status": None,
                 },
                 "private": False,
                 "submitting_group": {

--- a/src/backend/aspen/database/models/sequences.py
+++ b/src/backend/aspen/database/models/sequences.py
@@ -13,8 +13,10 @@ from sqlalchemy import (
     func,
     Integer,
     String,
+    text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import backref, deferred, relationship
 
 from aspen.database.models.base import base
@@ -195,6 +197,14 @@ class PathogenGenome(Entity):
             "Number of sites with an ambiguous allele, e.g. M, K, Y, etc.,"
             " indicating support for 2 or more alleles in the reads."
         ),
+    )
+
+    # Store a map of the fields in this pango output file
+    pangolin_output = Column(
+        JSONB,
+        nullable=True,
+        default=text("'{}'::jsonb"),
+        server_default=text("'{}'::jsonb"),
     )
 
     pangolin_lineage = Column(String, nullable=True)

--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -45,6 +45,7 @@ def uploaded_pathogen_genome_factory(
     sequencing_depth=0.1,
     sequencing_date=datetime.date.today(),
     upload_date=datetime.datetime.now(),
+    pangolin_output={},
 ):
     uploaded_pathogen_genome = UploadedPathogenGenome(
         sample=sample,
@@ -59,6 +60,7 @@ def uploaded_pathogen_genome_factory(
         sequencing_depth=sequencing_depth,
         sequencing_date=sequencing_date,
         upload_date=upload_date,
+        pangolin_output=pangolin_output,
     )
 
     return uploaded_pathogen_genome

--- a/src/backend/aspen/workflows/pangolin/save.py
+++ b/src/backend/aspen/workflows/pangolin/save.py
@@ -48,6 +48,7 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
                 "lineage": row["lineage"],
                 "probability": get_probability(row),
                 "version": row["version"],
+                "full_output": {k: v for k, v in row.items() if v and k != "taxon"},
             }
             for row in pango_csv
         }
@@ -67,6 +68,7 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
             pathogen_genome.pangolin_lineage = pango_info["lineage"]  # type: ignore
             pathogen_genome.pangolin_probability = pango_info["probability"]  # type: ignore
             pathogen_genome.pangolin_version = pango_info["version"]  # type: ignore
+            pathogen_genome.pangolin_output = pango_info["full_output"]  # type: ignore
             session.commit()
 
 

--- a/src/backend/aspen/workflows/pangolin/save.py
+++ b/src/backend/aspen/workflows/pangolin/save.py
@@ -43,7 +43,9 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
 
     with session_scope(interface) as session:
         pango_csv: csv.DictReader = csv.DictReader(pangolin_fh)
-        taxon_to_pango_info: Mapping[int, Mapping[str, Union[str, float, None]]] = {
+        taxon_to_pango_info: Mapping[
+            int, Mapping[str, Union[str, float, Mapping, None]]
+        ] = {
             int(row["taxon"]): {
                 "lineage": row["lineage"],
                 "probability": get_probability(row),
@@ -61,9 +63,9 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
         }
 
         for entity_id, pathogen_genome in entity_id_to_pathogen_genome.items():
-            pango_info: Mapping[str, Union[str, float, None]] = taxon_to_pango_info[
-                entity_id
-            ]
+            pango_info: Mapping[
+                str, Union[str, float, None, Mapping]
+            ] = taxon_to_pango_info[entity_id]
             pathogen_genome.pangolin_last_updated = pangolin_last_updated
             pathogen_genome.pangolin_lineage = pango_info["lineage"]  # type: ignore
             pathogen_genome.pangolin_probability = pango_info["probability"]  # type: ignore

--- a/src/backend/database_migrations/versions/20220425_225456_save_pango_json.py
+++ b/src/backend/database_migrations/versions/20220425_225456_save_pango_json.py
@@ -1,0 +1,31 @@
+"""save pango json
+
+Create Date: 2022-04-25 22:55:03.018662
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20220425_225456"
+down_revision = "20220419_110151"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pathogen_genomes",
+        sa.Column(
+            "pangolin_output",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=True,
+        ),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    raise NotImplementedError("don't downgrade")


### PR DESCRIPTION
### Summary:
- **What:** Copy all pangolin csv output data so we can surface it via our API if necessary, and send back scorpio info.
- **Ticket:** [sc191869](https://app.shortcut.com/genepi/story/191869)
- **Env:** `<rdev link>`

### Notes:
This updates our pangolin job to write all of the (non-empty) pangolin output fields to our DB so we can do what we want with them later. It also adds `scorpio_call` and `scorpio_support` fields to our sample lineage API responses.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)