### PR TITLE
Fix dev bug in table cleanup migration

### DIFF
--- a/src/backend/database_migrations/versions/20220502_171903_clean_up_unused_tables.py
+++ b/src/backend/database_migrations/versions/20220502_171903_clean_up_unused_tables.py
@@ -23,6 +23,12 @@ def upgrade():
     op.drop_table("sequencing_protocol_types", schema="aspen")
     op.drop_table("bams", schema="aspen")
     op.drop_table("called_pathogen_genomes", schema="aspen")
+
+    # Drop dummy data tied to our enums, relevant for dev environments
+    op.execute(
+        "DELETE FROM aspen.entities WHERE entity_type IN ('SEQUENCING_READS', 'BAM', 'CALLED_PATHOGEN_GENOME', 'HOST_FILTERED_SEQUENCE_READS')"
+    )
+
     op.enum_delete(
         "entity_types",
         [


### PR DESCRIPTION
### Summary:
- **What:** Dev db has dummy data in `sequencing_reads_collections`, preventing the migration in #1064 from running cleanly (can't bypass foreign key restrictions when the key is still present in the db). This will not affect prod, but allows dev instances to spin up cleanly.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** [https://nextdbg-frontend.dev.czgenepi.org](https://nextdbg-frontend.dev.czgenepi.org)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)