### PR TITLE
Maya/cache issues

### DIFF
--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -11,7 +11,13 @@ import ENV from "src/common/constants/ENV";
 import { API, DEFAULT_PUT_OPTIONS, getBackendApiJson } from "../api";
 import { ROUTES } from "../routes";
 import { ENTITIES } from "./entities";
-import { mapGroupData, RawGroupRequest } from "./groups";
+import {
+  mapGroupData,
+  RawGroupRequest,
+  USE_GROUP_INFO,
+  USE_GROUP_INVITATION_INFO,
+  USE_GROUP_MEMBER_INFO,
+} from "./groups";
 
 const { API_URL } = ENV;
 
@@ -62,7 +68,12 @@ export function useUpdateUserInfo(): UseMutationResult<
 
   return useMutation(updateUserInfo, {
     onSuccess: async () => {
-      await queryClient.invalidateQueries([USE_USER_INFO]);
+      await queryClient.invalidateQueries([
+        USE_USER_INFO,
+        USE_GROUP_INFO,
+        USE_GROUP_INVITATION_INFO,
+        USE_GROUP_MEMBER_INFO,
+      ]);
     },
   });
 }

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -2,6 +2,7 @@ import {
   useMutation,
   UseMutationResult,
   useQuery,
+  useQueryClient,
   UseQueryResult,
 } from "react-query";
 import { API, DEFAULT_FETCH_OPTIONS, DEFAULT_POST_OPTIONS } from "../api";
@@ -235,8 +236,12 @@ export function useSendGroupInvitations({
   InvitationRequestType,
   unknown
 > {
+  const queryClient = useQueryClient();
   return useMutation(sendGroupInvitations, {
     onError: componentOnError,
-    onSuccess: componentOnSuccess,
+    onSuccess: async (data) => {
+      await queryClient.invalidateQueries([USE_GROUP_INVITATION_INFO]);
+      componentOnSuccess(data);
+    },
   });
 }

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -78,7 +78,7 @@ export const USE_GROUP_INFO = {
 };
 
 export function useGroupInfo(groupId: number): UseQueryResult<Group, unknown> {
-  return useQuery([USE_GROUP_INFO], () => fetchGroup({ groupId }), {
+  return useQuery([USE_GROUP_INFO, groupId], () => fetchGroup({ groupId }), {
     retry: false,
     select: mapGroupData,
   });
@@ -114,7 +114,7 @@ export function useGroupMembersInfo(
   groupId: number
 ): UseQueryResult<GroupMember[], unknown> {
   return useQuery(
-    [USE_GROUP_MEMBER_INFO],
+    [USE_GROUP_MEMBER_INFO, groupId],
     () => fetchGroupMembers({ groupId }),
     {
       retry: false,
@@ -156,7 +156,7 @@ export function useGroupInvitations(
   groupId: number
 ): UseQueryResult<Invitation[], unknown> {
   return useQuery(
-    [USE_GROUP_INVITATION_INFO],
+    [USE_GROUP_INVITATION_INFO, groupId],
     () => fetchGroupInvitations({ groupId }),
     {
       retry: false,

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   groupName?: string;
   groupId: number;
   members: GroupMember[];
+  userInfo: User;
 }
 
 const MembersTab = ({
@@ -29,13 +30,13 @@ const MembersTab = ({
   groupName,
   groupId,
   members,
+  userInfo,
 }: Props): JSX.Element | null => {
   const [tabValue, setTabValue] =
     useState<SecondaryTabType>(initialSecondaryTab);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const router = useRouter();
   const { data: invitations = [] } = useGroupInvitations(groupId);
-  const { data: userInfo } = useUserInfo();
   const currentUser = find(members, (m) => m.id === userInfo?.id);
 
   const isOwner = currentUser?.isGroupAdmin === true;

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -39,7 +39,6 @@ const MembersTab = ({
   const { data: invitations = [] } = useGroupInvitations(groupId);
   const currentUser = find(members, (m) => m.id === userInfo?.id);
 
-
   useEffect(() => {
     setTabValue(requestedSecondaryTab);
   }, [requestedSecondaryTab]);

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -43,7 +43,6 @@ const MembersTab = ({
     setTabValue(requestedSecondaryTab);
   }, [requestedSecondaryTab]);
 
-  const currentUser = find(members, (m) => m.id === userInfo?.id);
   const isOwner = currentUser?.isGroupAdmin === true;
   const numActive = Object.keys(members).length;
 

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -3,7 +3,6 @@ import { find } from "lodash";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { HeadAppTitle } from "src/common/components";
-import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInvitations } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
 import { TabEventHandler } from "../../index";
@@ -22,7 +21,7 @@ interface Props {
   groupName?: string;
   groupId: number;
   members: GroupMember[];
-  userInfo: User;
+  userInfo: User | undefined;
 }
 
 const MembersTab = ({

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -77,6 +77,7 @@ const GroupMembersPage = ({
             groupName={name}
             groupId={groupId}
             members={members}
+            userInfo={userInfo}
           />
         )}
         {tabValue === PrimaryTabType.DETAILS && (


### PR DESCRIPTION
### Summary
- **What:** 
  - Resolves caching issues for invites and members by automatically expiring those caches whenever /me gets me data
  - Invites tab count and Members tab counts (on the tabs themselves) should load quickly now (with a second or two, as api returns)
  - Invites and members tables will populate quickly as well
  - Refetches invite list after new invitations sent
- **Why:** Otherwise, the ui doesn't update with data quickly and it looks broken
- **Env:** https://maya-cache-frontend.dev.czgenepi.org/
- **Discussion:** https://docs.google.com/document/d/11YPmx-jT5ISA-qsORavNpxODmB-wGXFW3Lsa5CP0N7g/edit

### Testing
1. Load the group members page
2. Ensure the user table populates quickly
1. Ensure tab counts populate at the same time as tables, and are accurate
2. View invitations and ensure the invites are immediately visible
3. Send a new invitation
4. Ensure the table updates reasonably quickly with the new invitation

### Demos
![after](https://user-images.githubusercontent.com/7562933/174441846-9b5afccb-cbae-4097-90e9-51da0c0b49e8.gif)


### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)