### PR TITLE
Segment Analytics Initialization -- TEMPORARY

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -122,7 +122,10 @@ module frontend_service {
   api_url               = local.backend_url
   frontend_url          = local.frontend_url
   remote_dev_prefix     = local.remote_dev_prefix
-  extra_env_vars        = {"SPLIT_FRONTEND_KEY": local.app_secret["SPLIT_FRONTEND_KEY"]}
+  extra_env_vars        = {
+    "SPLIT_FRONTEND_KEY": local.app_secret["SPLIT_FRONTEND_KEY"],
+    "SEGMENT_FRONTEND_KEY": local.app_secret["SEGMENT_FRONTEND_KEY"]
+    }
 
   wait_for_steady_state = local.wait_for_steady_state
 }

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -6,7 +6,7 @@ const { createSecureHeaders } = require("next-secure-headers");
 
 const isProdBuild = ENV.NODE_ENV === nodeEnv.PRODUCTION;
 
-const SCRIPT_SRC = ["'self'"];
+const SCRIPT_SRC = ["'self'", "https://cdn.segment.com"];
 
 module.exports = {
   distDir: ENV.BUILD_PATH,
@@ -32,6 +32,8 @@ module.exports = {
                 "sdk.split.io",
                 "events.split.io",
                 "streaming.split.io",
+                "https://cdn.segment.com",
+                "https://api.segment.io",
                 ENV.API_URL,
               ],
               defaultSrc: ["'self'"],

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -7,12 +7,12 @@ import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import "semantic-ui-css/semantic.min.css";
 import style from "src/App.module.scss";
+import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
 import { ROUTES } from "src/common/routes";
 import { theme } from "src/common/styles/theme";
 import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
 import NavBarLoggedIn from "src/components/NavBar";
 import NavBarLanding from "src/components/NavBarV2";
-import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
 import SplitInitializer from "src/components/Split";
 
 const queryClient = new QueryClient();

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -13,6 +13,7 @@ import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
 import NavBarLoggedIn from "src/components/NavBar";
 import NavBarLanding from "src/components/NavBarV2";
 import SplitInitializer from "src/components/Split";
+import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
 
 const queryClient = new QueryClient();
 setFeatureFlagsFromQueryParams();
@@ -46,6 +47,7 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
           content="minimum-scale=1, initial-scale=1, width=device-width"
         />
       </Head>
+      <SegmentInitializer />
       <QueryClientProvider client={queryClient}>
         <SplitInitializer>
           <StylesProvider injectFirst>

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -12,8 +12,8 @@ import { theme } from "src/common/styles/theme";
 import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
 import NavBarLoggedIn from "src/components/NavBar";
 import NavBarLanding from "src/components/NavBarV2";
-import SplitInitializer from "src/components/Split";
 import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
+import SplitInitializer from "src/components/Split";
 
 const queryClient = new QueryClient();
 setFeatureFlagsFromQueryParams();

--- a/src/frontend/public/segmentInitScript.js
+++ b/src/frontend/public/segmentInitScript.js
@@ -1,0 +1,15 @@
+// See detailed docs at `src/common/analytics/SegmentInitializer`.
+// Bootstraps the Segment analytics once usage conditions are met.
+// Uses immediately invoked function to not pollute global namespace.
+(function () {
+  const segmentKey = document.querySelector(
+      '#segment-init-script').dataset.segmentKey;
+  // REMOVE -- logs temporary only to verify key being set as expected
+  console.log("segmentKey", segmentKey); // REMOVE after initial OneTrust scan
+  // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
+  analytics.load(segmentKey);
+  analytics.page();
+  }}();
+  console.log("Analytics loading should be complete!"); // REMOVE after scan
+})();

--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -1,0 +1,72 @@
+import Script from "next/script";
+import React from "react";
+import ENV from "src/common/constants/ENV";
+
+/**
+ * Actual initialization of Segment done by raw JS script at below route.
+ *
+ * Recommended way to set up Segment is to use Segment-provided JS snippet.
+ * However, their snippet is inline, which causes issues with our Content
+ * Security Policy and is also a hassle to use inside React. So instead,
+ * we made a static JS script file of it and run it via `src` reference.
+ *
+ * Additionally, the Segment snippet needs to know the "Write Key" -- it's
+ * the non-secret API key for a given Segment integration -- so we pass
+ * that value dynamically to the script via the script knowing its own ID
+ * (it has a copy of the value for SEGMENT_SCRIPT_TAG_ID) to find itself
+ * in the DOM, then pulls the passed value from the attr `data-segment-key`
+ * which becomes DOMobject.dataset.segmentKey in the script.
+ */
+const SEGMENT_INIT_SCRIPT_ROUTE = "/segmentInitScript.js"; // in `public` dir
+const SEGMENT_SCRIPT_TAG_ID = "segment-init-script";
+
+// The non-secret API key used to identify the app doing analytics.
+const SEGMENT_WRITE_KEY = ENV.SEGMENT_FRONTEND_KEY;
+
+// What `type` attr the script starts with to prevent early firing.
+// See docs below regarding interaction with OneTrust.
+// const INITIAL_SCRIPT_TYPE = "text/plain"; // TODO Use once OneTrust avail
+const INITIAL_SCRIPT_TYPE = "text/javascript"; // TEMPORARY for initial scan
+
+/**
+ * Initializes Segment analytics, enabling later analytics calls in app.
+ *
+ * This component does not actually do the initialization itself.
+ * It's a wrapper to alley-oop the init to the underlying JS snippet provided
+ * by Segment, while also working with OneTrust and React/Next.js
+ *
+ * NOTE:
+ * Mounting this component does not, by itself, kick off analytics init.
+ * There are a couple gatekeepers that prevent unwanted initialization:
+ *   1) The script tag starts off un-executable due to its type being
+ *      "text/plain". This is connected to our use of OneTrust: if a user
+ *      allows analytics, OneTrust will flip that to "text/javascript",
+ *      causing the referenced script to run and initialize analytics.
+ *      TODO: Implement this once OneTrust can be integrated.
+ *            For right now, we need to do an initial OneTrust scan with
+ *            live analytics. We'll confine this to Staging for the scan to
+ *            prevent accidental analytics before we can use OneTrust.
+ *   2) There must be a truth-y value present for the SEGMENT_FRONTEND_KEY.
+ *      We default to empty string when no env var present.
+ *      As of right now, during initial development, there is no Segment key
+ *      in Prod (we've also avoided creating a Prod integration on the Segment
+ *      side for now). This means that, even if this code gets to Prod,
+ *      no analytics will run right now on Prod.
+ *
+ * Usage note: Weirdly, even though this boils down to being a <script> tag,
+ * Next.js does not like it to be present in a Next `Head` or `Html` component.
+ * Instead, just put it anywhere in the "normal" flow of components. It's
+ * already been placed somewhere it works, so this probably won't affect you,
+ * but if you have to move it, beware this weirdness.
+ */
+export function SegmentInitializer() {
+  const segmentWriteKey = ENV.SEGMENT_FRONTEND_KEY;
+  return segmentWriteKey ? (
+    <Script
+      id={SEGMENT_SCRIPT_TAG_ID}
+      type={INITIAL_SCRIPT_TYPE}
+      src={SEGMENT_INIT_SCRIPT_ROUTE}
+      data-segment-key={SEGMENT_WRITE_KEY}
+    />
+  ) : null;
+}

--- a/src/frontend/src/common/constants/ENV.js
+++ b/src/frontend/src/common/constants/ENV.js
@@ -12,4 +12,7 @@ module.exports = {
   HEADLESS: process.env.HEADLESS || true,
   NODE_ENV: process.env.NODE_ENV || "development",
   SPLIT_FRONTEND_KEY: process.env.SPLIT_FRONTEND_KEY || "localhost",
+  // If Segment env var not present, use of empty string indicates
+  // to app that Segment analytics should be kept completely off.
+  SEGMENT_FRONTEND_KEY: process.env.SEGMENT_FRONTEND_KEY || "",
 };


### PR DESCRIPTION
# TEMPORARY
This is necessary for us to do a OneTrust scan on Staging before we can put Segment behind OneTrust so users are able to explicitly allow/disallow analytics via Segment. Code as-is should _not_ be deployed to Prod. Intended to be deployed to Staging, then a follow-up PR which will completely disable analytics until a later PR where it gets put behind OneTrust.

If we somehow forget and this code gets to Prod, it won't be terrible, we still won't be doing analytics on Prod because there is no Segment integration currently set up for Prod, it will just do nothing. But we want to be absolutely sure we don't accidentally release analytics before users can have a say in it, so that aspect is a failsafe, not something we want to rely on.

### Summary:
- **What:** Sets up Segment Analytics
- **Ticket:** [sc<192933>](https://app.shortcut.com/genepi/story/<192933>)
- **Env:** https://vince-segment-init-frontend.dev.czgenepi.org

### Demos:
<img width="1718" alt="image" src="https://user-images.githubusercontent.com/89553795/165889536-3699a360-92e7-47f5-ab1b-f9a8604d3978.png">
^^^ Segment working as expected in rdev



### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
  - [x] Chrome
  - [x] Safari
  - [ ] Firefox
  - [ ] Edge
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)