### PR TITLE
add group details dropdown

### DIFF
--- a/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/components/GroupMenuItem/index.tsx
+++ b/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/components/GroupMenuItem/index.tsx
@@ -1,0 +1,28 @@
+import { Icon } from "czifui";
+import React from "react";
+import { MenuItem, StyledIcon, StyledIconButton, StyledName } from "./style";
+
+interface Props {
+  id?: number; // this will be used once we hook up click handler to switch group
+  name: string;
+}
+
+const GroupMenuItem = ({ name }: Props): JSX.Element => {
+  const onClick = () => {
+    // switch group
+  };
+
+  return (
+    <MenuItem onClick={onClick}>
+      <StyledIcon>
+        <Icon sdsIcon="people" sdsSize="s" sdsType="static" />
+      </StyledIcon>
+      <StyledName>{name}</StyledName>
+      <StyledIconButton sdsType="tertiary" sdsSize="small">
+        <Icon sdsIcon="chevronRight" sdsType="iconButton" sdsSize="s" />
+      </StyledIconButton>
+    </MenuItem>
+  );
+};
+
+export { GroupMenuItem };

--- a/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/components/GroupMenuItem/style.ts
+++ b/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/components/GroupMenuItem/style.ts
@@ -1,0 +1,66 @@
+import styled from "@emotion/styled";
+import {
+  fontBodyXs,
+  getColors,
+  getFontWeights,
+  getSpaces,
+  IconButton,
+  MenuItem as LibMenuItem,
+} from "czifui";
+
+export const MenuItem = styled(LibMenuItem)`
+  ${fontBodyXs}
+
+  ${(props) => {
+    const colors = getColors(props);
+    const fontWeights = getFontWeights(props);
+    const spaces = getSpaces(props);
+
+    return `
+      cursor: pointer;
+      padding: ${spaces?.l}px ${spaces?.xl}px;
+
+      .primary-text {
+        display: flex;
+        font-weight: ${fontWeights?.semibold};
+        width: 100%;
+      }
+
+      &:hover {
+        ${StyledIcon} svg path {
+          fill: ${colors?.primary[400]};
+        }
+
+        svg path {
+          fill: black;
+        }
+      }
+    `;
+  }}
+`;
+
+export const StyledName = styled.div`
+  flex: 1 1 auto;
+  display: flex;
+  white-space: break-spaces;
+`;
+
+export const StyledIcon = styled.span`
+  flex: 0 0 auto;
+
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      margin-right: ${spaces?.m}px;
+      svg path {
+        fill: ${colors?.gray[400]};
+      }
+    `;
+  }}
+`;
+
+export const StyledIconButton = styled(IconButton)`
+  flex: 0 0 auto;
+`;

--- a/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/index.tsx
+++ b/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/index.tsx
@@ -1,0 +1,115 @@
+import { Icon } from "czifui";
+import React from "react";
+import { pluralize } from "src/common/utils/strUtils";
+import { GroupMenuItem } from "./components/GroupMenuItem";
+import {
+  CurrentGroup,
+  Details,
+  Dropdown,
+  GroupList,
+  GroupName,
+  StyledButton,
+  StyledIcon,
+} from "./style";
+
+interface Props {
+  anchorEl?: Element | null;
+  open: boolean;
+}
+
+const GroupDetailsDropdown = ({
+  anchorEl,
+  open,
+}: Props): JSX.Element | null => {
+  if (!open) return null;
+
+  // TODO (mlila): remove fake data
+  const groupInfo = {
+    id: 123,
+    name: "Santa Clara County",
+    location: "California/Santa Clara County",
+    memberCount: 4,
+  };
+
+  const groupInfo2 = {
+    id: 234,
+    name: "Santa Clara County and this group has a really really long name idk why",
+    location: "California/Santa Clara County",
+    memberCount: 6,
+  };
+
+  const usersGroups = [groupInfo, groupInfo2];
+  const { memberCount, name, location } = groupInfo;
+
+  const userInfo = {
+    isOwner: true,
+  };
+  const { isOwner } = userInfo;
+
+  const onClickGroupDetails = () => {
+    // redirect to group details page when it exists
+  };
+
+  const onClickInvite = () => {
+    //open invite modal
+  };
+
+  return (
+    <Dropdown
+      open
+      anchorEl={anchorEl}
+      getContentAnchorEl={null}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+    >
+      <CurrentGroup>
+        <GroupName>{name}</GroupName>
+        <Details>
+          <StyledIcon>
+            <Icon sdsIcon="pinLocation" sdsSize="s" sdsType="static" />
+          </StyledIcon>
+          {location}
+        </Details>
+        <Details>
+          <StyledIcon>
+            <Icon sdsIcon="people" sdsSize="s" sdsType="static" />
+          </StyledIcon>
+          {memberCount} {pluralize("Member", memberCount)}
+        </Details>
+        <div>
+          {isOwner && (
+            <StyledButton
+              sdsType="primary"
+              sdsStyle="rounded"
+              onClick={onClickInvite}
+            >
+              Invite Members
+            </StyledButton>
+          )}
+          <StyledButton
+            sdsType="secondary"
+            sdsStyle="rounded"
+            onClick={onClickGroupDetails}
+          >
+            Group Details
+          </StyledButton>
+        </div>
+      </CurrentGroup>
+      {usersGroups.length > 1 && (
+        <GroupList>
+          {usersGroups.map((group) => (
+            <GroupMenuItem key={group.id} id={group.id} name={group.name} />
+          ))}
+        </GroupList>
+      )}
+    </Dropdown>
+  );
+};
+
+export { GroupDetailsDropdown };

--- a/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/style.ts
+++ b/src/frontend/src/components/NavBar/components/GroupDetailsDropdown/style.ts
@@ -1,0 +1,99 @@
+import styled from "@emotion/styled";
+import {
+  Button,
+  fontBodyXs,
+  fontHeaderXl,
+  getColors,
+  getCorners,
+  getShadows,
+  getSpaces,
+  Menu,
+} from "czifui";
+
+export const Dropdown = styled(Menu)`
+  ${(props) => {
+    const corners = getCorners(props);
+    const shadows = getShadows(props);
+
+    return `
+      .MuiMenu-paper {
+        border-radius: ${corners?.m}px;
+        box-shadow: ${shadows?.m};
+        padding: 0;
+        width: 345px;
+      }
+    `;
+  }}
+`;
+
+export const GroupList = styled.div`
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+    return `
+      border-top: 2px solid ${colors?.gray[200]};
+      margin-bottom: ${spaces?.xxs}px;
+    `;
+  }}
+`;
+
+export const GroupName = styled.div`
+  ${fontHeaderXl}
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      margin-bottom: ${spaces?.l}px;
+    `;
+  }}
+`;
+
+export const Details = styled.div`
+  ${fontBodyXs}
+
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      color: ${colors?.gray[600]};
+      margin-bottom: ${spaces?.xs}px;
+    `;
+  }}
+`;
+
+export const StyledButton = styled(Button)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      margin-top: ${spaces?.xl}px;
+      margin-right: ${spaces?.m}px;
+    `;
+  }}
+`;
+
+export const StyledIcon = styled.span`
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      margin-right: ${spaces?.m}px;
+      svg {
+        path {
+          fill: ${colors?.gray[300]};
+        }
+      }
+    `;
+  }}
+`;
+
+export const CurrentGroup = styled.div`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      padding: ${spaces?.xl}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/components/NavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/index.tsx
@@ -1,17 +1,46 @@
+import { useTreatments } from "@splitsoftware/splitio-react";
+import { Icon } from "czifui";
 import Link from "next/link";
-import React from "react";
+import React, { MouseEventHandler, useState } from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
+import { FEATURE_FLAGS, isFlagOn } from "src/components/Split";
+import { GroupDetailsDropdown } from "./components/GroupDetailsDropdown";
 import RightNav from "./components/RightNav";
-import { LeftNav, Logo, LogoAnchor, NavBar, NavOrg, Separator } from "./style";
+import {
+  DropdownClickTarget,
+  LeftNav,
+  Logo,
+  LogoAnchor,
+  NavBar,
+  NavOrg,
+  Separator,
+  StyledIcon,
+} from "./style";
 
 // (thuang): Please make sure this value is in sync with what we have in css
-export const NAV_BAR_HEIGHT_PX = 50;
+export const NAV_BAR_HEIGHT_PX = 46;
 
 const NavBarLoggedIn = (): JSX.Element => {
+  const [anchorEl, setAnchorEl] = useState<Element | null>(null);
+  const [isGroupDetailsDropdownOpen, setIsGroupDetailsDropdownOpen] =
+    useState<boolean>(false);
   const { data: userInfo } = useUserInfo();
 
   const group = userInfo?.group;
+  const route = userInfo ? ROUTES.DATA : ROUTES.HOMEPAGE;
+
+  const flag = useTreatments([FEATURE_FLAGS.user_onboarding_v0]);
+  const isUserOnboardingFlagOn = isFlagOn(
+    flag,
+    FEATURE_FLAGS.user_onboarding_v0
+  );
+
+  const toggleDropdown: MouseEventHandler = (e) => {
+    const newAnchor = isGroupDetailsDropdownOpen ? null : e.currentTarget;
+    setAnchorEl(newAnchor);
+    setIsGroupDetailsDropdownOpen(!isGroupDetailsDropdownOpen);
+  };
 
   const orgElements = (
     <React.Fragment>
@@ -30,19 +59,31 @@ const NavBarLoggedIn = (): JSX.Element => {
 
   const orgSplash = hasOrg();
 
-  const route = userInfo ? ROUTES.DATA : ROUTES.HOMEPAGE;
-
   return (
     <NavBar data-test-id="navbar">
       <LeftNav>
         <Link href={route} passHref>
           <LogoAnchor href="passHref">
             <Logo data-test-id="logo" />
-            {orgSplash}
+            {!isUserOnboardingFlagOn && orgSplash}
           </LogoAnchor>
         </Link>
+        {group?.name && isUserOnboardingFlagOn && (
+          <>
+            <Separator />
+            <DropdownClickTarget onClick={toggleDropdown}>
+              <NavOrg>{group?.name}</NavOrg>
+              <StyledIcon>
+                <Icon sdsIcon="chevronDown" sdsSize="xs" sdsType="static" />
+              </StyledIcon>
+              <GroupDetailsDropdown
+                anchorEl={anchorEl}
+                open={isGroupDetailsDropdownOpen}
+              />
+            </DropdownClickTarget>
+          </>
+        )}
       </LeftNav>
-
       <RightNav />
     </NavBar>
   );

--- a/src/frontend/src/components/NavBar/style.ts
+++ b/src/frontend/src/components/NavBar/style.ts
@@ -69,3 +69,21 @@ export const NavOrg = styled.div`
     color: white;
   }
 `;
+
+export const StyledIcon = styled.div`
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      path {
+        fill: white;
+      }
+      margin: 0 ${spaces?.l}px;
+    `;
+  }}
+`;
+
+export const DropdownClickTarget = styled.span`
+  cursor: pointer;
+  display: flex;
+`;

--- a/src/frontend/src/components/Split/index.tsx
+++ b/src/frontend/src/components/Split/index.tsx
@@ -21,7 +21,7 @@
  *   1) Create the flag in Split, add it to the `FEATURE_FLAGS` enum.
  *      * If it's a simple flag of just "on"/"off", local dev defaults to on
  *   2) To pull the flag in a component in app, do the following
- *        import { useTreatments } from '@splitsoftware/splitio-react';
+ *        import { useTreatments } from "@splitsoftware/splitio-react";
  *        import { FEATURE_FLAGS } from <<This file right here>>;
  *        const flag = useTreatments([FEATURE_FLAGS.my_flag_name]);
  *   3) If the flag is just a simple "on"/"off" type flag, helper to get bool
@@ -46,6 +46,7 @@ import { useUserInfo } from "src/common/queries/auth";
 export enum FEATURE_FLAGS {
   // my_flag_name = "my_flag_name", (<-- format example)
   sample_filtering_tree_creation = "sample_filtering_tree_creation",
+  user_onboarding_v0 = "user_onboarding_v0",
 }
 
 // Keyword to tell Split client it's running in local-only mode.


### PR DESCRIPTION
### Summary
- **What:** Add group details dropdown to nav bar
- **Ticket:** [[sc-187629]](https://app.shortcut.com/genepi/story/187629)
- **Env:** https://maya-groupdetails-frontend.dev.czgenepi.org/
- **Design:** https://www.figma.com/file/SALQZGfIJntBes0HvIzVeX/Onboarding-New-Users-V0?node-id=447%3A43835

### Testing
1. Click group name in nav bar makes details appear
1. Check out the fake data and make sure it looks good
2. Turn flag off and ensure the old flow looks good too (clicking group name just redirects to samples table)

### Demos
![Screen Shot 2022-05-20 at 12 21 56 AM](https://user-images.githubusercontent.com/7562933/169475690-d0512299-ef58-4299-8119-ec2746be8339.png)
![Screen Shot 2022-05-20 at 12 22 14 AM](https://user-images.githubusercontent.com/7562933/169475693-cfda82d4-ca3a-4d38-9357-8a1b76928d82.png)
![Screen Shot 2022-05-20 at 12 23 18 AM](https://user-images.githubusercontent.com/7562933/169475696-a7afe897-7093-417c-9908-fdd21442ea30.png)
![Screen Shot 2022-05-20 at 12 23 33 AM](https://user-images.githubusercontent.com/7562933/169475697-d694b360-38aa-4a2c-ac01-560be3a01783.png)
![Screen Shot 2022-05-20 at 12 26 06 AM](https://user-images.githubusercontent.com/7562933/169475884-fc2c5a18-d81e-45db-a1e2-ae6b88d05f76.png)

### Notes
Buttons do not work yet! And the data is fake.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)