### PR TITLE
Patch staging/prod migrations.

### DIFF
--- a/src/backend/database_migrations/versions/20220616_232147_add_user_roles.py
+++ b/src/backend/database_migrations/versions/20220616_232147_add_user_roles.py
@@ -32,6 +32,7 @@ def upgrade():
             index=True,
             autoincrement=False,
             nullable=False,
+            primary_key=True,
         ),
         sa.Column(
             "user_id",

--- a/src/backend/database_migrations/versions/20220616_232148_add_group_roles.py
+++ b/src/backend/database_migrations/versions/20220616_232148_add_group_roles.py
@@ -23,6 +23,7 @@ def upgrade():
             index=True,
             autoincrement=False,
             nullable=False,
+            primary_key=True,
         ),
         sa.Column(
             "grantor_group_id",

--- a/src/backend/database_migrations/versions/20220621_232148_migrate_role_data.py
+++ b/src/backend/database_migrations/versions/20220621_232148_migrate_role_data.py
@@ -39,7 +39,7 @@ def upgrade():
 
     group_role_inserts = sa.sql.text(
         "INSERT INTO aspen.group_roles (role_id, grantor_group_id, grantee_group_id) "
-        "SELECT roles.id, can_see.owner_group_id, can_see.viewer_group_id FROM aspen.can_see "
+        "SELECT DISTINCT roles.id, can_see.owner_group_id, can_see.viewer_group_id FROM aspen.can_see "
         "LEFT JOIN aspen.roles AS roles on roles.name = 'viewer' WHERE data_type = 'TREES' "
     )
     conn.execute(group_role_inserts)


### PR DESCRIPTION
### Summary:
- **What:** Staging and prod have a lot of duplicate can_see rows so our insert/select is breaking due to unique constraints. Only select distinct rows here.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)