### PR TITLE
Use group name instead of S3 Prefix for tree names

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_scheduled.sh
@@ -35,7 +35,7 @@ TEMPLATE_ARGS=$(jq -c . < "${TEMPLATE_ARGS_FILE}")
 WORKFLOW_ID=$(aspen-cli db create-phylo-run                                       \
                   --group-name "${GROUP_NAME}"                                    \
                   --builds-template-args "${TEMPLATE_ARGS}"                       \
-                  --tree-name "${S3_FILESTEM} Contextual Recency-Focused Build"   \
+                  --tree-name "${GROUP_NAME} Contextual Recency-Focused Build"   \
                   --user hello@czgenepi.org                                       \
                   --tree-type "${TREE_TYPE}"
 )


### PR DESCRIPTION
### Summary:
- **What:** Scheduled tree builds are being named according to the s3 prefix for the tree, instead of using the group's name, which is creating some confusing names on the user's end.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:
Current:
![Screen Shot 2022-05-17 at 12 03 05](https://user-images.githubusercontent.com/24234461/168890537-077b375b-503a-43a3-83c8-d90fa9a82494.png)
After PR (and previous behavior):
![Screen Shot 2022-05-17 at 12 03 28](https://user-images.githubusercontent.com/24234461/168890574-157b7965-fc3f-48b9-b298-600d5a3b51a7.png)

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)