### PR TITLE
Add location search functionality in API and CLI

### DIFF
--- a/src/backend/aspen/api/schemas/locations.py
+++ b/src/backend/aspen/api/schemas/locations.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from aspen.api.schemas.base import BaseResponse, BaseRequest
+from aspen.api.schemas.base import BaseRequest, BaseResponse
 
 
 class LocationResponse(BaseResponse):

--- a/src/backend/aspen/api/schemas/locations.py
+++ b/src/backend/aspen/api/schemas/locations.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from aspen.api.schemas.base import BaseResponse
+from aspen.api.schemas.base import BaseResponse, BaseRequest
 
 
 class LocationResponse(BaseResponse):
@@ -13,3 +13,10 @@ class LocationResponse(BaseResponse):
 
 class LocationListResponse(BaseResponse):
     locations: List[LocationResponse]
+
+
+class LocationSearchRequest(BaseRequest):
+    region: Optional[str]
+    country: Optional[str]
+    division: Optional[str]
+    location: Optional[str]

--- a/src/backend/aspen/api/views/locations.py
+++ b/src/backend/aspen/api/views/locations.py
@@ -1,20 +1,23 @@
+import functools
+
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends
+from sqlalchemy import asc
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from aspen.api.auth import get_auth_user
 from aspen.api.deps import get_db, get_settings
-from aspen.api.schemas.locations import LocationListResponse, LocationResponse, LocationSearchRequest
+from aspen.api.schemas.locations import (
+    LocationListResponse,
+    LocationResponse,
+    LocationSearchRequest,
+)
 from aspen.api.settings import Settings
 from aspen.database.models import Location, User
 
 router = APIRouter()
 
-import logging
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 @router.get("/", response_model=LocationListResponse)
 async def list_locations(
@@ -41,8 +44,42 @@ async def search_locations(
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
 ):
-    logger.debug(search_query)
+    levenshtein_columns = [
+        sa.func.levenshtein(getattr(Location, category), value)
+        for category, value in dict(search_query).items()
+        if value is not None
+    ]
 
-    # levenshtein_subquery = sa.select(Location, sa.func.levenshtein())
-    # search_locations_query = sa.select(Location).filter()
-    return search_query
+    summed_columns = functools.reduce(lambda x, y: x + y, levenshtein_columns)
+
+    results = []
+
+    # Allow for searches for a division to show its entry in the locations table
+    # where the location column is null
+    if search_query.location is None:
+        divison_search_query = (
+            sa.select(
+                Location, sa.sql.expression.label("levenshtein_total", summed_columns)  # type: ignore
+            )
+            .where(Location.location == None)  # noqa: E711
+            .order_by(asc("levenshtein_total"))
+            .limit(1)
+        )
+        division_search = await db.execute(divison_search_query)
+        closest_division = division_search.scalars().one_or_none()
+        results.append(closest_division)
+
+    location_search_query = (
+        sa.select(
+            Location, sa.sql.expression.label("levenshtein_total", summed_columns)  # type: ignore
+        )
+        .where(Location.location != None)  # noqa: E711
+        .order_by(asc("levenshtein_total"))
+        .limit(20)
+    )
+
+    location_search = await db.execute(location_search_query)
+    locations = location_search.scalars().all()
+    results.extend(locations)
+
+    return LocationListResponse.parse_obj({"locations": results})

--- a/src/backend/aspen/api/views/locations.py
+++ b/src/backend/aspen/api/views/locations.py
@@ -4,6 +4,7 @@ import sqlalchemy as sa
 from fastapi import APIRouter, Depends
 from sqlalchemy import asc
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.expression import and_, literal
 from starlette.requests import Request
 
 from aspen.api.auth import get_auth_user
@@ -17,6 +18,14 @@ from aspen.api.settings import Settings
 from aspen.database.models import Location, User
 
 router = APIRouter()
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+LOCATION_KEYS = ("region", "country", "division", "location")
 
 
 @router.get("/", response_model=LocationListResponse)
@@ -44,36 +53,71 @@ async def search_locations(
     settings: Settings = Depends(get_settings),
     user: User = Depends(get_auth_user),
 ):
+    # Since most searches are going to be done at the division or location level,
+    # if a user includes a country in the query we want to find the closest match
+    # for that value and search for divisions and locations *within* that country.
+    # The same goes for regions, though in practice including a region is wholly
+    # unnecessary.
+    set_categories = []
+    for category in "region", "country":
+        query_value = getattr(search_query, category)
+        if query_value is not None:
+            category_search_query = (
+                sa.select(
+                    Location,
+                    sa.func.levenshtein(getattr(Location, category), query_value).label(
+                        "levenshtein"
+                    ),
+                )
+                .order_by(asc("levenshtein"))
+                .limit(1)
+            )
+            category_result = await db.execute(category_search_query)
+            category_value = category_result.scalars().one()
+            set_categories.append(
+                (getattr(Location, category) == getattr(category_value, category))
+            )
+
+    # We generally want to compare on columns with the most specificity.
+    comparable_columns = {
+        "division": search_query.division,
+        "location": search_query.location,
+    }
     levenshtein_columns = [
         sa.func.levenshtein(getattr(Location, category), value)
-        for category, value in dict(search_query).items()
+        for category, value in dict(comparable_columns).items()
         if value is not None
     ]
-
-    summed_columns = functools.reduce(lambda x, y: x + y, levenshtein_columns)
+    # But we can also support searches with only a region or country.
+    if levenshtein_columns:
+        summed_columns = functools.reduce(lambda x, y: x + y, levenshtein_columns)
+    else:
+        summed_columns = literal(0)
 
     results = []
-
     # Allow for searches for a division to show its entry in the locations table
     # where the location column is null
-    if search_query.location is None:
+    if (
+        comparable_columns["location"] is None
+        and comparable_columns["division"] is not None
+    ):
         divison_search_query = (
             sa.select(
                 Location, sa.sql.expression.label("levenshtein_total", summed_columns)  # type: ignore
             )
-            .where(Location.location == None)  # noqa: E711
+            .where(and_(Location.location == None, *set_categories))  # noqa: E711
             .order_by(asc("levenshtein_total"))
             .limit(1)
         )
         division_search = await db.execute(divison_search_query)
-        closest_division = division_search.scalars().one_or_none()
+        closest_division = division_search.scalars().one()
         results.append(closest_division)
 
     location_search_query = (
         sa.select(
             Location, sa.sql.expression.label("levenshtein_total", summed_columns)  # type: ignore
         )
-        .where(Location.location != None)  # noqa: E711
+        .where(and_(Location.location != None, *set_categories))  # noqa: E711
         .order_by(asc("levenshtein_total"))
         .limit(20)
     )

--- a/src/backend/aspen/api/views/locations.py
+++ b/src/backend/aspen/api/views/locations.py
@@ -5,12 +5,16 @@ from starlette.requests import Request
 
 from aspen.api.auth import get_auth_user
 from aspen.api.deps import get_db, get_settings
-from aspen.api.schemas.locations import LocationListResponse, LocationResponse
+from aspen.api.schemas.locations import LocationListResponse, LocationResponse, LocationSearchRequest
 from aspen.api.settings import Settings
 from aspen.database.models import Location, User
 
 router = APIRouter()
 
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 @router.get("/", response_model=LocationListResponse)
 async def list_locations(
@@ -28,3 +32,17 @@ async def list_locations(
         response.append(LocationResponse.from_orm(row))
 
     return LocationListResponse.parse_obj({"locations": response})
+
+
+@router.post("/search/")
+async def search_locations(
+    search_query: LocationSearchRequest,
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+    user: User = Depends(get_auth_user),
+):
+    logger.debug(search_query)
+
+    # levenshtein_subquery = sa.select(Location, sa.func.levenshtein())
+    # search_locations_query = sa.select(Location).filter()
+    return search_query

--- a/src/backend/database_migrations/versions/20220615_201620_enable_fuzzystrmatch_extension.py
+++ b/src/backend/database_migrations/versions/20220615_201620_enable_fuzzystrmatch_extension.py
@@ -1,0 +1,27 @@
+"""Enable fuzzystrmatch extension
+
+Create Date: 2022-06-15 20:16:25.397423
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220615_201620"
+down_revision = "20220524_174911"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    enable_fuzzystrmatch = sa.sql.text(
+        "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch WITH SCHEMA public"
+    )
+    conn.execute(enable_fuzzystrmatch)
+
+
+def downgrade():
+    pass

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -14,6 +14,7 @@ from auth0.v3.authentication.token_verifier import (
     AsymmetricSignatureVerifier,
     JwksFetcher,
 )
+from tabulate import tabulate
 
 
 class InsecureJwksFetcher(JwksFetcher):
@@ -508,7 +509,7 @@ def list_locations(ctx):
 
 
 @locations.command(name="search")
-@click.option("--region", required=False, type=str, help="A continental-level region, e.g. North America, Asia.")
+@click.option("--region", required=False, type=str, help="A continental-level region, e.g. North America, Asia. In practice, you do not need to provide this.")
 @click.option("--country", required=False, type=str, help="A country, e.g. USA, Canada.")
 @click.option("--division", required=False, type=str, help="A top-level division of a country, e.g. California, British Columbia.")
 @click.option("--location", required=False, type=str, help="A secondary division of a country, e.g. Alameda County, Toronto.")
@@ -532,7 +533,11 @@ def search_locations(
         "location": location,
     }
     resp = api_client.post(f"/v2/locations/search/", json=payload)
-    print(resp.text)
+    locations = resp.json()["locations"]
+    location_columns = ["region", "country", "division", "location", "id"]
+    location_values = [[entry.get(column) for column in location_columns] for entry in locations]
+    print(tabulate(location_values, headers=location_columns, tablefmt="psql"))
+
 
 @cli.group()
 def lineages():

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -462,6 +462,33 @@ def list_locations(ctx):
     print(resp.text)
 
 
+@locations.command(name="search")
+@click.option("--region", required=False, type=str, help="A continental-level region, e.g. North America, Asia.")
+@click.option("--country", required=False, type=str, help="A country, e.g. USA, Canada.")
+@click.option("--division", required=False, type=str, help="A top-level division of a country, e.g. California, British Columbia.")
+@click.option("--location", required=False, type=str, help="A secondary division of a country, e.g. Alameda County, Toronto.")
+@click.pass_context
+def search_locations(
+    ctx,
+    region: Optional[str],
+    country: Optional[str],
+    division: Optional[str],
+    location: Optional[str],
+):
+    if not region and not country and not division and not location:
+        print("Must provide at least one of region, country, division, or location.")
+        return
+        
+    api_client = ctx.obj["api_client"]
+    payload = {
+        "region": region,
+        "country": country,
+        "division": division,
+        "location": location,
+    }
+    resp = api_client.post(f"/v2/locations/search/", json=payload)
+    print(resp.text)
+
 @cli.group()
 def lineages():
     pass

--- a/src/cli/requirements.txt
+++ b/src/cli/requirements.txt
@@ -2,3 +2,4 @@ keyring==23.0.1
 click==7.1.2
 auth0-python==3.16.2
 dateparser==1.1.0
+tabulate==0.8.9


### PR DESCRIPTION
### Summary:
- **What:** Adds an api endpoint to search for locations in the database and return them as a list of json dicts. Adds a cli command to query this endpoint that prints results in a pretty table. Enables the `fuzzystrmatch` Postgres extension to make this all work.
- **Ticket:** [sc200306](https://app.shortcut.com/genepi/story/200306)
- **Env:** [https://locationsearch-backend.dev.czgenepi.org](https://locationsearch-backend.dev.czgenepi.org)

### Demos:
You will need to navigate to the `src/cli` directory and do a `pip install -r requirements.txt` to add a package needed for the cli (`tabulate`).

The cli command is `aspencli.py locations search`. The command has four available options: `--region`, `--country`, `--division`, `--location`. You must enter a value for at least one option. 

Querying with only a `--country` or `--division` without a `--location` will show you all the divisions in that country, and all the locations in that division respectively.
<img width="1091" alt="Screen Shot 2022-06-16 at 10 21 16" src="https://user-images.githubusercontent.com/24234461/174129856-dd194a55-0f8a-4e44-835f-e42b8e1156db.png">
<img width="1091" alt="Screen Shot 2022-06-15 at 15 49 38" src="https://user-images.githubusercontent.com/24234461/173955033-64c5bdbf-d708-49ed-a60d-27143219d1b3.png">
<img width="1085" alt="Screen Shot 2022-06-15 at 15 50 11" src="https://user-images.githubusercontent.com/24234461/173955093-bea26885-893a-4a27-9303-84e8b75ed400.png">

Querying using a `--location` will return the first 30 results.
Querying just a `--location` will attempt to do a closest text match, but it's rather simple and only uses levenshtein distance. 
<img width="1089" alt="Screen Shot 2022-06-15 at 15 50 59" src="https://user-images.githubusercontent.com/24234461/173955200-96766119-3537-4bdf-8998-67f007e32948.png">
<img width="1091" alt="Screen Shot 2022-06-15 at 15 52 04" src="https://user-images.githubusercontent.com/24234461/173955268-11d4d334-4707-4fdd-b4c1-5bf69357df1e.png">


Querying a `--location` with a `--country` or a `--division` will restrict the text search for that location to that country or division, increasing your odds of finding what you want.
<img width="1090" alt="Screen Shot 2022-06-15 at 15 52 47" src="https://user-images.githubusercontent.com/24234461/173955379-f06552b5-c5c0-432b-8186-bc66e1fb3dd9.png">
<img width="1088" alt="Screen Shot 2022-06-15 at 15 53 04" src="https://user-images.githubusercontent.com/24234461/173955389-a55a0ba9-5787-404c-82fd-576791f0a981.png">


### Notes:
I'm sure the API endpoint code could be made more readable somehow, but it works as-is and I can't easily see a better way at the moment.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)