### PR TITLE
update tooltip link out

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
@@ -142,7 +142,7 @@ const SAMPLE_FILTERING_TOOLTIP_TEXT = (
   <div>
     Samples already selected on the sample table or included by ID in the box
     below will still be force-included on your tree.{" "}
-    <StyledNewTabLink href="https://docs.google.com/document/d/1NhDW42YZQ7DMhPhUOIBWp04n51FO8GItCZPaw7hRtQk/edit?usp=sharing">
+    <StyledNewTabLink href="https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4/edit#heading=h.lmtbntly6tx9">
       Learn More
     </StyledNewTabLink>
   </div>


### PR DESCRIPTION
### Summary:
- **What:** Update the Learn More link out to the corresponding section of updated tree user manual: https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4/edit#heading=h.lmtbntly6tx9
<img width="401" alt="image" src="https://user-images.githubusercontent.com/20667188/168689109-8daafe5e-b0e8-450f-97c8-27b3a6fd644e.png">


### Demos:
The link works in incognito. 

### Notes:
Trying to send this in before prod deploy/feature release tomorrow.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)