### PR TITLE
whenever users requests a new page, go there

### DIFF
--- a/src/frontend/pages/group/[[...params]].tsx
+++ b/src/frontend/pages/group/[[...params]].tsx
@@ -11,27 +11,27 @@ const Page = (): JSX.Element => {
   const primaryToken = pathTokens.length > 0 && pathTokens[0];
   const secondaryToken = pathTokens.length > 1 && pathTokens[1];
 
-  let initialPrimaryTab = PrimaryTabType.MEMBERS;
-  let initialSecondaryTab = SecondaryTabType.ACTIVE;
+  let requestedPrimaryTab = PrimaryTabType.MEMBERS;
+  let requestedSecondaryTab = SecondaryTabType.ACTIVE;
 
   if (
     primaryToken === PrimaryTabType.MEMBERS ||
     primaryToken === PrimaryTabType.DETAILS
   ) {
-    initialPrimaryTab = primaryToken;
+    requestedPrimaryTab = primaryToken;
   }
 
   if (
     secondaryToken === SecondaryTabType.ACTIVE ||
     secondaryToken === SecondaryTabType.INVITATIONS
   ) {
-    initialSecondaryTab = secondaryToken;
+    requestedSecondaryTab = secondaryToken;
   }
 
   return (
     <GroupMembersPage
-      initialPrimaryTab={initialPrimaryTab}
-      initialSecondaryTab={initialSecondaryTab}
+      requestedPrimaryTab={requestedPrimaryTab}
+      requestedSecondaryTab={requestedSecondaryTab}
     />
   );
 };

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Tab } from "czifui";
 import { find } from "lodash";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { HeadAppTitle } from "src/common/components";
 import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInvitations } from "src/common/queries/groups";
@@ -18,26 +18,31 @@ export enum SecondaryTabType {
 }
 
 interface Props {
-  initialSecondaryTab: SecondaryTabType;
+  requestedSecondaryTab: SecondaryTabType;
   groupName?: string;
   groupId: number;
   members: GroupMember[];
 }
 
 const MembersTab = ({
-  initialSecondaryTab,
+  requestedSecondaryTab,
   groupName,
   groupId,
   members,
 }: Props): JSX.Element | null => {
-  const [tabValue, setTabValue] =
-    useState<SecondaryTabType>(initialSecondaryTab);
+  const [tabValue, setTabValue] = useState<SecondaryTabType>(
+    requestedSecondaryTab
+  );
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const router = useRouter();
   const { data: invitations = [] } = useGroupInvitations(groupId);
   const { data: userInfo } = useUserInfo();
-  const currentUser = find(members, (m) => m.id === userInfo?.id);
 
+  useEffect(() => {
+    setTabValue(requestedSecondaryTab);
+  }, [requestedSecondaryTab]);
+
+  const currentUser = find(members, (m) => m.id === userInfo?.id);
   const isOwner = currentUser?.isGroupAdmin === true;
   const numActive = Object.keys(members).length;
 

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -1,6 +1,6 @@
 import { Tab } from "czifui";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useProtectedRoute, useUserInfo } from "src/common/queries/auth";
 import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
@@ -26,17 +26,17 @@ export type TabEventHandler = (
 ) => void;
 
 interface Props {
-  initialPrimaryTab: PrimaryTabType;
-  initialSecondaryTab: SecondaryTabType;
+  requestedPrimaryTab: PrimaryTabType;
+  requestedSecondaryTab: SecondaryTabType;
 }
 
 const GroupMembersPage = ({
-  initialPrimaryTab,
-  initialSecondaryTab,
+  requestedPrimaryTab,
+  requestedSecondaryTab,
 }: Props): JSX.Element | null => {
   useProtectedRoute();
 
-  const [tabValue, setTabValue] = useState<PrimaryTabType>(initialPrimaryTab);
+  const [tabValue, setTabValue] = useState<PrimaryTabType>(requestedPrimaryTab);
   const router = useRouter();
 
   const { data: userInfo } = useUserInfo();
@@ -45,6 +45,10 @@ const GroupMembersPage = ({
   const { data: groupInfo } = useGroupInfo(groupId);
 
   const { address, location, name, prefix } = groupInfo ?? {};
+
+  useEffect(() => {
+    setTabValue(requestedPrimaryTab);
+  }, [requestedPrimaryTab]);
 
   // sort group members by name before display
   members.sort((a, b) => (a.name > b.name ? 1 : -1));
@@ -73,7 +77,7 @@ const GroupMembersPage = ({
       <StyledPageContent>
         {tabValue === PrimaryTabType.MEMBERS && (
           <MembersTab
-            initialSecondaryTab={initialSecondaryTab}
+            requestedSecondaryTab={requestedSecondaryTab}
             groupName={name}
             groupId={groupId}
             members={members}


### PR DESCRIPTION
### Summary
- **What:** When a user sends a new invite from members page, allow them to choose to View Invitations and get redirected to invites tab
- **Why:** It's expected behavior
- **Discussion:** https://docs.google.com/document/d/11YPmx-jT5ISA-qsORavNpxODmB-wGXFW3Lsa5CP0N7g/edit

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/174443076-0905cb41-424e-46b3-bef8-4d9bfafff626.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/174443078-23c9a63d-c95e-42bb-9d18-7cfa5029c526.gif)

### Notes
This change essentially. tells the tab components to listen to all changes to the router path as priority over the internal component state. I think this makes sense because any change to the address should happen as the result of user action.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)