### PR TITLE
Add a `group_id` column to the entities table.

### DIFF
--- a/src/backend/aspen/database/models/entity.py
+++ b/src/backend/aspen/database/models/entity.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import backref, relationship
 
 from aspen.database.models.base import base, idbase
 from aspen.database.models.enum import Enum
+from aspen.database.models.usergroup import Group
 
 if TYPE_CHECKING:
     from aspen.database.models.workflow import Workflow
@@ -61,6 +62,12 @@ class Entity(idbase):  # type: ignore
     __mapper_args__: Mapping[str, Union[EntityType, Column]] = {
         "polymorphic_on": entity_type
     }
+    group_id = Column(
+        Integer,
+        ForeignKey(Group.id),
+        nullable=True,
+    )
+    group = relationship(Group, backref=backref("entities", uselist=True))  # type: ignore
 
     consuming_workflows: MutableSequence[Workflow]
 

--- a/src/backend/aspen/workflows/nextstrain_run/save.py
+++ b/src/backend/aspen/workflows/nextstrain_run/save.py
@@ -98,6 +98,7 @@ def cli(
             s3_key=key,
             constituent_samples=included_samples,
             name=phylo_run.name,
+            group=phylo_run.group,
             tree_type=phylo_run.tree_type,
         )
 

--- a/src/backend/database_migrations/versions/20220503_215541_copy_group_id_to_entities.py
+++ b/src/backend/database_migrations/versions/20220503_215541_copy_group_id_to_entities.py
@@ -1,0 +1,45 @@
+"""copy group_id to entities
+
+Create Date: 2022-05-03 21:55:47.093470
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220503_215541"
+down_revision = "20220502_215324"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "entities",
+        sa.Column("group_id", sa.Integer(), nullable=True),
+        schema="aspen",
+    )
+    op.create_foreign_key(
+        op.f("fk_entities_group_id_groups"),
+        "entities",
+        "groups",
+        ["group_id"],
+        ["id"],
+        source_schema="aspen",
+        referent_schema="aspen",
+    )
+    op.execute(
+        """
+        UPDATE aspen.entities as e
+           SET group_id = (
+             SELECT pr.group_id
+               FROM aspen.phylo_runs AS pr
+              WHERE pr.workflow_id = e.producing_workflow_id
+                AND e.entity_type = 'PHYLO_TREE'
+           )
+    """
+    )
+
+
+def downgrade():
+    raise NotImplementedError("don't downgrade")


### PR DESCRIPTION
### Summary:
- **What:** Add a `group_id` column to the entities table so we can establish which group owns an entity more easily
- **Ticket:** [sc194358](https://app.shortcut.com/genepi/story/194358)

### Notes:
This is pretty straightforward - group_id is now a nullable field, since we currently have a variety of entities with unclear ownership, such as aligned gisaid dumps. However, all PhyloTree entities should now be owned by a group.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)