### PR TITLE
Allow user and group deactivation

### DIFF
--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -23,6 +23,7 @@ class Group(idbase, DictMixin):  # type: ignore
     __tablename__ = "groups"
 
     name = Column(String, unique=True, nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
     address = Column(String, nullable=True)
     prefix = Column(
         String,
@@ -33,7 +34,7 @@ class Group(idbase, DictMixin):  # type: ignore
     division = Column(String, nullable=True)
     location = Column(String, nullable=True)
 
-    auth0_org_id = Column(String, unique=True, nullable=False)
+    auth0_org_id = Column(String, unique=True, nullable=True)
 
     # Default location context (int'l or division or location level)
     default_tree_location_id = Column(
@@ -74,7 +75,8 @@ class User(idbase, DictMixin):  # type: ignore
 
     name = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
-    auth0_user_id = Column(String, unique=True, nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
+    auth0_user_id = Column(String, unique=True, nullable=True)
     group_admin = Column(Boolean, nullable=False)
     system_admin = Column(Boolean, nullable=False)
     agreed_to_tos = Column(Boolean, nullable=False, default=False)

--- a/src/backend/database_migrations/versions/20220527_001135_allow_deactivation_of_users_and_groups.py
+++ b/src/backend/database_migrations/versions/20220527_001135_allow_deactivation_of_users_and_groups.py
@@ -17,7 +17,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         "groups",
-        sa.Column("active", sa.Boolean(), nullable=False, server_default=True),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
         nullable=False,
         schema="aspen",
     )
@@ -30,7 +30,7 @@ def upgrade():
 
     op.add_column(
         "users",
-        sa.Column("active", sa.Boolean(), nullable=False, server_default=True),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
         nullable=False,
         schema="aspen",
     )

--- a/src/backend/database_migrations/versions/20220527_001135_allow_deactivation_of_users_and_groups.py
+++ b/src/backend/database_migrations/versions/20220527_001135_allow_deactivation_of_users_and_groups.py
@@ -1,0 +1,46 @@
+"""Allow deactivation of users and groups
+
+Create Date: 2022-05-27 00:11:40.525205
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220527_001135"
+down_revision = "20220524_174911"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "groups",
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=True),
+        nullable=False,
+        schema="aspen",
+    )
+    op.alter_column(
+        "groups",
+        "auth0_org_id",
+        nullable=True,
+        schema="aspen",
+    )
+
+    op.add_column(
+        "users",
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=True),
+        nullable=False,
+        schema="aspen",
+    )
+    op.alter_column(
+        "users",
+        "auth0_user_id",
+        nullable=True,
+        schema="aspen",
+    )
+
+
+def downgrade():
+    pass

--- a/src/backend/database_migrations/versions/20220527_001135_allow_deactivation_of_users_and_groups.py
+++ b/src/backend/database_migrations/versions/20220527_001135_allow_deactivation_of_users_and_groups.py
@@ -17,8 +17,12 @@ depends_on = None
 def upgrade():
     op.add_column(
         "groups",
-        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
-        nullable=False,
+        sa.Column(
+            "active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.true(),
+        ),
         schema="aspen",
     )
     op.alter_column(
@@ -30,8 +34,12 @@ def upgrade():
 
     op.add_column(
         "users",
-        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
-        nullable=False,
+        sa.Column(
+            "active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.true(),
+        ),
         schema="aspen",
     )
     op.alter_column(


### PR DESCRIPTION
### Summary:
- **What:** Allows us to mark users and groups as "deleted" by setting a value of `FALSE` in a column `active`. This makes it possible to keep samples in a group even if it was uploaded by a now-deleted user.
- **Ticket:** [sc190605](https://app.shortcut.com/genepi/story/190605)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)