### PR TITLE
200919/remove 2 columns

### DIFF
--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/index.tsx
@@ -1,24 +1,24 @@
 import React from "react";
 import { Table } from "src/common/components/library/Table";
 import { PersonIconCell } from "../PersonIconCell";
+import { Wrapper } from "./style";
 
 interface Props {
   members: GroupMember[];
 }
 
 const ActiveMembersTable = ({ members }: Props): JSX.Element => {
-  const headers = ["Member Name", "Email", "Date Added", "Role"];
+  const headers = ["Member Name", "Email"];
 
   const rows = members.map((m: GroupMember) => {
-    return [
-      <PersonIconCell key={0} content={m.name} />,
-      m.email,
-      m.createdAt,
-      m.role,
-    ];
+    return [<PersonIconCell key={0} content={m.name} />, m.email];
   });
 
-  return <Table headers={headers} rows={rows} />;
+  return (
+    <Wrapper>
+      <Table headers={headers} rows={rows} />
+    </Wrapper>
+  );
 };
 
 export { ActiveMembersTable };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/style.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+import { StyledCell } from "src/common/components/library/Table/components/Cell/style";
+import {
+  StyledHeader,
+  StyledRow,
+} from "src/common/components/library/Table/components/Row/style";
+
+export const Capitalized = styled.span`
+  text-transform: capitalize;
+`;
+
+// (mlila): This wrapper can be removed when we add more columns to this table again
+// for example, role and date added columns
+export const Wrapper = styled.div`
+  ${StyledHeader},
+  ${StyledRow} {
+    justify-content: space-evenly;
+
+    ${StyledCell} {
+      flex: unset;
+    }
+  }
+`;


### PR DESCRIPTION
### Summary
- **What:** Remove role and date added columns
- **Why:** They'll always be empty for now
- **Ticket:** [[sc-200919]](https://app.shortcut.com/genepi/story/200919)
- **Env:** https://maya-column-remove-frontend.dev.czgenepi.org/

### Demos
#### Before: 
![Screen Shot 2022-06-15 at 8 58 06 AM](https://user-images.githubusercontent.com/7562933/173872489-bb5db4eb-28dc-432b-8fc1-19a482960f89.png)

#### After: 
![Screen Shot 2022-06-15 at 8 57 53 AM](https://user-images.githubusercontent.com/7562933/173872545-465c5094-ee96-46f7-be77-56a8c6c472c8.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)