### PR TITLE
Return group roles as part of /users/me response.

### DIFF
--- a/src/backend/aspen/api/authn.py
+++ b/src/backend/aspen/api/authn.py
@@ -23,6 +23,8 @@ def get_usergroup_query(session: AsyncSession, auth0_user_id: str) -> Query:
     return (
         sa.select(User)  # type: ignore
         .options(joinedload(User.group).joinedload(Group.can_see))  # type: ignore
+        .options(joinedload(User.user_roles).joinedload(UserRole.group, innerjoin=True))  # type: ignore
+        .options(joinedload(User.user_roles).joinedload(UserRole.role, innerjoin=True))  # type: ignore
         .filter(User.auth0_user_id == auth0_user_id)  # type: ignore
     )
 

--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -40,11 +40,18 @@ class UserUpdateRequest(BaseRequest):
     name: Optional[str] = None
 
 
+class GroupRoleResponse(BaseResponse):
+    id: int
+    name: str
+    roles: List[str]
+
+
 # Only expose split id and groups to the user it belongs to.
 class UserMeResponse(UserBaseResponse):
     split_id: str
     group: GroupResponse
     group_admin: bool
+    groups: List[GroupRoleResponse]
 
 
 class GroupInvitationsRequest(BaseRequest):

--- a/src/backend/aspen/api/views/tests/test_auspice.py
+++ b/src/backend/aspen/api/views/tests/test_auspice.py
@@ -12,7 +12,7 @@ from aspen.api.views.tests.data.location_data import TEST_COUNTRY_DATA
 from aspen.api.views.tests.data.phylo_tree_data import TEST_TREE
 from aspen.api.views.tests.test_update_phylo_run_and_tree import make_shared_test_data
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -93,7 +93,8 @@ async def test_unauth_user_auspice_link_generation(
         async_session
     )
     group_that_did_not_make_tree = group_factory(name="i_want_to_see_trees")
-    user_that_did_not_make_tree = user_factory(
+    user_that_did_not_make_tree = await userrole_factory(
+        async_session,
         group_that_did_not_make_tree,
         name="trying_to_see",
         email="trying_to_see@hotmail.com",

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import joinedload
 from aspen.api.views.auth import create_user_if_not_exists
 from aspen.auth.auth0_management import Auth0Client
 from aspen.database.models import User
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -103,7 +103,7 @@ async def test_dont_create_new_user_if_exists(
         "email": "hello@czgenepi.org",
     }
     group = group_factory(auth0_org_id=userinfo["org_id"])
-    user = user_factory(auth0_user_id=userinfo["sub"], group=group)
+    user = await userrole_factory(async_session, auth0_user_id=userinfo["sub"], group=group)
     async_session.add(user)
     await start_new_transaction(async_session)
     await create_user_if_not_exists(async_session, auth0_apiclient, userinfo)

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -103,7 +103,9 @@ async def test_dont_create_new_user_if_exists(
         "email": "hello@czgenepi.org",
     }
     group = group_factory(auth0_org_id=userinfo["org_id"])
-    user = await userrole_factory(async_session, auth0_user_id=userinfo["sub"], group=group)
+    user = await userrole_factory(
+        async_session, auth0_user_id=userinfo["sub"], group=group
+    )
     async_session.add(user)
     await start_new_transaction(async_session)
     await create_user_if_not_exists(async_session, auth0_apiclient, userinfo)

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -6,7 +6,7 @@ from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 from aspen.test_infra.models.workflow import aligned_gisaid_dump_factory
 
 # All test coroutines will be treated as marked.
@@ -21,7 +21,7 @@ async def test_create_phylo_run(
     Test phylo tree creation, local-only samples.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -57,7 +57,7 @@ async def test_create_phylo_run_with_failed_sample(
     Test phylo tree creation, with a sample that failed genome recovery
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -87,7 +87,7 @@ async def test_create_phylo_run_with_invalid_args(
     Test phylo tree creation that includes a reference to a GISAID sequence.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -137,7 +137,7 @@ async def test_create_phylo_run_with_template_args(
     Test phylo tree creation that includes a reference to a GISAID sequence.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -197,7 +197,7 @@ async def test_create_phylo_run_with_gisaid_ids(
     Test phylo tree creation that includes a reference to a GISAID sequence.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -233,7 +233,7 @@ async def test_create_invalid_phylo_run_name(
     Test a phylo tree run request with a bad tree name.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -262,7 +262,7 @@ async def test_create_invalid_phylo_run_tree_type(
     Test a phylo tree run request with a bad tree type.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -291,7 +291,7 @@ async def test_create_invalid_phylo_run_bad_sample_id(
     Test a phylo tree run request with a bad sample id.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -320,15 +320,15 @@ async def test_create_invalid_phylo_run_sample_cannot_see(
     Test a phylo tree run request with a sample a group should not have access to.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
     sample = sample_factory(group, user, location)
 
     group2 = group_factory(name="The Other Group")
-    user2 = user_factory(
-        group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
+    user2 = await userrole_factory(
+        async_session, group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
     )
     location2 = location_factory(
         "North America", "USA", "California", "San Francisco County"
@@ -362,7 +362,7 @@ async def test_create_phylo_run_unauthorized_access_redirect(
     Test a request from an outside, unauthorized source.
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -328,7 +328,10 @@ async def test_create_invalid_phylo_run_sample_cannot_see(
 
     group2 = group_factory(name="The Other Group")
     user2 = await userrole_factory(
-        async_session, group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
+        async_session,
+        group2,
+        email="test_user@othergroup.org",
+        auth0_user_id="other_test_auth0_id",
     )
     location2 = location_factory(
         "North America", "USA", "California", "San Francisco County"

--- a/src/backend/aspen/api/views/tests/test_create_samples.py
+++ b/src/backend/aspen/api/views/tests/test_create_samples.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from aspen.database.models import PathogenGenome, Sample, UploadedPathogenGenome
-from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.usergroup import group_factory, userrole_factory
@@ -483,19 +482,3 @@ async def test_samples_create_view_fail_missing_required_fields(
             },
         ]
     }
-
-
-async def setup_validation_data(session: AsyncSession, client: AsyncClient):
-    group = group_factory()
-    user = await userrole_factory(async_session, group)
-    location = location_factory(
-        "North America", "USA", "California", "Santa Barbara County"
-    )
-    sample = sample_factory(group, user, location)
-    gisaid_sample = gisaid_metadata_factory()
-    session.add(group)
-    session.add(sample)
-    session.add(gisaid_sample)
-    await session.commit()
-
-    return client, sample, gisaid_sample

--- a/src/backend/aspen/api/views/tests/test_create_samples.py
+++ b/src/backend/aspen/api/views/tests/test_create_samples.py
@@ -11,7 +11,7 @@ from aspen.database.models import PathogenGenome, Sample, UploadedPathogenGenome
 from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -33,7 +33,7 @@ async def test_samples_create_view_pass_no_public_id(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -116,7 +116,7 @@ async def test_stripping_whitespace(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -175,7 +175,7 @@ async def test_samples_create_view_pass_no_sequencing_date(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -265,7 +265,7 @@ async def test_samples_create_view_invalid_sequence(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -313,7 +313,7 @@ async def test_samples_create_view_fail_duplicate_ids(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -372,7 +372,7 @@ async def test_samples_create_view_fail_duplicate_ids_in_request_data(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -431,7 +431,7 @@ async def test_samples_create_view_fail_missing_required_fields(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -487,7 +487,7 @@ async def test_samples_create_view_fail_missing_required_fields(
 
 async def setup_validation_data(session: AsyncSession, client: AsyncClient):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
@@ -9,7 +9,7 @@ from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 from aspen.test_infra.models.workflow import aligned_gisaid_dump_factory
 
 # All test coroutines will be treated as marked.
@@ -42,8 +42,8 @@ async def test_delete_phylo_run_matrix(
     """
     group = group_factory(name="group1")
     group2 = group_factory(name="group2")
-    user = user_factory(group, auth0_user_id="user1", email="user1")
-    user2 = user_factory(group2, auth0_user_id="user2", email="user2")
+    user = await userrole_factory(async_session, group, auth0_user_id="user1", email="user1")
+    user2 = await userrole_factory(async_session, group2, auth0_user_id="user2", email="user2")
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
@@ -42,8 +42,12 @@ async def test_delete_phylo_run_matrix(
     """
     group = group_factory(name="group1")
     group2 = group_factory(name="group2")
-    user = await userrole_factory(async_session, group, auth0_user_id="user1", email="user1")
-    user2 = await userrole_factory(async_session, group2, auth0_user_id="user2", email="user2")
+    user = await userrole_factory(
+        async_session, group, auth0_user_id="user1", email="user1"
+    )
+    user2 = await userrole_factory(
+        async_session, group2, auth0_user_id="user2", email="user2"
+    )
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
+++ b/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
@@ -17,7 +17,7 @@ from aspen.api.views.tests.utils.phylo_tree_utils import (
 )
 from aspen.database.models import Group, Location, User
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -97,7 +97,7 @@ async def test_phylo_tree_no_can_see(
 ):
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory(name="CADPH")
-    user: User = user_factory(viewer_group)
+    user: User = await userrole_factory(async_session, viewer_group)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -143,7 +143,7 @@ async def test_phylo_tree_admin(
 ):
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("admin")
-    user: User = user_factory(viewer_group, system_admin=True)
+    user: User = await userrole_factory(async_session, viewer_group, system_admin=True)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_groups.py
+++ b/src/backend/aspen/api/views/tests/test_groups.py
@@ -10,7 +10,7 @@ from aspen.api.views.tests.data.auth0_mock_responses import (
 )
 from aspen.auth.auth0_management import Auth0Client
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -20,15 +20,15 @@ async def test_list_members(
     http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory()
-    user = user_factory(
+    user = await userrole_factory(async_session, 
         group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
-    user2 = user_factory(
+    user2 = await userrole_factory(async_session, 
         group,
         name="Alice",
         auth0_user_id="testid01",
         email="alice@dph.org",
-        group_admin=True,
+        roles=["admin"]
     )
     async_session.add(group)
     await async_session.commit()
@@ -67,10 +67,10 @@ async def test_list_members_unauthorized(
 ) -> None:
     group = group_factory()
     group2 = group_factory(name="test_group2")
-    user = user_factory(
+    user = await userrole_factory(async_session, 
         group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
-    user2 = user_factory(
+    user2 = await userrole_factory(async_session, 
         group2, name="Alice", auth0_user_id="testid01", email="alice@dph.org"
     )
     async_session.add_all([group, group2, user, user2])
@@ -89,7 +89,7 @@ async def test_send_group_invitations(
     async_session: AsyncSession,
 ) -> None:
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     async_session.add_all([group, user])
     await async_session.commit()
 
@@ -129,7 +129,7 @@ async def test_list_group_invitations(
     auth0_apiclient: Auth0Client, http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     async_session.add_all([group, user])
     await async_session.commit()
 
@@ -155,10 +155,10 @@ async def test_list_group_invitations_unauthorized(
 ) -> None:
     group = group_factory()
     group2 = group_factory(name="test_group2")
-    user = user_factory(
+    user = await userrole_factory(async_session, 
         group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
-    user2 = user_factory(
+    user2 = await userrole_factory(async_session, 
         group2, name="Alice", auth0_user_id="testid01", email="alice@dph.org"
     )
     async_session.add_all([group, group2, user, user2])
@@ -174,7 +174,7 @@ async def test_create_group(
     auth0_apiclient: Auth0Client, http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory(division="California", location="San Mateo County")
-    user = user_factory(
+    user = await userrole_factory(async_session, 
         group,
         name="Alice",
         auth0_user_id="admin_id_01",
@@ -226,7 +226,7 @@ async def test_create_group_unauthorized(
     http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory(division="California", location="San Mateo County")
-    user = user_factory(
+    user = await userrole_factory(async_session, 
         group,
         name="Alice",
         auth0_user_id="auth0_id_01",

--- a/src/backend/aspen/api/views/tests/test_groups.py
+++ b/src/backend/aspen/api/views/tests/test_groups.py
@@ -20,15 +20,16 @@ async def test_list_members(
     http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory()
-    user = await userrole_factory(async_session, 
-        group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
+    user = await userrole_factory(
+        async_session, group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
-    user2 = await userrole_factory(async_session, 
+    user2 = await userrole_factory(
+        async_session,
         group,
         name="Alice",
         auth0_user_id="testid01",
         email="alice@dph.org",
-        roles=["admin"]
+        roles=["admin"],
     )
     async_session.add(group)
     await async_session.commit()
@@ -67,11 +68,15 @@ async def test_list_members_unauthorized(
 ) -> None:
     group = group_factory()
     group2 = group_factory(name="test_group2")
-    user = await userrole_factory(async_session, 
-        group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
+    user = await userrole_factory(
+        async_session, group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
-    user2 = await userrole_factory(async_session, 
-        group2, name="Alice", auth0_user_id="testid01", email="alice@dph.org"
+    user2 = await userrole_factory(
+        async_session,
+        group2,
+        name="Alice",
+        auth0_user_id="testid01",
+        email="alice@dph.org",
     )
     async_session.add_all([group, group2, user, user2])
     await async_session.commit()
@@ -155,11 +160,15 @@ async def test_list_group_invitations_unauthorized(
 ) -> None:
     group = group_factory()
     group2 = group_factory(name="test_group2")
-    user = await userrole_factory(async_session, 
-        group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
+    user = await userrole_factory(
+        async_session, group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
-    user2 = await userrole_factory(async_session, 
-        group2, name="Alice", auth0_user_id="testid01", email="alice@dph.org"
+    user2 = await userrole_factory(
+        async_session,
+        group2,
+        name="Alice",
+        auth0_user_id="testid01",
+        email="alice@dph.org",
     )
     async_session.add_all([group, group2, user, user2])
     await async_session.commit()
@@ -174,7 +183,8 @@ async def test_create_group(
     auth0_apiclient: Auth0Client, http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory(division="California", location="San Mateo County")
-    user = await userrole_factory(async_session, 
+    user = await userrole_factory(
+        async_session,
         group,
         name="Alice",
         auth0_user_id="admin_id_01",
@@ -226,7 +236,8 @@ async def test_create_group_unauthorized(
     http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory(division="California", location="San Mateo County")
-    user = await userrole_factory(async_session, 
+    user = await userrole_factory(
+        async_session,
         group,
         name="Alice",
         auth0_user_id="auth0_id_01",

--- a/src/backend/aspen/api/views/tests/test_list_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_list_phylo_runs.py
@@ -19,7 +19,7 @@ from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -112,7 +112,7 @@ async def test_phylo_tree_view(
     n_trees=3,
 ):
     group: Group = group_factory()
-    user: User = user_factory(group)
+    user: User = await userrole_factory(async_session, group)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -131,7 +131,7 @@ async def test_in_progress_and_failed_trees(
     n_trees=3,
 ):
     group: Group = group_factory()
-    user: User = user_factory(group)
+    user: User = await userrole_factory(async_session, group)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -185,7 +185,7 @@ async def test_phylo_trees_can_see(
 ):
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("CADPH")
-    user: User = user_factory(viewer_group)
+    user: User = await userrole_factory(async_session, viewer_group)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -206,7 +206,7 @@ async def test_phylo_trees_no_can_see(
 ):
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("CADPH")
-    user: User = user_factory(viewer_group)
+    user: User = await userrole_factory(async_session, viewer_group)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -230,7 +230,7 @@ async def test_phylo_trees_admin(
 ):
     owner_group: Group = group_factory()
     viewer_group: Group = group_factory("admin")
-    user: User = user_factory(viewer_group, system_admin=True)
+    user: User = await userrole_factory(async_session, viewer_group, system_admin=True)
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
@@ -10,7 +10,7 @@ from aspen.database.models import CanSee, DataType
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -57,7 +57,7 @@ async def test_phylo_tree_rename(
             data_type=DataType.SEQUENCES,
         )
     )
-    user = user_factory(viewer_group)
+    user = await userrole_factory(async_session, viewer_group)
     async_session.add_all(
         [viewer_group, can_see_group, wrong_can_see_group, no_can_see_group]
     )
@@ -143,7 +143,7 @@ async def test_phylo_tree_rename_admin(
     viewer is an admin.  Verify that the nodes are renamed correctly."""
     viewer_group = group_factory()
     owner_group = group_factory("no_can_see")
-    user = user_factory(viewer_group)
+    user = await userrole_factory(async_session, viewer_group)
     viewer_group.can_see = []
     async_session.add_all([viewer_group, owner_group])
 

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -745,8 +745,11 @@ async def test_delete_sample_failures(
 
     # A group that doesn't have access to our sample.
     group2 = group_factory(name="The Other Group")
-    user2 = await userrole_factory(async_session, 
-        group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
+    user2 = await userrole_factory(
+        async_session,
+        group2,
+        email="test_user@othergroup.org",
+        auth0_user_id="other_test_auth0_id",
     )
     location2 = location_factory(
         "North America", "USA", "California", "San Francisco County"
@@ -794,8 +797,11 @@ async def make_test_samples(
     async_session: AsyncSession, suffix=None
 ) -> Tuple[User, Group, List[Sample], Location]:
     group = group_factory(name=f"testgroup{suffix}")
-    user = await userrole_factory(async_session, 
-        group, email=f"testemail{suffix}", auth0_user_id=f"testemail{suffix}"
+    user = await userrole_factory(
+        async_session,
+        group,
+        email=f"testemail{suffix}",
+        auth0_user_id=f"testemail{suffix}",
     )
     location1 = location_factory(
         "North America", "USA", "California", f"Santa Barbara County{suffix}"

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -23,7 +23,7 @@ from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -37,7 +37,7 @@ async def test_samples_view(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -110,7 +110,7 @@ async def test_samples_view_gisaid_rejected(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -176,7 +176,7 @@ async def test_samples_view_gisaid_no_info(
     http_client: AsyncClient,
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -243,7 +243,7 @@ async def test_samples_view_gisaid_not_eligible(
     async_session: AsyncSession, http_client: AsyncClient
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     # Mark the sample as failed
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
@@ -310,7 +310,7 @@ async def _test_samples_view_cansee(
     user_factory_kwargs = user_factory_kwargs or {}
     owner_group = group_factory()
     viewer_group = group_factory(name="cdph")
-    user = user_factory(viewer_group, **user_factory_kwargs)
+    user = await userrole_factory(async_session, viewer_group, **user_factory_kwargs)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -507,7 +507,7 @@ async def test_samples_view_no_pangolin(
     async_session: AsyncSession, http_client: AsyncClient
 ):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -583,7 +583,7 @@ async def test_bulk_delete_sample_success(
     Test successful sample deletion by ID
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -649,7 +649,7 @@ async def test_delete_sample_success(
     Test successful sample deletion by ID
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -734,7 +734,7 @@ async def test_delete_sample_failures(
     Test a sample deletion failure by a user without write access
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -745,7 +745,7 @@ async def test_delete_sample_failures(
 
     # A group that doesn't have access to our sample.
     group2 = group_factory(name="The Other Group")
-    user2 = user_factory(
+    user2 = await userrole_factory(async_session, 
         group2, email="test_user@othergroup.org", auth0_user_id="other_test_auth0_id"
     )
     location2 = location_factory(
@@ -794,7 +794,7 @@ async def make_test_samples(
     async_session: AsyncSession, suffix=None
 ) -> Tuple[User, Group, List[Sample], Location]:
     group = group_factory(name=f"testgroup{suffix}")
-    user = user_factory(
+    user = await userrole_factory(async_session, 
         group, email=f"testemail{suffix}", auth0_user_id=f"testemail{suffix}"
     )
     location1 = location_factory(
@@ -1105,7 +1105,7 @@ async def test_update_samples_request_failures(
 
 async def setup_validation_data(async_session: AsyncSession):
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )

--- a/src/backend/aspen/api/views/tests/test_sequences.py
+++ b/src/backend/aspen/api/views/tests/test_sequences.py
@@ -8,7 +8,7 @@ from aspen.database.models import CanSee, DataType, Sample
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -22,7 +22,7 @@ async def test_prepare_sequences_download(
     Test a regular sequence download for a sample submitted by the user's group
     """
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -57,8 +57,8 @@ async def test_prepare_sequences_download_no_access(
     # create a sample for one group and another viewer group
     owner_group = group_factory()
     viewer_group = group_factory(name="County")
-    viewer = user_factory(viewer_group)
-    owner = user_factory(
+    viewer = await userrole_factory(async_session, viewer_group)
+    owner = await userrole_factory(async_session, 
         owner_group,
         name="Owner",
         auth0_user_id="owner_id",
@@ -93,7 +93,7 @@ async def test_prepare_sequences_download_no_private_id_access(
     """
     owner_group = group_factory()
     viewer_group = group_factory(name="CDPH")
-    user = user_factory(viewer_group)
+    user = await userrole_factory(async_session, viewer_group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
@@ -137,8 +137,8 @@ async def test_access_matrix(
     owner_group1 = group_factory(name="group1")
     owner_group2 = group_factory(name="group2")
     viewer_group = group_factory(name="CDPH")
-    user = user_factory(viewer_group)
-    owner = user_factory(
+    user = await userrole_factory(async_session, viewer_group)
+    owner = await userrole_factory(async_session, 
         owner_group1,
         email="owner@ownersite.com",
         name="Owner User",

--- a/src/backend/aspen/api/views/tests/test_sequences.py
+++ b/src/backend/aspen/api/views/tests/test_sequences.py
@@ -58,7 +58,8 @@ async def test_prepare_sequences_download_no_access(
     owner_group = group_factory()
     viewer_group = group_factory(name="County")
     viewer = await userrole_factory(async_session, viewer_group)
-    owner = await userrole_factory(async_session, 
+    owner = await userrole_factory(
+        async_session,
         owner_group,
         name="Owner",
         auth0_user_id="owner_id",
@@ -138,7 +139,8 @@ async def test_access_matrix(
     owner_group2 = group_factory(name="group2")
     viewer_group = group_factory(name="CDPH")
     user = await userrole_factory(async_session, viewer_group)
-    owner = await userrole_factory(async_session, 
+    owner = await userrole_factory(
+        async_session,
         owner_group1,
         email="owner@ownersite.com",
         name="Owner User",

--- a/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
+++ b/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
@@ -9,7 +9,7 @@ from aspen.database.models import Group, PhyloRun, PhyloTree, Sample, User
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -27,7 +27,7 @@ async def make_shared_test_data(
         -119.9858232,
     )
     group = group_factory(default_tree_location=location)
-    user = user_factory(group, system_admin=system_admin)
+    user = await userrole_factory(async_session, group, system_admin=system_admin)
     samples = [
         sample_factory(
             group,
@@ -119,7 +119,7 @@ async def test_update_phylo_tree_wrong_group(
         phylo_tree,
     ) = await make_shared_test_data(async_session)
     group_that_did_not_make_tree = group_factory(name="i_want_to_see_trees")
-    user_that_did_not_make_tree = user_factory(
+    user_that_did_not_make_tree = await userrole_factory(async_session, 
         group_that_did_not_make_tree,
         name="trying_to_see",
         email="trying_to_see@hotmail.com",

--- a/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
+++ b/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
@@ -119,7 +119,8 @@ async def test_update_phylo_tree_wrong_group(
         phylo_tree,
     ) = await make_shared_test_data(async_session)
     group_that_did_not_make_tree = group_factory(name="i_want_to_see_trees")
-    user_that_did_not_make_tree = await userrole_factory(async_session, 
+    user_that_did_not_make_tree = await userrole_factory(
+        async_session,
         group_that_did_not_make_tree,
         name="trying_to_see",
         email="trying_to_see@hotmail.com",

--- a/src/backend/aspen/api/views/tests/test_users.py
+++ b/src/backend/aspen/api/views/tests/test_users.py
@@ -33,7 +33,7 @@ async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -
         "agreed_to_tos": True,
         "groups": [
             {"id": group.id, "name": group.name, "roles": ["member"]},
-        ]
+        ],
     }
     resp_data = response.json()
     for key in expected:

--- a/src/backend/aspen/api/views/tests/test_users.py
+++ b/src/backend/aspen/api/views/tests/test_users.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from aspen.api.views.tests.data.auth0_mock_responses import DEFAULT_AUTH0_USER
 from aspen.auth.auth0_management import Auth0Client
 from aspen.database.models import User
-from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -> None:
     group = group_factory()
-    user = user_factory(group)
+    user = await userrole_factory(async_session, group)
     async_session.add(group)
     await async_session.commit()
 
@@ -31,6 +31,9 @@ async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -
         "group": {"id": 1, "name": "groupname"},
         "acknowledged_policy_version": None,
         "agreed_to_tos": True,
+        "groups": [
+            {"id": group.id, "name": group.name, "roles": ["member"]},
+        ]
     }
     resp_data = response.json()
     for key in expected:
@@ -44,7 +47,7 @@ async def test_users_view_put_pass(
     async_session: AsyncSession,
 ):
     group = group_factory()
-    user = user_factory(group, agreed_to_tos=False)
+    user = await userrole_factory(async_session, group, agreed_to_tos=False)
     async_session.add(group)
     await async_session.commit()
 
@@ -93,7 +96,7 @@ async def test_usergroup_view_put_fail(
     http_client: AsyncClient, async_session: AsyncSession
 ):
     group = group_factory()
-    user = user_factory(group, agreed_to_tos=False)
+    user = await userrole_factory(async_session, group, agreed_to_tos=False)
     async_session.add(group)
     await async_session.commit()
     headers = {"user_id": user.auth0_user_id}

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -35,6 +35,7 @@ def set_user_groups(user):
             }
     user.groups = list(groups.values())
 
+
 @router.get("/me", response_model=UserMeResponse)
 async def get_current_user(
     request: Request, db: AsyncSession = Depends(get_db), user=Depends(get_auth_user)

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -22,10 +22,7 @@ from aspen.database.models import User
 router = APIRouter()
 
 
-@router.get("/me", response_model=UserMeResponse)
-async def get_current_user(
-    request: Request, db: AsyncSession = Depends(get_db), user=Depends(get_auth_user)
-) -> UserMeResponse:
+def set_user_groups(user):
     groups = {}
     for row in user.user_roles:
         if groups.get(row.group.id):
@@ -38,6 +35,11 @@ async def get_current_user(
             }
     user.groups = list(groups.values())
 
+@router.get("/me", response_model=UserMeResponse)
+async def get_current_user(
+    request: Request, db: AsyncSession = Depends(get_db), user=Depends(get_auth_user)
+) -> UserMeResponse:
+    set_user_groups(user)
     return UserMeResponse.from_orm(user)
 
 
@@ -63,6 +65,7 @@ async def update_user_info(
 
     if user.auth0_user_id and len(auth0_update_items) > 0:
         auth0_client.update_user(user.auth0_user_id, **auth0_update_items)
+    set_user_groups(user)
     return UserMeResponse.from_orm(user)
 
 
@@ -82,4 +85,5 @@ async def post_usergroup(
     user_query = get_usergroup_query(db, user_creation_request.auth0_user_id)
     user_query_result = await db.execute(user_query)
     created_user = user_query_result.unique().scalars().one()
+    set_user_groups(created_user)
     return UserMeResponse.from_orm(created_user)

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -26,6 +26,18 @@ router = APIRouter()
 async def get_current_user(
     request: Request, db: AsyncSession = Depends(get_db), user=Depends(get_auth_user)
 ) -> UserMeResponse:
+    groups = {}
+    for row in user.user_roles:
+        if groups.get(row.group.id):
+            groups[row.group.id]["roles"].append(row.role.name)
+        else:
+            groups[row.group.id] = {
+                "id": row.group.id,
+                "name": row.group.name,
+                "roles": [row.role.name],
+            }
+    user.groups = list(groups.values())
+
     return UserMeResponse.from_orm(user)
 
 


### PR DESCRIPTION
### Summary:
- **What:** Add groups & group roles to `/v2/users/me` response.
- **Ticket:** [sc192742](https://app.shortcut.com/genepi/story/192742)
- **Env:** `<rdev link>`

### Notes:
This builds on #1184

### Demos:
The response format looks like this for now, we can tweak it as necessary if it helps with anything @mmmmmmaya 
![Screen Shot 2022-06-24 at 11 11 17 AM](https://user-images.githubusercontent.com/475208/175618584-9c9f9670-4dd8-469f-81d0-cbf770babbab.png)

- [ ] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)