### PR TITLE
Let users fetch group info for all the groups they are members of

### DIFF
--- a/src/backend/aspen/api/authn.py
+++ b/src/backend/aspen/api/authn.py
@@ -206,24 +206,34 @@ class AuthContext:
         self.group_roles = group_roles
 
 
+async def get_group_context(
+    org_id: Optional[int] = None,  # NOTE - This comes from our route!
+    group_id: Optional[
+        int
+    ] = None,  # NOTE - This comes from our route for group endpoints!
+    user: User = Depends(get_auth_user),
+) -> Optional[int]:
+    # Look for a group context in one of these places.
+    # NOTE - user.group_id is going to go away soon but we need it temporarily.
+    group = group_id or org_id or user.group_id
+    return group
+
+
 async def require_group_membership(
-    org_id: Optional[int] = None,
+    group_id: Optional[int] = Depends(get_group_context),
     user: User = Depends(get_auth_user),
     session: AsyncSession = Depends(get_db),
 ) -> MutableSequence[UserRole]:
-    # Default to the user's old primary group if we don't get an explicit org id in the URL
-    if org_id is None:
-        org_id = user.group.id
     # Figure out whether this user is a *direct member* of the group
     # we're trying to get context for.
     query = (
         sa.select(UserRole)  # type: ignore
-        .options(
+        .options(  # type: ignore
             joinedload(UserRole.role, innerjoin=True),  # type: ignore
             joinedload(UserRole.group, innerjoin=True),  # type: ignore
         )
         .filter(UserRole.user == user)  # type: ignore
-        .filter(UserRole.group_id == org_id)  # type: ignore
+        .filter(UserRole.group_id == group_id)  # type: ignore
     )
     rolewait = await session.execute(query)
     user_roles = rolewait.unique().scalars().all()
@@ -231,7 +241,7 @@ async def require_group_membership(
 
 
 async def get_auth_context(
-    org_id: Optional[int] = None,  # NOTE - This comes from our route!
+    group_id: Optional[int] = Depends(get_group_context),
     user: User = Depends(get_auth_user),
     session: AsyncSession = Depends(get_db),
     user_roles: MutableSequence[UserRole] = Depends(require_group_membership),
@@ -241,8 +251,6 @@ async def get_auth_context(
     # org info *intentionally* for user self-management endpoints (get all my
     # roles, change my username, etc) so we need to handle that case
     group = None
-    if org_id is None:
-        org_id = user.group.id
     roles: List[str] = []
     for row in user_roles:
         roles.append(row.role.name)
@@ -252,11 +260,11 @@ async def get_auth_context(
         raise ex.UnauthorizedException("not authorized")
     query = (
         sa.select(GroupRole)  # type: ignore
-        .options(
+        .options(  # type: ignore
             joinedload(GroupRole.role, innerjoin=True),  # type: ignore
             joinedload(GroupRole.grantor_group, innerjoin=True),  # type: ignore
         )
-        .filter(GroupRole.grantee_group_id == org_id)  # type: ignore
+        .filter(GroupRole.grantee_group_id == group_id)  # type: ignore
     )
     rolewait = await session.execute(query)
     group_roles = rolewait.unique().scalars().all()


### PR DESCRIPTION
### Summary:
Our backend usually needs to know what group you're acting on behalf of, to determine what access you have. For most endpoints, we fetch this "group context" info from the `/orgs/{org_id}` part of an endpoint URL.

While it might be possible to have group A grant admin access to group B, and then move the group management endpoints under a structure more like `/orgs/B/groups/A/members` I think that's outside of the scope of our current product spec. This change temporarily lets us use the group id part of a `/groups/{group_id}` path to act as a stand-in for org_id.

I think we probably need to think harder about how we'll manage auth context for any endpoints that will likely *never* need a group context (like updating my user profile) but this should keep us moving for now. 

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)