### PR TITLE
Disable Segment analytics until ready

### DIFF
--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -7,7 +7,6 @@ import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import "semantic-ui-css/semantic.min.css";
 import style from "src/App.module.scss";
-import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
 import { ROUTES } from "src/common/routes";
 import { theme } from "src/common/styles/theme";
 import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
@@ -47,7 +46,6 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
           content="minimum-scale=1, initial-scale=1, width=device-width"
         />
       </Head>
-      <SegmentInitializer />
       <QueryClientProvider client={queryClient}>
         <SplitInitializer>
           <StylesProvider injectFirst>

--- a/src/frontend/public/segmentInitScript.js
+++ b/src/frontend/public/segmentInitScript.js
@@ -1,12 +1,15 @@
 // See detailed docs at `src/common/analytics/SegmentInitializer`.
 // Bootstraps the Segment analytics once usage conditions are met.
 // Uses immediately invoked function to not pollute global namespace.
-(function () {
-  const segmentKey = document.querySelector(
-      '#segment-init-script').dataset.segmentKey;
-  // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
-  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
-  analytics.load(segmentKey);
-  analytics.page();
-  }}();
-})();
+// TODO [Vince] -- Uncomment from here down once ready to start releasing
+// analytics (either b/c behind OneTrust or a feature flag).
+// Commenting out for now as way to absolutely ensure analytics remains off.
+// (function () {
+//   const segmentKey = document.querySelector(
+//       '#segment-init-script').dataset.segmentKey;
+//   // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
+//   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
+//   analytics.load(segmentKey);
+//   analytics.page();
+//   }}();
+// })();

--- a/src/frontend/public/segmentInitScript.js
+++ b/src/frontend/public/segmentInitScript.js
@@ -4,12 +4,9 @@
 (function () {
   const segmentKey = document.querySelector(
       '#segment-init-script').dataset.segmentKey;
-  // REMOVE -- logs temporary only to verify key being set as expected
-  console.log("segmentKey", segmentKey); // REMOVE after initial OneTrust scan
   // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
   analytics.load(segmentKey);
   analytics.page();
   }}();
-  console.log("Analytics loading should be complete!"); // REMOVE after scan
 })();

--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -53,11 +53,17 @@ const INITIAL_SCRIPT_TYPE = "text/javascript"; // TEMPORARY for initial scan
  *      side for now). This means that, even if this code gets to Prod,
  *      no analytics will run right now on Prod.
  *
+ * TODO: Eventually use this component. Right now, this is unused until we're
+ * have additional processes in place to ensure we don't run analytics on
+ * users until they can allow/deny analytics (either by using OneTrust, or
+ * by putting it behind a feature flag that only internal dev team would have
+ * enabled, or both).
+ *
  * Usage note: Weirdly, even though this boils down to being a <script> tag,
  * Next.js does not like it to be present in a Next `Head` or `Html` component.
- * Instead, just put it anywhere in the "normal" flow of components. It's
- * already been placed somewhere it works, so this probably won't affect you,
- * but if you have to move it, beware this weirdness.
+ * Instead, just put it anywhere in the "normal" flow of components. A good
+ * place to put it is just under the `</Head>` in `_app.tsx`, but you could
+ * put it somewhere else as well.
  */
 export function SegmentInitializer() {
   const segmentWriteKey = ENV.SEGMENT_FRONTEND_KEY;


### PR DESCRIPTION
### Summary:
- **What:** Disable analytics (Segment) until we're either ready to release it or have it blocked in additional ways
- **Ticket:** [sc<192933>](https://app.shortcut.com/genepi/story/<192933>)
- **Env:** https://vince-segment-off-frontend.dev.czgenepi.org

### Notes:
Disables Segment analytics in two ways:
- Removes use of the component that triggers Segment init (`SegmentInitializer` component still exists in code and is what we'll eventually use, but nothing in the app currently uses it)
- Completely comments out the Segment init JS script

Additionally, Segment would already be blocked from gathering data on Prod because there is no API key or integration for Segment on Prod yet, so data would not have a place to go. But that was more of a fail-safe in case this PR somehow got dropped.

Long-term, still not sure of the exact rollout plans for analytics. We might put it behind a feature flag in the near-term so we can develop with it blocked for users on Prod, or we might have a long-lived branch and merge in a bunch of work at once, need to discuss with Product how they want to do messaging around analytics and the timing of that.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)