### PR TITLE
Expanded group information in usergroup API response

### DIFF
--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -7,9 +7,9 @@ from aspen.api.schemas.base import BaseRequest, BaseResponse
 class GroupResponse(BaseResponse):
     id: int
     name: str
-    address: str
+    address: Optional[str]
     prefix: str
-    location: str
+    location: Optional[str]
 
 
 class UserBaseResponse(BaseResponse):

--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -7,6 +7,9 @@ from aspen.api.schemas.base import BaseRequest, BaseResponse
 class GroupResponse(BaseResponse):
     id: int
     name: str
+    address: str
+    prefix: str
+    location: str
 
 
 class UserBaseResponse(BaseResponse):

--- a/src/backend/aspen/api/views/tests/test_users.py
+++ b/src/backend/aspen/api/views/tests/test_users.py
@@ -26,7 +26,13 @@ async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -
     expected = {
         "id": 1,
         "name": "test",
-        "group": {"id": 1, "name": "groupname"},
+        "group": {
+            "id": 1,
+            "name": "groupname",
+            "address": "123 Main St",
+            "prefix": "groupname",
+            "location": "groupname city",
+        },
         "acknowledged_policy_version": None,
         "agreed_to_tos": True,
     }


### PR DESCRIPTION
### Summary:
- **What:** Expand group information response in `users/me` endpoint. Includes fields necessary for group management frontend work.
- **Ticket:** [sc187629](https://app.shortcut.com/genepi/story/187629)
- **Env:** [https://groupinfo-backend.dev.czgenepi.org/v2/users/me](https://groupinfo-backend.dev.czgenepi.org/v2/users/me)

### Demos:
<img width="353" alt="Screen Shot 2022-05-27 at 11 47 56" src="https://user-images.githubusercontent.com/24234461/170772378-26346351-aff2-4feb-be1a-7c98e693f110.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)