### PR TITLE
Don't json-quote pango_lineages; add debug option to dump yaml config

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -1,4 +1,3 @@
-import json
 import re
 from math import ceil
 

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -165,8 +165,9 @@ def apply_filters(config, subsampling, template_args):
 
     pango_lineages = template_args.get("filter_pango_lineages")
     if pango_lineages:
-        # Techically pango_lineages should be a *python* encoded list, but we're
-        # cheating since json is interoperable as long as we remove bad characters
+        # Nextstrain is rather particular about the acceptable syntax for
+        # values in the pango_lineages key. Before modifying please see
+        # https://discussion.nextstrain.org/t/failure-when-specifying-multiple-pango-lineages-in-a-build/670
         clean_values = [re.sub(r"[^0-9a-zA-Z.]", "", item) for item in pango_lineages]
         config["builds"]["aspen"]["pango_lineage"] = clean_values
         # Remove the last " from our old query so we can inject more filters

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -169,7 +169,7 @@ def apply_filters(config, subsampling, template_args):
         # Techically pango_lineages should be a *python* encoded list, but we're
         # cheating since json is interoperable as long as we remove bad characters
         clean_values = [re.sub(r"[^0-9a-zA-Z.]", "", item) for item in pango_lineages]
-        config["builds"]["aspen"]["pango_lineage"] = json.dumps(clean_values)
+        config["builds"]["aspen"]["pango_lineage"] = clean_values
         # Remove the last " from our old query so we can inject more filters
         old_query = subsampling["group"]["query"][:-1]
         pango_query = " & (pango_lineage in {pango_lineage})"

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -74,7 +74,7 @@ METADATA_CSV_FIELDS = [
     help="Should the status of this workflow be set to 'STARTED'?",
 )
 @click.option("--test", type=bool, is_flag=True)
-@click.option("--dump-config", type=bool, is_flag=True)
+@click.option("--builds-file-only", type=bool, is_flag=True)
 def cli(
     phylo_run_id: int,
     sequences_fh: io.TextIOWrapper,
@@ -83,11 +83,10 @@ def cli(
     builds_file_fh: io.TextIOWrapper,
     reset_status: bool,
     test: bool,
-    dump_config: bool,
+    builds_file_only: bool,
 ):
-    if dump_config:
-        msg = dump_yaml_template(phylo_run_id, builds_file_fh)
-        print(msg)
+    if builds_file_only:
+        dump_yaml_template(phylo_run_id, builds_file_fh)
         return
     if test:
         print("Success!")
@@ -103,6 +102,7 @@ def cli(
     print(json.dumps(aligned_gisaid_dump))
 
 
+# For local debugging of our yaml building process.
 def dump_yaml_template(
     phylo_run_id: int,
     builds_file_fh: io.TextIOWrapper,
@@ -126,7 +126,7 @@ def dump_yaml_template(
         )
         builder.write_file(builds_file_fh)
 
-        return f"YAML Build Config dumped to {builds_file_fh.name}"
+        print(f"YAML Build Config dumped to {builds_file_fh.name}")
 
 
 def export_run_config(

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -77,10 +77,10 @@ METADATA_CSV_FIELDS = [
 @click.option("--dump-config", type=bool, is_flag=True)
 def cli(
     phylo_run_id: int,
-    sequences_fh: io.TextIOBase,
-    selected_fh: io.TextIOBase,
-    metadata_fh: io.TextIOBase,
-    builds_file_fh: io.TextIOBase,
+    sequences_fh: io.TextIOWrapper,
+    selected_fh: io.TextIOWrapper,
+    metadata_fh: io.TextIOWrapper,
+    builds_file_fh: io.TextIOWrapper,
     reset_status: bool,
     test: bool,
     dump_config: bool,
@@ -105,7 +105,7 @@ def cli(
 
 def dump_yaml_template(
     phylo_run_id: int,
-    builds_file_fh: io.TextIOBase,
+    builds_file_fh: io.TextIOWrapper,
 ):
     interface: SqlAlchemyInterface = init_db(get_db_uri(Config()))
 

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -106,7 +106,7 @@ def cli(
 def dump_yaml_template(
     phylo_run_id: int,
     builds_file_fh: io.TextIOBase,
-    ):
+):
     interface: SqlAlchemyInterface = init_db(get_db_uri(Config()))
 
     num_sequences: int = 0

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -173,7 +173,7 @@ def test_overview_config_ondemand(mocker, session, postgres_database):
 
     max_date = dateparser.parse("10 days ago").strftime("%Y-%m-%d")
     assert nextstrain_config["files"]["include"] == "data/include.txt"
-    assert nextstrain_config["builds"]["aspen"]["pango_lineage"] == '["AY", "B.1.116"]'
+    assert nextstrain_config["builds"]["aspen"]["pango_lineage"] == ["AY", "B.1.116"]
     assert subsampling_scheme["group"]["min_date"] == "--min-date 2021-04-30"
     assert subsampling_scheme["group"]["max_date"] == f"--max-date {max_date}"
     assert subsampling_scheme["group"]["max_sequences"] == 2000


### PR DESCRIPTION
### Summary:
- **What:** Fixes a bug in nextstrain builds where augur did not accept our pango lineage filters as formatted in the builds yaml
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** [https://pangoarray-frontend.dev.czgenepi.org/](https://pangoarray-frontend.dev.czgenepi.org/)

### Demos:

### Notes:
Added a debug option to nextstrain run's `export.py` that only writes out a `builds.yaml`.

YAML output now looks like this, an array:
<img width="534" alt="Screen Shot 2022-05-10 at 13 34 33" src="https://user-images.githubusercontent.com/24234461/167717203-8ea7c7de-cc53-4f65-8856-e0561b1b3a0d.png">


### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)