### PR TITLE
Handle multi-delimited emails; handle spaces

### DIFF
--- a/src/frontend/src/common/constants/inputDelimiters.ts
+++ b/src/frontend/src/common/constants/inputDelimiters.ts
@@ -1,1 +1,2 @@
-export const INPUT_DELIMITERS = /[\n\t,]/g;
+export const INPUT_DELIMITERS = /[\n\t, ]/g;
+export const GREEDY_SPACES = / +/g;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -63,10 +63,6 @@ const InviteModal = ({ groupName, onClose, open }: Props): JSX.Element => {
    *     user1@example.com,   user2@example.com, ,, ,,  , user3@example.com,,
    *   user2@example.com, user4@example.com,,
    * Would return as four emails in total, as you'd expect to read them.
-   *
-   * Arguable if it's best UX -- should double commas bring up an error? etc --
-   * but it's easiest to code and reasonably sane to just ignore that sort
-   * of stuff. Approach was approved by Design.
    */
   const getAddressArrayFromInputValue = (): string[] => {
     // First pass may have multiple spaces between chunks or pre/suffix spaces

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -2,7 +2,10 @@ import { Button, Dialog, DialogActions, DialogTitle } from "czifui";
 import { compact, uniq } from "lodash";
 import React, { ChangeEvent, useState } from "react";
 import { noop } from "src/common/constants/empty";
-import { INPUT_DELIMITERS } from "src/common/constants/inputDelimiters";
+import {
+  GREEDY_SPACES,
+  INPUT_DELIMITERS,
+} from "src/common/constants/inputDelimiters";
 import { useUserInfo } from "src/common/queries/auth";
 import { useSendGroupInvitations } from "src/common/queries/groups";
 import { B } from "src/common/styles/basicStyle";
@@ -48,12 +51,35 @@ const InviteModal = ({ groupName, onClose, open }: Props): JSX.Element => {
     onClose();
   };
 
-  const getAddressArrayFromInputValue = () => {
-    return uniq(inputValue.trim().split(INPUT_DELIMITERS));
+  /**
+   * Gets user input and chunks into (what should be) email addresses.
+   *
+   * Original user input text is broken into chunks by delimiters. Repeated
+   * delimiters between chunks are taken as a single delimiter. Leading and
+   * trailing delimiters are dropped. If a given chunk is found multiple times
+   * in the input, only one copy of the chunk is returned in output array.
+   *
+   * Example:
+   *     user1@example.com,   user2@example.com, ,, ,,  , user3@example.com,,
+   *   user2@example.com, user4@example.com,,
+   * Would return as four emails in total, as you'd expect to read them.
+   *
+   * Arguable if it's best UX -- should double commas bring up an error? etc --
+   * but it's easiest to code and reasonably sane to just ignore that sort
+   * of stuff. Approach was approved by Design.
+   */
+  const getAddressArrayFromInputValue = (): string[] => {
+    // First pass may have multiple spaces between chunks or pre/suffix spaces
+    const delimitBySpaces = inputValue.replace(INPUT_DELIMITERS, " ");
+    const delimitBySingleSpaceTrimmed = delimitBySpaces
+      .trim()
+      .replace(GREEDY_SPACES, " ");
+    const addressChunks = delimitBySingleSpaceTrimmed.split(" ");
+    return uniq(addressChunks);
   };
 
-  const validate = (): boolean => {
-    const addresses = getAddressArrayFromInputValue();
+  // Returns bool of if emails valid. If not, sets the state to show errors.
+  const validate = (addresses: string[]): boolean => {
     const newInvalidAddresses = compact(
       addresses.filter((address) => !address.match(EMAIL_REGEX))
     );
@@ -65,6 +91,7 @@ const InviteModal = ({ groupName, onClose, open }: Props): JSX.Element => {
 
     // after they click the button to send invites once, we should debounce validate on
     // all subsequent changes
+    // TODO: debounce check validation on subsequent changes
     setShouldValidateOnChange(true);
 
     return (
@@ -98,11 +125,12 @@ const InviteModal = ({ groupName, onClose, open }: Props): JSX.Element => {
   });
 
   const handleFormSubmit = () => {
-    const areAllAddressesValid = validate();
-    if (!areAllAddressesValid) return;
-
     const emails = getAddressArrayFromInputValue();
-    sendInvitationMutation.mutate({ emails, groupId });
+    // If invalid, `validate` will alter state and cause error display
+    const areAllAddressesValid = validate(emails);
+    if (areAllAddressesValid) {
+      sendInvitationMutation.mutate({ emails, groupId });
+    }
   };
 
   return (


### PR DESCRIPTION
### Summary:
- **What:** Fixes to email address parsing in the "invite" new members dialog
- **Ticket:** Part of [sc<200919>](https://app.shortcut.com/genepi/story/<200919>)
- **Env:** none

### Demos:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/89553795/173117020-f6477b4a-96d0-4178-897b-44cdc91a0917.png">

Would send out these three invites

<img width="673" alt="image" src="https://user-images.githubusercontent.com/89553795/173117080-a19b0123-f500-44a4-a9b0-04156a470cc4.png">

---

Still capturing bad emails

<img width="567" alt="image" src="https://user-images.githubusercontent.com/89553795/173117237-eb9ab04f-4cca-41f9-83e8-91d9912a208f.png">


### Notes:



### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)