### PR TITLE
fix: Add a delay when migrations are not needed

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -55,6 +55,7 @@ remote-db-migrations:
 		aspen-cli db --remote setup; \
 	fi
 	DB=remote alembic upgrade head
+	sleep 60
 
 .PHONY: remote-db-drop
 remote-db-drop:


### PR DESCRIPTION
Let happy pick up the logs; if `sleep 60` is not present, and migrations don't run, happy doesn't pick up any logs and fails with a non-0 return code, even though the whole process succeeds.