### PR TITLE
Fix tree title

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -1,6 +1,7 @@
 from typing import Any, Mapping
 
 import yaml
+import dateparser
 
 from aspen.database.models import Group
 
@@ -55,14 +56,17 @@ class BaseNextstrainConfigBuilder:
         #   - It's title-case'd and included in the tree title as human-readable text
         build["subsampling_scheme"] = self.subsampling_scheme
 
-        # Update the tree's title with build type & location.
-        if self.subsampling_scheme == "OVERVIEW":
-            title_template = "Contextualized tree for samples collected in {location} in the last 3 months"
+        # Update the tree's title with build type, location and date range.
+        if (self.template_args.get("filter_start_date") is not None) and (self.template_args.get("filter_end_date") is not None):
+            title_template = "{tree_type} tree for samples collected in {location} between {start_date} and {end_date}"
         else:
             title_template = "{tree_type} tree for samples collected in {location}"
+
         build["title"] = title_template.format(
             tree_type=self.subsampling_scheme.title(),
             location=", ".join(location_values),
+            start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
+            end_data=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
         )
         config["files"]["description"] = config["files"]["description"].format(
             tree_type=self.subsampling_scheme.lower()

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping
 
-import yaml
 import dateparser
+import yaml
 
 from aspen.database.models import Group
 

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -59,15 +59,19 @@ class BaseNextstrainConfigBuilder:
         # Update the tree's title with build type, location and date range.
         if (self.template_args.get("filter_start_date") is not None) and (self.template_args.get("filter_end_date") is not None):
             title_template = "{tree_type} tree for samples collected in {location} between {start_date} and {end_date}"
+            build["title"] = title_template.format(
+                        tree_type=self.subsampling_scheme.title(),
+                        location=", ".join(location_values),
+                        start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
+                        end_data=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
+                    )
         else:
             title_template = "{tree_type} tree for samples collected in {location}"
+            build["title"] = title_template.format(
+                        tree_type=self.subsampling_scheme.title(),
+                        location=", ".join(location_values)
+                    )
 
-        build["title"] = title_template.format(
-            tree_type=self.subsampling_scheme.title(),
-            location=", ".join(location_values),
-            start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
-            end_data=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
-        )
         config["files"]["description"] = config["files"]["description"].format(
             tree_type=self.subsampling_scheme.lower()
         )

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -60,17 +60,17 @@ class BaseNextstrainConfigBuilder:
         if (self.template_args.get("filter_start_date") is not None) and (self.template_args.get("filter_end_date") is not None):
             title_template = "{tree_type} tree for samples collected in {location} between {start_date} and {end_date}"
             build["title"] = title_template.format(
-                        tree_type=self.subsampling_scheme.title(),
-                        location=", ".join(location_values),
-                        start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
-                        end_date=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
-                    )
+                tree_type=self.subsampling_scheme.title(),
+                location=", ".join(location_values),
+                start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
+                end_date=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
+            )
         else:
             title_template = "{tree_type} tree for samples collected in {location}"
             build["title"] = title_template.format(
-                        tree_type=self.subsampling_scheme.title(),
-                        location=", ".join(location_values)
-                    )
+                tree_type=self.subsampling_scheme.title(),
+                location=", ".join(location_values)
+            )
 
         config["files"]["description"] = config["files"]["description"].format(
             tree_type=self.subsampling_scheme.lower()

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -63,7 +63,7 @@ class BaseNextstrainConfigBuilder:
                         tree_type=self.subsampling_scheme.title(),
                         location=", ".join(location_values),
                         start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
-                        end_data=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
+                        end_date=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
                     )
         else:
             title_template = "{tree_type} tree for samples collected in {location}"

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -69,13 +69,13 @@ class BaseNextstrainConfigBuilder:
                 ).strftime("%Y-%m-%d"),
                 end_date=dateparser.parse(
                     self.template_args.get("filter_end_date")
-                ).strftime("%Y-%m-%d")
+                ).strftime("%Y-%m-%d"),
             )
         else:
             title_template = "{tree_type} tree for samples collected in {location}"
             build["title"] = title_template.format(
                 tree_type=self.subsampling_scheme.title(),
-                location=", ".join(location_values)
+                location=", ".join(location_values),
             )
 
         config["files"]["description"] = config["files"]["description"].format(

--- a/src/backend/aspen/workflows/nextstrain_run/builder_base.py
+++ b/src/backend/aspen/workflows/nextstrain_run/builder_base.py
@@ -57,13 +57,19 @@ class BaseNextstrainConfigBuilder:
         build["subsampling_scheme"] = self.subsampling_scheme
 
         # Update the tree's title with build type, location and date range.
-        if (self.template_args.get("filter_start_date") is not None) and (self.template_args.get("filter_end_date") is not None):
+        if (self.template_args.get("filter_start_date") is not None) and (
+            self.template_args.get("filter_end_date") is not None
+        ):
             title_template = "{tree_type} tree for samples collected in {location} between {start_date} and {end_date}"
             build["title"] = title_template.format(
                 tree_type=self.subsampling_scheme.title(),
                 location=", ".join(location_values),
-                start_date=dateparser.parse(self.template_args.get("filter_start_date")).strftime("%Y-%m-%d"),
-                end_date=dateparser.parse(self.template_args.get("filter_end_date")).strftime("%Y-%m-%d")
+                start_date=dateparser.parse(
+                    self.template_args.get("filter_start_date")
+                ).strftime("%Y-%m-%d"),
+                end_date=dateparser.parse(
+                    self.template_args.get("filter_end_date")
+                ).strftime("%Y-%m-%d")
             )
         else:
             title_template = "{tree_type} tree for samples collected in {location}"

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -117,10 +117,7 @@ def test_build_config(mocker, session, postgres_database):
         sequences, selected, metadata, nextstrain_config = generate_run(phylo_run.id)
         build = nextstrain_config["builds"]["aspen"]
         assert build["subsampling_scheme"] == tree_type.value
-        if tree_type.value == "OVERVIEW":
-            assert build["title"].startswith("Contextualized tree for samples")
-        else:
-            assert build["title"].startswith(tree_type.value.title())
+        assert build["title"].startswith(tree_type.value.title())
         assert phylo_run.group.default_tree_location.location in build["title"]
         assert phylo_run.group.default_tree_location.division in build["title"]
         assert build["division"] == phylo_run.group.default_tree_location.division


### PR DESCRIPTION
### Summary:
- **What:** overview tree title currently says "in the last 3 months". This PR will fill the title based on the date range specified [here](https://github.com/chanzuckerberg/czgenepi/blob/9290a4943396a81276d218871b6b63045707c9ce/src/backend/aspen/workflows/nextstrain_run/autorun_scheduled.py#L24) for automatic build, or user selection. 

- **Ticket:** [sc<200292>](https://app.shortcut.com/genepi/story/200292/fix-tree-title-for-on-demand-trees-with-date-and-lineage-filter)

### Demos:
With no date specification, `builds.yaml` has: 
<img width="909" alt="image" src="https://user-images.githubusercontent.com/20667188/173674409-1e896cb5-0d9f-46a8-af31-cc7000d2de99.png">

With date specification
<img width="1707" alt="image" src="https://user-images.githubusercontent.com/20667188/173674810-5c65f099-9212-4f2b-a748-a50e5394b38f.png">

`builds.yaml` has:
<img width="905" alt="image" src="https://user-images.githubusercontent.com/20667188/173675818-b8cee547-299b-48fd-85db-02cefe5d6f3c.png">

Then on the tree (I had to change the date back to 2020 so there are samples left lol)
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/20667188/173684028-a6f4a606-10f7-48d5-b184-20b22926d1cd.png">

With only 1 date sepcification (although I don't think the app allows this on the UI):
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/20667188/173687374-0963c471-b518-4a00-8310-5aed8a3f0f52.png">

`builds.yaml` has:
<img width="881" alt="image" src="https://user-images.githubusercontent.com/20667188/173687776-b70acd5e-5251-4238-8e38-c1e0266558af.png">
and
<img width="412" alt="image" src="https://user-images.githubusercontent.com/20667188/173687830-e628a5f5-36cb-492f-b8a6-bac92bed2280.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)