### PR TITLE
redirect /resources to new help center

### DIFF
--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -75,6 +75,12 @@ module.exports = {
         destination: "/.well-known/security.txt",
         permanent: true,
       },
+      {
+        source: "/resources",
+        destination:
+          "https://help.czgenepi.org/hc/en-us/categories/6217716150804-Genomic-Epidemiology-Learning-Center",
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
### Summary
- **What:** Redirect /resources to the new help center
- **Why:** Users may have the link bookmarked and we removed the page
- **Ticket:** [[sc-195441]](https://app.shortcut.com/genepi/story/195441)
- **Env:** https://maya-redirect-frontend.dev.czgenepi.org/

### Testing
1. Visit the old resources page
1. You should get redirected to the help center
2. You should not even see a flicker of our app
3. Make sure other in-app links to the help center still work (such as in the dropdown in the burger menu in the right side on the nav bar)

### Notes
I don't love that this link is a copy from ROUTES enum. But 1. commonjs can't import from .ts files, and 2. enums don't allow computed members. I don't think this is that big of a deal, so I'm not interested in spending a lot of time to rig up a complex solution for this redirect that is an edge case anyway.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)