### PR TITLE
Make uploaded_by_id nullable

### DIFF
--- a/src/backend/aspen/database/models/sample.py
+++ b/src/backend/aspen/database/models/sample.py
@@ -53,7 +53,7 @@ class Sample(idbase, DictMixin):  # type: ignore
     uploaded_by_id = Column(
         Integer,
         ForeignKey(User.id),
-        nullable=False,
+        nullable=True,
     )
     uploaded_by = relationship(User, backref=backref("samples", uselist=True))  # type: ignore
     private = Column(Boolean, nullable=False, default=False)

--- a/src/backend/database_migrations/versions/20220531_163736_nullable_uploaded_by_id_in_samples.py
+++ b/src/backend/database_migrations/versions/20220531_163736_nullable_uploaded_by_id_in_samples.py
@@ -1,0 +1,22 @@
+"""nullable uploaded_by_id in samples
+
+Create Date: 2022-05-31 16:37:42.491598
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220531_163736"
+down_revision = "20220524_174911"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("samples", "uploaded_by_id", nullable=True, schema="aspen")
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### Summary:
- **What:** Makes the `uploaded_by_id` column in the samples table nullable, so we can delete a user while keeping their samples.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)