### PR TITLE
Add support for case-insensitive location searches

### DIFF
--- a/src/backend/aspen/api/views/locations.py
+++ b/src/backend/aspen/api/views/locations.py
@@ -67,9 +67,9 @@ async def search_locations(
             category_search_query = (
                 sa.select(
                     target_column.distinct(),
-                    sa.func.levenshtein(target_column, query_value).label(
-                        "levenshtein"
-                    ),
+                    sa.func.levenshtein(
+                        sa.func.lower(target_column), sa.func.lower(query_value)
+                    ).label("levenshtein"),
                 )
                 .where(and_(True, *set_category_conditionals))
                 .order_by(asc("levenshtein"))
@@ -83,7 +83,9 @@ async def search_locations(
             )
 
     levenshtein_columns = [
-        sa.func.levenshtein(getattr(Location, category), value)
+        sa.func.levenshtein(
+            sa.func.lower(getattr(Location, category)), sa.func.lower(value)
+        )
         for category, value in dict(search_query).items()
         if value is not None
     ]


### PR DESCRIPTION
### Summary:
- **What:** Make the locations search endpoint to a case-agnostic search.
- **Ticket:** [sc200304](https://app.shortcut.com/genepi/story/200304)
- **Env:** `<rdev link>`

### Demos:
Searching for `usa` now returns results for `USA`, not `Cuba`.

<img width="1085" alt="Screen Shot 2022-06-17 at 13 41 04" src="https://user-images.githubusercontent.com/24234461/174398470-70a6eaf1-5ac8-4e84-a425-46d0c0ce9394.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)