### PR TITLE
allow no smaple tress for overview and noncontextualized trees

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/CreateTreeButton/index.tsx
@@ -1,12 +1,13 @@
 import { Tooltip } from "czifui";
 import React, { MouseEventHandler } from "react";
+import { TreeType, TreeTypes } from "src/common/constants/types";
 import { StyledButton, StyledButtonWrapper } from "./style";
 
 interface Props {
   hasSamples: boolean;
   hasValidName: boolean;
   isInEditMode: boolean;
-  isValidTreeType: boolean;
+  treeType: TreeType | undefined;
   onClick: MouseEventHandler;
 }
 
@@ -14,7 +15,7 @@ const CreateTreeButton = ({
   hasSamples,
   hasValidName,
   isInEditMode,
-  isValidTreeType,
+  treeType,
   onClick,
 }: Props): JSX.Element => {
   const NO_NAME_NO_SAMPLES =
@@ -23,16 +24,21 @@ const CreateTreeButton = ({
   const NO_SAMPLES = "Your tree requires at least 1 Sample or Sample ID.";
   const SAMPLES_ARE_IN_EDIT =
     "Finish adding Sample IDs before creating your tree.";
+  const NO_TREE_TYPE_SELECTED = "Please select a Tree Type to proceed.";
 
   let tooltipTitle = "";
+  const treeTypeNeedsSamples = treeType === TreeTypes.Targeted;
+  const hasSamplesIfRequired =
+    (treeTypeNeedsSamples && hasSamples) || !treeTypeNeedsSamples;
 
-  if (!hasValidName && !hasSamples) tooltipTitle = NO_NAME_NO_SAMPLES;
+  if (!hasValidName && !hasSamplesIfRequired) tooltipTitle = NO_NAME_NO_SAMPLES;
   else if (!hasValidName) tooltipTitle = NO_NAME;
-  else if (!hasSamples) tooltipTitle = NO_SAMPLES;
   else if (isInEditMode) tooltipTitle = SAMPLES_ARE_IN_EDIT;
+  else if (!treeType) tooltipTitle = NO_TREE_TYPE_SELECTED;
+  else if (!hasSamplesIfRequired) tooltipTitle = NO_SAMPLES;
 
   const isTreeBuildDisabled =
-    !hasValidName || !hasSamples || isInEditMode || !isValidTreeType;
+    !hasValidName || !hasSamplesIfRequired || isInEditMode || !treeType;
 
   return (
     <Tooltip

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -74,7 +74,6 @@ export const CreateNSTreeModal = ({
   const [validatedInputSamples, setValidatedInputSamples] = useState<string[]>(
     []
   );
-  const [isValidTreeType, setIsValidTreeType] = useState<boolean>(false);
 
   // Certain tree types can filter based on lineages and date ranges
   const { data: lineagesData } = useLineages();
@@ -87,19 +86,10 @@ export const CreateNSTreeModal = ({
     if (shouldReset) setShouldReset(false);
   }, [shouldReset]);
 
-  useEffect(() => {
-    if (treeType !== undefined && Object.values(TreeTypes).includes(treeType)) {
-      setIsValidTreeType(true);
-    } else {
-      setIsValidTreeType(false);
-    }
-  }, [treeType]);
-
   const clearState = function () {
     setShouldReset(true);
     setTreeName("");
     setTreeType(undefined);
-    setIsValidTreeType(false);
     setMissingInputSamples([]);
     setValidatedInputSamples([]);
     setStartDate(undefined);
@@ -321,7 +311,7 @@ export const CreateNSTreeModal = ({
             hasValidName={hasValidName}
             hasSamples={allValidSamplesForTreeCreation.length > 0}
             isInEditMode={isInputInEditMode}
-            isValidTreeType={isValidTreeType}
+            treeType={treeType}
             onClick={handleSubmit}
           />
           <CreateTreeInfo>


### PR DESCRIPTION
### Summary
- **What:** Allow user to create non-contextulaized and overview trees without providing any sample IDs
- **Ticket:** [[sc-196733]](https://app.shortcut.com/genepi/story/196733)
- **Env:** https://nosampletree-frontend.dev.czgenepi.org/

### Demos
![after](https://user-images.githubusercontent.com/7562933/168347320-f54a1f9e-4a68-4d41-ab6c-d7e162c43cd1.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)