### PR TITLE
update eventsource pakg version due to critical vulnerability

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -2936,7 +2936,7 @@
         "@babel/runtime": "^7.13.10",
         "@types/google.analytics": "0.0.40",
         "events": "3.1.0",
-        "eventsource": "^1.0.7",
+        "eventsource": "^2.0.2",
         "ioredis": "^4.28.0",
         "ip": "1.1.5",
         "js-yaml": "3.13.1",
@@ -4517,7 +4517,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "brace-expansion": {
@@ -6185,8 +6185,8 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "optional": true,
       "requires": {


### PR DESCRIPTION
### Summary
- **What:** Attempt to use a safe version of `eventsource`
- **Why:** 9.3/10 (critical vulnerability) coming from split
- **Ticket:** [[sc-199705]](https://app.shortcut.com/genepi/story/199705)
- **Env:** https://maya-eventsource-frontend.dev.czgenepi.org/
- **Discussion:** https://czi-sci.slack.com/archives/C01HYJYA50W/p1653582813178509
- **Dependabot Alert:** https://github.com/chanzuckerberg/czgenepi/security/dependabot/18

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)