### PR TITLE
design tweaks

### DIFF
--- a/src/frontend/src/common/components/library/Table/components/Row/style.ts
+++ b/src/frontend/src/common/components/library/Table/components/Row/style.ts
@@ -1,18 +1,32 @@
 import styled from "@emotion/styled";
-import { fontHeaderS, fontHeaderXs, getColors, getSpaces } from "czifui";
+import {
+  CommonThemeProps,
+  fontHeaderS,
+  fontHeaderXs,
+  getColors,
+  getSpaces,
+} from "czifui";
+
+const sharedRowStyles = (props: CommonThemeProps) => {
+  const spaces = getSpaces(props);
+
+  return `
+    display: flex;
+    align-items: center;
+    padding: ${spaces?.l}px;
+  `;
+};
 
 export const StyledRow = styled.div`
   ${fontHeaderXs}
-  display: flex;
+  ${sharedRowStyles}
+
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 
   ${(props) => {
     const colors = getColors(props);
-    const spaces = getSpaces(props);
 
     return `
-      padding: ${spaces?.l}px;
-
       &:hover {
         background-color: ${colors?.primary[100]};
       }
@@ -22,17 +36,16 @@ export const StyledRow = styled.div`
 
 export const StyledHeader = styled.div`
   ${fontHeaderS}
-  display: flex;
+  ${sharedRowStyles}
+
   margin: 0;
 
   ${(props) => {
     const colors = getColors(props);
-    const spaces = getSpaces(props);
 
     return `
       color: ${colors?.gray[500]};
       border-bottom: 4px ${colors?.gray[100]} solid;
-      padding: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/style.ts
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/ActiveMembersTable/style.ts
@@ -14,10 +14,11 @@ export const Capitalized = styled.span`
 export const Wrapper = styled.div`
   ${StyledHeader},
   ${StyledRow} {
-    justify-content: space-evenly;
+    justify-content: flex-start;
 
     ${StyledCell} {
-      flex: unset;
+      display: unset;
+      flex: 1 1 50%;
     }
   }
 `;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/MemberInvitationsTable/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Table } from "src/common/components/library/Table";
+import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
 import { EmailCell } from "./components/EmailCell";
 
 interface Props {
@@ -17,7 +18,7 @@ const MemberInvitationsTable = ({ invites }: Props): JSX.Element => {
 
     return [
       <EmailCell key={0} email={invitee.email} status={status} />,
-      createdAt,
+      datetimeWithTzToLocalDate(createdAt),
       "Member", // this may vary in the future, but for now only one type of invitation is available
     ];
   });


### PR DESCRIPTION
### Summary
- **What:** Two design tweaks for invitations table
  - nice user friendly timestamp for invite create date
  - column alignment
- **Why:** polish
- **Ticket:** [[sc-200919]](https://app.shortcut.com/genepi/story/200919)
- **Env:** https://maya-tweaks-frontend.dev.czgenepi.org/

### Demos
#### Before: 
![Screen Shot 2022-06-16 at 1 16 06 PM](https://user-images.githubusercontent.com/7562933/174156358-fbee72a4-3ad0-4304-a7a0-ad0dfd2809a5.png)

#### After: 
![Screen Shot 2022-06-16 at 1 15 31 PM](https://user-images.githubusercontent.com/7562933/174156389-aa2f057f-083e-41f5-9e3b-03385e15e4e0.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)