### PR TITLE
Make sure system admins can invite people to any group

### DIFF
--- a/src/backend/aspen/api/views/groups.py
+++ b/src/backend/aspen/api/views/groups.py
@@ -90,7 +90,7 @@ async def invite_group_members(
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
 ) -> GroupInvitationsResponse:
-    if user.group.id != group_id:
+    if user.group.id != group_id and not user.system_admin:
         raise ex.UnauthorizedException("Not authorized")
     group = (
         (await db.execute(sa.select(Group).where(Group.id == group_id))).scalars().one()  # type: ignore

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -361,21 +361,24 @@ def create(
 def group():
     pass
 
+
 @group.command(name="get")
 @click.argument("group_id")
 @click.pass_context
 def get_group_info(ctx, group_id):
     api_client = ctx.obj["api_client"]
-    resp = api_client.get(f"/v2/groups/{group_id}")
+    resp = api_client.get(f"/v2/groups/{group_id}/")
     print(resp.text)
+
 
 @group.command(name="members")
 @click.argument("group_id")
 @click.pass_context
-def get_group_imembers(ctx, group_id):
+def get_group_members(ctx, group_id):
     api_client = ctx.obj["api_client"]
-    resp = api_client.get(f"/v2/groups/{group_id}/members")
+    resp = api_client.get(f"/v2/groups/{group_id}/members/")
     print(resp.text)
+
 
 @group.command(name="invites")
 @click.argument("group_id")
@@ -385,12 +388,16 @@ def get_group_invitations(ctx, group_id):
     resp = api_client.get(f"/v2/groups/{group_id}/invitations/")
     print(resp.text)
 
+
 @group.command(name="invite")
 @click.argument("group_id")
 @click.argument("email")
-@click.option("--role", help="Role to invite the user to",
+@click.option(
+    "--role",
+    help="Role to invite the user to",
     type=click.Choice(["admin", "member"], case_sensitive=False),
-    default="member")
+    default="member",
+)
 @click.pass_context
 def invite_group_members(ctx, group_id, email, role):
     api_client = ctx.obj["api_client"]
@@ -401,16 +408,10 @@ def invite_group_members(ctx, group_id, email, role):
     resp = api_client.post(f"/v2/groups/{group_id}/invitations/", json=body)
     print(resp.text)
 
+
 @cli.group()
 def userinfo():
     pass
-
-@userinfo.command(name="get")
-@click.pass_context
-def get_userinfo(ctx):
-    api_client = ctx.obj["api_client"]
-    resp = api_client.get("/api/usergroup")
-    print(resp.text)
 
 
 @cli.group()
@@ -539,9 +540,7 @@ def delete_samples(ctx, sample_ids):
 @click.option(
     "--location", required=False, type=int, help="Set the sample's collection location"
 )
-@click.option(
-    "--json-data", required=False, type=str, help="provide json for update"
-)
+@click.option("--json-data", required=False, type=str, help="provide json for update")
 @click.pass_context
 def update_samples(
     ctx,


### PR DESCRIPTION
### Summary:
- **What:** Make sure system admins can invite users to any group
- **Ticket:** [sc200305](https://app.shortcut.com/genepi/story/200305)

### Notes:
For the time being, only system admins can create new groups, so only system admins will have the authority to invite the first user(s) to new, memberless groups. This PR increases their privileges and has a few small path/route fixes for the CLI.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)