### PR TITLE
Maya/187629 members page

### DIFF
--- a/src/frontend/pages/members.tsx
+++ b/src/frontend/pages/members.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import GroupMembersPage from "src/views/GroupMembersPage";
+
+const Page = (): JSX.Element => <GroupMembersPage />;
+
+export default Page;

--- a/src/frontend/src/common/components/library/Table/index.tsx
+++ b/src/frontend/src/common/components/library/Table/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const Table = (): JSX.Element => {
+  return (
+    <div>beep</div>
+  );
+};
+
+export { Table };

--- a/src/frontend/src/common/components/library/Table/index.tsx
+++ b/src/frontend/src/common/components/library/Table/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
 const Table = (): JSX.Element => {
-  return (
-    <div>beep</div>
-  );
+  return <div>beep</div>;
 };
 
 export { Table };

--- a/src/frontend/src/common/routes.ts
+++ b/src/frontend/src/common/routes.ts
@@ -22,4 +22,5 @@ export enum ROUTES {
   UPLOAD_STEP2 = "/upload/2",
   UPLOAD_STEP3 = "/upload/3",
   USHER = "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace",
+  GROUP_MEMBERS = "/members",
 }

--- a/src/frontend/src/common/styles/mixins/global.ts
+++ b/src/frontend/src/common/styles/mixins/global.ts
@@ -1,6 +1,15 @@
 import styled from "@emotion/styled";
+import { CommonThemeProps, getSpaces } from "czifui";
 import { NAV_BAR_HEIGHT_PX } from "src/components/NavBar";
 
 export const PageContent = styled.div`
   height: calc(100% - ${NAV_BAR_HEIGHT_PX}px);
 `;
+
+export const ContentStyles = (props: CommonThemeProps) => {
+  const spaces = getSpaces(props);
+
+  return `
+    padding: ${spaces?.xl}px 125px ${spaces?.l}px 125px;
+  `;
+};

--- a/src/frontend/src/common/styles/mixins/global.ts
+++ b/src/frontend/src/common/styles/mixins/global.ts
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import { CommonThemeProps, getSpaces } from "czifui";
 import { NAV_BAR_HEIGHT_PX } from "src/components/NavBar";
 
+export const PAGE_PADDING = 125;
+
 export const PageContent = styled.div`
   height: calc(100% - ${NAV_BAR_HEIGHT_PX}px);
 `;
@@ -11,7 +13,7 @@ export const ContentStyles = (props: CommonThemeProps) => {
 
   return `
     @media only screen and (min-width: 768px) {
-      padding: ${spaces?.xl}px 125px;
+      padding: ${spaces?.xl}px ${PAGE_PADDING}px;
     }
 
     @media only screen and (max-width: 768px) {

--- a/src/frontend/src/common/styles/mixins/global.ts
+++ b/src/frontend/src/common/styles/mixins/global.ts
@@ -10,6 +10,12 @@ export const ContentStyles = (props: CommonThemeProps) => {
   const spaces = getSpaces(props);
 
   return `
-    padding: ${spaces?.xl}px 125px ${spaces?.l}px 125px;
+    @media only screen and (min-width: 768px) {
+      padding: ${spaces?.xl}px 125px;
+    }
+
+    @media only screen and (max-width: 768px) {
+      padding: ${spaces?.xl}px;
+    }
   `;
 };

--- a/src/frontend/src/common/titles.ts
+++ b/src/frontend/src/common/titles.ts
@@ -5,4 +5,5 @@ export const PAGE_TITLES: Record<string, string> = {
   [ROUTES.HOMEPAGE]: "Public Health Open-Source Tool",
   [ROUTES.DATA_SAMPLES]: "Samples",
   [ROUTES.PHYLO_TREES]: "Phylogenetic Trees",
+  [ROUTES.GROUP_MEMBERS]: "Group Member Data",
 };

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import {
-  DetailsDisplay,
+  DetailDisplay,
+  DetailHeader,
+  DetailPage,
   DetailSection,
-  DetailsHeader,
   DetailSubheader,
   Text,
 } from "./style";
@@ -15,24 +16,22 @@ interface Props {
 
 const GroupDetailsTab = ({ address, location, prefix }: Props): JSX.Element => {
   return (
-    <div>
-      <DetailsHeader>Group Details</DetailsHeader>
+    <DetailPage>
       <DetailSection>
+        <DetailHeader>Group Details</DetailHeader>
         <DetailSubheader>Default Location for Trees</DetailSubheader>
         <Text>
           Group’s full Nextstrain location ID. CZ GEN EPI uses this as the
           default location parameters when building trees for this group. Learn
           More.
         </Text>
-        <DetailsDisplay>{location}</DetailsDisplay>
-      </DetailSection>
-      <DetailSection>
+        <DetailDisplay>{location}</DetailDisplay>
         <DetailSubheader>Address</DetailSubheader>
         <Text>
           Group’s primary address. CZ GEN EPI uses this information to help
           prepare samples for GISAID submisions. Learn More.
         </Text>
-        <DetailsDisplay>{address}</DetailsDisplay>
+        <DetailDisplay>{address}</DetailDisplay>
       </DetailSection>
       <DetailSection>
         <DetailSubheader>Sample Public ID Prefix</DetailSubheader>
@@ -41,9 +40,9 @@ const GroupDetailsTab = ({ address, location, prefix }: Props): JSX.Element => {
           for samples uploaded to this Group if a Public or GISAID ID is not
           provided. Learn More.
         </Text>
-        <DetailsDisplay>{prefix}</DetailsDisplay>
+        <DetailDisplay>{prefix}</DetailDisplay>
       </DetailSection>
-    </div>
+    </DetailPage>
   );
 };
 

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Content,
   DetailDisplay,
   DetailHeader,
   DetailPage,
@@ -17,31 +18,33 @@ interface Props {
 const GroupDetailsTab = ({ address, location, prefix }: Props): JSX.Element => {
   return (
     <DetailPage>
-      <DetailSection>
-        <DetailHeader>Group Details</DetailHeader>
-        <DetailSubheader>Default Location for Trees</DetailSubheader>
-        <Text>
-          Group’s full Nextstrain location ID. CZ GEN EPI uses this as the
-          default location parameters when building trees for this group. Learn
-          More.
-        </Text>
-        <DetailDisplay>{location}</DetailDisplay>
-        <DetailSubheader>Address</DetailSubheader>
-        <Text>
-          Group’s primary address. CZ GEN EPI uses this information to help
-          prepare samples for GISAID submisions. Learn More.
-        </Text>
-        <DetailDisplay>{address}</DetailDisplay>
-      </DetailSection>
-      <DetailSection>
-        <DetailSubheader>Sample Public ID Prefix</DetailSubheader>
-        <Text>
-          This set of characters is used when auto-generating unique Public IDs
-          for samples uploaded to this Group if a Public or GISAID ID is not
-          provided. Learn More.
-        </Text>
-        <DetailDisplay>{prefix}</DetailDisplay>
-      </DetailSection>
+      <DetailHeader>Group Details</DetailHeader>
+      <Content>
+        <DetailSection>
+          <DetailSubheader>Default Location for Trees</DetailSubheader>
+          <Text>
+            Group’s full Nextstrain location ID. CZ GEN EPI uses this as the
+            default location parameters when building trees for this group.
+            Learn More.
+          </Text>
+          <DetailDisplay>{location}</DetailDisplay>
+          <DetailSubheader>Address</DetailSubheader>
+          <Text>
+            Group’s primary address. CZ GEN EPI uses this information to help
+            prepare samples for GISAID submisions. Learn More.
+          </Text>
+          <DetailDisplay>{address}</DetailDisplay>
+        </DetailSection>
+        <DetailSection>
+          <DetailSubheader>Sample Public ID Prefix</DetailSubheader>
+          <Text>
+            This set of characters is used when auto-generating unique Public
+            IDs for samples uploaded to this Group if a Public or GISAID ID is
+            not provided. Learn More.
+          </Text>
+          <DetailDisplay>{prefix}</DetailDisplay>
+        </DetailSection>
+      </Content>
     </DetailPage>
   );
 };

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import {
+  DetailsDisplay,
+  DetailSection,
+  DetailsHeader,
+  DetailSubheader,
+  Text,
+} from "./style";
+
+interface Props {
+  address: string;
+  location: string;
+  prefix: string;
+}
+
+const GroupDetailsTab = ({ address, location, prefix }: Props): JSX.Element => {
+  return (
+    <div>
+      <DetailsHeader>Group Details</DetailsHeader>
+      <DetailSection>
+        <DetailSubheader>Default Location for Trees</DetailSubheader>
+        <Text>
+          Group’s full Nextstrain location ID. CZ GEN EPI uses this as the
+          default location parameters when building trees for this group. Learn
+          More.
+        </Text>
+        <DetailsDisplay>{location}</DetailsDisplay>
+      </DetailSection>
+      <DetailSection>
+        <DetailSubheader>Address</DetailSubheader>
+        <Text>
+          Group’s primary address. CZ GEN EPI uses this information to help
+          prepare samples for GISAID submisions. Learn More.
+        </Text>
+        <DetailsDisplay>{address}</DetailsDisplay>
+      </DetailSection>
+      <DetailSection>
+        <DetailSubheader>Sample Public ID Prefix</DetailSubheader>
+        <Text>
+          This set of characters is used when auto-generating unique Public IDs
+          for samples uploaded to this Group if a Public or GISAID ID is not
+          provided. Learn More.
+        </Text>
+        <DetailsDisplay>{prefix}</DetailsDisplay>
+      </DetailSection>
+    </div>
+  );
+};
+
+export { GroupDetailsTab };

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
@@ -1,11 +1,38 @@
 import styled from "@emotion/styled";
-import { fontBodyS, fontHeaderM, fontHeaderXl } from "czifui";
+import {
+  fontBodyM,
+  fontBodyS,
+  fontHeaderM,
+  fontHeaderXl,
+  getColors,
+  getSpaces,
+} from "czifui";
 
-export const DetailsDisplay = styled.div``;
+export const DetailsDisplay = styled.div`
+  ${fontBodyM}
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      padding: ${spaces?.l}px;
+      background-color: ${colors?.gray[100]};
+      margin-bottom: ${spaces?.xl}px;
+      white-space: pre-wrap;
+    `;
+  }}
+`;
 
 export const DetailsHeader = styled.div`
   ${fontHeaderXl}
   order: 1;
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.l}px;
+    `;
+  }}
 `;
 
 export const DetailSection = styled.div``;
@@ -16,4 +43,13 @@ export const DetailSubheader = styled.div`
 
 export const Text = styled.div`
   ${fontBodyS}
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.s}px;
+      margin-bottom: ${spaces?.l}px;
+    `;
+  }}
 `;
+

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+import { fontBodyS, fontHeaderM, fontHeaderXl } from "czifui";
+
+export const DetailsDisplay = styled.div``;
+
+export const DetailsHeader = styled.div`
+  ${fontHeaderXl}
+  order: 1;
+`;
+
+export const DetailSection = styled.div``;
+
+export const DetailSubheader = styled.div`
+  ${fontHeaderM}
+`;
+
+export const Text = styled.div`
+  ${fontBodyS}
+`;

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
@@ -8,7 +8,7 @@ import {
   getSpaces,
 } from "czifui";
 
-export const DetailsDisplay = styled.div`
+export const DetailDisplay = styled.div`
   ${fontBodyM}
   ${(props) => {
     const colors = getColors(props);
@@ -19,11 +19,12 @@ export const DetailsDisplay = styled.div`
       background-color: ${colors?.gray[100]};
       margin-bottom: ${spaces?.xl}px;
       white-space: pre-wrap;
+      overflow-wrap: break-word;
     `;
   }}
 `;
 
-export const DetailsHeader = styled.div`
+export const DetailHeader = styled.div`
   ${fontHeaderXl}
   order: 1;
 
@@ -35,7 +36,22 @@ export const DetailsHeader = styled.div`
   }}
 `;
 
-export const DetailSection = styled.div``;
+export const DetailSection = styled.div`
+  @media only screen and (min-width: 768px) {
+    ${(props) => {
+      const spaces = getSpaces(props);
+      return `
+        &:first-child {
+          margin-right: ${spaces?.xl}px;
+        }
+
+        &:last-child {
+          margin-right: ${spaces?.xl}px;
+        }
+      `;
+    }}
+  }
+`;
 
 export const DetailSubheader = styled.div`
   ${fontHeaderM}
@@ -53,3 +69,8 @@ export const Text = styled.div`
   }}
 `;
 
+export const DetailPage = styled.div`
+  @media only screen and (min-width: 768px) {
+    display: flex;
+  }
+`;

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/style.ts
@@ -26,12 +26,12 @@ export const DetailDisplay = styled.div`
 
 export const DetailHeader = styled.div`
   ${fontHeaderXl}
-  order: 1;
 
   ${(props) => {
     const spaces = getSpaces(props);
     return `
       margin-bottom: ${spaces?.l}px;
+      width: 100%;
     `;
   }}
 `;
@@ -39,14 +39,16 @@ export const DetailHeader = styled.div`
 export const DetailSection = styled.div`
   @media only screen and (min-width: 768px) {
     ${(props) => {
+      const colors = getColors(props);
       const spaces = getSpaces(props);
       return `
         &:first-child {
-          margin-right: ${spaces?.xl}px;
+          padding-right: ${spaces?.xl}px;
+          border-right: 1px solid ${colors?.gray[300]};
         }
 
         &:last-child {
-          margin-right: ${spaces?.xl}px;
+          padding-left: ${spaces?.xl}px;
         }
       `;
     }}
@@ -70,6 +72,13 @@ export const Text = styled.div`
 `;
 
 export const DetailPage = styled.div`
+  @media only screen and (min-width: 768px) {
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;
+
+export const Content = styled.div`
   @media only screen and (min-width: 768px) {
     display: flex;
   }

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -1,0 +1,48 @@
+import { Button, Tab } from "czifui";
+import React, { useState } from "react";
+import { Table } from "src/common/components/library/Table";
+import { Header, StyledTabs } from "./style";
+
+type TabType = "active" | "invitations";
+
+interface Props {
+  invites: any[];
+  members: any[];
+}
+
+const MembersTab = ({ invites, members }: Props): JSX.Element => {
+  const [tabValue, setTabValue] = useState<TabType>("active");
+  const numActive = Object.keys(members).length;
+
+  const handleTabClick = (_, value) => {
+    setTabValue(value);
+  };
+
+  return (
+    <>
+      <Header>
+        <StyledTabs
+          value={tabValue}
+          sdsSize="small"
+          onChange={handleTabClick}
+          underlined
+        >
+          <Tab value="active" label="Active" count={numActive} />
+          <Tab value="invitations" label="Invitations" count={invites.length} />
+        </StyledTabs>
+        <Button sdsType="primary" sdsStyle="rounded">
+          Invite
+        </Button>
+      </Header>
+      <Table />
+      {tabValue === "active" && (
+        <div>{members.map((m) => <div>{m.name}</div>)}</div>
+      )}
+      {tabValue === "invitations" && (
+        <div>{invites.map((i) => <div>{i.email}</div>)}</div>
+      )}
+    </>
+  );
+};
+
+export { MembersTab };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Tab } from "czifui";
 import React, { useState } from "react";
 import { Table } from "src/common/components/library/Table";
+import { TabEventHandler } from "../../index";
 import { Header, StyledTabs } from "./style";
 
 type TabType = "active" | "invitations";
@@ -14,7 +15,7 @@ const MembersTab = ({ invites, members }: Props): JSX.Element => {
   const [tabValue, setTabValue] = useState<TabType>("active");
   const numActive = Object.keys(members).length;
 
-  const handleTabClick = (_, value) => {
+  const handleTabClick: TabEventHandler = (_, value) => {
     setTabValue(value);
   };
 
@@ -36,10 +37,18 @@ const MembersTab = ({ invites, members }: Props): JSX.Element => {
       </Header>
       <Table />
       {tabValue === "active" && (
-        <div>{members.map((m) => <div>{m.name}</div>)}</div>
+        <div>
+          {members.map((m) => (
+            <div key={m.name}>{m.name}</div>
+          ))}
+        </div>
       )}
       {tabValue === "invitations" && (
-        <div>{invites.map((i) => <div>{i.email}</div>)}</div>
+        <div>
+          {invites.map((i) => (
+            <div key={i.email}>{i.email}</div>
+          ))}
+        </div>
       )}
     </>
   );

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/style.ts
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+import { getSpaces, Tabs } from "czifui";
+
+export const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const StyledTabs = styled(Tabs)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.m}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -10,7 +10,11 @@ const GroupMembersPage = (): JSX.Element => {
   const [tabValue, setTabValue] = useState<PrimaryTabType>("members");
 
   const group = {
-    name: "Santa Clara County",
+    address: `1234 South Main Street
+Suite 210
+Santa Clara, CA 95050
+United States`,
+    location: "North America/USA/California/Santa Clara County",
     members: [
       {
         name: "Albert",
@@ -37,6 +41,8 @@ const GroupMembersPage = (): JSX.Element => {
         role: "member",
       },
     ],
+    name: "Santa Clara County",
+    prefix: "CA-CZB",
   };
 
   const invites = [
@@ -62,9 +68,11 @@ const GroupMembersPage = (): JSX.Element => {
     setTabValue(value);
   };
 
+  const { address, location, name, prefix } = group;
+
   return (
     <StyledPageContent>
-      <StyledHeader>{group.name}</StyledHeader>
+      <StyledHeader>{name}</StyledHeader>
       <Tabs
         value={tabValue}
         sdsSize="large"
@@ -77,7 +85,13 @@ const GroupMembersPage = (): JSX.Element => {
       {tabValue === "members" && (
         <MembersTab invites={invites} members={group.members} />
       )}
-      {tabValue === "details" && <GroupDetailsTab />}
+      {tabValue === "details" && (
+        <GroupDetailsTab
+          address={address}
+          location={location}
+          prefix={prefix}
+        />
+      )}
     </StyledPageContent>
   );
 };

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -1,8 +1,13 @@
-import { Tab, Tabs } from "czifui";
+import { Tab } from "czifui";
 import React, { useState } from "react";
 import { GroupDetailsTab } from "./components/GroupDetailsTab";
 import { MembersTab } from "./components/MembersTab";
-import { StyledHeader, StyledPageContent } from "./style";
+import {
+  StyledHeader,
+  StyledName,
+  StyledPageContent,
+  StyledTabs,
+} from "./style";
 
 type PrimaryTabType = "members" | "details";
 
@@ -71,28 +76,32 @@ United States`,
   const { address, location, name, prefix } = group;
 
   return (
-    <StyledPageContent>
-      <StyledHeader>{name}</StyledHeader>
-      <Tabs
-        value={tabValue}
-        sdsSize="large"
-        onChange={handleTabClick}
-        underlined
-      >
-        <Tab value="members" label="Members" />
-        <Tab value="details" label="Details" />
-      </Tabs>
-      {tabValue === "members" && (
-        <MembersTab invites={invites} members={group.members} />
-      )}
-      {tabValue === "details" && (
-        <GroupDetailsTab
-          address={address}
-          location={location}
-          prefix={prefix}
-        />
-      )}
-    </StyledPageContent>
+    <>
+      <StyledHeader>
+        <StyledName>{name}</StyledName>
+        <StyledTabs
+          value={tabValue}
+          sdsSize="large"
+          onChange={handleTabClick}
+          underlined
+        >
+          <Tab value="members" label="Members" />
+          <Tab value="details" label="Details" />
+        </StyledTabs>
+      </StyledHeader>
+      <StyledPageContent>
+        {tabValue === "members" && (
+          <MembersTab invites={invites} members={group.members} />
+        )}
+        {tabValue === "details" && (
+          <GroupDetailsTab
+            address={address}
+            location={location}
+            prefix={prefix}
+          />
+        )}
+      </StyledPageContent>
+    </>
   );
 };
 

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -11,6 +11,11 @@ import {
 
 type PrimaryTabType = "members" | "details";
 
+export type TabEventHandler = (
+  _: React.SyntheticEvent<Record<string, unknown>>,
+  tabsValue: never
+) => void;
+
 const GroupMembersPage = (): JSX.Element => {
   const [tabValue, setTabValue] = useState<PrimaryTabType>("members");
 
@@ -69,7 +74,7 @@ United States`,
   group.members.sort((a, b) => (a.name > b.name ? 1 : -1));
   invites.sort((a, b) => (a.date > b.date ? 1 : -1));
 
-  const handleTabClick = (_, value) => {
+  const handleTabClick: TabEventHandler = (_, value) => {
     setTabValue(value);
   };
 

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -1,0 +1,85 @@
+import { Tab, Tabs } from "czifui";
+import React, { useState } from "react";
+import { GroupDetailsTab } from "./components/GroupDetailsTab";
+import { MembersTab } from "./components/MembersTab";
+import { StyledHeader, StyledPageContent } from "./style";
+
+type PrimaryTabType = "members" | "details";
+
+const GroupMembersPage = (): JSX.Element => {
+  const [tabValue, setTabValue] = useState<PrimaryTabType>("members");
+
+  const group = {
+    name: "Santa Clara County",
+    members: [
+      {
+        name: "Albert",
+        email: "albert@fake.com",
+        joinedDate: "2022-02-02",
+        role: "member",
+      },
+      {
+        name: "Charles",
+        email: "charles@fake.com",
+        joinedDate: "2021-06-06",
+        role: "member",
+      },
+      {
+        name: "Beatrice",
+        email: "beatrice@fake.com",
+        joinedDate: "2021-01-01",
+        role: "member",
+      },
+      {
+        name: "Danielle",
+        email: "danielle@fake.com",
+        joinedDate: "2022-03-03",
+        role: "member",
+      },
+    ],
+  };
+
+  const invites = [
+    {
+      email: "erica@fake.com",
+      state: "pending",
+      date: "2022-05-24",
+      role: "Member",
+    },
+    {
+      email: "frank@fake.com",
+      state: "expired",
+      date: "2022-03-24",
+      role: "Member",
+    },
+  ];
+
+  // sort group members by name before display
+  group.members.sort((a, b) => (a.name > b.name ? 1 : -1));
+  invites.sort((a, b) => (a.date > b.date ? 1 : -1));
+
+  const handleTabClick = (_, value) => {
+    setTabValue(value);
+  };
+
+  return (
+    <StyledPageContent>
+      <StyledHeader>{group.name}</StyledHeader>
+      <Tabs
+        value={tabValue}
+        sdsSize="large"
+        onChange={handleTabClick}
+        underlined
+      >
+        <Tab value="members" label="Members" />
+        <Tab value="details" label="Details" />
+      </Tabs>
+      {tabValue === "members" && (
+        <MembersTab invites={invites} members={group.members} />
+      )}
+      {tabValue === "details" && <GroupDetailsTab />}
+    </StyledPageContent>
+  );
+};
+
+export default GroupMembersPage;

--- a/src/frontend/src/views/GroupMembersPage/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/style.ts
@@ -1,0 +1,18 @@
+import styled from "@emotion/styled";
+import { fontHeaderXxl, getSpaces } from "czifui";
+import { ContentStyles, PageContent } from "src/common/styles/mixins/global";
+
+export const StyledHeader = styled.div`
+  ${fontHeaderXxl}
+
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin: ${spaces?.xl}px 0;
+    `;
+  }}
+`;
+
+export const StyledPageContent = styled(PageContent)`
+  ${ContentStyles}
+`;

--- a/src/frontend/src/views/GroupMembersPage/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/style.ts
@@ -1,8 +1,12 @@
 import styled from "@emotion/styled";
-import { fontHeaderXxl, getSpaces } from "czifui";
-import { ContentStyles, PageContent } from "src/common/styles/mixins/global";
+import { fontHeaderXxl, getColors, getSpaces, Tabs } from "czifui";
+import {
+  ContentStyles,
+  PageContent,
+  PAGE_PADDING,
+} from "src/common/styles/mixins/global";
 
-export const StyledHeader = styled.div`
+export const StyledName = styled.div`
   ${fontHeaderXxl}
 
   ${(props) => {
@@ -15,4 +19,25 @@ export const StyledHeader = styled.div`
 
 export const StyledPageContent = styled(PageContent)`
   ${ContentStyles}
+`;
+
+export const StyledTabs = styled(Tabs)`
+  margin-bottom: unset;
+  border-bottom: unset;
+`;
+
+export const StyledHeader = styled.div`
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      border-bottom: 2px solid ${colors?.gray[200]};
+      padding: 0 ${PAGE_PADDING}px;
+
+      @media only screen and (max-width: 768px) {
+        padding: 0 ${spaces?.xl}px;
+      }
+    `;
+  }}
 `;

--- a/src/frontend/src/views/Upload/components/common/style.ts
+++ b/src/frontend/src/views/Upload/components/common/style.ts
@@ -19,16 +19,16 @@ export function marginBottom(props: CommonThemeProps): string {
 }
 
 export const Header = styled.div`
+  ${ContentStyles}
+
   display: flex;
   justify-content: space-between;
   align-items: center;
 
   ${(props) => {
-    const spaces = getSpaces(props);
     const colors = getColors(props);
 
     return `
-      padding: ${spaces?.xl}px 125px;
       border-bottom: 5px solid ${colors?.gray[100]};
     `;
   }}

--- a/src/frontend/src/views/Upload/components/common/style.ts
+++ b/src/frontend/src/views/Upload/components/common/style.ts
@@ -7,14 +7,15 @@ import {
   getColors,
   getSpaces,
 } from "czifui";
+import { ContentStyles } from "src/common/styles/mixins/global";
 import Instructions from "src/components/Instructions";
 
 export function marginBottom(props: CommonThemeProps): string {
   const spaces = getSpaces(props);
 
   return `
-      margin-bottom: ${spaces?.xl}px;
-    `;
+    margin-bottom: ${spaces?.xl}px;
+  `;
 }
 
 export const Header = styled.div`
@@ -27,8 +28,8 @@ export const Header = styled.div`
     const colors = getColors(props);
 
     return `
-        padding: ${spaces?.xl}px 125px;
-        border-bottom: 5px solid ${colors?.gray[100]};
+      padding: ${spaces?.xl}px 125px;
+      border-bottom: 5px solid ${colors?.gray[100]};
     `;
   }}
 `;
@@ -36,13 +37,7 @@ export const Header = styled.div`
 export const Content = styled.div`
   flex: 2;
 
-  ${(props) => {
-    const spaces = getSpaces(props);
-
-    return `
-        margin: ${spaces?.xxl}px 125px ${spaces?.l}px 125px;
-    `;
-  }}
+  ${ContentStyles}
 `;
 
 export const Title = styled.div`


### PR DESCRIPTION
### Summary
- **What:** 
  - Add new page to see information about group members
  - Tab navigation at two levels
  - Group details page styles at small and large screen sizes
  - Reduce horizontal padding on small screen sizes
- **Ticket:** [[sc-187629]](https://app.shortcut.com/genepi/story/187629)
- **Env:** https://maya-members-frontend.dev.czgenepi.org/members
- **Design:** https://www.figma.com/file/SALQZGfIJntBes0HvIzVeX/Onboarding-New-Users-V0?node-id=280%3A48892

### Demos
- Here's a before and after of the uploads page, as far as padding changes go
<img width="612" alt="Screen Shot 2022-05-26 at 6 15 54 PM" src="https://user-images.githubusercontent.com/7562933/170609104-c75e2521-fe08-4556-93a7-6a00f2229a13.png">
<img width="612" alt="Screen Shot 2022-05-26 at 6 15 41 PM" src="https://user-images.githubusercontent.com/7562933/170609113-67581790-eaf3-48c4-b9a3-be84c22e6d3a.png">

- And the new content
<img width="1904" alt="Screen Shot 2022-05-26 at 6 15 29 PM" src="https://user-images.githubusercontent.com/7562933/170609147-e20853ed-797a-456d-898a-0b7a708f674d.png">
<img width="612" alt="Screen Shot 2022-05-26 at 6 15 34 PM" src="https://user-images.githubusercontent.com/7562933/170609153-f3be6bcb-416b-4fbe-8007-02aeb775ced6.png">

### Notes
Tagging @Janeece for a review of:
- Group Details page, large and small screen layouts
- The outer level of tab navigation (I had to do some css hacks to get the tab border to extend all the way across the page. Mainly checking in whether it looks right)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)