### PR TITLE
Remove custom coloring

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/mega_template.yaml
@@ -26,7 +26,6 @@ custom_rules:
 files:
   include: "data/include.txt" # for the automtic-built overview tree, this file needs to exist but can be empty. for the other trees, this includes user selected samples.
   lat_longs: "my_profiles/aspen/lat_longs.tsv"
-  ordering: "my_profiles/aspen/ordering.tsv"
   description: "my_profiles/aspen/description_{tree_type}.md"  # current file names use lower case but tree_type is upper case. need to consolidate 
   auspice_config: "my_profiles/aspen/aspen_auspice_config_v2.json"   # this will work for all
 


### PR DESCRIPTION
### Summary:
- **What:** now country colors are selected automatically (and state/county changes coming up in future sprints), we do not need to specify colors during tree build. The current implementation in county colors reveals who we support in CZ Gen Epi and is not good since we're onboarding more and more users.

### Demos:
Tested in tree EC2.

### Notes:
There are multiple files in `my_profile/aspen/` that are not used along with `ordering.tsv`. I'll do a systematic clean up in the next `ncov` pin update. 

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)