### PR TITLE
Fix `get_auth0_client` name collision.

### DIFF
--- a/src/backend/aspen/api/auth.py
+++ b/src/backend/aspen/api/auth.py
@@ -90,7 +90,7 @@ async def get_admin_user(auth_user: User = Depends(get_auth_user)) -> None:
         raise ex.UnauthorizedException("Not authorized")
 
 
-async def get_auth0_client(
+async def get_auth0_apiclient(
     request: Request, settings: Settings = Depends(get_settings)
 ):
     client_id: str = settings.AUTH0_MANAGEMENT_CLIENT_ID

--- a/src/backend/aspen/api/conftest.py
+++ b/src/backend/aspen/api/conftest.py
@@ -9,7 +9,7 @@ from fastapi import Depends, FastAPI, Request
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from aspen.api.auth import get_auth0_client, get_auth_user, setup_userinfo
+from aspen.api.auth import get_auth0_apiclient, get_auth_user, setup_userinfo
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.main import get_app
@@ -127,15 +127,15 @@ async def override_get_auth_user(
     return found_auth_user
 
 
-async def override_get_auth0_client(
+async def override_get_auth0_apiclient(
     request: Request,
     settings: Settings = Depends(get_settings),
 ) -> Auth0Client:
     client_id: str = settings.AUTH0_MANAGEMENT_CLIENT_ID
     client_secret: str = settings.AUTH0_MANAGEMENT_CLIENT_SECRET
     domain: str = settings.AUTH0_MANAGEMENT_DOMAIN
-    auth0_client = MockAuth0Client(client_id, client_secret, domain)
-    return auth0_client
+    auth0_apiclient = MockAuth0Client(client_id, client_secret, domain)
+    return auth0_apiclient
 
 
 @pytest.fixture()
@@ -145,7 +145,7 @@ async def api(
     api = get_app()
     api.dependency_overrides[get_db] = partial(override_get_db, async_db)
     api.dependency_overrides[get_auth_user] = override_get_auth_user
-    api.dependency_overrides[get_auth0_client] = override_get_auth0_client
+    api.dependency_overrides[get_auth0_apiclient] = override_get_auth0_apiclient
     return api
 
 

--- a/src/backend/aspen/api/views/groups.py
+++ b/src/backend/aspen/api/views/groups.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from starlette.requests import Request
 
-from aspen.api.auth import get_auth0_client, get_auth_user
+from aspen.api.auth import get_auth0_apiclient, get_auth_user
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.usergroup import (
@@ -64,7 +64,7 @@ async def get_group_invitations(
     group_id: int,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    auth0_client: Auth0Client = Depends(get_auth0_client),
+    auth0_client: Auth0Client = Depends(get_auth0_apiclient),
     user: User = Depends(get_auth_user),
 ) -> InvitationsResponse:
     if user.group.id != group_id and not user.system_admin:
@@ -85,7 +85,7 @@ async def get_group_invitations(
 async def invite_group_members(
     group_id: int,
     group_invitation_request: GroupInvitationsRequest,
-    auth0_client: Auth0Client = Depends(get_auth0_client),
+    auth0_client: Auth0Client = Depends(get_auth0_apiclient),
     db: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),


### PR DESCRIPTION
### Summary:
- **What:** it turns out we had *two* `get_auth0_client` dependencies available in our app. This did *work* at the end of the day since they were in different modules, but it was pretty confusing. This renames one of them so the intent is a little clearer

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)