### PR TITLE
We can initiate runs without samples now.

### DIFF
--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -93,11 +93,6 @@ async def kick_off_phylo_run(
     pathogen_genomes: MutableSequence[PathogenGenome] = list()
     for sample in user_visible_samples:
         pathogen_genomes.append(sample.uploaded_pathogen_genome)
-    if len(pathogen_genomes) == 0 and len(gisaid_ids) == 0:
-        sentry_sdk.capture_message(
-            f"No sequences selected for run from {sample_ids}.", "error"
-        )
-        raise ex.BadRequestException("No sequences selected for run")
 
     # 4B - AlignedGisaidDump
     aligned_gisaid_dump_query = (  # type: ignore


### PR DESCRIPTION
### Summary:
- **What:** Enable on-demand tree builds without any samples
- **Ticket:** [sc196733](https://app.shortcut.com/genepi/story/196733)


### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)