### PR TITLE
Maya/187620 invite email input

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -1,5 +1,6 @@
 import { compact, filter } from "lodash";
 import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
+import { INPUT_DELIMITERS } from "src/common/constants/inputDelimiters";
 import {
   SampleValidationResponseType,
   useValidateSampleIds,
@@ -67,7 +68,7 @@ const SampleIdInput = ({
   }, [handleInputModeChange, hasUnsavedChanges, isInEditMode]);
 
   const parseInputIds = useCallback(() => {
-    const tokens = inputValue.split(/[\n\t,]/g);
+    const tokens = inputValue.split(INPUT_DELIMITERS);
     const trimmedTokens = tokens.map((t) => t.trim());
     return compact(trimmedTokens);
   }, [inputValue]);

--- a/src/frontend/src/common/constants/inputDelimiters.ts
+++ b/src/frontend/src/common/constants/inputDelimiters.ts
@@ -1,0 +1,1 @@
+export const INPUT_DELIMITERS = /[\n\t,]/g;

--- a/src/frontend/src/common/routes.ts
+++ b/src/frontend/src/common/routes.ts
@@ -6,6 +6,7 @@ export enum ROUTES {
   DATA = "/data",
   GISAID = "https://www.gisaid.org/",
   GITHUB = "https://github.com/chanzuckerberg/czgenepi/",
+  INVITATIONS = "/members/invitations",
   NEXTSTRAIN = "https://nextstrain.org/",
   TERMS = "/terms",
   PANGOLIN = "https://pangolin.cog-uk.io/",

--- a/src/frontend/src/components/Instructions/index.tsx
+++ b/src/frontend/src/components/Instructions/index.tsx
@@ -7,21 +7,25 @@ interface Props {
   items: React.ReactNode[];
   ordered?: boolean;
   className?: string;
+  titleSize?: string;
+  bodySize?: string;
 }
 
 export default function Instructions({
   items,
   ordered = false,
   title,
+  titleSize = "xs",
+  bodySize = "s",
   className,
 }: Props): JSX.Element {
   return (
     <Wrapper className={className}>
-      {title && <Title>{title}</Title>}
+      {title && <Title titleSize={titleSize}>{title}</Title>}
       <List ordered={ordered}>
         {items.map((item, index) => {
           return (
-            <ListItem fontSize="s" key={index} ordered={ordered}>
+            <ListItem fontSize={bodySize} key={index} ordered={ordered}>
               {item}
             </ListItem>
           );

--- a/src/frontend/src/components/Instructions/index.tsx
+++ b/src/frontend/src/components/Instructions/index.tsx
@@ -2,13 +2,15 @@ import { List, ListItem } from "czifui";
 import React from "react";
 import { Title, Wrapper } from "./style";
 
+export type TitleSize = "s" | "m" | "l" | "xs" | "xxxs" | "xxs";
+
 interface Props {
   title?: string | undefined;
   items: React.ReactNode[];
   ordered?: boolean;
   className?: string;
-  titleSize?: string;
-  bodySize?: string;
+  titleSize?: TitleSize;
+  bodySize?: TitleSize;
 }
 
 export default function Instructions({

--- a/src/frontend/src/components/Instructions/style.ts
+++ b/src/frontend/src/components/Instructions/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontHeaderXs, getColors, getSpaces } from "czifui";
+import { fontHeader, getColors, getSpaces } from "czifui";
 
 export const Wrapper = styled.div`
   ${(props) => {
@@ -13,8 +13,15 @@ export const Wrapper = styled.div`
   }}
 `;
 
-export const Title = styled.div`
-  ${fontHeaderXs}
+const doNotForwardProps = ["titleSize"];
+
+export const Title = styled("div", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  ${(props) => {
+    const { titleSize } = props;
+    return fontHeader(titleSize);
+  }}
 
   ${(props) => {
     const spaces = getSpaces(props);

--- a/src/frontend/src/components/Instructions/style.ts
+++ b/src/frontend/src/components/Instructions/style.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
-import { fontHeader, getColors, getSpaces } from "czifui";
+import { CommonThemeProps, fontHeader, getColors, getSpaces } from "czifui";
+import { TitleSize } from "./index";
 
 export const Wrapper = styled.div`
   ${(props) => {
@@ -13,17 +14,21 @@ export const Wrapper = styled.div`
   }}
 `;
 
+interface TitleProps extends CommonThemeProps {
+  titleSize: TitleSize;
+}
+
 const doNotForwardProps = ["titleSize"];
 
 export const Title = styled("div", {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
-  ${(props) => {
+  ${(props: TitleProps) => {
     const { titleSize } = props;
     return fontHeader(titleSize);
   }}
 
-  ${(props) => {
+  ${(props: TitleProps) => {
     const spaces = getSpaces(props);
     return `
       margin-bottom: ${spaces?.xxs}px;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/components/SentNotification/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/components/SentNotification/index.tsx
@@ -1,0 +1,33 @@
+import { Link } from "czifui";
+import React from "react";
+import { ROUTES } from "src/common/routes";
+import { pluralize } from "src/common/utils/strUtils";
+import Notification from "src/components/Notification";
+
+interface Props {
+  onDismiss(): void;
+  open: boolean;
+  numSent: number;
+}
+
+const SentNotification = ({ numSent, onDismiss, open }: Props): JSX.Element => {
+  return (
+    <Notification
+      buttonText="DISMISS"
+      buttonOnClick={onDismiss}
+      dismissDirection="right"
+      intent="info"
+      dismissed={!open}
+      autoDismiss
+    >
+      {numSent} {pluralize("Invitation", numSent)} {pluralize("has", numSent)}{" "}
+      been sent.{" "}
+      <Link sdsStyle="dashed" href={ROUTES.INVITATIONS}>
+        View Invitations
+      </Link>
+      .
+    </Notification>
+  );
+};
+
+export { SentNotification };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/index.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { B } from "src/common/styles/basicStyle";
+import { pluralize } from "src/common/utils/strUtils";
+import AlertAccordion from "src/components/AlertAccordion";
+import { StyledDiv } from "./style";
+
+interface Props {
+  invalidAddresses: string[];
+}
+
+const InvalidEmailError = ({ invalidAddresses }: Props): JSX.Element | null => {
+  const numInvalid = invalidAddresses.length;
+  if (!numInvalid) return null;
+
+  const title = (
+    <>
+      <B>
+        {numInvalid} {pluralize("email", numInvalid)}{" "}
+        {pluralize("has", numInvalid)} invalid {pluralize("format", numInvalid)}{" "}
+        and can’t be sent.{" "}
+      </B>
+      Please correct any errors and try sending again.
+    </>
+  );
+
+  const content = (
+    <div>
+      {invalidAddresses.map((a) => (
+        <StyledDiv key={a}>{a}</StyledDiv>
+      ))}
+    </div>
+  );
+
+  return (
+    <AlertAccordion intent="error" title={title} collapseContent={content} />
+  );
+};
+
+export { InvalidEmailError };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/style.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+import { getSpaces } from "czifui";
+
+export const StyledDiv = styled.div`
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    // TODO (mlila): overlay colors not yet available from sds,
+    // TODO          so hardcoding this for now.
+    return `
+      padding: ${spaces?.l}px;
+
+      :nth-of-type(odd) {
+        background-color: #F6EAEA;
+        width: 100%;
+      }
+    `;
+  }}
+`;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -52,7 +52,6 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
   const onInputChange = (e: ChangeEvent) => {
     const value = e.target.value;
     setInputValue(value);
-    validate();
   };
 
   const title = (
@@ -103,6 +102,7 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
             placeholder="e.g. userone@domain.com, usertwo@domain.com"
             intent={inputIntent}
             value={inputValue}
+            maxRows={4}
           />
           {hasMoreThan50Invites && (
             <StyledCallout intent="error">
@@ -116,7 +116,7 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
           <Button
             sdsType="primary"
             sdsStyle="rounded"
-            disabled={!inputValue || invalidAddresses.length > 0}
+            disabled={!inputValue}
             onClick={handleFormSubmit}
           >
             Send Invites

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -89,7 +89,12 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
       <Dialog open onClose={onClose} sdsSize="s">
         <DialogTitle title={title} onClose={onClose} />
         <StyledDialogContent>
-          <StyledInstructions title="Instructions" items={instructions} />
+          <StyledInstructions
+            title="Instructions"
+            titleSize="s"
+            bodySize="xs"
+            items={instructions}
+          />
           <StyledInputText
             id="invite-email-input"
             sdsType="textArea"

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -64,7 +64,7 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
     <span key={0}>You can send a maximum of 50 invitations at a time.</span>,
     <span key={1}>Separate emails by tabs, commas, or enter one per row.</span>,
     <span key={2}>
-      Members have full access to group samples and phyogenetic trees; they are
+      Members have full access to group samples and phylogenetic trees; they are
       able to build trees, upload, download, edit, and delete data.
     </span>,
   ];

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -1,0 +1,126 @@
+import { Button, Dialog, DialogActions, DialogTitle } from "czifui";
+import { compact } from "lodash";
+import React, { ChangeEvent, useState } from "react";
+import { INPUT_DELIMITERS } from "src/common/constants/inputDelimiters";
+import { B } from "src/common/styles/basicStyle";
+import { InvalidEmailError } from "./components/InvalidEmailError";
+import { SentNotification } from "./components/InvalidEmailError/components/SentNotification";
+import {
+  SmallText,
+  StyledCallout,
+  StyledDialogContent,
+  StyledInputText,
+  StyledInstructions,
+  StyledSpan,
+} from "./style";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/g;
+
+interface Props {
+  onClose(): void;
+}
+
+const InviteModal = ({ onClose }: Props): JSX.Element => {
+  const [inputValue, setInputValue] = useState<string>("");
+  const [hasMoreThan50Invites, setHasMoreThan50Invites] =
+    useState<boolean>(false);
+  const [invalidAddresses, setInvalidAddresses] = useState<string[]>([]);
+  const [shouldValidateOnChange, setShouldValidateOnChange] = // eslint-disable-line @typescript-eslint/no-unused-vars
+    useState<boolean>(false);
+  const [isNotificationOpen, setIsNotificationOpen] = useState<boolean>(false);
+
+  const validate = (): boolean => {
+    const addresses = inputValue.trim().split(INPUT_DELIMITERS);
+    const newInvalidAddresses = compact(
+      addresses.filter((address) => !address.match(EMAIL_REGEX))
+    );
+
+    setInvalidAddresses(newInvalidAddresses);
+
+    const hasMoreThan50 = addresses.length > 50;
+    setHasMoreThan50Invites(hasMoreThan50);
+
+    // after they click the button to send invites once, we should debounce validate on
+    // all subsequent changes
+    setShouldValidateOnChange(true);
+
+    return (
+      !hasMoreThan50 && newInvalidAddresses.length === 0 && addresses.length > 0
+    );
+  };
+
+  const onInputChange = (e: ChangeEvent) => {
+    const value = e.target.value;
+    setInputValue(value);
+    validate();
+  };
+
+  const title = (
+    <StyledSpan>
+      Invite to <B>Santa Clara County</B>
+    </StyledSpan>
+  );
+
+  const instructions = [
+    <span key={0}>You can send a maximum of 50 invitations at a time.</span>,
+    <span key={1}>Separate emails by tabs, commas, or enter one per row.</span>,
+    <span key={2}>
+      Members have full access to group samples and phyogenetic trees; they are
+      able to build trees, upload, download, edit, and delete data.
+    </span>,
+  ];
+
+  const inputIntent = invalidAddresses.length > 0 ? "error" : "default";
+
+  const handleFormSubmit = () => {
+    const areAllAddressesValid = validate();
+    if (!areAllAddressesValid) return;
+
+    // TODO (mlila): api call
+  };
+
+  return (
+    <>
+      <SentNotification
+        numSent={5} // TODO (mlila): update after API call return
+        onDismiss={() => setIsNotificationOpen(false)}
+        open={isNotificationOpen}
+      />
+      <Dialog open onClose={onClose} sdsSize="s">
+        <DialogTitle title={title} onClose={onClose} />
+        <StyledDialogContent>
+          <StyledInstructions title="Instructions" items={instructions} />
+          <StyledInputText
+            id="invite-email-input"
+            sdsType="textArea"
+            label={<B>Emails</B>}
+            onChange={onInputChange}
+            placeholder="e.g. userone@domain.com, usertwo@domain.com"
+            intent={inputIntent}
+            value={inputValue}
+          />
+          {hasMoreThan50Invites && (
+            <StyledCallout intent="error">
+              <B>You can’t send more than 50 invites at a time. </B>
+              Please reduce the number of emails before continuing.
+            </StyledCallout>
+          )}
+          <InvalidEmailError invalidAddresses={invalidAddresses} />
+        </StyledDialogContent>
+        <DialogActions buttonPosition="left">
+          <Button
+            sdsType="primary"
+            sdsStyle="rounded"
+            disabled={!inputValue || invalidAddresses.length > 0}
+            onClick={handleFormSubmit}
+          >
+            Send Invites
+          </Button>
+        </DialogActions>
+        <SmallText>Invites will expire 14 days after they are sent.</SmallText>
+      </Dialog>
+    </>
+  );
+};
+
+export { InviteModal };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -11,7 +11,6 @@ import {
   StyledDialogContent,
   StyledInputText,
   StyledInstructions,
-  StyledSpan,
 } from "./style";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/g;
@@ -25,6 +24,7 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
   const [hasMoreThan50Invites, setHasMoreThan50Invites] =
     useState<boolean>(false);
   const [invalidAddresses, setInvalidAddresses] = useState<string[]>([]);
+  // @ts-expect-error remove when api call finished
   const [shouldValidateOnChange, setShouldValidateOnChange] = // eslint-disable-line @typescript-eslint/no-unused-vars
     useState<boolean>(false);
   const [isNotificationOpen, setIsNotificationOpen] = useState<boolean>(false);
@@ -49,16 +49,16 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
     );
   };
 
-  const onInputChange = (e: ChangeEvent) => {
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInputValue(value);
   };
 
-  const title = (
-    <StyledSpan>
-      Invite to <B>Santa Clara County</B>
-    </StyledSpan>
-  );
+  // const title = (
+  //   <StyledSpan>
+  //     Invite to <B>Santa Clara County</B>
+  //   </StyledSpan>
+  // );
 
   const instructions = [
     <span key={0}>You can send a maximum of 50 invitations at a time.</span>,
@@ -86,7 +86,8 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
         open={isNotificationOpen}
       />
       <Dialog open onClose={onClose} sdsSize="s">
-        <DialogTitle title={title} onClose={onClose} />
+        <DialogTitle title="Invite to Santa Clara County" onClose={onClose} />{" "}
+        {/* TODO (mlila): make group name bold after sds dialog allows ReactNode */}
         <StyledDialogContent>
           <StyledInstructions
             title="Instructions"
@@ -97,7 +98,7 @@ const InviteModal = ({ onClose }: Props): JSX.Element => {
           <StyledInputText
             id="invite-email-input"
             sdsType="textArea"
-            label={<B>Emails</B>}
+            label="Emails"
             onChange={onInputChange}
             placeholder="e.g. userone@domain.com, usertwo@domain.com"
             intent={inputIntent}

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/style.ts
@@ -1,0 +1,79 @@
+import styled from "@emotion/styled";
+import {
+  Callout,
+  DialogContent,
+  fontBodyXxs,
+  fontHeaderXl,
+  getColors,
+  getFontWeights,
+  getSpaces,
+  InputText,
+} from "czifui";
+import Instructions from "src/components/Instructions";
+
+export const StyledInputText = styled(InputText)`
+  margin-right: 0;
+  height: 70px;
+
+  div,
+  textarea {
+    width: 100%;
+  }
+`;
+
+export const SmallText = styled.span`
+  ${fontBodyXxs}
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      color: ${colors?.gray[600]};
+      margin-top: ${spaces?.s}px;
+    `;
+  }}
+`;
+
+export const StyledSpan = styled.span`
+  ${fontHeaderXl}
+
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      font-weight: ${fontWeights?.regular};
+    `;
+  }}
+`;
+
+export const StyledCallout = styled(Callout)`
+  width: 100%;
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.xs}px;
+    `;
+  }}
+`;
+
+export const StyledDialogContent = styled(DialogContent)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      label {
+        margin-bottom: ${spaces?.s}px;
+        margin-top: ${spaces?.l}px;
+      }
+    `;
+  }}
+`;
+
+export const StyledInstructions = styled(Instructions)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      padding: ${spaces?.l}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/style.ts
@@ -12,12 +12,18 @@ import {
 import Instructions from "src/components/Instructions";
 
 export const StyledInputText = styled(InputText)`
-  margin-right: 0;
-  height: 70px;
+  margin: 0;
+  min-height: 70px;
+  height: auto;
 
-  div,
-  textarea {
+  div {
     width: 100%;
+  }
+
+  /* MUI has a really specific selector for resize on this input, for some reason */
+  textarea.MuiInputBase-input.MuiInputBase-inputMultiline {
+    width: 100%;
+    resize: vertical;
   }
 `;
 

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/style.ts
@@ -64,9 +64,12 @@ export const StyledCallout = styled(Callout)`
 
 export const StyledDialogContent = styled(DialogContent)`
   ${(props) => {
+    const fontWeights = getFontWeights(props);
     const spaces = getSpaces(props);
+
     return `
       label {
+        font-weight: ${fontWeights?.semibold};
         margin-bottom: ${spaces?.s}px;
         margin-top: ${spaces?.l}px;
       }


### PR DESCRIPTION
### Summary
- **What:** Add UI for inviting new users
- **Ticket:** [[sc-187620]](https://app.shortcut.com/genepi/story/187620)
- **Env:** https://maya-invitedialog-frontend.dev.czgenepi.org/data/samples
- **Design:** https://www.figma.com/file/SALQZGfIJntBes0HvIzVeX/Onboarding-New-Users-V0?node-id=280%3A48892

### Demos
![after](https://user-images.githubusercontent.com/7562933/170274278-e10a961c-ad5f-4e0a-8b6a-3fbc4d61b5f9.gif)

### Known outstanding tasks
- Button doesn't currently send invites
- The header should have the group name bolded, but sds only allows simple string in DialogTitle, so a PR will be required before that can be implemented
- No debounce on the input validation yet
- In the example rdev, the modal is permanently open. The actual modal will not be like this.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)