### PR TITLE
move instructions into its own component

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSampleMetadataInstructions/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSampleMetadataInstructions/index.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { NewTabLink } from "src/common/components/library/NewTabLink";
+import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
+import { SampleEditTsvTemplateDownload } from "src/components/DownloadMetadataTemplate";
+import {
+  InstructionsNotSemiBold,
+  InstructionsSemiBold,
+} from "src/components/TreeNameInput/style";
+import { StyledButton } from "./style";
+
+// TODO fix types
+interface Props {
+  templateInstructionRows: any;
+  templateRows: any;
+  templateHeaders: any;
+}
+
+const EditSampleMetaDataInstructions = ({
+  templateInstructionRows,
+  templateRows,
+  templateHeaders,
+}: Props): JSX.Element => {
+  const downloadTSVButton = (
+    <SampleEditTsvTemplateDownload
+      headers={templateHeaders}
+      rows={templateRows}
+      instructions={templateInstructionRows}
+    >
+      <StyledButton sdsType="secondary">
+        Download Metadata Template (TSV)
+      </StyledButton>
+    </SampleEditTsvTemplateDownload>
+  );
+
+  const HREF =
+    "https://docs.google.com/document/d/1QxNcDip31DA40SRIOmdV1I_ZC7rWDz5YQGk26Mr2kfA/edit";
+
+  const instructionItems = [
+    <InstructionsSemiBold key="1">
+      Please refer to the
+      <NewTabLink href={HREF}>
+        {" "}
+        Upload and Updating Metadata help documentation
+      </NewTabLink>{" "}
+      detailed instructions on setting up your file and troubleshooting errors
+      and warnings.
+    </InstructionsSemiBold>,
+    <InstructionsNotSemiBold key="2">
+      You can only import one file at a time. Importing a new file will
+      overwrite previously imported data.
+    </InstructionsNotSemiBold>,
+    <InstructionsNotSemiBold key="3">
+      Metadata will be imported to the webform table below, and any changes will
+      be highlighted.
+    </InstructionsNotSemiBold>,
+  ];
+
+  const secondSetInstructionItems = [
+    <InstructionsSemiBold key="1">
+      We recommend you copy your metadata into our TSV template, but you can
+      import your own file as well. Accepted file formats: TSV, CSV.
+    </InstructionsSemiBold>,
+    <InstructionsNotSemiBold key="2">
+      Column header naming conventions and metadata value formatting must match
+      those found in the TSV template. See the help documentation above for more
+      details.
+    </InstructionsNotSemiBold>,
+    <InstructionsNotSemiBold key="3">
+      Do not include any personal identifying information (PII) in the Private
+      or Public Sample IDs.
+    </InstructionsNotSemiBold>,
+  ];
+
+  return (
+    <CollapsibleInstructions
+      additionalHeaderLink={downloadTSVButton}
+      header="Import Data from TSV or CSV File"
+      headerSize="s"
+      instructionListTitle="Importing Files"
+      items={instructionItems}
+      shouldStartOpen
+      secondInstructionListTitle="File Requirements"
+      secondSetItems={secondSetInstructionItems}
+      InstructionsTitleMarginBottom="xxs"
+      listItemFontSize="xs"
+    />
+  );
+};
+
+export { EditSampleMetaDataInstructions };

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSampleMetadataInstructions/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSampleMetadataInstructions/style.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+import { Button, fontBodyXxs, getColors, getSpaces } from "czifui";
+
+export const StyledButton = styled(Button)`
+  ${fontBodyXxs}
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+    return `
+      padding-bottom: ${spaces?.s}px;
+      color: ${colors?.primary[500]};
+      &:hover {
+        background-color: transparent;
+      }
+    `;
+  }}
+`;

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -2,19 +2,12 @@ import CloseIcon from "@material-ui/icons/Close";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
-import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
 import { useNamedLocations } from "src/common/queries/locations";
 import { pluralize } from "src/common/utils/strUtils";
 import { Content, Title } from "src/components/BaseDialog/style";
-import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
 import Dialog from "src/components/Dialog";
-import { SampleEditTsvTemplateDownload } from "src/components/DownloadMetadataTemplate";
 import { prepEditMetadataTemplate } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
-import {
-  InstructionsNotSemiBold,
-  InstructionsSemiBold,
-} from "src/components/TreeNameInput/style";
 import { WebformTable } from "src/components/WebformTable";
 import {
   Metadata,
@@ -24,10 +17,10 @@ import {
 import { ContinueButton } from "src/views/Upload/components/common/style";
 import { NamedGisaidLocation } from "src/views/Upload/components/common/types";
 import { SampleIdToWarningMessages } from "src/views/Upload/components/Metadata/components/ImportFile/parseFile";
+import { EditSampleMetaDataInstructions } from "./components/EditSampleMetadataInstructions";
 import ImportFile from "./components/ImportFile";
 import { LoseProgressModal } from "./components/LoseProgressModal";
 import {
-  StyledButton,
   StyledDiv,
   StyledIconButton,
   StyledPreTitle,
@@ -171,44 +164,6 @@ const EditSamplesConfirmationModal = ({
   const numSamples = checkedSamples.length;
   const title = "Edit Sample Metadata";
 
-  const HREF =
-    "https://docs.google.com/document/d/1QxNcDip31DA40SRIOmdV1I_ZC7rWDz5YQGk26Mr2kfA/edit";
-  const instructionItems = [
-    <InstructionsSemiBold key="1">
-      Please refer to the
-      <NewTabLink href={HREF}>
-        {" "}
-        Upload and Updating Metadata help documentation
-      </NewTabLink>{" "}
-      detailed instructions on setting up your file and troubleshooting errors
-      and warnings.
-    </InstructionsSemiBold>,
-    <InstructionsNotSemiBold key="2">
-      You can only import one file at a time. Importing a new file will
-      overwrite previously imported data.
-    </InstructionsNotSemiBold>,
-    <InstructionsNotSemiBold key="3">
-      Metadata will be imported to the webform table below, and any changes will
-      be highlighted.
-    </InstructionsNotSemiBold>,
-  ];
-
-  const secondSetInstructionItems = [
-    <InstructionsSemiBold key="1">
-      We recommend you copy your metadata into our TSV template, but you can
-      import your own file as well. Accepted file formats: TSV, CSV.
-    </InstructionsSemiBold>,
-    <InstructionsNotSemiBold key="2">
-      Column header naming conventions and metadata value formatting must match
-      those found in the TSV template. See the help documentation above for more
-      details.
-    </InstructionsNotSemiBold>,
-    <InstructionsNotSemiBold key="3">
-      Do not include any personal identifying information (PII) in the Private
-      or Public Sample IDs.
-    </InstructionsNotSemiBold>,
-  ];
-
   const closeIcon = (
     <StyledIconButton onClick={handleClose}>
       <CloseIcon />
@@ -227,18 +182,6 @@ const EditSamplesConfirmationModal = ({
         collectionLocation
       );
     }, [checkedSamples]);
-
-  const downloadTSVButton = (
-    <SampleEditTsvTemplateDownload
-      headers={templateHeaders}
-      rows={templateRows}
-      instructions={templateInstructionRows}
-    >
-      <StyledButton sdsType="secondary">
-        Download Metadata Template (TSV)
-      </StyledButton>
-    </SampleEditTsvTemplateDownload>
-  );
 
   return (
     <>
@@ -269,17 +212,10 @@ const EditSamplesConfirmationModal = ({
               onClose={onClose}
               clearState={clearState}
             />
-            <CollapsibleInstructions
-              additionalHeaderLink={downloadTSVButton}
-              header="Import Data from TSV or CSV File"
-              headerSize="s"
-              instructionListTitle="Importing Files"
-              items={instructionItems}
-              shouldStartOpen
-              secondInstructionListTitle="File Requirements"
-              secondSetItems={secondSetInstructionItems}
-              InstructionsTitleMarginBottom="xxs"
-              listItemFontSize="xs"
+            <EditSampleMetaDataInstructions
+              templateInstructionRows={templateInstructionRows}
+              templateRows={templateRows}
+              templateHeaders={templateHeaders}
             />
             <ImportFile
               metadata={metadata}

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/style.ts
@@ -1,13 +1,6 @@
 import styled from "@emotion/styled";
 import IconButton from "@material-ui/core/IconButton";
-import {
-  Button,
-  fontBodyS,
-  fontBodyXs,
-  fontBodyXxs,
-  getColors,
-  getSpaces,
-} from "czifui";
+import { fontBodyS, fontBodyXs, getColors, getSpaces } from "czifui";
 
 export const StyledIconButton = styled(IconButton)`
   display: flex;
@@ -46,21 +39,6 @@ export const StyledSubTitle = styled.span`
     return `
       color: ${colors?.gray[600]};
       margin-bottom: ${spaces?.xl}px;
-    `;
-  }}
-`;
-
-export const StyledButton = styled(Button)`
-  ${fontBodyXxs}
-  ${(props) => {
-    const colors = getColors(props);
-    const spaces = getSpaces(props);
-    return `
-      padding-bottom: ${spaces?.s}px;
-      color: ${colors?.primary[500]};
-      &:hover {
-        background-color: transparent;
-      }
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Move instructions into its own component
- **Why:** it's almost 100 lines and makes it more clear what logic is related to managing the edit samples view.

### Demos
No visual changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)