### PR TITLE
Add authorizedsession object for using oso in Depends calls

### DIFF
--- a/src/backend/aspen/api/authz.py
+++ b/src/backend/aspen/api/authz.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from pathlib import Path
 
 from fastapi import Depends
@@ -187,7 +188,7 @@ class AuthorizedSession:
     ):
         self.auth_context = auth_context
         self.oso = oso
-        return self
+        return await self.authorized_query()
 
     async def authorized_query(self):
         return await self.oso.authorized_query(
@@ -195,6 +196,7 @@ class AuthorizedSession:
         )
 
 
+@lru_cache
 def require_access(
     privilege: str,
     model: idbase,

--- a/src/backend/aspen/api/authz.py
+++ b/src/backend/aspen/api/authz.py
@@ -175,7 +175,7 @@ async def get_oso(session: AsyncSession = Depends(get_db)) -> AsyncOso:
     return oso
 
 
-class AuthorizedSession():
+class AuthorizedSession:
     def __init__(self, privilege: str, model: idbase):
         self.privilege = privilege
         self.model = model
@@ -190,10 +190,12 @@ class AuthorizedSession():
         return self
 
     async def authorized_query(self):
-        return await self.oso.authorized_query(self.auth_context, self.privilege, self.model)
+        return await self.oso.authorized_query(
+            self.auth_context, self.privilege, self.model
+        )
 
 
-def require_access( 
+def require_access(
     privilege: str,
     model: idbase,
 ) -> AuthorizedSession:

--- a/src/backend/aspen/api/authz.py
+++ b/src/backend/aspen/api/authz.py
@@ -163,3 +163,38 @@ async def get_authz_session(
     session: AsyncSession = Depends(get_db),
 ) -> AuthZSession:
     return AuthZSession(session, auth_context)
+
+
+async def get_oso(session: AsyncSession = Depends(get_db)) -> AsyncOso:
+    oso = AsyncOso()
+    oso.set_data_filtering_adapter(AsyncSqlAlchemyAdapter(session))
+    register_classes(oso)
+    await oso.load_files(
+        [Path.joinpath(Path(__file__).parent.absolute(), "policy.polar")]
+    )
+    return oso
+
+
+class AuthorizedSession():
+    def __init__(self, privilege: str, model: idbase):
+        self.privilege = privilege
+        self.model = model
+
+    async def __call__(
+        self,
+        auth_context: AuthContext = Depends(get_auth_context),
+        oso: AsyncOso = Depends(get_oso),
+    ):
+        self.auth_context = auth_context
+        self.oso = oso
+        return self
+
+    async def authorized_query(self):
+        return await self.oso.authorized_query(self.auth_context, self.privilege, self.model)
+
+
+def require_access( 
+    privilege: str,
+    model: idbase,
+) -> AuthorizedSession:
+    return AuthorizedSession(privilege, model)

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -15,12 +15,7 @@ from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 
 from aspen.api.authn import get_auth_user
-from aspen.api.authz import (
-    AuthorizedSession,
-    AuthZSession,
-    get_authz_session,
-    require_access,
-)
+from aspen.api.authz import AuthZSession, get_authz_session
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.samples import (
@@ -54,12 +49,12 @@ GISAID_REJECTION_TIME = datetime.timedelta(days=4)
 @router.get("/", response_model=SamplesResponse)
 async def list_samples(
     db: AsyncSession = Depends(get_db),
-    az: AuthorizedSession = Depends(require_access("read", Sample)),
+    az: AuthZSession = Depends(get_authz_session),
     user: User = Depends(get_auth_user),
 ) -> SamplesResponse:
 
     # load the samples.
-    user_visible_samples_query = await az.authorized_query()
+    user_visible_samples_query = await az.authorized_query("read", Sample)
     user_visible_samples_query = user_visible_samples_query.options(  # type: ignore
         selectinload(Sample.uploaded_pathogen_genome),
         selectinload(Sample.submitting_group),

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -15,7 +15,12 @@ from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 
 from aspen.api.authn import get_auth_user
-from aspen.api.authz import AuthZSession, get_authz_session, require_access, AuthorizedSession
+from aspen.api.authz import (
+    AuthorizedSession,
+    AuthZSession,
+    get_authz_session,
+    require_access,
+)
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.samples import (

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 
 from aspen.api.authn import get_auth_user
-from aspen.api.authz import AuthZSession, get_authz_session
+from aspen.api.authz import AuthZSession, get_authz_session, require_access, AuthorizedSession
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
 from aspen.api.schemas.samples import (
@@ -49,12 +49,12 @@ GISAID_REJECTION_TIME = datetime.timedelta(days=4)
 @router.get("/", response_model=SamplesResponse)
 async def list_samples(
     db: AsyncSession = Depends(get_db),
-    az: AuthZSession = Depends(get_authz_session),
+    az: AuthorizedSession = Depends(require_access("read", Sample)),
     user: User = Depends(get_auth_user),
 ) -> SamplesResponse:
 
     # load the samples.
-    user_visible_samples_query = await az.authorized_query("read", Sample)
+    user_visible_samples_query = await az.authorized_query()
     user_visible_samples_query = user_visible_samples_query.options(  # type: ignore
         selectinload(Sample.uploaded_pathogen_genome),
         selectinload(Sample.submitting_group),


### PR DESCRIPTION
### Summary:
- **What:** Adds a function, `require_access(permission, resource)` that can be used as part of a `Depends()` call in the function signature of an API endpoint. Returns an oso authorized query.
- **Ticket:** [sc202422](https://app.shortcut.com/genepi/story/202422)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)