### PR TITLE
Update the sync script to write auth0 group ID's to the db

### DIFF
--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -41,8 +41,11 @@ done
 
 
 ONETRUST_FRONTEND_KEY=$(jq -c .ONETRUST_FRONTEND_KEY <<< "${EXTRA_SECRETS}")
+AUTH0_MANAGEMENT_CLIENT_ID=$(jq -c .AUTH0_MANAGEMENT_CLIENT_ID <<< "${EXTRA_SECRETS}")
+AUTH0_MANAGEMENT_CLIENT_SECRET=$(jq -c .AUTH0_MANAGEMENT_CLIENT_SECRET <<< "${EXTRA_SECRETS}")
+AUTH0_MANAGEMENT_DOMAIN=$(jq -c .AUTH0_MANAGEMENT_DOMAIN <<< "${EXTRA_SECRETS}")
 echo "Creating secretsmanager secrets"
-local_aws="aws --endpoint-url=${LOCALSTACK_URL}"
+local_aws="aws --no-paginate --endpoint-url=${LOCALSTACK_URL}"
 ${local_aws} secretsmanager create-secret --name genepi-config &> /dev/null || true
 # AUSPICE_MAC_KEY is just the result of urlsafe_b64encode(b'auspice-mac-key')
 ${local_aws} secretsmanager update-secret --secret-id genepi-config --secret-string '{
@@ -63,7 +66,10 @@ ${local_aws} secretsmanager update-secret --secret-id genepi-config --secret-str
   "DB_address": "database.genepinet.localdev",
   "S3_external_auspice_bucket": "genepi-external-auspice-data",
   "S3_db_bucket": "genepi-db-data",
-  "ONETRUST_FRONTEND_KEY": '"${ONETRUST_FRONTEND_KEY}"'
+  "ONETRUST_FRONTEND_KEY": '"${ONETRUST_FRONTEND_KEY}"',
+  "AUTH0_MANAGEMENT_CLIENT_ID": '"${AUTH0_MANAGEMENT_CLIENT_ID}"',
+  "AUTH0_MANAGEMENT_CLIENT_SECRET": '"${AUTH0_MANAGEMENT_CLIENT_SECRET}"',
+  "AUTH0_MANAGEMENT_DOMAIN": '"${AUTH0_MANAGEMENT_DOMAIN}"'
 }' || true
 
 echo "Creating IAM role"

--- a/src/backend/aspen/auth/auth0_management.py
+++ b/src/backend/aspen/auth/auth0_management.py
@@ -147,7 +147,7 @@ class Auth0Client:
             org["id"], {"members": [user_id]}
         )
 
-    def add_org(self, group_id: int, org_name: str):
+    def add_org(self, group_id: int, org_name: str) -> Auth0Org:
         # TODO, learn more about connections! For now we only have this one, let's use it wherever we need to.
         connection = self.get_connection("Username-Password-Authentication")
         body = {
@@ -165,7 +165,7 @@ class Auth0Client:
     def delete_org(self, org_id: str) -> None:
         self.client.organizations.delete_organization(org_id)
 
-    def create_user(self, email: str, name: str):
+    def create_user(self, email: str, name: str) -> Auth0User:
         body = {
             "email": email,
             "user_metadata": {},

--- a/src/backend/aspen/auth/auth0_management.py
+++ b/src/backend/aspen/auth/auth0_management.py
@@ -147,7 +147,7 @@ class Auth0Client:
             org["id"], {"members": [user_id]}
         )
 
-    def add_org(self, group_id: int, org_name: str) -> None:
+    def add_org(self, group_id: int, org_name: str):
         # TODO, learn more about connections! For now we only have this one, let's use it wherever we need to.
         connection = self.get_connection("Username-Password-Authentication")
         body = {
@@ -160,12 +160,12 @@ class Auth0Client:
                 }
             ],
         }
-        self.client.organizations.create_organization(body)
+        return self.client.organizations.create_organization(body)
 
     def delete_org(self, org_id: str) -> None:
         self.client.organizations.delete_organization(org_id)
 
-    def create_user(self, email: str, name: str) -> None:
+    def create_user(self, email: str, name: str):
         body = {
             "email": email,
             "user_metadata": {},
@@ -175,7 +175,7 @@ class Auth0Client:
             "password": generate_password(),
             "connection": "Username-Password-Authentication",
         }
-        self.client.users.create(body)
+        return self.client.users.create(body)
 
     def delete_user(self, auth0_user_id: str) -> None:
         self.client.users.delete(auth0_user_id)

--- a/src/backend/aspen/cli/sync_auth0.py
+++ b/src/backend/aspen/cli/sync_auth0.py
@@ -17,19 +17,6 @@ from aspen.database.connection import (
 from aspen.database.models import Group, User
 
 
-def find_missing_objects(
-    auth0_objects: MutableSequence[Any],
-    db_objects: MutableSequence[Any],
-    auth0_match_field: str,
-    db_match_field: str,
-) -> Tuple[MutableSequence[Any], MutableSequence[Any]]:
-    db_map = {getattr(obj, db_match_field): obj for obj in db_objects}
-    auth0_map = {obj[auth0_match_field]: obj for obj in auth0_objects}
-    auth0_only = [auth0_map[key] for key in auth0_map.keys() - db_map.keys()]
-    db_only = [db_map[key] for key in db_map.keys() - auth0_map.keys()]
-    return auth0_only, db_only
-
-
 class ObjectManager:
     def __init__(self, auth0_client: Auth0Client, db: Session, dry_run: bool) -> None:
         self.auth0_client = auth0_client
@@ -50,6 +37,9 @@ class ObjectManager:
 
 
 class UserGroupManager(ObjectManager):
+    auth0_match_field = "user_id"
+    db_match_field = "auth0_user_id"
+
     def __init__(
         self,
         auth0_client: Auth0Client,
@@ -107,6 +97,10 @@ class UserGroupManager(ObjectManager):
 
 
 class GroupManager(ObjectManager):
+    auth0_field = "auth0_org_id"
+    auth0_match_field = "display_name"
+    db_match_field = "name"
+
     def auth0_delete(self, auth0_group: Auth0Org) -> None:
         logging.info(f"Deleting auth0 group {auth0_group['name']}")
         if self.dry_run:
@@ -121,23 +115,32 @@ class GroupManager(ObjectManager):
         # TODO - this is complicated and we don't even know if we want it.
         raise Exception("deleting orgs is not currently supported")
 
-    def auth0_create(self, db_group: Group) -> None:
+    def auth0_create(self, db_group: Group) -> Auth0Org:
         logging.info(f"Adding auth0 group {db_group.name}")
         if self.dry_run:
             return
-        self.auth0_client.add_org(db_group.id, db_group.name)
+        res = self.auth0_client.add_org(db_group.id, db_group.name)
         logging.info("...done")
+        return res
 
     def db_create(self, auth0_group: Group) -> None:
         logging.info(f"Adding db group {auth0_group['display_name']}")
         if self.dry_run:
             return
-        group = Group(name=auth0_group["display_name"], prefix=auth0_group["name"])
+        group = Group(
+            name=auth0_group["display_name"],
+            prefix=auth0_group["name"],
+            auth0_org_id=auth0_group["id"],
+        )
         self.db.add(group)
         logging.info("...done")
 
 
 class UserManager(ObjectManager):
+    auth0_field = "auth0_user_id"
+    auth0_match_field = "user_id"
+    db_match_field = "auth0_user_id"
+
     def auth0_delete(self, auth0_user: Auth0User) -> None:
         logging.info(f"Deleting auth0 user {auth0_user['email']}")
         if self.dry_run:
@@ -152,12 +155,13 @@ class UserManager(ObjectManager):
         # TODO - this is complicated and we don't even know if we want it.
         raise Exception("Removing users from DB groups is not supported")
 
-    def auth0_create(self, db_user: User) -> None:
+    def auth0_create(self, db_user: User) -> Auth0User:
         logging.info(f"Adding db user {db_user.email} to auth0")
         if self.dry_run:
             return
-        self.auth0_client.create_user(db_user.email, db_user.name)
+        res = self.auth0_client.create_user(db_user.email, db_user.name)
         logging.info("...done")
+        return res
 
     def db_create(self, auth0_user: Auth0User) -> None:
         logging.info(f"Adding auth0 user {auth0_user['email']} to db")
@@ -182,11 +186,42 @@ class SuperSyncer:
         self.source_of_truth = source_of_truth
         self.delete_ok = delete_ok
 
+    def find_missing_objects(
+        self,
+        auth0_objects: MutableSequence[Any],
+        db_objects: MutableSequence[Any],
+        auth0_match_field: str,
+        db_match_field: str,
+    ) -> Tuple[MutableSequence[Any], MutableSequence[Any]]:
+        db_map = {getattr(obj, db_match_field): obj for obj in db_objects}
+        auth0_map = {obj[auth0_match_field]: obj for obj in auth0_objects}
+        auth0_only = [auth0_map[key] for key in auth0_map.keys() - db_map.keys()]
+        db_only = [db_map[key] for key in db_map.keys() - auth0_map.keys()]
+        matching_tuples = [
+            (db_map[key], auth0_map[key])
+            for key in set(db_map.keys()) & set(auth0_map.keys())
+        ]
+        return auth0_only, db_only, matching_tuples
+
     def update_objects(
-        self, auth0_only: Any, db_only: Any, object_manager: ObjectManager
+        self, object_manager: ObjectManager, auth0_objects: Any, db_objects: Any
     ) -> None:
         # Only add/create entries in the data store that is NOT our designated
         # source of truth.
+        auth0_only, db_only, matching_tuples = self.find_missing_objects(
+            auth0_objects,
+            db_objects,
+            object_manager.auth0_match_field,
+            object_manager.db_match_field,
+        )
+        # Set db object ID's to use the proper auth0 id wherever possible:
+        try:
+            db_key_name = object_manager.auth0_field
+            for db_obj, auth0_obj in matching_tuples:
+                setattr(db_obj, db_key_name, auth0_obj["id"])
+        except AttributeError:
+            # There is no identifier key to sync, that's ok.
+            pass
         if self.source_of_truth == "auth0":
             delete_callback = object_manager.db_delete
             create_callback = object_manager.db_create
@@ -198,7 +233,10 @@ class SuperSyncer:
             to_add = db_only
             to_delete = auth0_only
         for obj in to_add:
-            create_callback(obj)
+            res = create_callback(obj)
+            if res:
+                print(res)
+                setattr(obj, object_manager.auth0_field, res["id"])
         if self.delete_ok:
             for obj in to_delete:
                 delete_callback(obj)
@@ -208,22 +246,16 @@ class SuperSyncer:
             self.db.execute(sa.select(User)).scalars().all()  # type: ignore
         )
         auth0_users: List[Auth0User] = self.auth0_client.get_users()
-        auth0_only, db_only = find_missing_objects(
-            auth0_users, db_users, "user_id", "auth0_user_id"
-        )
         user_manager = UserManager(self.auth0_client, self.db, self.dry_run)
-        self.update_objects(auth0_only, db_only, user_manager)
+        self.update_objects(user_manager, auth0_users, db_users)
 
     def sync_groups(self) -> None:
         db_groups: MutableSequence[Group] = (
             self.db.execute(sa.select(Group)).scalars().all()  # type: ignore
         )
         auth0_orgs: List[Auth0Org] = self.auth0_client.get_orgs()
-        auth0_only, db_only = find_missing_objects(
-            auth0_orgs, db_groups, "display_name", "name"
-        )
         group_manager = GroupManager(self.auth0_client, self.db, self.dry_run)
-        self.update_objects(auth0_only, db_only, group_manager)
+        self.update_objects(group_manager, auth0_orgs, db_groups)
 
     def sync_memberships(self) -> None:
         auth0_orgs: List[Auth0Org] = self.auth0_client.get_orgs()
@@ -255,13 +287,10 @@ class SuperSyncer:
             # that "good enough" for the purposes of this sync script. We need to *ALSO*
             # validate that they have the correct role, but that will be more important
             # in the next version, so we're skipping that right now.
-            auth0_only, db_only = find_missing_objects(
-                auth0_memberships, db_group_users, "user_id", "auth0_user_id"
-            )
             group_manager = UserGroupManager(
                 self.auth0_client, self.db, self.dry_run, org, db_group
             )
-            self.update_objects(auth0_only, db_only, group_manager)
+            self.update_objects(group_manager, auth0_memberships, db_group_users)
 
 
 @click.command("sync_users")
@@ -326,9 +355,13 @@ def cli(
         if sync_groups:
             logging.info("Syncing groups")
             syncer.sync_groups()
+    with session_scope(interface) as db:
+        syncer = SuperSyncer(auth0_client, source_of_truth, db, dry_run, delete_ok)
         if sync_users:
             logging.info("Syncing users")
             syncer.sync_users()
+    with session_scope(interface) as db:
+        syncer = SuperSyncer(auth0_client, source_of_truth, db, dry_run, delete_ok)
         if sync_memberships:
             logging.info("Syncing memberships")
             syncer.sync_memberships()

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -55,7 +55,7 @@ def create_test_user(session, group, user_id, name):
         name=name,
         auth0_user_id=user_id,
         split_id=user_id,
-        email=f"{user_id}@chanzuckerberg.com",
+        email=f"{user_id}@czgenepi.org",
         group_admin=True,
         system_admin=True,
         group=group,


### PR DESCRIPTION
### Summary:
This PR contains a few different changes:
- Now that we have a separate auth0 tenant for localdev, we're using @vincent-czi's new flow to pull in auth0 management credentials to local dev, so we should actually be able to generate invitations from local dev once we get the DB's sync'd properly.
- Update the auth0 sync script to write auth0 group ID's to our DB when we sync data.
- @mmmmmmaya was noticing that since we've changed the `setup_dev_data.sh` script to run outside of a container, all the AWS commands are paginating if they run in a small terminal (like in an IDE pane). We're disabling pagination in that script now

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)