### PR TITLE
prevent table from flickering on scroll

### DIFF
--- a/src/frontend/src/common/components/library/Table/components/Row/index.tsx
+++ b/src/frontend/src/common/components/library/Table/components/Row/index.tsx
@@ -1,22 +1,23 @@
-import React, { ReactNode } from "react";
+import React, { CSSProperties, ReactNode } from "react";
 import { Cell } from "../Cell";
 import { StyledHeader, StyledRow } from "./style";
 
 interface Props {
   cells: ReactNode[];
   isHeader?: boolean;
+  style?: CSSProperties;
 }
 
-const Row = ({ cells, isHeader }: Props): JSX.Element | null => {
+const Row = ({ cells, isHeader, style }: Props): JSX.Element | null => {
   if (cells.length === 0) return null;
 
   const mappedCells = cells.map((c, i) => <Cell key={i} content={c} />);
 
   if (isHeader) {
-    return <StyledHeader>{mappedCells}</StyledHeader>;
+    return <StyledHeader style={style}>{mappedCells}</StyledHeader>;
   }
 
-  return <StyledRow>{mappedCells}</StyledRow>;
+  return <StyledRow style={style}>{mappedCells}</StyledRow>;
 };
 
 export { Row };

--- a/src/frontend/src/common/components/library/Table/index.tsx
+++ b/src/frontend/src/common/components/library/Table/index.tsx
@@ -23,7 +23,7 @@ const Table = ({ headers, rows }: Props): JSX.Element => (
               itemSize={ITEM_HEIGHT_PX}
               width={width}
             >
-              {({ index }) => <Row cells={rows[index]} />}
+              {({ index, style }) => <Row cells={rows[index]} style={style} />}
             </FixedSizeList>
           );
         }}


### PR DESCRIPTION
### Summary
- **What:** Prevent table from flickering when you scroll to the bottom
- **Why:** Too stressful to look at
- **Ticket:** [[sc-200919]](https://app.shortcut.com/genepi/story/200919)
- **Env:** https://maya-flickerbegone-frontend.dev.czgenepi.org/

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/173995325-242f56a8-d30e-4af5-9329-47d32acfad71.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/173995333-6db1caca-fd0c-4240-83c1-08f0a57bbad2.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)