### PR TITLE
Vince/segment methods

### DIFF
--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -2,9 +2,11 @@ import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { StylesProvider, ThemeProvider } from "@material-ui/core/styles";
 import { AppProps } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import "semantic-ui-css/semantic.min.css";
+import { analyticsRecordRouteChange } from "src/common/analytics/methods";
 import { OneTrustInitializer } from "src/common/analytics/OneTrustInitializer";
 import { PlausibleInitializer } from "src/common/analytics/PlausibleInitializer";
 import { SegmentInitializer } from "src/common/analytics/SegmentInitializer";
@@ -28,6 +30,30 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
       jssStyles.parentElement?.removeChild(jssStyles);
     }
   }, []);
+
+  const router = useRouter(); // Used to track page changes for analytics.
+  /**
+   * Whenever route changes, fire off an analytics event to track page change.
+   *
+   * In theory, the returned unmount func should be used seldom, because the
+   * top-level App should always stay mounted. However, we have outstanding
+   * issues with repeated mount/unmounts. See this ticket:
+   *   FIXME: https://app.shortcut.com/genepi/story/204578
+   *
+   * Additionally, when the app loads, the `routeChangeComplete` event fires
+   * repeatedly. It's unclear at the moment if it's connected to the above,
+   * but that issue is being tracked by this ticket:
+   *   FIXME: https://app.shortcut.com/genepi/story/204580
+   * As a workaround for the above, we keep track of the route each `page`
+   * method call happens on, and then don't fire off another `page` call until
+   * the next time it changes.
+   */
+  useEffect(() => {
+    router.events.on("routeChangeComplete", analyticsRecordRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", analyticsRecordRouteChange);
+    };
+  }, [router]);
 
   return (
     <>

--- a/src/frontend/public/segmentInitScript.js
+++ b/src/frontend/public/segmentInitScript.js
@@ -2,11 +2,20 @@
 // Bootstraps the Segment analytics once usage conditions are met.
 // Uses immediately invoked function to not pollute global namespace.
 (function () {
-  const segmentKey = document.querySelector(
-      '#segment-init-script').dataset.segmentKey;
-  // Mostly verbatim from Segment-provided snippet. Only change is dynamic key.
+  const dataset = document.querySelector('#segment-init-script').dataset;
+  const segmentKey = dataset.segmentKey;
+  const anonUserId = dataset.anonUserId;
+  const groupId = dataset.groupId;
+  const groupName = dataset.groupName;
+  // This is mostly verbatim from Segment-provided snippet. Only change is dynamic key.
   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
   analytics.load(segmentKey);
   analytics.page();
+  // Back to custom code. Send de-identified user info.
+  analytics.identify(anonUserId,
+    {
+      group_id: groupId,
+      group_name: groupName,
+    });
   }}();
 })();

--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -1,7 +1,9 @@
 import Script from "next/script";
 import React from "react";
+import { extractAnalyticsUserInfo } from "src/common/analytics/methods";
 import { ONETRUST_ENABLING_CLASS } from "src/common/analytics/OneTrustInitializer";
 import ENV from "src/common/constants/ENV";
+import { useUserInfo } from "src/common/queries/auth";
 
 /**
  * Actual initialization of Segment done by raw JS script at below route.
@@ -50,6 +52,15 @@ const INITIAL_SCRIPT_TYPE = "text/plain";
  *      side for now). This means that, even if this code gets to Prod,
  *      no analytics will run right now on Prod.
  *
+ * In addition to initializing the Segment analytics framework, the init script
+ * also kicks off an initial `page` call to record what page the user starts on
+ * and an initial `identify` (but using non-PII info only) to send info about
+ * the user. Subsequent changes to the page or user info are captured via
+ * `analyticsRecordRouteChange` and `analyticsSendUserInfo`, for more details
+ * read their documentation. This bifurcation between how the Segment method
+ * calls happen is necessary to avoid race conditions and to avoid spamming
+ * our analytics data with duplicate entries.
+ *
  * Usage note: Weirdly, even though this boils down to being a <script> tag,
  * Next.js does not like it to be present in a Next `Head` or `Html` component.
  * Instead, just put it anywhere in the "normal" flow of components. A good
@@ -57,14 +68,24 @@ const INITIAL_SCRIPT_TYPE = "text/plain";
  * put it somewhere else as well.
  */
 export function SegmentInitializer() {
-  const segmentWriteKey = ENV.SEGMENT_FRONTEND_KEY;
-  return segmentWriteKey ? (
+  // `userInfo` will be false-y if user is not logged in
+  const { data: userInfo } = useUserInfo();
+  if (!userInfo) return null;
+
+  // IMPORTANT: If `extractAnalyticsUserInfo` changes at any point, be sure
+  // that the user info we pass to segmentInitScript and use there matches
+  // the structure of what is sent in the `analyticsSendUserInfo` function.
+  const analyticsUserInfo = extractAnalyticsUserInfo(userInfo);
+  return userInfo && SEGMENT_WRITE_KEY ? (
     <Script
       id={SEGMENT_SCRIPT_TAG_ID}
       type={INITIAL_SCRIPT_TYPE}
       src={SEGMENT_INIT_SCRIPT_ROUTE}
-      data-segment-key={SEGMENT_WRITE_KEY}
       className={ONETRUST_ENABLING_CLASS}
+      data-segment-key={SEGMENT_WRITE_KEY}
+      data-anon-user-id={analyticsUserInfo.anonUserId}
+      data-group-id={analyticsUserInfo.groupId}
+      data-group-name={analyticsUserInfo.groupName}
     />
   ) : null;
 }

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonical list of all the various event types we track with analytics.
+ *
+ * This exists to ensure consistency/clarity across types and to provide
+ * a reference for data analysts working on CZ GE.
+ *
+ * - Each event type should have a plain-English description of what it means.
+ * - Event types should be written in SCREAMING_SNAKE_CASE
+ * - Each entry in the enum should be a duplicate key/value string enum
+ */
+export enum EVENT_TYPES {
+  // User has been sent to Nextstrain to view a phylo tree
+  TREE_VIEW_NEXTSTRAIN = "TREE_VIEW_NEXTSTRAIN",
+}

--- a/src/frontend/src/common/analytics/methods.ts
+++ b/src/frontend/src/common/analytics/methods.ts
@@ -1,0 +1,184 @@
+/**
+ * Funcs that handle calling the various Segment methods we use for analytics.
+ *
+ * Broadly speaking, our data capture for analytics splits into three types:
+ * - Events: A discrete "thing" happening in our app, generally initiated by
+ *   a user, but could also could be an event to track an internal happening
+ *   (e.g., noting an upload failing because of a BE error).
+ *     Handled by `analyticsTrackEvent`
+ * - User info: Capturing info on the user. We make sure to de-identify the
+ *   user and only send up non-PII data to analytics. This occurs when the
+ *   app loads, and also if they later change something about how they are
+ *   seen as a user (e.g., which group they are viewing).
+ *     Handled by `analyticsSendUserInfo`
+ * - Page/Route: Noting when the user's page changes and recording what page
+ *   they are now on. This happens for every route change.
+ *     Handled by `analyticsRecordRouteChange`
+ *
+ * For all of the functions here, if a user has opted-out of analytics, the
+ * functions will do nothing. That way these functions can be safely called
+ * in the rest of our code and all of the opt-in/out logic is taken care of.
+ */
+import { debounce, isEmpty, isEqual } from "lodash";
+import { EVENT_TYPES } from "./eventTypes";
+
+/**
+ * Values we consider reasonable to send to Segment as properties of event.
+ *
+ * Note that `undefined` is also acceptable within the event properties object
+ * as a value, but it is instead interpreted as "delete this key" when Segment
+ * receives. The `analyticsTrackEvent` function allows undefined, but for
+ * clarity it's not considered an EventValue since it's not a value, per se.
+ *
+ * This is a convention we are choosing to make. Segment does not care what is
+ * sent, this could be `any` type, but we want to ensure a flat structure of
+ * key-value pairs for downstream analysis since the structure of the event
+ * properties implicitly determines the schema used for the event table when
+ * Segment syncs with the data warehouse.
+ */
+type EventValue = string | number | boolean | null;
+
+/**
+ * Send occurrence of an event we track to Segment for analytics.
+ *
+ * Fires off a Segment `track` event. If user is opted-out of analytics, this
+ * function does nothing.
+ *
+ * When calling this function, be careful to ensure it only gets called once
+ * per event. There are a couple gotchas in our app around components double
+ * mounting -- see https://app.shortcut.com/genepi/story/204578 -- so it is
+ * usually best to avoid firing an event on component mount, since that can
+ * result in duplicates. Be sure to verify that your event is firing as
+ * expected in the Segment debugger before considering any work around
+ * implementing or changing an event complete.
+ *
+ * Args:
+ *   eventType (str, from EVENT_TYPES enum): canonical, unique name for event
+ *   additionalEventData (obj): any additional data pertaining to event
+ *     --- IMPORTANT USAGE NOTES ---
+ *     The structure of this object will determine the (implicitly created)
+ *     schema that Segment makes when it lands event in data warehouse. So:
+ *     - All the keys in additionalEventData should be in **snake_case** to
+ *     match expectation when working with analytics database.
+ *     - additionalEventData should be a flat object of simple key-value pairs.
+ *     You can send `undefined` for a value, but it will cause the key to be
+ *     considered deleted for that event when it lands in Segment.
+ */
+export function analyticsTrackEvent(
+  eventType: EVENT_TYPES,
+  additionalEventData: Record<string, EventValue | undefined> = {}
+): void {
+  if (window.analytics && window.isCzGenEpiAnalyticsEnabled) {
+    window.analytics.track(eventType, additionalEventData);
+  }
+}
+
+// Info on user that we send for analytics. Note that user is de-identified.
+interface AnalyticsUserInfo {
+  anonUserId?: string;
+  groupId?: number;
+  groupName?: string;
+}
+/**
+ * Helper to extract de-identified user info for sending to analytics.
+ *
+ * Important to have a standardized way because we need to ensure that the
+ * data being pulled is consistent across the different ways we `identify`:
+ * both initial app load via segmentInitScript and later user info changes
+ * via analyticsSendUserInfo. For more info, see analyticsSendUserInfo docs.
+ *
+ * Also important because we need to be sure that we don't accidentally pull
+ * PII and send as part of an `identify`. The data this helper pulls is the
+ * non-PII data that's safe for analytics and we don't want to inadvertently
+ * expose any sensitive data from FE to analytics.
+ *
+ * TODO -- This function will need to grow in complexity and probably alter
+ * its signature once we have multi-group membership in place.
+ */
+export function extractAnalyticsUserInfo(userInfo: User): AnalyticsUserInfo {
+  // TODO [Vincent, near future] Below is a temporary anonymous ID for dev work
+  // and will be replaced soon by a proper anonymized user ID once that aspect
+  // is in place in the backend and comes with rest of userInfo data.
+  const PLACEHOLDER_ANON_USER_ID = "warrrbargl";
+  return {
+    anonUserId: PLACEHOLDER_ANON_USER_ID,
+    groupId: userInfo.group.id,
+    groupName: userInfo.group.name,
+  };
+}
+
+/**
+ * Send user info to Segment. Initial app load handled elsewhere, see below.
+ *
+ * Sends de-identified user info to Segment. It tracks user's current group
+ * and should be re-fired every time the user changes the group that they
+ * are currently operating as (if they're in multiple groups). If user is
+ * opted-out of analytics, this function does nothing.
+ *
+ * Because of how our app loads user info and the Segment analytics framework,
+ * there is a race condition: we don't know if user info from BE or analytics
+ * will finish first. As such, we do **not** use this function as part of the
+ * app's initial load. We fire off first `identify` method (assuming opt-in)
+ * as part of the SegmentInitializer -> segmentInitScript interaction. By
+ * relying on the init script to handle first `identify`, we can avoid the
+ * race condition.
+ *   IMPORTANT: Because of ^^^ above, we must ensure that the `identify` call
+ *   in segmentInitScript matches the structure of how `identify` is used here
+ *   and that SegmentInitializer is pulling that same data to pass to script,
+ *   otherwise the structure of the `identify` payload will change depending
+ *   on where it came from and it will cause problems for our data analyst.
+ */
+let previouslySentUserInfo: AnalyticsUserInfo = {};
+function analyticsSendUserInfo_(userInfo: User): void {
+  const analyticsUserInfo = extractAnalyticsUserInfo(userInfo);
+  if (isEmpty(previouslySentUserInfo)) {
+    // Very first user info payload handled by Segment init script.
+    // If this is empty now, record info, but skip doing anything.
+    previouslySentUserInfo = analyticsUserInfo;
+  } else if (
+    window.analytics &&
+    window.isCzGenEpiAnalyticsEnabled &&
+    !isEqual(previouslySentUserInfo, analyticsUserInfo)
+  ) {
+    window.analytics.identify(analyticsUserInfo.anonUserId, {
+      group_id: analyticsUserInfo.groupId,
+      group_name: analyticsUserInfo.groupName,
+    });
+    previouslySentUserInfo = analyticsUserInfo;
+  }
+}
+// Sending user info (ignoring app load `identify` call) usually happens based
+// on `useUserInfo` calls. Since these tend to bunch up and get called one on
+// top of the other, we debounce so we don't spam analytics.
+export const analyticsSendUserInfo = debounce(analyticsSendUserInfo_, 500, {
+  trailing: true,
+});
+
+/**
+ * Record page change in Segment. Meant for use in Nextjs router.events.
+ *
+ * The Nextjs `router` allows you to subscribe to various events. This func is
+ * subscribed to the routeChangeComplete event, so whenever the route changes,
+ * we kick off an analtyics call and report new page to Segment (assuming that
+ * the user has opted in to analytics, if not, it's a no-op).
+ *
+ * While this should be a simple process as outlined above, we currently have
+ * an issue where the router fires off lots of duplicate "changes" when the
+ * app is loading. See this ticket for more details:
+ *   FIXME: https://app.shortcut.com/genepi/story/204580
+ * To avoid spamming a bunch of duplicate page change events, we keep a var
+ * of the previouslyRecordedRoute: if a new route "change" matches the "change"
+ * we just saw, we ignore it and do nothing. This prevents firing duplicate
+ * `page` calls until we can fix whatever is causing the weird router stuff.
+ */
+let previouslyRecordedRoute = "";
+export function analyticsRecordRouteChange(pageUrl: string): void {
+  if (
+    window.analytics &&
+    window.isCzGenEpiAnalyticsEnabled &&
+    previouslyRecordedRoute !== pageUrl
+  ) {
+    window.analytics.page();
+    previouslyRecordedRoute = pageUrl;
+  }
+}

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -7,6 +7,7 @@ import {
   useQueryClient,
   UseQueryResult,
 } from "react-query";
+import { analyticsSendUserInfo } from "src/common/analytics/methods";
 import ENV from "src/common/constants/ENV";
 import { API, DEFAULT_PUT_OPTIONS, getBackendApiJson } from "../api";
 import { ROUTES } from "../routes";
@@ -78,10 +79,19 @@ export function useUpdateUserInfo(): UseMutationResult<
   });
 }
 
+// Performs the needed `select` for `useUserInfo`, but also inserts a call
+// to analytics as a way to easily catch any changes to user info over time.
+function mapUserDataAndHandleAnalytics(obj: RawUserRequest): User {
+  const user = mapUserData(obj);
+  analyticsSendUserInfo(user);
+  return user;
+}
+
 export function useUserInfo(): UseQueryResult<User, unknown> {
   return useQuery([USE_USER_INFO], fetchUserInfo, {
     retry: false,
-    select: mapUserData,
+    // Analytics rides along here as a way to capture user info changes
+    select: mapUserDataAndHandleAnalytics,
   });
 }
 

--- a/src/frontend/src/common/types/windowAnalytics.d.ts
+++ b/src/frontend/src/common/types/windowAnalytics.d.ts
@@ -21,9 +21,10 @@ declare global {
   interface Window {
     // Below **adds** to Window properties, not a replacement.
     analytics?: {
-      identify: (userId: string, traits: Record<string, unknown>) => void;
+      identify: (userId?: string, traits: Record<string, unknown>) => void;
       page: () => void;
       track: (eventType: string, properties: Record<string, unknown>) => void;
     };
+    isCzGenEpiAnalyticsEnabled?: boolean;
   }
 }

--- a/src/frontend/src/common/types/windowAnalytics.d.ts
+++ b/src/frontend/src/common/types/windowAnalytics.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Adds the `analytics` property for TypeScript to global window object.
+ *
+ * Our analytics library, Segment, adds the `analytics` object to the global
+ * namespace. In our React code, we access it as `window.analytics`. This
+ * file adds the appropriate types to `window`. The methods on `analytics`
+ * is not an exhaustive listing of everything available via Segment, it's
+ * just the methods we use in our app.
+ *
+ * I [Vince] found this a bit surprising as the way to add types to a global
+ * object, but after some searching, it seems like the best way to do it.
+ * References:
+ *   https://stackoverflow.com/a/47130953
+ *   https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#augmenting-globalmodule-scope-from-modules
+ */
+
+// Ensure this is treated as a module so we can add to global interface.
+export {};
+
+declare global {
+  interface Window {
+    // Below **adds** to Window properties, not a replacement.
+    analytics?: {
+      identify: (userId: string, traits: Record<string, unknown>) => void;
+      page: () => void;
+      track: (eventType: string, properties: Record<string, unknown>) => void;
+    };
+  }
+}

--- a/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { EVENT_TYPES } from "src/common/analytics/eventTypes";
+import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { RedirectConfirmationModal } from "src/common/components/library/data_subview/components/RedirectConfirmationModal";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import nextstrainLogo from "src/common/images/nextstrain.png";
@@ -24,7 +26,12 @@ const NextstrainConfirmationModal = ({
     </>
   );
 
-  const confirmButton = <ConfirmButton treeId={treeId} />;
+  const confirmButton = (
+    <ConfirmButton
+      treeId={treeId}
+      onClick={() => analyticsTrackEvent(EVENT_TYPES.TREE_VIEW_NEXTSTRAIN)}
+    />
+  );
 
   return (
     <RedirectConfirmationModal


### PR DESCRIPTION
### Summary:
- **What:** Establish process to call all the analytics framework methods we care about
- **Ticket:** [sc<192935>](https://app.shortcut.com/genepi/story/<192935>) -- This ticket is really not a good indication of the work done here. I basically started at proof of concept and figured I might as well implement all the structure for actually using the framework in one go, but never updated the ticket to match.
- **Env:** no rdev, going to launch an rdev with next PR once all the various events are in place and verify everything is landing as expected at once (I was verifying locally though as I worked)

### Notes:
Big goal of this work was twofold:
1. Set up the analytics stuff to be very easy to use in the future (just import function and fire away, no need to really understand any of how analytics is set up)
2. Set it up in such a way so that it would be hard to use wrong (try to ensure the functions all handle opting-out, already deal with edge case / race condition and will just quietly work as expected, decent guard rails in place to avoid leaking PII)

### Checklist:
- [x] I merged latest `vince/analytics` (long lived analytics branch)
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
~[ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)~