### PR TITLE
don't show invite button if user isn't admin

### DIFF
--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -1,7 +1,9 @@
 import { Button, Tab } from "czifui";
+import { find } from "lodash";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { HeadAppTitle } from "src/common/components";
+import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInvitations } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
 import { TabEventHandler } from "../../index";
@@ -27,13 +29,16 @@ const MembersTab = ({
   groupName,
   groupId,
   members,
-}: Props): JSX.Element => {
+}: Props): JSX.Element | null => {
   const [tabValue, setTabValue] =
     useState<SecondaryTabType>(initialSecondaryTab);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const router = useRouter();
   const { data: invitations = [] } = useGroupInvitations(groupId);
+  const { data: userInfo } = useUserInfo();
+  const currentUser = find(members, (m) => m.id === userInfo?.id);
 
+  const isOwner = currentUser?.isGroupAdmin === true;
   const numActive = Object.keys(members).length;
 
   const handleTabClick: TabEventHandler = (_, value) => {
@@ -66,13 +71,15 @@ const MembersTab = ({
             count={invitations.length}
           />
         </StyledTabs>
-        <Button
-          sdsType="primary"
-          sdsStyle="rounded"
-          onClick={() => setIsInviteModalOpen(true)}
-        >
-          Invite
-        </Button>
+        {isOwner && (
+          <Button
+            sdsType="primary"
+            sdsStyle="rounded"
+            onClick={() => setIsInviteModalOpen(true)}
+          >
+            Invite
+          </Button>
+        )}
       </Header>
       {tabValue === SecondaryTabType.ACTIVE && (
         <ActiveMembersTable members={members} />


### PR DESCRIPTION
### Summary:
- **What:** only admins should be allowed to invite new users to group
- **Ticket:** [sc200919](https://app.shortcut.com/genepi/story/200919)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)