### PR TITLE
Sanitize group prefix in auth0 org creation

### DIFF
--- a/src/backend/aspen/api/views/groups.py
+++ b/src/backend/aspen/api/views/groups.py
@@ -36,6 +36,8 @@ async def create_group(
 ) -> GroupInfoResponse:
     # Auth0 requires we only have alphanumerics, "-" and "_" in a group name.
     # This regex replaces all other characters with an underscore, "_".
+    # There is also a 50 character limit, but we limit prefixes to 20 characters
+    # anyways.
     auth0_safe_prefix = re.sub(
         r"[^a-zA-Z0-9_-]+", "_", group_creation_request.prefix.lower()
     )


### PR DESCRIPTION
### Summary:
- **What:** Auth0 has strict requirements for an org name that our group prefixes sometimes run afoul of. This sanitizes those prefixes so we can still use them as group names.
- **Ticket:** [sc200304](https://app.shortcut.com/genepi/story/200304)
- **Env:** `<rdev link>`

### Demos:

### Notes:
Example of issue:
<img width="1685" alt="Screen Shot 2022-06-17 at 10 41 09" src="https://user-images.githubusercontent.com/24234461/174353070-dec530ee-f1b7-4cd9-b8ad-5751f73327b4.png">


### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)