### PR TITLE
dont reload page hen viewing invitations from notification

### DIFF
--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/components/SentNotification/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/components/InvalidEmailError/components/SentNotification/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "czifui";
+import { useRouter } from "next/router";
 import React from "react";
 import { ROUTES } from "src/common/routes";
 import { pluralize } from "src/common/utils/strUtils";
@@ -11,6 +12,12 @@ interface Props {
 }
 
 const SentNotification = ({ numSent, onDismiss, open }: Props): JSX.Element => {
+  const router = useRouter();
+  const onClick = () => {
+    router.push(ROUTES.GROUP_INVITATIONS, undefined, { shallow: true });
+    onDismiss();
+  };
+
   return (
     <Notification
       buttonText="DISMISS"
@@ -22,7 +29,7 @@ const SentNotification = ({ numSent, onDismiss, open }: Props): JSX.Element => {
     >
       {numSent} {pluralize("Invitation", numSent)} {pluralize("has", numSent)}{" "}
       been sent.{" "}
-      <Link sdsStyle="dashed" href={ROUTES.GROUP_INVITATIONS}>
+      <Link sdsStyle="dashed" onClick={onClick}>
         View Invitations
       </Link>
       .


### PR DESCRIPTION
### Summary
- **What:** Don't reload page when going to invites tab from notification
- **Ticket:** [[sc-200919]](https://app.shortcut.com/genepi/story/200919)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)