### PR TITLE
Migrate some endpoints to Oso

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - API_URL=http://backend.genepinet.localdev:3000
       - FLASK_ENV=development
       - PYTHONUNBUFFERED=1
+      - WORKERS=2
       - RESTART_ON_FAILURE=yes
       - BOTO_ENDPOINT_URL=http://localstack.genepinet.localdev:4566
       - AWS_ACCESS_KEY_ID=dev_access_key_id

--- a/src/backend/aspen/api/authn.py
+++ b/src/backend/aspen/api/authn.py
@@ -23,8 +23,12 @@ def get_usergroup_query(session: AsyncSession, auth0_user_id: str) -> Query:
     return (
         sa.select(User)  # type: ignore
         .options(joinedload(User.group).joinedload(Group.can_see))  # type: ignore
-        .options(joinedload(User.user_roles).joinedload(UserRole.group, innerjoin=True))  # type: ignore
-        .options(joinedload(User.user_roles).joinedload(UserRole.role, innerjoin=True))  # type: ignore
+        .options(
+            joinedload(User.user_roles).options(  # type: ignore
+                joinedload(UserRole.group, innerjoin=True),  # type: ignore
+                joinedload(UserRole.role, innerjoin=True),
+            )
+        )  # type: ignore
         .filter(User.auth0_user_id == auth0_user_id)  # type: ignore
     )
 
@@ -117,14 +121,13 @@ class AuthContext:
 
 
 async def require_group_membership(
-    org_id: Optional[int],
-    request: Request,
+    org_id: Optional[int] = None,
     user: User = Depends(get_auth_user),
     session: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
 ) -> MutableSequence[UserRole]:
+    # Default to the user's old primary group if we don't get an explicit org id in the URL
     if org_id is None:
-        return []
+        org_id = user.group.id
     # Figure out whether this user is a *direct member* of the group
     # we're trying to get context for.
     query = (
@@ -142,7 +145,7 @@ async def require_group_membership(
 
 
 async def get_auth_context(
-    org_id: Optional[int],  # NOTE - This comes from our route!
+    org_id: Optional[int] = None,  # NOTE - This comes from our route!
     user: User = Depends(get_auth_user),
     session: AsyncSession = Depends(get_db),
     user_roles: MutableSequence[UserRole] = Depends(require_group_membership),
@@ -152,6 +155,8 @@ async def get_auth_context(
     # org info *intentionally* for user self-management endpoints (get all my
     # roles, change my username, etc) so we need to handle that case
     group = None
+    if org_id is None:
+        org_id = user.group.id
     roles = []
     for row in user_roles:
         roles.append(row.role.name)
@@ -169,5 +174,8 @@ async def get_auth_context(
     )
     rolewait = await session.execute(query)
     group_roles = rolewait.unique().scalars().all()
-    ac = AuthContext(user, group, roles, group_roles)
+    groles = []
+    for row in group_roles:
+        groles.append({"group_id": row.grantor_group.id, "role": row.role.name})
+    ac = AuthContext(user, group, roles, groles)
     return ac

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -145,7 +145,6 @@ def get_app() -> FastAPI:
     # Which routes are "ready" to accept org prefixes?
     org_routers = {
         "phylo_runs": phylo_runs.router,
-        "phylo_trees": phylo_trees.router,
         "samples": samples.router,
     }
     for suffix, router in org_routers.items():

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -8,7 +8,7 @@ from fastapi.responses import ORJSONResponse
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
-from aspen.api.authn import get_auth_user
+from aspen.api.authn import get_auth_user, require_group_membership
 from aspen.api.error.http_exceptions import AspenException, exception_handler
 from aspen.api.middleware.session import SessionMiddleware
 from aspen.api.settings import Settings
@@ -141,6 +141,19 @@ def get_app() -> FastAPI:
         AspenException,
         exception_handler,
     )
+
+    # Which routes are "ready" to accept org prefixes?
+    org_routers = {
+        "phylo_runs": phylo_runs.router,
+        "phylo_trees": phylo_trees.router,
+        "samples": samples.router,
+    }
+    for suffix, router in org_routers.items():
+        _app.include_router(
+            router,
+            prefix="/v2/orgs/{org_id}/" + suffix,
+            dependencies=[Depends(require_group_membership)],
+        )
 
     return _app
 

--- a/src/backend/aspen/api/policy.polar
+++ b/src/backend/aspen/api/policy.polar
@@ -9,45 +9,56 @@ resource Group {
 
 resource Sample {
   roles = ["admin", "viewer", "member"];
-  permissions = [ "read", "write" ];
+  permissions = [ "read", "read_private", "read_public", "write"];
   relations = { owner: Group };
 
   "viewer" if "viewer" on "owner";
   "member" if "member" on "owner";
   "admin" if "admin" on "owner";
 
-  "read" if "viewer";
-  "read" if "admin";
-  "read" if "member";
+  # viewer permissions
+  "read_public" if "viewer";
+  # admin permissions
+  "read_public" if "admin";
+  "read_private" if "admin";
+  "write" if "admin";
+  # member permissions
+  "read_public" if "member";
+  "read_private" if "member";
   "write" if "member";
 }
 
 resource PhyloRun {
   roles = ["admin", "viewer", "member"];
-  permissions = ["read", "write", "read_private"];
+  permissions = ["read", "write"];
   relations = { owner: Group };
 
   "viewer" if "viewer" on "owner";
   "member" if "member" on "owner";
   "admin" if "admin" on "owner";
 
+  # viewer permissions
   "read" if "viewer";
+  # admin permissions
   "read" if "admin";
+  # member permissions
   "read" if "member";
   "write" if "member";
-  "read_private" if "member";
 }
 
+has_permission(ac: AuthContext, "read", sample: Sample) if
+  has_permission(ac, "read_private", sample) or (
+    has_permission(ac, "read_public", sample) and
+    sample.private = false
+  );
+
 has_role(ac: AuthContext, name: String, group: Group) if
-    ( name in ac.user_roles and ac.group == group) or (
-    grole in ac.group.group_roles and
-    grole.role.name = name and
-    grole.grantor_group_id = group.id);
+    (name in ac.user_roles and
+    group.id = ac.group.id) or (
+        grole in ac.group_roles and
+        grole.role = name and
+        grole.group_id = group.id
+    );
 
-has_permission(authcontext: AuthContext, "read", sample: Sample)
-  if has_role(authcontext, "member", sample)
-    or (has_role(authcontext, "viewer", sample)
-        and sample.private = false);
-
-has_relation(group: Group, "owner", sample: Sample) if sample.submitting_group = group;
 has_relation(group: Group, "owner", phylo_run: PhyloRun) if phylo_run.group = group;
+has_relation(group: Group, "owner", sample: Sample) if sample.submitting_group = group;

--- a/src/backend/aspen/api/utils/__init__.py
+++ b/src/backend/aspen/api/utils/__init__.py
@@ -1,7 +1,6 @@
 from aspen.api.utils.authz import (  # noqa: F401
     authz_phylo_tree_filters,
     authz_sample_filters,
-    authz_samples_cansee,
 )
 from aspen.api.utils.fasta_streamer import FastaStreamer  # noqa: F401
 from aspen.api.utils.find_samples_by_id import (  # noqa: F401
@@ -18,5 +17,6 @@ from aspen.api.utils.sample import (  # noqa: F401
     check_duplicate_samples_in_request,
     determine_gisaid_status,
     format_sample_lineage,
+    samples_by_identifiers,
 )
 from aspen.api.utils.tsv_streamer import MetadataTSVStreamer  # noqa: F401

--- a/src/backend/aspen/api/utils/authz.py
+++ b/src/backend/aspen/api/utils/authz.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Set
 
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql.expression import and_, or_
@@ -30,56 +30,6 @@ def authz_sample_filters(query: Query, sample_ids: Set[str], user: User) -> Quer
             and_(
                 Sample.submitting_group_id.in_(cansee_groups_private_identifiers),
                 Sample.private_identifier.in_(sample_ids),
-            ),
-        )
-    )
-    query = query.filter(
-        and_(or_(~Sample.private, Sample.submitting_group_id == user.group_id))
-    )
-    return query
-
-
-def authz_samples_cansee(
-    query: Query, sample_ids: Optional[Set[str]], user: User
-) -> Query:
-    # No filters for system admins
-    if user.system_admin:
-        if sample_ids:
-            query = query.filter(
-                or_(
-                    Sample.public_identifier.in_(sample_ids),
-                    Sample.private_identifier.in_(sample_ids),
-                )
-            )
-        return query
-
-    # Which groups can this user query public identifiers for?
-    cansee_groups: Set[int] = {
-        cansee.owner_group_id
-        for cansee in user.group.can_see
-        if cansee.data_type == DataType.TREES
-    }
-    # add the user's own group
-    cansee_groups.add(user.group_id)
-
-    cansee_groups_private_identifiers: Set[int] = {user.group_id}
-
-    public_identifier_filter = True
-    private_identifier_filter = True
-    if sample_ids:
-        public_identifier_filter = Sample.public_identifier.in_(sample_ids)
-        private_identifier_filter = Sample.private_identifier.in_(sample_ids)
-
-    cansee_groups.add(user.group_id)
-    query = query.filter(
-        or_(
-            and_(
-                Sample.submitting_group_id.in_(cansee_groups),
-                public_identifier_filter,
-            ),
-            and_(
-                Sample.submitting_group_id.in_(cansee_groups_private_identifiers),
-                private_identifier_filter,
             ),
         )
     )

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -1,13 +1,44 @@
 from collections import Counter
-from typing import Any, Dict, List, Mapping, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.expression import or_
 
+from aspen.api.authz import AuthZSession
 from aspen.database.models import Accession, AccessionType, Sample
 
 if TYPE_CHECKING:
     from aspen.api.schemas.samples import CreateSampleRequest
+
+
+async def samples_by_identifiers(
+    az: AuthZSession, sample_ids: Optional[Set[str]]
+) -> Query:
+    # TODO, this query can be updated to use an "id in (select id from...)" clause when we get a chance to fix it.
+    public_samples_query = (
+        (await az.authorized_query("read_public", Sample))
+        .filter(Sample.public_identifier.in_(sample_ids))  # type: ignore
+        .subquery()  # type: ignore
+    )
+    private_samples_query = (
+        (await az.authorized_query("read_private", Sample))
+         .filter(Sample.public_identifier.in_(sample_ids))  # type: ignore
+        .subquery()  # type: ignore
+    )
+    query = (
+        sa.select(Sample)  # type: ignore
+        .outerjoin(public_samples_query, Sample.id == public_samples_query.c.id)  # type: ignore
+        .outerjoin(private_samples_query, Sample.id == private_samples_query.c.id)  # type: ignore
+        .where(
+            or_(
+                public_samples_query.c.id != None,  # noqa: E711
+                private_samples_query.c.id != None,  # noqa: E711
+            )
+        )
+    )
+    return query
 
 
 def get_all_identifiers_in_request(

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -24,7 +24,7 @@ async def samples_by_identifiers(
     )
     private_samples_query = (
         (await az.authorized_query("read_private", Sample))
-         .filter(Sample.public_identifier.in_(sample_ids))  # type: ignore
+        .filter(Sample.public_identifier.in_(sample_ids))  # type: ignore
         .subquery()  # type: ignore
     )
     query = (

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -13,9 +13,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncResult, AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
-from starlette.requests import Request
 
 from aspen.api.authn import get_auth_user
+from aspen.api.authz import AuthZSession, get_authz_session
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.samples import (
@@ -31,12 +31,12 @@ from aspen.api.schemas.samples import (
 )
 from aspen.api.settings import Settings
 from aspen.api.utils import (
-    authz_samples_cansee,
     check_duplicate_samples,
     check_duplicate_samples_in_request,
     determine_gisaid_status,
     get_matching_gisaid_ids,
     get_missing_and_found_sample_ids,
+    samples_by_identifiers,
 )
 from aspen.database.models import Location, Sample, UploadedPathogenGenome, User
 
@@ -47,21 +47,20 @@ GISAID_REJECTION_TIME = datetime.timedelta(days=4)
 
 @router.get("/", response_model=SamplesResponse)
 async def list_samples(
-    request: Request,
     db: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
+    az: AuthZSession = Depends(get_authz_session),
     user: User = Depends(get_auth_user),
 ) -> SamplesResponse:
 
     # load the samples.
-    all_samples_query = sa.select(Sample).options(  # type: ignore
+    user_visible_samples_query = await az.authorized_query("read", Sample)
+    user_visible_samples_query = user_visible_samples_query.options(  # type: ignore
         selectinload(Sample.uploaded_pathogen_genome),
         selectinload(Sample.submitting_group),
         selectinload(Sample.uploaded_by),
         selectinload(Sample.collection_location),
         selectinload(Sample.accessions),
     )
-    user_visible_samples_query = authz_samples_cansee(all_samples_query, None, user)
     user_visible_samples_result = await db.execute(user_visible_samples_query)
     user_visible_samples: List[Sample] = (
         user_visible_samples_result.unique().scalars().all()
@@ -69,7 +68,9 @@ async def list_samples(
 
     # populate sample object using pydantic response schema
     result = SamplesResponse(samples=[])
+    tot_rows = 0
     for sample in user_visible_samples:
+        tot_rows += 1
         sample.gisaid = determine_gisaid_status(
             sample,
         )
@@ -82,25 +83,18 @@ async def list_samples(
     return result
 
 
-async def get_owned_samples_by_ids(
-    db: AsyncSession, sample_ids: List[int], user: User
+async def get_write_samples_by_ids(
+    db: AsyncSession, az: AuthZSession, sample_ids: List[int]
 ) -> AsyncResult:
-    query = (
-        sa.select(Sample)  # type: ignore
-        .options(
-            joinedload(Sample.uploaded_pathogen_genome),
-            joinedload(Sample.submitting_group),
-            joinedload(Sample.uploaded_by),
-            joinedload(Sample.collection_location),
-        )
-        .filter(  # type: ignore
-            sa.and_(
-                Sample.submitting_group
-                == user.group,  # This is an access control check!
-                Sample.id.in_(sample_ids),
-            )
-        )
-    )
+    query = await az.authorized_query("write", Sample)
+    query = query.options(
+        joinedload(Sample.uploaded_pathogen_genome),
+        joinedload(Sample.submitting_group),
+        joinedload(Sample.uploaded_by),
+        joinedload(Sample.collection_location),
+    ).filter(
+        Sample.id.in_(sample_ids)
+    )  # type: ignore
     results = await db.execute(query)
     return results.scalars()
 
@@ -108,13 +102,11 @@ async def get_owned_samples_by_ids(
 @router.delete("/", responses={200: {"model": SampleBulkDeleteResponse}})
 async def delete_samples(
     sample_info: SampleBulkDeleteRequest,
-    request: Request,
     db: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
-    user: User = Depends(get_auth_user),
+    az: AuthZSession = Depends(get_authz_session),
 ) -> SampleDeleteResponse:
     # Make sure this sample exists and is delete-able by the current user.
-    samples_res = await get_owned_samples_by_ids(db, sample_info.ids, user)
+    samples_res = await get_write_samples_by_ids(db, az, sample_info.ids)
     samples = samples_res.all()
     if len(samples) != len(sample_info.ids):
         raise ex.NotFoundException("samples not found")
@@ -131,13 +123,11 @@ async def delete_samples(
 @router.delete("/{sample_id}", responses={200: {"model": SampleDeleteResponse}})
 async def delete_sample(
     sample_id: int,
-    request: Request,
     db: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
-    user: User = Depends(get_auth_user),
+    az: AuthZSession = Depends(get_authz_session),
 ) -> SampleDeleteResponse:
     # Make sure this sample exists and is delete-able by the current user.
-    sample_db_res = await get_owned_samples_by_ids(db, [sample_id], user)
+    sample_db_res = await get_write_samples_by_ids(db, az, [sample_id])
     try:
         sample = sample_db_res.one()
     except NoResultFound:
@@ -153,8 +143,7 @@ async def delete_sample(
 async def update_samples(
     update_samples_request: UpdateSamplesRequest,
     db: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
-    user: User = Depends(get_auth_user),
+    az: AuthZSession = Depends(get_authz_session),
 ) -> SamplesResponse:
 
     # reorganize request data to make it easier to update
@@ -162,7 +151,7 @@ async def update_samples(
     sample_ids_to_update = list(reorganized_request_data.keys())
 
     # Make sure these samples exist and are delete-able by the current user.
-    sample_db_res = await get_owned_samples_by_ids(db, sample_ids_to_update, user)
+    sample_db_res = await get_write_samples_by_ids(db, az, sample_ids_to_update)
     editable_samples: MutableSequence[Sample] = sample_db_res.all()
 
     # are there any samples that can't be updated?
@@ -210,8 +199,7 @@ async def update_samples(
 async def validate_ids(
     request_data: ValidateIDsRequest,
     db: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
-    user: User = Depends(get_auth_user),
+    az: AuthZSession = Depends(get_authz_session),
 ) -> ValidateIDsResponse:
 
     """
@@ -222,13 +210,9 @@ async def validate_ids(
 
     sample_ids: Set[str] = {item for item in request_data.sample_ids}
 
-    all_samples_query = sa.select(Sample).options()  # type: ignore
-
     # get all samples from request that the user has permission to use and scope down
     # the search for matching ID's to groups that the user has read access to.
-    user_visible_samples_query = authz_samples_cansee(
-        all_samples_query, sample_ids, user
-    )
+    user_visible_samples_query = await samples_by_identifiers(az, sample_ids)
     user_visible_samples_res = await (db.execute(user_visible_samples_query))
     user_visible_samples = user_visible_samples_res.scalars().all()
 

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -75,6 +75,7 @@ async def list_samples(
             sample,
         )
         sample.show_private_identifier = False
+        # TODO - convert this to an oso check.
         if sample.submitting_group_id == user.group_id or user.system_admin:
             sample.show_private_identifier = True
 

--- a/src/backend/aspen/api/views/tests/test_list_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_list_phylo_runs.py
@@ -222,23 +222,3 @@ async def test_phylo_trees_no_can_see(
     results = res.json()["phylo_runs"]
 
     assert len(results) == 0
-
-
-async def test_phylo_trees_admin(
-    async_session,
-    http_client,
-    n_samples=5,
-    n_trees=3,
-):
-    owner_group: Group = group_factory()
-    viewer_group: Group = group_factory("admin")
-    user: User = await userrole_factory(async_session, viewer_group, system_admin=True)
-    location: Location = location_factory(
-        "North America", "USA", "California", "Santa Barbara County"
-    )
-    _, _, trees, _ = make_all_test_data(owner_group, user, location, n_samples, n_trees)
-
-    async_session.add_all((owner_group, viewer_group))
-    await async_session.commit()
-
-    await check_results(http_client, user, trees)

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -364,28 +364,6 @@ async def test_samples_view_no_cansee(
     assert response["samples"] == []
 
 
-async def test_samples_view_system_admin(
-    async_session: AsyncSession,
-    http_client: AsyncClient,
-):
-
-    sample, uploaded_pathogen_genome, response = await _test_samples_view_cansee(
-        async_session,
-        http_client,
-        group_roles=[],
-        user_factory_kwargs={
-            "system_admin": True,
-        },
-    )
-    # assert that we get both the public and private samples back
-    samples = response["samples"]
-    assert len(samples) == 2
-    private_ids = {sample["private_identifier"] for sample in samples}
-    private = {sample["private"] for sample in samples}
-    assert private_ids == {"private_identifer", "private_id"}
-    assert private == {True, False}
-
-
 async def test_samples_view_cansee(
     async_session: AsyncSession,
     http_client: AsyncClient,


### PR DESCRIPTION
### Summary:
- **What:** Migrate the first few endpoints to using Oso for authz
- **Ticket:** [sc202422](https://app.shortcut.com/genepi/story/202422)
- **Env:** `<rdev link>`

### Notes:
This migrates a handful of endpoints to using our new AuthZSession interface and handling optional org_id parameters in endpoint paths.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)