### PR TITLE
Maya/refactor 2

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
@@ -16,10 +16,7 @@ import {
   SampleIdToEditMetadataWebform,
   WARNING_CODE,
 } from "src/components/WebformTable/common/types";
-import {
-  NamedGisaidLocation,
-  Props as CommonProps,
-} from "src/views/Upload/components/common/types";
+import { NamedGisaidLocation } from "src/views/Upload/components/common/types";
 import { getMetadataEntryOrEmpty } from "../../utils";
 import {
   parseFileEdit,
@@ -31,22 +28,16 @@ interface Props {
   metadata: SampleIdToEditMetadataWebform | null;
   changedMetadata: SampleIdToEditMetadataWebform | null;
   namedLocations: NamedGisaidLocation[];
-  setMetadata: CommonProps["setMetadata"];
   hasImportedMetadataFile: boolean;
-  setHasImportedMetadataFile(x: boolean): void;
-  setAutocorrectWarnings(x: SampleIdToWarningMessages): void;
-  setChangedMetadata: CommonProps["setMetadata"];
+  onMetadataFileUploaded(): void;
 }
 
 export default function ImportFile({
   metadata,
   namedLocations,
-  setMetadata,
-  setChangedMetadata,
   hasImportedMetadataFile,
-  setHasImportedMetadataFile,
-  setAutocorrectWarnings,
   changedMetadata,
+  onMetadataFileUploaded,
 }: Props): JSX.Element {
   const [missingFields, setMissingFields] = useState<string[] | null>(null);
   const [autocorrectCount, setAutocorrectCount] = useState<number>(0);
@@ -106,7 +97,6 @@ export default function ImportFile({
     const duplicatePublicIds = getDuplicatePublicIds(result);
     const autocorrectCount =
       getAutocorrectCount(warningMessages.get(WARNING_CODE.AUTO_CORRECT)) || 0;
-    setHasImportedMetadataFile(true);
     setMissingFields(missingFields);
     setDuplicatePrivateIds(duplicatePrivateIds);
     setDuplicatePublicIds(duplicatePublicIds);
@@ -187,13 +177,12 @@ export default function ImportFile({
       }
     }
 
-    setMetadata(uploadedMetadata);
-    setChangedMetadata(changedMetadataUpdated);
-    setHasImportedMetadataFile(true);
-
-    setAutocorrectWarnings(
-      warningMessages.get(WARNING_CODE.AUTO_CORRECT) || EMPTY_OBJECT
-    );
+    onMetadataFileUploaded({
+      uploadedMetadata,
+      changedMetadataUpdated,
+      autocorrectWarnings:
+        warningMessages.get(WARNING_CODE.AUTO_CORRECT) || EMPTY_OBJECT,
+    });
   }
 
   return (

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
@@ -17,6 +17,7 @@ import {
   WARNING_CODE,
 } from "src/components/WebformTable/common/types";
 import { NamedGisaidLocation } from "src/views/Upload/components/common/types";
+import { FileUploadProps } from "../../index";
 import { getMetadataEntryOrEmpty } from "../../utils";
 import {
   parseFileEdit,
@@ -29,7 +30,7 @@ interface Props {
   changedMetadata: SampleIdToEditMetadataWebform | null;
   namedLocations: NamedGisaidLocation[];
   hasImportedMetadataFile: boolean;
-  onMetadataFileUploaded(): void;
+  onMetadataFileUploaded(props: FileUploadProps): void;
 }
 
 export default function ImportFile({

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/LoseProgressModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/LoseProgressModal/index.tsx
@@ -3,37 +3,24 @@ import ConfirmDialog from "src/components/ConfirmDialog";
 
 interface Props {
   isModalOpen: boolean;
-  setIsModalOpen(x: boolean): void;
   onClose(): void;
-  clearState(): void;
+  onConfirm(): void;
 }
 
 export const LoseProgressModal = ({
   isModalOpen,
-  setIsModalOpen,
   onClose,
-  clearState,
+  onConfirm,
 }: Props): JSX.Element => {
   const title = "Leave sample editing?";
   const message =
     "If you leave, your current edits will be canceled and your work will not be saved.";
 
-  const handleCloseAfterConfirmation = function () {
-    // user confirms that they would like to leave edit and lose progress
-    clearState();
-    onClose();
-  };
-
-  const handleLoseProgressModalClose = function () {
-    // User wants to return to edit and not abandon changes
-    setIsModalOpen(false);
-  };
-
   return (
     <ConfirmDialog
-      onConfirm={handleCloseAfterConfirmation}
+      onConfirm={onConfirm}
       open={isModalOpen}
-      onClose={handleLoseProgressModalClose}
+      onClose={onClose}
       cancelButtonText="Return To Edit"
       continueButtonText="Leave"
       title={title}

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -98,6 +98,17 @@ const EditSamplesConfirmationModal = ({
     clearState();
   };
 
+  const handleMetadataFileUploaded = ({
+    uploadedMetadata,
+    changedMetadataUpdated,
+    autocorrectWarnings,
+  }) => {
+    setMetadata(uploadedMetadata);
+    setChangedMetadata(changedMetadataUpdated);
+    setHasImportedMetadataFile(true);
+    setAutocorrectWarnings(autocorrectWarnings);
+  };
+
   const updateChangedMetadata = useCallback(
     (id, sampleMetadata) => {
       // get all current metadata properties for a sample, if metadata is undefined return empty object
@@ -290,11 +301,8 @@ const EditSamplesConfirmationModal = ({
               metadata={metadata}
               changedMetadata={changedMetadata}
               namedLocations={namedLocations}
-              setMetadata={setMetadata}
-              setChangedMetadata={setChangedMetadata}
               hasImportedMetadataFile={hasImportedMetadataFile}
-              setHasImportedMetadataFile={setHasImportedMetadataFile}
-              setAutocorrectWarnings={setAutocorrectWarnings}
+              onMetadataFileUploaded={handleMetadataFileUploaded}
             />
             <WebformTable
               setIsValid={setIsValid}

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -46,20 +46,26 @@ interface Props {
   open: boolean;
 }
 
+type MetadataType = SampleIdToEditMetadataWebform | null;
+
+export interface FileUploadProps {
+  uploadedMetadata: MetadataType;
+  changedMetadataUpdated: MetadataType;
+  autocorrectWarnings: SampleIdToWarningMessages;
+}
+
 const EditSamplesConfirmationModal = ({
   checkedSamples,
   onClose,
   open,
 }: Props): JSX.Element | null => {
   const [isValid, setIsValid] = useState(false);
-  const [metadata, setMetadata] =
-    useState<SampleIdToEditMetadataWebform | null>(null);
+  const [metadata, setMetadata] = useState<MetadataType>(null);
   const [isContinueButtonActive, setIsContinueButtonActive] =
     useState<boolean>(false);
   const [isLoseProgessModalOpen, setLoseProgressModalOpen] =
     useState<boolean>(false);
-  const [changedMetadata, setChangedMetadata] =
-    useState<SampleIdToEditMetadataWebform | null>(null);
+  const [changedMetadata, setChangedMetadata] = useState<MetadataType>(null);
   const { data: namedLocationsData } = useNamedLocations();
   const namedLocations: NamedGisaidLocation[] =
     namedLocationsData?.namedLocations ?? [];
@@ -102,7 +108,7 @@ const EditSamplesConfirmationModal = ({
     uploadedMetadata,
     changedMetadataUpdated,
     autocorrectWarnings,
-  }) => {
+  }: FileUploadProps) => {
     setMetadata(uploadedMetadata);
     setChangedMetadata(changedMetadataUpdated);
     setHasImportedMetadataFile(true);

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -169,7 +169,6 @@ const EditSamplesConfirmationModal = ({
   }, [checkedSamples, metadata]);
 
   const numSamples = checkedSamples.length;
-  const title = "Edit Sample Metadata";
 
   const HREF =
     "https://docs.google.com/document/d/1QxNcDip31DA40SRIOmdV1I_ZC7rWDz5YQGk26Mr2kfA/edit";
@@ -208,12 +207,6 @@ const EditSamplesConfirmationModal = ({
       or Public Sample IDs.
     </InstructionsNotSemiBold>,
   ];
-
-  const closeIcon = (
-    <StyledIconButton onClick={handleClose}>
-      <CloseIcon />
-    </StyledIconButton>
-  );
 
   const { templateInstructionRows, templateHeaders, templateRows } =
     useMemo(() => {
@@ -254,9 +247,13 @@ const EditSamplesConfirmationModal = ({
         onClose={handleClose}
       >
         <DialogTitle>
-          <StyledDiv>{closeIcon}</StyledDiv>
+          <StyledDiv>
+            <StyledIconButton onClick={handleClose}>
+              <CloseIcon />
+            </StyledIconButton>
+          </StyledDiv>
           <StyledPreTitle>Step 1 of 2</StyledPreTitle>
-          <Title>{title}</Title>
+          <Title>Edit Sample Metadata</Title>
           <StyledSubTitle>
             {numSamples} {pluralize("Sample", numSamples)} Selected
           </StyledSubTitle>

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -89,6 +89,15 @@ const EditSamplesConfirmationModal = ({
     setLoseProgressModalOpen(true);
   };
 
+  const handleCloseLoseProgressModal = () => {
+    setLoseProgressModalOpen(false);
+  };
+
+  const handleConfirmLoseProgressModal = () => {
+    onClose();
+    clearState();
+  };
+
   const updateChangedMetadata = useCallback(
     (id, sampleMetadata) => {
       // get all current metadata properties for a sample, if metadata is undefined return empty object
@@ -262,9 +271,8 @@ const EditSamplesConfirmationModal = ({
           <Content>
             <LoseProgressModal
               isModalOpen={isLoseProgessModalOpen}
-              setIsModalOpen={setLoseProgressModalOpen}
-              onClose={onClose}
-              clearState={clearState}
+              onClose={handleCloseLoseProgressModal}
+              onConfirm={handleConfirmLoseProgressModal}
             />
             <CollapsibleInstructions
               additionalHeaderLink={downloadTSVButton}


### PR DESCRIPTION
### Summary
- **What:**
  - Restrict state management by child components
  - Inline some small subcomponents to improve readability
  - Rename modal-closing related event handlers so the logic is easier to follow and match used apis
- **Why:** In general, the parent component should specify an interface for a callback, rather than directly exposing every state management function. This way, if the parent wants to refactor its internals, the children don't need to worry about it. Also, it limits the number of props you need to pass down, and makes children components easier to reason about.

### Demos
No visual changes.

### Notes
Read this PR by viewing each commit on its own. The changes are atomic per commit.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)