### PR TITLE
Maya/187620 clean up

### DIFF
--- a/src/frontend/pages/group/[[...params]].tsx
+++ b/src/frontend/pages/group/[[...params]].tsx
@@ -1,13 +1,39 @@
 import { useRouter } from "next/router";
 import React from "react";
-import GroupMembersPage from "src/views/GroupMembersPage";
+import GroupMembersPage, { PrimaryTabType } from "src/views/GroupMembersPage";
+import { SecondaryTabType } from "src/views/GroupMembersPage/components/MembersTab";
 
 const Page = (): JSX.Element => {
   const router = useRouter();
   const { params } = router.query;
   const pathTokens = typeof params === "object" ? params : [params];
 
-  return <GroupMembersPage pathTokens={pathTokens} />;
+  const primaryToken = pathTokens.length > 0 && pathTokens[0];
+  const secondaryToken = pathTokens.length > 1 && pathTokens[1];
+
+  let initialPrimaryTab;
+  let initialSecondaryTab;
+
+  if (
+    primaryToken === PrimaryTabType.MEMBERS ||
+    primaryToken === PrimaryTabType.DETAILS
+  ) {
+    initialPrimaryTab = primaryToken;
+  }
+
+  if (
+    secondaryToken === SecondaryTabType.ACTIVE ||
+    secondaryToken === SecondaryTabType.INVITATIONS
+  ) {
+    initialSecondaryTab = secondaryToken;
+  }
+
+  return (
+    <GroupMembersPage
+      initialPrimaryTab={initialPrimaryTab}
+      initialSecondaryTab={initialSecondaryTab}
+    />
+  );
 };
 
 export default Page;

--- a/src/frontend/pages/group/[[...params]].tsx
+++ b/src/frontend/pages/group/[[...params]].tsx
@@ -11,8 +11,8 @@ const Page = (): JSX.Element => {
   const primaryToken = pathTokens.length > 0 && pathTokens[0];
   const secondaryToken = pathTokens.length > 1 && pathTokens[1];
 
-  let initialPrimaryTab;
-  let initialSecondaryTab;
+  let initialPrimaryTab = PrimaryTabType.MEMBERS;
+  let initialSecondaryTab = SecondaryTabType.ACTIVE;
 
   if (
     primaryToken === PrimaryTabType.MEMBERS ||

--- a/src/frontend/pages/members.tsx
+++ b/src/frontend/pages/members.tsx
@@ -1,6 +1,0 @@
-import React from "react";
-import GroupMembersPage from "src/views/GroupMembersPage";
-
-const Page = (): JSX.Element => <GroupMembersPage />;
-
-export default Page;

--- a/src/frontend/src/common/components/library/Table/style.ts
+++ b/src/frontend/src/common/components/library/Table/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { MAX_CONTENT_WIDTH } from "src/common/styles/mixins/global";
 
 export const DataRows = styled.div`
   height: 77vh;
@@ -10,6 +11,6 @@ export const DataRows = styled.div`
 `;
 
 export const Container = styled.div`
-  max-width: 1308px;
+  max-width: ${MAX_CONTENT_WIDTH}px;
   margin: 0 auto;
 `;

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -7,6 +7,7 @@ import {
   getFontWeights,
   getSpaces,
 } from "czifui";
+import { MAX_CONTENT_WIDTH } from "src/common/styles/mixins/global";
 
 export const StyledDiv = styled.div`
   ${fontHeaderXs}
@@ -68,7 +69,7 @@ export const TooltipDescriptionText = styled.div`
 export const StyledFlexChildDiv = styled.div`
   flex: 1 1 0;
   margin: 0 auto;
-  max-width: 1308px;
+  max-width: ${MAX_CONTENT_WIDTH}px;
   align-items: stretch;
   flex-direction: column;
 

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -31,20 +31,14 @@ export interface RawUserRequest {
 }
 
 export const mapUserData = (obj: RawUserRequest): User => {
-  const mappedUserData: User = {
+  return {
     acknowledgedPolicyVersion: obj.acknowledged_policy_version,
     agreedToTos: obj.agreed_to_tos,
-    // @ts-expect-error TODO (mlila): types
-    email: obj.email,
+    group: mapGroupData(obj.group),
     id: obj.id,
-    isGroupAdmin: obj.group_admin,
     name: obj.name,
     splitId: obj.split_id,
   };
-
-  if (obj.group) mappedUserData.group = mapGroupData(obj.group);
-
-  return mappedUserData;
 };
 
 export const fetchUserInfo = (): Promise<RawUserRequest> => {

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -77,7 +77,7 @@ export const USE_GROUP_INFO = {
   id: "groupInfo",
 };
 
-export function useGroupInfo(groupId?: number): UseQueryResult<Group, unknown> {
+export function useGroupInfo(groupId: number): UseQueryResult<Group, unknown> {
   return useQuery([USE_GROUP_INFO], () => fetchGroup({ groupId }), {
     retry: false,
     select: mapGroupData,
@@ -87,10 +87,8 @@ export function useGroupInfo(groupId?: number): UseQueryResult<Group, unknown> {
 export async function fetchGroup({
   groupId,
 }: {
-  groupId?: number;
-}): Promise<RawGroupRequest> | undefined {
-  if (!groupId) return;
-
+  groupId: number;
+}): Promise<RawGroupRequest> {
   const response = await fetch(API_URL + API.GROUPS + groupId, {
     ...DEFAULT_FETCH_OPTIONS,
   });
@@ -113,7 +111,7 @@ export const USE_GROUP_MEMBER_INFO = {
 };
 
 export function useGroupMembersInfo(
-  groupId?: number
+  groupId: number
 ): UseQueryResult<GroupMember[], unknown> {
   return useQuery(
     [USE_GROUP_MEMBER_INFO],
@@ -131,10 +129,8 @@ export function useGroupMembersInfo(
 export async function fetchGroupMembers({
   groupId,
 }: {
-  groupId?: number;
-}): Promise<GroupMembersFetchResponseType> | undefined {
-  if (!groupId) return;
-
+  groupId: number;
+}): Promise<GroupMembersFetchResponseType> {
   const response = await fetch(API_URL + API.GROUPS + groupId + "/members", {
     ...DEFAULT_FETCH_OPTIONS,
   });
@@ -157,7 +153,7 @@ export const USE_GROUP_INVITATION_INFO = {
 };
 
 export function useGroupInvitations(
-  groupId?: number
+  groupId: number
 ): UseQueryResult<Invitation[], unknown> {
   return useQuery(
     [USE_GROUP_INVITATION_INFO],
@@ -175,7 +171,7 @@ export function useGroupInvitations(
 export async function fetchGroupInvitations({
   groupId,
 }: {
-  groupId?: number;
+  groupId: number;
 }): Promise<FetchInvitationResponseType> {
   const response = await fetch(
     API_URL + API.GROUPS + groupId + "/invitations/",
@@ -199,7 +195,7 @@ interface InvitationPayload {
 
 interface InvitationRequestType {
   emails: string[];
-  groupId?: number;
+  groupId: number;
 }
 
 interface InvitationResponseType {

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -89,6 +89,8 @@ export async function fetchGroup({
 }: {
   groupId?: number;
 }): Promise<RawGroupRequest> {
+  if (!groupId) return;
+
   const response = await fetch(API_URL + API.GROUPS + groupId, {
     ...DEFAULT_FETCH_OPTIONS,
   });
@@ -131,6 +133,8 @@ export async function fetchGroupMembers({
 }: {
   groupId?: number;
 }): Promise<GroupMembersFetchResponseType> {
+  if (!groupId) return;
+
   const response = await fetch(API_URL + API.GROUPS + groupId + "/members", {
     ...DEFAULT_FETCH_OPTIONS,
   });

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -88,7 +88,7 @@ export async function fetchGroup({
   groupId,
 }: {
   groupId?: number;
-}): Promise<RawGroupRequest> {
+}): Promise<RawGroupRequest> | undefined {
   if (!groupId) return;
 
   const response = await fetch(API_URL + API.GROUPS + groupId, {
@@ -132,7 +132,7 @@ export async function fetchGroupMembers({
   groupId,
 }: {
   groupId?: number;
-}): Promise<GroupMembersFetchResponseType> {
+}): Promise<GroupMembersFetchResponseType> | undefined {
   if (!groupId) return;
 
   const response = await fetch(API_URL + API.GROUPS + groupId + "/members", {

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -6,7 +6,6 @@ import {
 } from "react-query";
 import { API, DEFAULT_FETCH_OPTIONS, DEFAULT_POST_OPTIONS } from "../api";
 import { API_URL } from "../constants/ENV";
-import { mapUserData, RawUserRequest } from "./auth";
 import { ENTITIES } from "./entities";
 import { MutationCallbacks } from "./types";
 
@@ -26,6 +25,17 @@ interface RawInvitationResponse {
   inviter: { name: string };
 }
 
+export interface RawGroupMemberRequest {
+  id: number;
+  name: string;
+  agreed_to_tos: boolean;
+  acknowledged_policy_version: string | null;
+  group_admin: boolean;
+  email: string;
+  created_at: string;
+  role: GroupRole;
+}
+
 export const mapGroupData = (obj: RawGroupRequest): Group => {
   return {
     address: obj.address,
@@ -43,6 +53,19 @@ const mapGroupInvitations = (obj: RawInvitationResponse): Invitation => {
     id: obj.id,
     invitee: obj.invitee,
     inviter: obj.inviter,
+  };
+};
+
+export const mapGroupMemberData = (obj: RawGroupMemberRequest): GroupMember => {
+  return {
+    acknowledgedPolicyVersion: obj.acknowledged_policy_version,
+    agreedToTos: obj.agreed_to_tos,
+    createdAt: obj.created_at,
+    email: obj.email,
+    id: obj.id,
+    isGroupAdmin: obj.group_admin,
+    name: obj.name,
+    role: obj.role,
   };
 };
 
@@ -79,7 +102,7 @@ export async function fetchGroup({
  */
 
 interface GroupMembersFetchResponseType {
-  members: RawUserRequest[];
+  members: RawGroupMemberRequest[];
 }
 
 export const USE_GROUP_MEMBER_INFO = {
@@ -89,7 +112,7 @@ export const USE_GROUP_MEMBER_INFO = {
 
 export function useGroupMembersInfo(
   groupId?: number
-): UseQueryResult<User[], unknown> {
+): UseQueryResult<GroupMember[], unknown> {
   return useQuery(
     [USE_GROUP_MEMBER_INFO],
     () => fetchGroupMembers({ groupId }),
@@ -97,7 +120,7 @@ export function useGroupMembersInfo(
       retry: false,
       select: (data) => {
         const { members } = data;
-        return members.map((m) => mapUserData(m));
+        return members.map((m) => mapGroupMemberData(m));
       },
     }
   );

--- a/src/frontend/src/common/styles/mixins/global.ts
+++ b/src/frontend/src/common/styles/mixins/global.ts
@@ -39,3 +39,5 @@ export const ContentStyles = (props: CommonThemeProps) => {
     `)}
   `;
 };
+
+export const MAX_CONTENT_WIDTH = 1308;

--- a/src/frontend/src/common/types/invitation.d.ts
+++ b/src/frontend/src/common/types/invitation.d.ts
@@ -1,0 +1,11 @@
+interface Invitation {
+  id: string;
+  createdAt: string;
+  expiresAt: string;
+  inviter: {
+    name: string;
+  };
+  invitee: {
+    email: string;
+  };
+}

--- a/src/frontend/src/common/types/user.d.ts
+++ b/src/frontend/src/common/types/user.d.ts
@@ -6,12 +6,23 @@ interface Group {
   prefix: string;
 }
 
-interface User {
+type BaseUser = {
   id: number;
   name: string;
-  isGroupAdmin?: boolean;
-  group?: Group;
   agreedToTos: boolean;
   acknowledgedPolicyVersion: string | null; // Date or null in DB. ISO 8601: "YYYY-MM-DD"
+};
+
+interface User extends BaseUser {
+  group: Group;
   splitId: string;
+}
+
+type GroupRole = "member" | "admin";
+
+interface GroupMember extends BaseUser {
+  createdAt: string; // not yet returned from backend
+  email: string;
+  isGroupAdmin: boolean;
+  role: GroupRole; // not yet returned from backend
 }

--- a/src/frontend/src/common/utils/userUtils.ts
+++ b/src/frontend/src/common/utils/userUtils.ts
@@ -1,8 +1,17 @@
-export const getGroupIdFromUser = (user?: User): number | undefined => {
-  if (!user) return;
+// (mlila): get the group id off a user. If one is not available, return an invalid number.
+// This is a hack to enable multiple hooks to be used in components.
+// For example, if we run /me and the request has not returned yet, no user info is
+// available to get a group id. However, since data hooks (api calls) cannot be run conditionally,
+// we cannot return null from the component at the point where we know there is no user
+// data available.
+
+// In the future, we may want to consider changing api calls from hooks (function whose names begin
+// with `use`, to regular functions to facilitate this kind of request stacking)
+export const getGroupIdFromUser = (user?: User): number => {
+  if (!user) return -1;
 
   const { group } = user;
-  if (!group) return;
+  if (!group) return -1;
 
   const { id } = group;
   return id;

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
@@ -10,9 +10,9 @@ import {
 } from "./style";
 
 interface Props {
-  address: string;
-  location: string;
-  prefix: string;
+  address?: string;
+  location?: string;
+  prefix?: string;
 }
 
 const GroupDetailsTab = ({ address, location, prefix }: Props): JSX.Element => {

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/index.tsx
@@ -3,18 +3,17 @@ import { Table } from "src/common/components/library/Table";
 import { PersonIconCell } from "../PersonIconCell";
 
 interface Props {
-  members: any;
+  members: GroupMember[];
 }
 
 const ActiveMembersTable = ({ members }: Props): JSX.Element => {
   const headers = ["Member Name", "Email", "Date Added", "Role"];
 
-  // TODO (mlila): types
-  const rows = members.map((m: any) => {
+  const rows = members.map((m: GroupMember) => {
     return [
       <PersonIconCell key={0} content={m.name} />,
       m.email,
-      m.joinedDate,
+      m.createdAt,
       m.role,
     ];
   });

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Dialog, DialogActions, DialogTitle } from "czifui";
-import { compact } from "lodash";
+import { compact, uniq } from "lodash";
 import React, { ChangeEvent, useState } from "react";
 import { noop } from "src/common/constants/empty";
 import { INPUT_DELIMITERS } from "src/common/constants/inputDelimiters";
@@ -49,7 +49,7 @@ const InviteModal = ({ groupName, onClose, open }: Props): JSX.Element => {
   };
 
   const getAddressArrayFromInputValue = () => {
-    return inputValue.trim().split(INPUT_DELIMITERS);
+    return uniq(inputValue.trim().split(INPUT_DELIMITERS));
   };
 
   const validate = (): boolean => {

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/components/EmailCell/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/components/EmailCell/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Tag } from "src/common/components/library/Tag";
 import { PersonIconCell } from "../../../PersonIconCell";
-import { Wrapper } from "./style";
+import { StyledChip, Wrapper } from "./style";
 
 interface Props {
   email: string;
@@ -9,17 +8,12 @@ interface Props {
 }
 
 const EmailCell = ({ email, status }: Props): JSX.Element => {
-  const color = status === "expired" ? "warning" : "primary";
+  const color = status === "expired" ? "warning" : "info";
 
   return (
     <Wrapper>
       <PersonIconCell content={email} />
-      <Tag
-        color={color}
-        sdsType="secondary"
-        sdsStyle="rounded"
-        label={status}
-      />
+      <StyledChip status={color} isRounded size="small" label={status} />
     </Wrapper>
   );
 };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/components/EmailCell/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/components/EmailCell/style.ts
@@ -1,6 +1,16 @@
 import styled from "@emotion/styled";
+import { Chip, getSpaces } from "czifui";
 
 export const Wrapper = styled.span`
   display: flex;
   align-items: center;
+`;
+
+export const StyledChip = styled(Chip)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-left: ${spaces?.l}px;
+    `;
+  }}
 `;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/index.tsx
@@ -3,18 +3,24 @@ import { Table } from "src/common/components/library/Table";
 import { EmailCell } from "./components/EmailCell";
 
 interface Props {
-  invites: any;
+  invites: Invitation[];
 }
 
 const MemberInvitationsTable = ({ invites }: Props): JSX.Element => {
   const headers = ["Email", "Date Sent", "Role"];
 
-  // TODO (mlila): types
-  const rows = invites.map((i: any) => [
-    <EmailCell key={0} email={i.email} status={i.status} />,
-    i.dateSent,
-    i.role,
-  ]);
+  const rows = invites.map((i: Invitation) => {
+    const { invitee, expiresAt, createdAt } = i;
+    const expirationDate = Date.parse(expiresAt);
+    const hasExpired = expirationDate < Date.now();
+    const status = hasExpired ? "expired" : "pending";
+
+    return [
+      <EmailCell key={0} email={invitee.email} status={status} />,
+      createdAt,
+      "member", // this may vary in the future, but for now only one type of invitation is available
+    ];
+  });
 
   return <Table headers={headers} rows={rows} />;
 };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/index.tsx
@@ -18,7 +18,7 @@ const MemberInvitationsTable = ({ invites }: Props): JSX.Element => {
     return [
       <EmailCell key={0} email={invitee.email} status={status} />,
       createdAt,
-      "member", // this may vary in the future, but for now only one type of invitation is available
+      "Member", // this may vary in the future, but for now only one type of invitation is available
     ];
   });
 

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/PersonIconCell/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/PersonIconCell/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { getColors } from "czifui";
+import { getColors, getSpaces } from "czifui";
 
 export const StyledCell = styled.span`
   display: flex;
@@ -14,8 +14,13 @@ export const StyledCell = styled.span`
 
   ${(props) => {
     const colors = getColors(props);
+    const spaces = getSpaces(props);
 
     return `
+      svg {
+        margin-right: ${spaces?.m}px;
+      }
+
       path {
         fill: ${colors?.gray[300]};
       }

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -12,35 +12,22 @@ import { InviteModal } from "./components/InviteModal";
 import { MemberInvitationsTable } from "./components/MemberInvitationsTable";
 import { Header, StyledTabs } from "./style";
 
-enum SecondaryTabType {
+export enum SecondaryTabType {
   ACTIVE = "active",
   INVITATIONS = "invitations",
 }
 
 interface Props {
-  secondaryQueryParam?: string;
+  initialSecondaryTab?: SecondaryTabType;
   groupName: string;
   members: GroupMember[];
 }
 
-const isValidSecondaryTab = (token?: string) => {
-  if (!token) return false;
-  return (
-    token === SecondaryTabType.ACTIVE || token === SecondaryTabType.INVITATIONS
-  );
-};
-
 const MembersTab = ({
-  secondaryQueryParam,
+  initialSecondaryTab = SecondaryTabType.ACTIVE,
   groupName,
   members,
 }: Props): JSX.Element => {
-  const initialSecondaryTab = (
-    isValidSecondaryTab(secondaryQueryParam)
-      ? secondaryQueryParam
-      : SecondaryTabType.ACTIVE
-  ) as SecondaryTabType;
-
   const [tabValue, setTabValue] =
     useState<SecondaryTabType>(initialSecondaryTab);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -2,7 +2,10 @@ import { Button, Tab } from "czifui";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import { HeadAppTitle } from "src/common/components";
+import { useUserInfo } from "src/common/queries/auth";
+import { useGroupInvitations } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
+import { getGroupIdFromUser } from "src/common/utils/userUtils";
 import { TabEventHandler } from "../../index";
 import { ActiveMembersTable } from "./components/ActiveMembersTable";
 import { InviteModal } from "./components/InviteModal";
@@ -44,6 +47,10 @@ const MembersTab = ({
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const router = useRouter();
 
+  const { data: userInfo } = useUserInfo();
+  const groupId = getGroupIdFromUser(userInfo);
+  const { data: invitations = [] } = useGroupInvitations(groupId);
+
   useEffect(() => {
     router.push(`${ROUTES.GROUP_MEMBERS}/${tabValue}`, undefined, {
       shallow: true,
@@ -56,23 +63,7 @@ const MembersTab = ({
     setTabValue(value);
   };
 
-  // TODO (mlila): api call
-  const invites = [
-    {
-      email: "erica@fake.com",
-      status: "pending",
-      dateSent: "2022-05-24",
-      role: "Member",
-    },
-    {
-      email: "frank@fake.com",
-      status: "expired",
-      dateSent: "2022-03-24",
-      role: "Member",
-    },
-  ];
-
-  invites.sort((a, b) => (a.dateSent > b.dateSent ? 1 : -1));
+  invitations.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));
 
   return (
     <>
@@ -97,7 +88,7 @@ const MembersTab = ({
           <Tab
             value={SecondaryTabType.INVITATIONS}
             label="Invitations"
-            count={invites.length}
+            count={invitations.length}
           />
         </StyledTabs>
         <Button
@@ -112,7 +103,7 @@ const MembersTab = ({
         <ActiveMembersTable members={members} />
       )}
       {tabValue === SecondaryTabType.INVITATIONS && (
-        <MemberInvitationsTable invites={invites} />
+        <MemberInvitationsTable invites={invitations} />
       )}
     </>
   );

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -16,8 +16,8 @@ export enum SecondaryTabType {
 }
 
 interface Props {
-  initialSecondaryTab?: SecondaryTabType;
-  groupName: string;
+  initialSecondaryTab: SecondaryTabType;
+  groupName?: string;
   groupId?: number;
   members: GroupMember[];
 }
@@ -46,11 +46,13 @@ const MembersTab = ({
   return (
     <Container>
       <HeadAppTitle subTitle="Group Details" />
-      <InviteModal
-        onClose={() => setIsInviteModalOpen(false)}
-        groupName={groupName}
-        open={isInviteModalOpen}
-      />
+      {groupName && (
+        <InviteModal
+          onClose={() => setIsInviteModalOpen(false)}
+          groupName={groupName}
+          open={isInviteModalOpen}
+        />
+      )}
       <Header>
         <StyledTabs value={tabValue} sdsSize="small" onChange={handleTabClick}>
           <Tab

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -17,11 +17,10 @@ enum SecondaryTabType {
   INVITATIONS = "invitations",
 }
 
-//TODO (mlila): types
 interface Props {
   secondaryQueryParam?: string;
   groupName: string;
-  members: any[];
+  members: GroupMember[];
 }
 
 const isValidSecondaryTab = (token?: string) => {

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -1,11 +1,9 @@
 import { Button, Tab } from "czifui";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { HeadAppTitle } from "src/common/components";
-import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInvitations } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
-import { getGroupIdFromUser } from "src/common/utils/userUtils";
 import { TabEventHandler } from "../../index";
 import { ActiveMembersTable } from "./components/ActiveMembersTable";
 import { InviteModal } from "./components/InviteModal";
@@ -20,33 +18,27 @@ export enum SecondaryTabType {
 interface Props {
   initialSecondaryTab?: SecondaryTabType;
   groupName: string;
+  groupId?: number;
   members: GroupMember[];
 }
 
 const MembersTab = ({
-  initialSecondaryTab = SecondaryTabType.ACTIVE,
+  initialSecondaryTab,
   groupName,
+  groupId,
   members,
 }: Props): JSX.Element => {
   const [tabValue, setTabValue] =
     useState<SecondaryTabType>(initialSecondaryTab);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const router = useRouter();
-
-  const { data: userInfo } = useUserInfo();
-  const groupId = getGroupIdFromUser(userInfo);
   const { data: invitations = [] } = useGroupInvitations(groupId);
-
-  useEffect(() => {
-    router.push(`${ROUTES.GROUP_MEMBERS}/${tabValue}`, undefined, {
-      shallow: true,
-    });
-  }, [tabValue]);
 
   const numActive = Object.keys(members).length;
 
   const handleTabClick: TabEventHandler = (_, value) => {
     setTabValue(value);
+    router.push(`${ROUTES.GROUP_MEMBERS}/${value}`);
   };
 
   invitations.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -41,7 +41,7 @@ const MembersTab = ({
     router.push(`${ROUTES.GROUP_MEMBERS}/${value}`);
   };
 
-  invitations.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));
+  invitations.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
 
   return (
     <>

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -52,12 +52,7 @@ const MembersTab = ({
         open={isInviteModalOpen}
       />
       <Header>
-        <StyledTabs
-          value={tabValue}
-          sdsSize="small"
-          onChange={handleTabClick}
-          underlined
-        >
+        <StyledTabs value={tabValue} sdsSize="small" onChange={handleTabClick}>
           <Tab
             value={SecondaryTabType.ACTIVE}
             label="Active"

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -8,7 +8,7 @@ import { TabEventHandler } from "../../index";
 import { ActiveMembersTable } from "./components/ActiveMembersTable";
 import { InviteModal } from "./components/InviteModal";
 import { MemberInvitationsTable } from "./components/MemberInvitationsTable";
-import { Header, StyledTabs } from "./style";
+import { Container, Header, StyledTabs } from "./style";
 
 export enum SecondaryTabType {
   ACTIVE = "active",
@@ -44,7 +44,7 @@ const MembersTab = ({
   invitations.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
 
   return (
-    <>
+    <Container>
       <HeadAppTitle subTitle="Group Details" />
       <InviteModal
         onClose={() => setIsInviteModalOpen(false)}
@@ -78,7 +78,7 @@ const MembersTab = ({
       {tabValue === SecondaryTabType.INVITATIONS && (
         <MemberInvitationsTable invites={invitations} />
       )}
-    </>
+    </Container>
   );
 };
 

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -18,7 +18,7 @@ export enum SecondaryTabType {
 interface Props {
   initialSecondaryTab: SecondaryTabType;
   groupName?: string;
-  groupId?: number;
+  groupId: number;
   members: GroupMember[];
 }
 

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/style.ts
@@ -1,5 +1,13 @@
 import styled from "@emotion/styled";
 import { getSpaces, Tabs } from "czifui";
+import { MAX_CONTENT_WIDTH } from "src/common/styles/mixins/global";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+  max-width: ${MAX_CONTENT_WIDTH}px;
+`;
 
 export const Header = styled.div`
   display: flex;

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -26,8 +26,8 @@ export type TabEventHandler = (
 ) => void;
 
 interface Props {
-  initialPrimaryTab?: PrimaryTabType;
-  initialSecondaryTab?: SecondaryTabType;
+  initialPrimaryTab: PrimaryTabType;
+  initialSecondaryTab: SecondaryTabType;
 }
 
 const GroupMembersPage = ({

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -1,6 +1,6 @@
 import { Tab } from "czifui";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
@@ -31,7 +31,7 @@ interface Props {
 }
 
 const GroupMembersPage = ({
-  initialPrimaryTab = PrimaryTabType.MEMBERS,
+  initialPrimaryTab,
   initialSecondaryTab,
 }: Props): JSX.Element | null => {
   const [tabValue, setTabValue] = useState<PrimaryTabType>(initialPrimaryTab);
@@ -57,6 +57,7 @@ const GroupMembersPage = ({
 
   const handleTabClick: TabEventHandler = (_, value) => {
     setTabValue(value);
+    router.push(`${ROUTES.GROUP}/${value}`);
   };
 
   return (

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -42,13 +42,7 @@ const GroupMembersPage = ({
   const { data: members = [] } = useGroupMembersInfo(groupId);
   const { data: groupInfo } = useGroupInfo(groupId);
 
-  useEffect(() => {
-    router.push(`${ROUTES.GROUP}/${tabValue}`, undefined, { shallow: true });
-  }, [tabValue]);
-
-  if (!groupInfo) return null;
-
-  const { address, location, name, prefix } = groupInfo;
+  const { address, location, name, prefix } = groupInfo ?? {};
 
   // sort group members by name before display
   members.sort((a, b) => (a.name > b.name ? 1 : -1));
@@ -79,6 +73,7 @@ const GroupMembersPage = ({
           <MembersTab
             initialSecondaryTab={initialSecondaryTab}
             groupName={name}
+            groupId={groupId}
             members={members}
           />
         )}

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -7,7 +7,7 @@ import { ROUTES } from "src/common/routes";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import { getGroupIdFromUser } from "src/common/utils/userUtils";
 import { GroupDetailsTab } from "./components/GroupDetailsTab";
-import { MembersTab } from "./components/MembersTab";
+import { MembersTab, SecondaryTabType } from "./components/MembersTab";
 import {
   StyledHeader,
   StyledName,
@@ -15,7 +15,7 @@ import {
   StyledTabs,
 } from "./style";
 
-enum PrimaryTabType {
+export enum PrimaryTabType {
   MEMBERS = "members",
   DETAILS = "details",
 }
@@ -26,21 +26,14 @@ export type TabEventHandler = (
 ) => void;
 
 interface Props {
-  pathTokens?: string[];
+  initialPrimaryTab?: PrimaryTabType;
+  initialSecondaryTab?: SecondaryTabType;
 }
 
-const isValidPrimaryTab = (token?: string) => {
-  return token === PrimaryTabType.MEMBERS || token === PrimaryTabType.DETAILS;
-};
-
-const GroupMembersPage = ({ pathTokens }: Props): JSX.Element | null => {
-  const [primaryQueryParam, secondaryQueryParam] = pathTokens ?? [];
-  const initialPrimaryTab = (
-    isValidPrimaryTab(primaryQueryParam)
-      ? primaryQueryParam
-      : PrimaryTabType.MEMBERS
-  ) as PrimaryTabType;
-
+const GroupMembersPage = ({
+  initialPrimaryTab = PrimaryTabType.MEMBERS,
+  initialSecondaryTab,
+}: Props): JSX.Element | null => {
   const [tabValue, setTabValue] = useState<PrimaryTabType>(initialPrimaryTab);
   const router = useRouter();
 
@@ -83,7 +76,7 @@ const GroupMembersPage = ({ pathTokens }: Props): JSX.Element | null => {
       <StyledPageContent>
         {tabValue === PrimaryTabType.MEMBERS && (
           <MembersTab
-            secondaryQueryParam={secondaryQueryParam}
+            initialSecondaryTab={initialSecondaryTab}
             groupName={name}
             members={members}
           />


### PR DESCRIPTION
### Summary
- **What:**
  - Cleaned up the majority of the outstanding nits, bad types, and design tweaks for the group pages and invite flow
  - Pull invites from API instead of hard code
- **Ticket:** [[sc-187620]](https://app.shortcut.com/genepi/story/187620)
- **Env:** https://maya-onboarding-frontend.dev.czgenepi.org/group
- **Design:** https://www.figma.com/file/SALQZGfIJntBes0HvIzVeX/Onboarding-New-Users-V0?node-id=402%3A54277

### Notes
- Review each commit ~1 at a time for clarity
- Jess said the invites endpoint is expected to eat it atm since we haven't completed the migration yet, so don't expect the requests to succeed of display anything (invites table only)
  - On this note, PLEASE DO NOT RELEASE THIS PUBLICLY until the the migration is complete or we expect it to work in prod. Also, the front end code will need a manual test after that happens to make sure there aren't bugs.
- I did not get to debounce validation in the invite modal

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)