### PR TITLE
Fix selected sample download

### DIFF
--- a/src/backend/aspen/api/views/tests/test_groups.py
+++ b/src/backend/aspen/api/views/tests/test_groups.py
@@ -33,7 +33,11 @@ async def test_list_members(
         roles=["admin"],
     )
     user3 = await userrole_factory(
-        async_session, group2, name="Jane", auth0_user_id="testid03", email="jane@dph.org"
+        async_session,
+        group2,
+        name="Jane",
+        auth0_user_id="testid03",
+        email="jane@dph.org",
     )
     async_session.add(group)
     async_session.add(user3)

--- a/src/backend/aspen/api/views/tests/test_groups.py
+++ b/src/backend/aspen/api/views/tests/test_groups.py
@@ -20,6 +20,7 @@ async def test_list_members(
     http_client: AsyncClient, async_session: AsyncSession
 ) -> None:
     group = group_factory()
+    group2 = group_factory(name="test_group2")
     user = await userrole_factory(
         async_session, group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
     )
@@ -31,24 +32,21 @@ async def test_list_members(
         email="alice@dph.org",
         roles=["admin"],
     )
+    user3 = await userrole_factory(
+        async_session, group2, name="Jane", auth0_user_id="testid03", email="jane@dph.org"
+    )
     async_session.add(group)
+    async_session.add(user3)
+    async_session.add(group2)
     await async_session.commit()
 
     response = await http_client.get(
         f"/v2/groups/{group.id}/members/", headers={"user_id": user.auth0_user_id}
     )
     assert response.status_code == 200
+    # TODO - this response isn't sorted, so our test should handle unordered results.
     expected = {
         "members": [
-            {
-                "id": user.id,
-                "name": user.name,
-                "agreed_to_tos": True,
-                "acknowledged_policy_version": None,
-                "email": user.email,
-                "group_admin": False,
-                "role": "member",
-            },
             {
                 "id": user2.id,
                 "name": user2.name,
@@ -57,6 +55,15 @@ async def test_list_members(
                 "email": user2.email,
                 "group_admin": True,
                 "role": "admin",
+            },
+            {
+                "id": user.id,
+                "name": user.name,
+                "agreed_to_tos": True,
+                "acknowledged_policy_version": None,
+                "email": user.email,
+                "group_admin": False,
+                "role": "member",
             },
         ]
     }

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -506,6 +506,16 @@ def phylo_trees():
     pass
 
 
+@phylo_trees.command(name="selected-samples")
+@click.argument("tree_id")
+@click.pass_context
+def selected_samples(ctx, tree_id):
+    api_client = ctx.obj["api_client"]
+    params = {}
+    resp = api_client.get(f"/v2/phylo_trees/{tree_id}/sample_ids", params=params)
+    print(resp.text)
+
+
 @phylo_trees.command(name="download")
 @click.argument("tree_id")
 @click.option("--public-ids/--private-ids", is_flag=True, default=False)


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`
- 
### Notes:
oso's authorized queries tend to include a "DISTINCT ON" at the beginning, which means that they don't work very well when using these queries with joined-loading of one-to-many relationships. This query was essentially structured like:

```
SELECT *
FROM (SELECT DISTINCT ON (aspen.entities.id, aspen.phylo_trees.entity_id) entities_1.id AS id, ... more columns...
FROM <all the tables and join conditions you'd expect>
```

the `distinct on` prevented us from loading all of the samples we provided as input to a phylo run.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)