### PR TITLE
Add groupinfo endpoint

### DIFF
--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -2,11 +2,18 @@ import datetime
 from typing import List, Optional
 
 from aspen.api.schemas.base import BaseRequest, BaseResponse
+from aspen.api.schemas.locations import LocationResponse
 
 
 class GroupResponse(BaseResponse):
     id: int
     name: str
+
+
+class GroupInfoResponse(GroupResponse):
+    address: Optional[str]
+    prefix: str
+    default_tree_location: LocationResponse
 
 
 class UserBaseResponse(BaseResponse):


### PR DESCRIPTION
### Summary:
- **What:** Adds a group information endpoint that returns info for a given group.
- **Ticket:** [sc187629](https://app.shortcut.com/genepi/story/187629)
- **Env:** [https://groupinfo-backend.dev.czgenepi.org/v2/users/me](https://groupinfo-backend.dev.czgenepi.org/v2/users/me)

### Demos:
<img width="418" alt="Screen Shot 2022-05-31 at 11 28 57" src="https://user-images.githubusercontent.com/24234461/171261144-1085c977-22c8-4125-8c8f-ea7b2af0fe24.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)