### PR TITLE
npm i

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -4517,7 +4517,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "brace-expansion": {
@@ -6186,7 +6186,7 @@
     },
     "eventsource": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "optional": true,
       "requires": {


### PR DESCRIPTION
[This](https://github.com/chanzuckerberg/czgenepi/pull/1113), but I just ran `npm i` (no manual changes), looks like the dependency was fixed upstream.

As far as sha changes for boolbase, those also came with a simple npm i.