### PR TITLE
Add auth0_org_id column to Group model

### DIFF
--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -33,6 +33,8 @@ class Group(idbase, DictMixin):  # type: ignore
     division = Column(String, nullable=True)
     location = Column(String, nullable=True)
 
+    auth0_org_id = Column(String, unique=True, nullable=False)
+
     # Default location context (int'l or division or location level)
     default_tree_location_id = Column(
         Integer,

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from uuid import uuid1
 
 from aspen.database.models import Group, Location, User
@@ -9,6 +10,7 @@ def group_factory(
     prefix=None,
     location=None,
     division=None,
+    default_tree_location: Optional[Location] = None,
     auth0_org_id=None,
 ) -> Group:
     # shortcut so we don't need to specify prefix
@@ -19,9 +21,10 @@ def group_factory(
         location = f"{name} city"
     if division is None:
         division = f"{name} state"
-    tree_loc = Location(
-        region="North America", country="USA", location=location, division=division
-    )
+    if default_tree_location is None:
+        default_tree_location = Location(
+            region="North America", country="USA", location=location, division=division
+        )
     if auth0_org_id is None:
         auth0_org_id = f"org_test_{uuid1()}"
     return Group(
@@ -30,7 +33,7 @@ def group_factory(
         prefix=prefix,
         location=location,
         division=division,
-        default_tree_location=tree_loc,
+        default_tree_location=default_tree_location,
         auth0_org_id=auth0_org_id,
     )
 

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -1,3 +1,5 @@
+from uuid import uuid1
+
 from aspen.database.models import Group, Location, User
 
 
@@ -7,6 +9,7 @@ def group_factory(
     prefix=None,
     location=None,
     division=None,
+    auth0_org_id=None,
 ) -> Group:
     # shortcut so we don't need to specify prefix
     if not prefix:
@@ -19,6 +22,8 @@ def group_factory(
     tree_loc = Location(
         region="North America", country="USA", location=location, division=division
     )
+    if auth0_org_id is None:
+        auth0_org_id = f"org_test_{uuid1()}"
     return Group(
         name=name,
         address=address,
@@ -26,6 +31,7 @@ def group_factory(
         location=location,
         division=division,
         default_tree_location=tree_loc,
+        auth0_org_id=auth0_org_id,
     )
 
 

--- a/src/backend/aspen/workflows/transform_gisaid/tests/test_update_locations.py
+++ b/src/backend/aspen/workflows/transform_gisaid/tests/test_update_locations.py
@@ -3,10 +3,10 @@ from typing import Optional
 
 from sqlalchemy.sql.expression import and_
 
-from aspen.database.models import Group, Location, User
+from aspen.database.models import Location, User
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
-from aspen.test_infra.models.usergroup import user_factory
+from aspen.test_infra.models.usergroup import group_factory, user_factory
 from aspen.workflows.transform_gisaid.update_locations import update_locations
 
 
@@ -43,7 +43,7 @@ def create_test_data(
             )
         db_locations.append(db_loc)
 
-    group = Group(
+    group = group_factory(
         name=group_name,
         address="none",
         prefix="GRP-",


### PR DESCRIPTION
### Summary:
- **What:** Adds the column implemented in #1107 to the Group model.
- **Ticket:** [sc187629](https://app.shortcut.com/genepi/story/187629)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)