### PR TITLE
update nextstrain docker

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -1,4 +1,4 @@
-FROM nextstrain/base@sha256:9d65e6d5dee02fc59c57e0a5043af082ccf42c728aa0dfa867f7585a816a67c2
+FROM nextstrain/base
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer = "CZ Gen Epi"

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -1,7 +1,7 @@
 ## Dockerfile for aspen batch jobs
 ##
 ##
-FROM nextstrain/base@sha256:9d65e6d5dee02fc59c57e0a5043af082ccf42c728aa0dfa867f7585a816a67c2
+FROM nextstrain/base
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer = "CZ Gen Epi"


### PR DESCRIPTION
### Summary:
- **What:** Brought in the latest upstream from `nextstrain/ncov` which included the Nextclade V2 update https://github.com/chanzuckerberg/ncov/pull/8. This PR releases the pin on our nextstrain docker so we can use the latest one which has Nextclade V2. 

### Demos:
Tree build w the new docker and new ncov pin worked together. Will test again in staging.

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)