### PR TITLE
Add missing trailing slash in health route

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -152,7 +152,7 @@ module backend_service {
   api_url               = local.backend_url
   frontend_url          = local.frontend_url
   remote_dev_prefix     = local.remote_dev_prefix
-  health_check_path     = "/v2/health"
+  health_check_path     = "/v2/health/"  # the trailing slash here is vital.
 
   wait_for_steady_state = local.wait_for_steady_state
 }


### PR DESCRIPTION
### Summary:
- **What:** Adds a missing trailing slash in our backend ECS health route.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)