### PR TITLE
filter trees by lineage and date

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
@@ -24,6 +24,10 @@ interface TreeChoiceWithFilteringProps extends BaseTreeChoiceProps {
   availableLineages: string[];
   selectedLineages: string[];
   setSelectedLineages: (lineages: string[]) => void;
+  startDate: FormattedDateType;
+  endDate: FormattedDateType;
+  setStartDate(d: FormattedDateType): void;
+  setEndDate(d: FormattedDateType): void;
 }
 
 export const RadioLabelOverview = ({

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/index.tsx
@@ -31,6 +31,10 @@ export const RadioLabelOverview = ({
   availableLineages,
   selectedLineages,
   setSelectedLineages,
+  startDate,
+  endDate,
+  setStartDate,
+  setEndDate,
 }: TreeChoiceWithFilteringProps): JSX.Element => {
   const flag = useTreatments([FEATURE_FLAGS.sample_filtering_tree_creation]);
   const isSampleFilteringEnabled = isFlagOn(
@@ -130,6 +134,10 @@ export const RadioLabelOverview = ({
             availableLineages={availableLineages}
             selectedLineages={selectedLineages}
             setSelectedLineages={setSelectedLineages}
+            startDate={startDate}
+            endDate={endDate}
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
           />
         </>
       )}
@@ -184,6 +192,10 @@ export const RadioLabelNonContextualized = ({
   availableLineages,
   selectedLineages,
   setSelectedLineages,
+  startDate,
+  endDate,
+  setStartDate,
+  setEndDate,
 }: TreeChoiceWithFilteringProps): JSX.Element => {
   const flag = useTreatments([FEATURE_FLAGS.sample_filtering_tree_creation]);
   const isSampleFilteringEnabled = isFlagOn(
@@ -242,6 +254,10 @@ export const RadioLabelNonContextualized = ({
               availableLineages={availableLineages}
               selectedLineages={selectedLineages}
               setSelectedLineages={setSelectedLineages}
+              startDate={startDate}
+              endDate={endDate}
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
             />
           )}
         </>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/index.tsx
@@ -12,11 +12,12 @@ interface Props {
 
 const CollectionDateFilter = ({
   updateDateFilter,
+  startDate,
+  endDate,
+  setStartDate,
+  setEndDate,
   ...props
 }: Props): JSX.Element => {
-  // `startDate` and `endDate` represent the active filter dates. Update on filter change.
-  const [startDate, setStartDate] = useState<FormattedDateType>();
-  const [endDate, setEndDate] = useState<FormattedDateType>();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>();
   // What menu option is chosen. If none chosen, `null`.
   const [selectedDateMenuOption, setSelectedDateMenuOption] =

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/components/CollectionDateFilter/index.tsx
@@ -8,6 +8,10 @@ interface Props {
   fieldKeyStart: string;
   menuOptions: DateMenuOption[];
   updateDateFilter: UpdateDateFilterType;
+  startDate: FormattedDateType;
+  endDate: FormattedDateType;
+  setStartDate(d: FormattedDateType): void;
+  setEndDate(d: FormattedDateType): void;
 }
 
 const CollectionDateFilter = ({

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
@@ -176,6 +176,10 @@ export function SampleFiltering({
   availableLineages,
   selectedLineages,
   setSelectedLineages,
+  startDate,
+  endDate,
+  setStartDate,
+  setEndDate,
 }: Props): JSX.Element {
   const lineageDropdownOptions = generateLineageDropdownOptions(
     selectedLineages,
@@ -307,6 +311,10 @@ export function SampleFiltering({
               ...MENU_OPTIONS_COLLECTION_DATE,
               MENU_OPTION_ALL_TIME,
             ]}
+            startDate={startDate}
+            endDate={endDate}
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
           />
         </StyledFilterGroup>
       </StyledFiltersSection>

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
@@ -25,6 +25,10 @@ interface Props {
   availableLineages: string[];
   selectedLineages: string[];
   setSelectedLineages: (lineages: string[]) => void;
+  startDate: FormattedDateType;
+  endDate: FormattedDateType;
+  setStartDate(d: FormattedDateType): void;
+  setEndDate(d: FormattedDateType): void;
 }
 
 // We present a pseudo-option to the user to enable choosing "All" lineages,

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/style.ts
@@ -68,7 +68,7 @@ export const StyledNewTabLink = styled(NewTabLink)`
   }}
 `;
 
-const DROPDOWN_WIDTH = "200px";
+const DROPDOWN_WIDTH = "209px";
 
 // High specificity label styling is to beat out czifui coloring.
 export const StyledDropdown = styled(Dropdown)`
@@ -76,6 +76,15 @@ export const StyledDropdown = styled(Dropdown)`
   .MuiButton-label > span {
     color: black;
   }
+
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      path {
+        fill: ${colors?.gray[500]};
+      }
+    `;
+  }}
 ` as typeof Dropdown; // assert b/c `styled` causes an interface hiccup;
 
 // The `min-width` property is necessary to cancel out a hardcoded czifui

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -76,10 +76,12 @@ export const CreateNSTreeModal = ({
   );
   const [isValidTreeType, setIsValidTreeType] = useState<boolean>(false);
 
-  // Certain tree types can filter based on lineages
+  // Certain tree types can filter based on lineages and date ranges
   const { data: lineagesData } = useLineages();
   const availableLineages: string[] = lineagesData?.lineages || [];
   const [selectedLineages, setSelectedLineages] = useState<string[]>([]);
+  const [startDate, setStartDate] = useState<FormattedDateType>();
+  const [endDate, setEndDate] = useState<FormattedDateType>();
 
   useEffect(() => {
     if (shouldReset) setShouldReset(false);
@@ -154,10 +156,21 @@ export const CreateNSTreeModal = ({
 
   const handleSubmit = (evt: SyntheticEvent) => {
     evt.preventDefault();
+
+    // clear state so it doesn't persist if they make another tree
+    setStartDate(null);
+    setEndDate(null);
+    setSelectedLineages([]);
+
     mutation.mutate({
       sampleIds: allValidSamplesForTreeCreation,
       treeName,
       treeType,
+      filters: {
+        startDate,
+        endDate,
+        lineages: selectedLineages,
+      },
     });
   };
 
@@ -259,6 +272,10 @@ export const CreateNSTreeModal = ({
                     availableLineages={availableLineages}
                     selectedLineages={selectedLineages}
                     setSelectedLineages={setSelectedLineages}
+                    startDate={startDate}
+                    endDate={endDate}
+                    setStartDate={setStartDate}
+                    setEndDate={setEndDate}
                   />
                 }
               />
@@ -282,6 +299,10 @@ export const CreateNSTreeModal = ({
                     availableLineages={availableLineages}
                     selectedLineages={selectedLineages}
                     setSelectedLineages={setSelectedLineages}
+                    startDate={startDate}
+                    endDate={endDate}
+                    setStartDate={setStartDate}
+                    setEndDate={setEndDate}
                   />
                 }
               />

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -102,6 +102,9 @@ export const CreateNSTreeModal = ({
     setIsValidTreeType(false);
     setMissingInputSamples([]);
     setValidatedInputSamples([]);
+    setStartDate(undefined);
+    setEndDate(undefined);
+    setSelectedLineages([]);
   };
 
   const handleClose = function () {
@@ -156,11 +159,6 @@ export const CreateNSTreeModal = ({
 
   const handleSubmit = (evt: SyntheticEvent) => {
     evt.preventDefault();
-
-    // clear state so it doesn't persist if they make another tree
-    setStartDate(null);
-    setEndDate(null);
-    setSelectedLineages([]);
 
     mutation.mutate({
       sampleIds: allValidSamplesForTreeCreation,

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -32,16 +32,29 @@ async function createTree({
   sampleIds,
   treeName,
   treeType,
+  filters,
 }: {
   sampleIds: string[];
   treeName: string;
   treeType: string | undefined;
+  filters: {
+    startDate?: any;
+    endDate?: any;
+    lineages?: any;
+  };
 }): Promise<unknown> {
+  const { startDate, endDate, lineages } = filters;
   const payload: CreateTreePayload = {
     name: treeName,
     samples: sampleIds,
     tree_type: treeType,
+    template_args: {
+      filter_start_date: startDate,
+      filter_end_date: endDate,
+      filter_pango_lineages: lineages,
+    },
   };
+
   const response = await fetch(API_URL + API.PHYLO_RUNS, {
     ...DEFAULT_POST_OPTIONS,
     body: JSON.stringify(payload),

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -18,12 +18,22 @@ interface CreateTreePayload {
   name: string;
   samples: string[];
   tree_type: string | undefined; // treeType can be undefined when user first opens the NSTreeCreate modal
+  template_args?: {
+    filter_start_date?: string;
+    filter_end_date?: string;
+    filter_pango_lineages?: string[];
+  };
 }
 
 interface CreateTreeType {
   treeName: string;
   sampleIds: string[];
   treeType: string | undefined;
+  filters: {
+    startDate?: FormattedDateType;
+    endDate?: FormattedDateType;
+    lineages?: string[];
+  };
 }
 
 type CreateTreeCallbacks = MutationCallbacks<void>;
@@ -33,16 +43,7 @@ async function createTree({
   treeName,
   treeType,
   filters,
-}: {
-  sampleIds: string[];
-  treeName: string;
-  treeType: string | undefined;
-  filters: {
-    startDate?: any;
-    endDate?: any;
-    lineages?: any;
-  };
-}): Promise<unknown> {
+}: CreateTreeType): Promise<unknown> {
   const { startDate, endDate, lineages } = filters;
   const payload: CreateTreePayload = {
     name: treeName,


### PR DESCRIPTION
### Summary
- **What:** Allow users to filter tree samples by lineage and date
- **Ticket:** [[sc-184616]](https://app.shortcut.com/genepi/story/184616)
- **Env:** https://samplefiltering-frontend.dev.czgenepi.org/

### Demos
Small visual change to properly color dropdown carat in lineage menu
Before: ![Screen Shot 2022-04-25 at 5 57 32 PM](https://user-images.githubusercontent.com/7562933/165198013-576dddae-10a0-4e6a-bc81-4e02ccf7346b.png)
After: ![Screen Shot 2022-04-25 at 5 57 09 PM](https://user-images.githubusercontent.com/7562933/165198009-e4584065-9609-4cab-95b2-51facbd4e1bf.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)