### PR TITLE
Set up OneTrust, put Segment behind it

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -124,7 +124,8 @@ module frontend_service {
   remote_dev_prefix     = local.remote_dev_prefix
   extra_env_vars        = {
     "SPLIT_FRONTEND_KEY": local.app_secret["SPLIT_FRONTEND_KEY"],
-    "SEGMENT_FRONTEND_KEY": local.app_secret["SEGMENT_FRONTEND_KEY"]
+    "SEGMENT_FRONTEND_KEY": local.app_secret["SEGMENT_FRONTEND_KEY"],
+    "ONETRUST_FRONTEND_KEY": local.app_secret["ONETRUST_FRONTEND_KEY"]
     }
 
   wait_for_steady_state = local.wait_for_steady_state

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -55,6 +55,7 @@ remote-db-migrations:
 		aspen-cli db --remote setup; \
 	fi
 	DB=remote alembic upgrade head
+	sleep 60
 
 .PHONY: remote-db-drop
 remote-db-drop:

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -13,7 +13,7 @@ black:
 	black --check $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --exclude $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES)
 
 isort:
-	isort --profile black --check $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES) 
+	isort --profile black --check $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES)
 
 mypy:
 	mypy --ignore-missing-imports aspen
@@ -27,7 +27,7 @@ run-black:
 	black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --exclude $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES)
 
 run-isort:
-	isort --profile black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES) 
+	isort --profile black $(STYLE_CHECK_PYTHON_CODE_DIRECTORIES) --skip $(STYLE_CHECK_PYTHON_CODE_SKIPPED_DIRECTORIES)
 
 run-autoflake:
 	autoflake -v -i --ignore-init-module-imports --remove-all-unused-imports --remove-unused-variables -r $(TYPE_CHECK_BASE_PYTHON_CODE_DIRECTORIES)
@@ -55,7 +55,6 @@ remote-db-migrations:
 		aspen-cli db --remote setup; \
 	fi
 	DB=remote alembic upgrade head
-	sleep 60
 
 .PHONY: remote-db-drop
 remote-db-drop:

--- a/src/backend/database_migrations/versions/20220524_174911_add_auth0_org_id_column_to_groups_table.py
+++ b/src/backend/database_migrations/versions/20220524_174911_add_auth0_org_id_column_to_groups_table.py
@@ -1,0 +1,35 @@
+"""Add auth0 org id column to groups table
+
+Create Date: 2022-05-24 17:49:12.876167
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220524_174911"
+down_revision = "20220503_215541"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "groups",
+        sa.Column("auth0_org_id", sa.String(), nullable=True),
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        op.f("uq_groups_auth0_org_id"), "groups", ["auth0_org_id"], schema="aspen"
+    )
+    op.execute(
+        sa.sql.text(
+            "UPDATE aspen.groups SET auth0_org_id = ('migration_placeholder_' || id)"
+        )
+    )
+    op.alter_column("groups", "auth0_org_id", nullable=False, schema="aspen")
+
+
+def downgrade():
+    pass

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -6,7 +6,7 @@ const { createSecureHeaders } = require("next-secure-headers");
 
 const isProdBuild = ENV.NODE_ENV === nodeEnv.PRODUCTION;
 
-const SCRIPT_SRC = ["'self'", "https://cdn.segment.com"];
+const SCRIPT_SRC = ["'self'", "https://cdn.cookielaw.org", "https://cdn.segment.com"];
 
 module.exports = {
   distDir: ENV.BUILD_PATH,
@@ -32,6 +32,9 @@ module.exports = {
                 "sdk.split.io",
                 "events.split.io",
                 "streaming.split.io",
+                "https://cdn.cookielaw.org",
+                "https://geolocation.onetrust.com",
+                "https://cookies-data.onetrust.io",
                 "https://cdn.segment.com",
                 "https://api.segment.io",
                 ENV.API_URL,
@@ -41,7 +44,7 @@ module.exports = {
               formAction: "'self'",
               frameAncestors: ["'none'"],
               frameSrc: ["'self'"],
-              imgSrc: ["'self'", "data:"],
+              imgSrc: ["'self'", "data:", "https://cdn.cookielaw.org"],
               manifestSrc: ["'self'"],
               mediaSrc: ["'self'"],
               objectSrc: ["'none'"],

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -40,15 +40,6 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
     }
   }, []);
 
-  // TODO [Vince]: Move somewhere permanent, very ugly smushing in right now
-  const OneTrustSettingsOpener = () => {
-    return (
-      <a href="#" className="optanon-show-settings">
-        Cookie Settings
-      </a>
-    );
-  };
-
   return (
     <>
       <Head>
@@ -66,7 +57,6 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
               <EmotionThemeProvider theme={theme}>
                 <StyledApp>
                   <Nav />
-                  <OneTrustSettingsOpener />
                   <Component {...pageProps} />
                 </StyledApp>
               </EmotionThemeProvider>

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -57,9 +57,9 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
           content="minimum-scale=1, initial-scale=1, width=device-width"
         />
       </Head>
-      <OneTrustInitializer />
-      <SegmentInitializer />
       <QueryClientProvider client={queryClient}>
+        <OneTrustInitializer />
+        <SegmentInitializer />
         <SplitInitializer>
           <StylesProvider injectFirst>
             <ThemeProvider theme={theme}>

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import "semantic-ui-css/semantic.min.css";
+import { OneTrustInitializer } from "src/common/analytics/OneTrustInitializer";
+import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
 import { ROUTES } from "src/common/routes";
 import { StyledApp } from "src/common/styles/appStyle";
 import { theme } from "src/common/styles/theme";
@@ -38,6 +40,15 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
     }
   }, []);
 
+  // TODO [Vince]: Move somewhere permanent, very ugly smushing in right now
+  const OneTrustSettingsOpener = () => {
+    return (
+      <a href="#" className="optanon-show-settings">
+        Cookie Settings
+      </a>
+    );
+  };
+
   return (
     <>
       <Head>
@@ -46,6 +57,8 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
           content="minimum-scale=1, initial-scale=1, width=device-width"
         />
       </Head>
+      <OneTrustInitializer />
+      <SegmentInitializer />
       <QueryClientProvider client={queryClient}>
         <SplitInitializer>
           <StylesProvider injectFirst>
@@ -53,6 +66,7 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
               <EmotionThemeProvider theme={theme}>
                 <StyledApp>
                   <Nav />
+                  <OneTrustSettingsOpener />
                   <Component {...pageProps} />
                 </StyledApp>
               </EmotionThemeProvider>

--- a/src/frontend/public/oneTrustWrapperScript.js
+++ b/src/frontend/public/oneTrustWrapperScript.js
@@ -1,5 +1,14 @@
-// [Vince]: I only have a vague grasp on what the purpose of this is, but it's
-// part of the standard OneTrust setup. I think OneTrust expects a global func
-// with this name for a callback...? Honestly, not sure, since it's currently
-// a no-op, but I'm going to keep it for now since it's SOP for OneTrust.
-function OptanonWrapper() { }
+// Callback function for OneTrust. Fires on load and on OT settings changes.
+// See docs in `OneTrustInitializer` component for explanation of use.
+function OptanonWrapper() {
+  // OneTrust API is poorly documented, feels shaky. Try/catch everything, JIC.
+  try {
+    const ANALYTICS_GROUP = "C0002";  // Needs to match `OneTrustInitializer`
+    const currentActiveGroups = window.OnetrustActiveGroups;
+    const isAnalyticsEnabled = currentActiveGroups.includes(ANALYTICS_GROUP);
+    // Attach to window so we can access in React
+    window.isCzGenEpiAnalyticsEnabled = isAnalyticsEnabled;
+  } catch (error) {
+    console.warn("Something went wrong with OneTrust. Please refresh. Debug:", error);
+  }
+}

--- a/src/frontend/public/oneTrustWrapperScript.js
+++ b/src/frontend/public/oneTrustWrapperScript.js
@@ -1,0 +1,5 @@
+// [Vince]: I only have a vague grasp on what the purpose of this is, but it's
+// part of the standard OneTrust setup. I think OneTrust expects a global func
+// with this name for a callback...? Honestly, not sure, since it's currently
+// a no-op, but I'm going to keep it for now since it's SOP for OneTrust.
+function OptanonWrapper() { }

--- a/src/frontend/public/segmentInitScript.js
+++ b/src/frontend/public/segmentInitScript.js
@@ -1,17 +1,12 @@
 // See detailed docs at `src/common/analytics/SegmentInitializer`.
 // Bootstraps the Segment analytics once usage conditions are met.
 // Uses immediately invoked function to not pollute global namespace.
-// TODO [Vince] -- Uncomment from here down once ready to start releasing
-// analytics (either b/c behind OneTrust or a feature flag).
-// NOTE: Make sure to discuss release timing with Product since we need
-// to communicate info about analytics with users.
-// Commenting out for now as way to absolutely ensure analytics remains off.
-// (function () {
-//   const segmentKey = document.querySelector(
-//       '#segment-init-script').dataset.segmentKey;
-//   // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
-//   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
-//   analytics.load(segmentKey);
-//   analytics.page();
-//   }}();
-// })();
+(function () {
+  const segmentKey = document.querySelector(
+      '#segment-init-script').dataset.segmentKey;
+  // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
+  analytics.load(segmentKey);
+  analytics.page();
+  }}();
+})();

--- a/src/frontend/src/common/analytics/OneTrustInitializer.tsx
+++ b/src/frontend/src/common/analytics/OneTrustInitializer.tsx
@@ -1,6 +1,7 @@
 import Script from "next/script";
 import React from "react";
 import ENV from "src/common/constants/ENV";
+import { useUserInfo } from "src/common/queries/auth";
 
 // The non-secret API key used to identify the app to OneTrust.
 const ONETRUST_KEY = ENV.ONETRUST_FRONTEND_KEY;
@@ -19,16 +20,38 @@ export const ONETRUST_ENABLING_CLASS = "optanon-category-C0002";
  * This component does not actually do the initialization itself.
  * It mounts <script> tags that do the OneTrust initialization.
  *
- * TODO [Vince]: Write some docs explaining method of action for OneTrust
+ * We only present OneTrust interaction (and thus also only potentially gather
+ * app usage analytics) for logged-in users. We check they are logged-in
+ * before we mount the script and bring in OneTrust. Additionally, we only
+ * attempt to use OneTrust if we have a key present for it. Every environment
+ * /should/ have a key, but just in case it's missing, it defaults to empty
+ * string and we do not attempt to use OneTrust (and thus, analytics either).
  *
+ *  --- Method of Action: how does OneTrust work? ---
+ * The core idea of OneTrust is that it can block other <script> tags from
+ * loading on the page unless the user's OneTrust settings opt them in. While
+ * OneTrust has a lot of language about cookies, it isn't generally trying to
+ * directly block cookies, but rather prevent other scripts from running that
+ * would make use of those cookies. OneTrust stores this opt-in/out preference
+ * as a cookie on the user's browser (Note: if the user changes to a different
+ * browser, they will have to set opt-in/out settings again, it is NOT a user
+ * record aspect in our DB), and from those preferences OneTrust determines
+ * which <script> tags on the page should be allowed to run.
+ *
+ * OneTrust accomplishes this <script> enabling/disabling by changing the
+ * `type` attr on the <script> tag. All scripts being controlled by OneTrust
+ * should start as "text/plain", which browsers simply will not run. Then, if
+ * OneTrust determines a script should run, it changes its `type` to being
+ * "text/javascript" instead, and the browser picks up the change, sees it as
+ * a runnable script, and the script runs like usual at that point.
+ *
+ * --- OptanonWrapper callback func: ONETRUST_ADD_ON_SCRIPT ---
  * TODO [Vince]: Explain add on script
  */
 export function OneTrustInitializer() {
-  // Every environment should have a ONETRUST_KEY env var available, but if
-  // it's not there for some reason, we keep OneTrust off, which, in turn,
-  // will prevent any scripts it controls from running (eg, analytics).
-  console.log("ONETRUST_KEY", ONETRUST_KEY); // REMOVE
-  return ONETRUST_KEY ? (
+  // `userInfo` will be false-y if user is not logged in
+  const { data: userInfo } = useUserInfo();
+  return userInfo && ONETRUST_KEY ? (
     <>
       <Script
         src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"

--- a/src/frontend/src/common/analytics/OneTrustInitializer.tsx
+++ b/src/frontend/src/common/analytics/OneTrustInitializer.tsx
@@ -28,6 +28,13 @@ export const ONETRUST_ENABLING_CLASS = `optanon-category-${ANALYTICS_GROUP}`;
  * /should/ have a key, but just in case it's missing, it defaults to empty
  * string and we do not attempt to use OneTrust (and thus, analytics either).
  *
+ * Usage note: Weirdly, even though this boils down to being a <script> tag,
+ * Next.js does not like it to be present in a Next `Head` or `Html` component.
+ * Instead, just put it anywhere in the "normal" flow of components. This uses
+ * a react-query call, so it also needs to be in the `QueryClientProvider`,
+ * but beyond that it just needs to be somewhere fairly high up so it mounts
+ * on every logged-in view/page.
+ *
  *  --- Method of Action: how does OneTrust work? ---
  * The core idea of OneTrust is that it can block other <script> tags from
  * loading on the page unless the user's OneTrust settings opt them in. While

--- a/src/frontend/src/common/analytics/OneTrustInitializer.tsx
+++ b/src/frontend/src/common/analytics/OneTrustInitializer.tsx
@@ -1,0 +1,36 @@
+import Script from "next/script";
+import React from "react";
+// import ENV from "src/common/constants/ENV";
+
+// TODO Convert `data-domain-script` to being pulled from an ENV var
+// The non-secret API key used to identify the app to OneTrust.
+const ONE_TRUST_KEY = "c3428097-e56e-4f3a-ae48-5d1d26761bed-test";
+
+// Not totally clear on purpose of this script, but it's part of OneTrust
+// install instructions. TODO Figure out what it's doing, maybe remove?
+const ONE_TRUST_ADD_ON_SCRIPT = "/oneTrustWrapperScript.js";
+
+// Keyword to enable scripts with that class if user opts-in via OneTrust.
+export const ONE_TRUST_ENABLING_CLASS = "optanon-category-C0002";
+
+/**
+ * Initializes OneTrust usage, enabling user to opt-in/out of analytics, etc.
+ *
+ * This component does not actually do the initialization itself.
+ * It mounts <script> tags that do the OneTrust initialization.
+ *
+ * TODO [Vince]: Write some docs explaining method of action for OneTrust
+ */
+export function OneTrustInitializer() {
+  return (
+    <>
+      <Script
+        src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+        type="text/javascript"
+        charSet="UTF-8"
+        data-domain-script={ONE_TRUST_KEY}
+      />
+      <Script type="text/javascript" src={ONE_TRUST_ADD_ON_SCRIPT} />
+    </>
+  );
+}

--- a/src/frontend/src/common/analytics/OneTrustInitializer.tsx
+++ b/src/frontend/src/common/analytics/OneTrustInitializer.tsx
@@ -1,17 +1,17 @@
 import Script from "next/script";
 import React from "react";
-// import ENV from "src/common/constants/ENV";
+import ENV from "src/common/constants/ENV";
 
-// TODO Convert `data-domain-script` to being pulled from an ENV var
 // The non-secret API key used to identify the app to OneTrust.
-const ONE_TRUST_KEY = "c3428097-e56e-4f3a-ae48-5d1d26761bed-test";
+const ONETRUST_KEY = ENV.ONETRUST_FRONTEND_KEY;
 
-// Not totally clear on purpose of this script, but it's part of OneTrust
-// install instructions. TODO Figure out what it's doing, maybe remove?
-const ONE_TRUST_ADD_ON_SCRIPT = "/oneTrustWrapperScript.js";
+// Sets up callback function that OneTrust will run after init and any change
+// to settings. Important because we're a single page app. See below docs.
+const ONETRUST_ADD_ON_SCRIPT = "/oneTrustWrapperScript.js";
 
 // Keyword to enable scripts with that class if user opts-in via OneTrust.
-export const ONE_TRUST_ENABLING_CLASS = "optanon-category-C0002";
+// TODO break out the C0002 aspect probably?
+export const ONETRUST_ENABLING_CLASS = "optanon-category-C0002";
 
 /**
  * Initializes OneTrust usage, enabling user to opt-in/out of analytics, etc.
@@ -20,17 +20,23 @@ export const ONE_TRUST_ENABLING_CLASS = "optanon-category-C0002";
  * It mounts <script> tags that do the OneTrust initialization.
  *
  * TODO [Vince]: Write some docs explaining method of action for OneTrust
+ *
+ * TODO [Vince]: Explain add on script
  */
 export function OneTrustInitializer() {
-  return (
+  // Every environment should have a ONETRUST_KEY env var available, but if
+  // it's not there for some reason, we keep OneTrust off, which, in turn,
+  // will prevent any scripts it controls from running (eg, analytics).
+  console.log("ONETRUST_KEY", ONETRUST_KEY); // REMOVE
+  return ONETRUST_KEY ? (
     <>
       <Script
         src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
         type="text/javascript"
         charSet="UTF-8"
-        data-domain-script={ONE_TRUST_KEY}
+        data-domain-script={ONETRUST_KEY}
       />
-      <Script type="text/javascript" src={ONE_TRUST_ADD_ON_SCRIPT} />
+      <Script type="text/javascript" src={ONETRUST_ADD_ON_SCRIPT} />
     </>
-  );
+  ) : null;
 }

--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -1,5 +1,6 @@
 import Script from "next/script";
 import React from "react";
+import { ONE_TRUST_ENABLING_CLASS } from "src/common/analytics/OneTrustInitializer";
 import ENV from "src/common/constants/ENV";
 
 /**
@@ -25,8 +26,7 @@ const SEGMENT_WRITE_KEY = ENV.SEGMENT_FRONTEND_KEY;
 
 // What `type` attr the script starts with to prevent early firing.
 // See docs below regarding interaction with OneTrust.
-// const INITIAL_SCRIPT_TYPE = "text/plain"; // TODO Use once OneTrust avail
-const INITIAL_SCRIPT_TYPE = "text/javascript"; // TEMPORARY for initial scan
+const INITIAL_SCRIPT_TYPE = "text/plain";
 
 /**
  * Initializes Segment analytics, enabling later analytics calls in app.
@@ -42,6 +42,7 @@ const INITIAL_SCRIPT_TYPE = "text/javascript"; // TEMPORARY for initial scan
  *      "text/plain". This is connected to our use of OneTrust: if a user
  *      allows analytics, OneTrust will flip that to "text/javascript",
  *      causing the referenced script to run and initialize analytics.
+ *      (it finds the script to flip via class `ONE_TRUST_ENABLING_CLASS`)
  *      TODO: Implement this once OneTrust can be integrated.
  *            For right now, we need to do an initial OneTrust scan with
  *            live analytics. We'll confine this to Staging for the scan to
@@ -73,6 +74,7 @@ export function SegmentInitializer() {
       type={INITIAL_SCRIPT_TYPE}
       src={SEGMENT_INIT_SCRIPT_ROUTE}
       data-segment-key={SEGMENT_WRITE_KEY}
+      className={ONE_TRUST_ENABLING_CLASS}
     />
   ) : null;
 }

--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -1,6 +1,6 @@
 import Script from "next/script";
 import React from "react";
-import { ONE_TRUST_ENABLING_CLASS } from "src/common/analytics/OneTrustInitializer";
+import { ONETRUST_ENABLING_CLASS } from "src/common/analytics/OneTrustInitializer";
 import ENV from "src/common/constants/ENV";
 
 /**
@@ -42,7 +42,7 @@ const INITIAL_SCRIPT_TYPE = "text/plain";
  *      "text/plain". This is connected to our use of OneTrust: if a user
  *      allows analytics, OneTrust will flip that to "text/javascript",
  *      causing the referenced script to run and initialize analytics.
- *      (it finds the script to flip via class `ONE_TRUST_ENABLING_CLASS`)
+ *      (it finds the script to flip via class `ONETRUST_ENABLING_CLASS`)
  *      TODO: Implement this once OneTrust can be integrated.
  *            For right now, we need to do an initial OneTrust scan with
  *            live analytics. We'll confine this to Staging for the scan to
@@ -74,7 +74,7 @@ export function SegmentInitializer() {
       type={INITIAL_SCRIPT_TYPE}
       src={SEGMENT_INIT_SCRIPT_ROUTE}
       data-segment-key={SEGMENT_WRITE_KEY}
-      className={ONE_TRUST_ENABLING_CLASS}
+      className={ONETRUST_ENABLING_CLASS}
     />
   ) : null;
 }

--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -43,22 +43,12 @@ const INITIAL_SCRIPT_TYPE = "text/plain";
  *      allows analytics, OneTrust will flip that to "text/javascript",
  *      causing the referenced script to run and initialize analytics.
  *      (it finds the script to flip via class `ONETRUST_ENABLING_CLASS`)
- *      TODO: Implement this once OneTrust can be integrated.
- *            For right now, we need to do an initial OneTrust scan with
- *            live analytics. We'll confine this to Staging for the scan to
- *            prevent accidental analytics before we can use OneTrust.
  *   2) There must be a truth-y value present for the SEGMENT_FRONTEND_KEY.
  *      We default to empty string when no env var present.
  *      As of right now, during initial development, there is no Segment key
  *      in Prod (we've also avoided creating a Prod integration on the Segment
  *      side for now). This means that, even if this code gets to Prod,
  *      no analytics will run right now on Prod.
- *
- * TODO: Eventually use this component. Right now, this is unused until we're
- * have additional processes in place to ensure we don't run analytics on
- * users until they can allow/deny analytics (either by using OneTrust, or
- * by putting it behind a feature flag that only internal dev team would have
- * enabled, or both).
  *
  * Usage note: Weirdly, even though this boils down to being a <script> tag,
  * Next.js does not like it to be present in a Next `Head` or `Html` component.

--- a/src/frontend/src/common/constants/ENV.js
+++ b/src/frontend/src/common/constants/ENV.js
@@ -12,6 +12,7 @@ module.exports = {
   HEADLESS: process.env.HEADLESS || true,
   NODE_ENV: process.env.NODE_ENV || "development",
   SPLIT_FRONTEND_KEY: process.env.SPLIT_FRONTEND_KEY || "localhost",
+  ONETRUST_FRONTEND_KEY: process.env.ONETRUST_FRONTEND_KEY || "",
   // If Segment env var not present, use of empty string indicates
   // to app that Segment analytics should be kept completely off.
   SEGMENT_FRONTEND_KEY: process.env.SEGMENT_FRONTEND_KEY || "",


### PR DESCRIPTION
### Summary:
- **What:** Adds OneTrust framework, uses it to block Segment (analytics) unless user has opted-in via OneTrust
- **Ticket:** [sc<192931>](https://app.shortcut.com/genepi/story/<192931>)
- **Env:** https://vince-onetrust-frontend.dev.czgenepi.org/

### Demos:
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/89553795/170130218-86bf8031-c505-4eb0-b9d1-302f645a3707.png">

### Notes:
There is still a fair amount of visual stuff that needs to get handled for OneTrust:
- Branding as CZ GE (our version from OneTrust was forked off the CZ ID version, and it still has their branding in place when you open the cookie settings menu)
- General visual styling
- Copywriting and any specific language we need depending on conversations with Trust team
- Adding in a "cookie settings" button or similar somewhere in app so user can change mind after initial banner presentation (probably in User dropdown menu in nav, need to finalize)

I've created a [new ticket to track that here](https://app.shortcut.com/genepi/story/199423).

That said, all the framework and interaction with blocking Segment should be in place with this PR.

### Checklist:
- [x] I merged latest `trunk` [minor whoops here, should actually be based off `vince/analytics`, but it's not a big deal]
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)