### PR TITLE
Remove auth0_user_id requirement for CLI command

### DIFF
--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -335,7 +335,6 @@ def create(
     email,
     name,
     group_id,
-    auth0_user_id,
     group_admin,
     system_admin,
 ):

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -327,12 +327,6 @@ def update_me(ctx, agreed_to_tos, ack_policy_version):
     type=str,
     help="The id of the group to create the user in.",
 )
-@click.option(
-    "--auth0-user-id",
-    required=True,
-    type=str,
-    help="The auth0 identifier attached to the user's auth0 account.",
-)
 @click.option("--group-admin", is_flag=True, default=False)
 @click.option("--system-admin", is_flag=True, default=False)
 @click.pass_context
@@ -352,7 +346,6 @@ def create(
         "group_id": group_id,
         "group_admin": group_admin,
         "system_admin": system_admin,
-        "auth0_user_id": auth0_user_id,
     }
     print(user)
     resp = api_client.post("/v2/users/", json=user)


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)