### PR TITLE
Automatically strip leading/trailing whitespace in input strings.

### DIFF
--- a/src/backend/aspen/api/schemas/base.py
+++ b/src/backend/aspen/api/schemas/base.py
@@ -4,7 +4,12 @@ from pydantic import BaseModel
 
 
 class BaseRequest(BaseModel):
-    pass
+    class Config:
+        """Extra configuration options"""
+
+        anystr_strip_whitespace = (
+            True  # remove leading/trailing whitespace from strings
+        )
 
 
 def convert_datetime_to_iso_8601(dt: datetime) -> str:

--- a/src/backend/aspen/api/views/tests/test_create_samples.py
+++ b/src/backend/aspen/api/views/tests/test_create_samples.py
@@ -128,7 +128,7 @@ async def test_stripping_whitespace(
     data = [
         {
             "sample": {
-                "private_identifier": "   private   ",
+                "private_identifier": "\t   private   ",
                 "public_identifier": "   public   ",
                 "collection_date": format_date(test_date),
                 "location_id": location.id,


### PR DESCRIPTION
### Summary:
- **What:** Enable pydantic automatic leading/trailing whitespace stripping feature

### Notes:
Pydantic docs are here: https://pydantic-docs.helpmanual.io/usage/model_config/#options
We've already encountered some issues with samples with leading/trailing tabs and spaces in their identifier names, and keeping extra whitespace is never the right behavior for this app.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)