### PR TITLE
backend for trees with no user selection

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -45,7 +45,7 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
             subsampling["country"]["max_sequences"] = 800
             subsampling["international"]["max_sequences"] = 200
 
-        # If there aren't any selected samples 
+        # If there aren't any selected samples
         # Either due to being a scheduled run or no user selection
         # Put reference sequences in include.txt so tree run don't break
         if self.num_included_samples == 0:
@@ -68,7 +68,7 @@ class NonContextualizedBuilder(BaseNextstrainConfigBuilder):
         if self.num_included_samples == 0:
             del config["files"]["include"]
 
-            
+
 # Set max_sequences for targeted builds.
 class TargetedBuilder(BaseNextstrainConfigBuilder):
     subsampling_scheme = "TARGETED"

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -45,7 +45,8 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
             subsampling["country"]["max_sequences"] = 800
             subsampling["international"]["max_sequences"] = 200
 
-        # If there aren't any selected samples, either a scheduled run or no user selection
+        # If there aren't any selected samples 
+        # Either due to being a scheduled run or no user selection
         # Put reference sequences in include.txt so tree run don't break
         if self.num_included_samples == 0:
             del config["files"]["include"]

--- a/src/backend/aspen/workflows/nextstrain_run/build_config.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_config.py
@@ -45,8 +45,8 @@ class OverviewBuilder(BaseNextstrainConfigBuilder):
             subsampling["country"]["max_sequences"] = 800
             subsampling["international"]["max_sequences"] = 200
 
-        # If there aren't any selected samples this is probably a scheduled run
-        # and we should use the reference sequences
+        # If there aren't any selected samples, either a scheduled run or no user selection
+        # Put reference sequences in include.txt so tree run don't break
         if self.num_included_samples == 0:
             del config["files"]["include"]
 
@@ -62,7 +62,12 @@ class NonContextualizedBuilder(BaseNextstrainConfigBuilder):
         # Update our sampling for state/country level builds if necessary
         update_subsampling_for_location(self.tree_build_level, subsampling)
 
+        # If there aren't any selected samples due to no user selection
+        # Put reference sequences in include.txt so tree run don't break
+        if self.num_included_samples == 0:
+            del config["files"]["include"]
 
+            
 # Set max_sequences for targeted builds.
 class TargetedBuilder(BaseNextstrainConfigBuilder):
     subsampling_scheme = "TARGETED"


### PR DESCRIPTION
### Summary:
- **What:** With lineage and date filter in place, we can now allow users to build overview and non-contextualized trees without selecting any samples. In the back end, this is already ready for overview trees, and this PR extends it to non-contextualized trees.

### Demos:
The change will remove `include.txt` from the `files` section in the final builds.yaml if the user selected no samples. 
<img width="952" alt="image" src="https://user-images.githubusercontent.com/20667188/167658364-2734d5d9-14ae-4f5a-90c5-1df846a5b173.png">

### Notes:
The `num_included_samples` is calculated [here](https://github.com/chanzuckerberg/czgenepi/blob/48132693794ca0047b2a4a2b129d5b4854a939b8/src/backend/aspen/workflows/nextstrain_run/export.py#L136-L143) and if no samples were selected, it goes to 0.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)