### PR TITLE
Sync auth0 user/group roles to the db on login

### DIFF
--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -83,6 +83,7 @@ async def create_user_if_not_exists(db, auth0_mgmt, userinfo) -> Optional[User]:
     }
     newuser = User(**user_fields)
     db.add(newuser)
+    return newuser
 
 
 @router.get("/callback")

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -1,14 +1,20 @@
+from typing import Optional, Set, Tuple
+
 import pytest
 import sqlalchemy as sa
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
-from typing import Set, Tuple, Optional
 
 from aspen.api.views.auth import create_user_if_not_exists
 from aspen.auth.auth0_management import Auth0Client
-from aspen.database.models import User, UserRole, Role
-from aspen.test_infra.models.usergroup import group_factory, userrole_factory
+from aspen.auth.role_manager import RoleManager
+from aspen.database.models import User, UserRole
+from aspen.test_infra.models.usergroup import (
+    group_factory,
+    user_factory,
+    userrole_factory,
+)
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -19,14 +25,21 @@ async def start_new_transaction(session: AsyncSession):
     await session.close()
     session.begin()
 
-async def check_roles(async_session: AsyncSession, auth0_user_id: str, expected_roles: Set[Tuple[str, str]]):
+
+async def check_roles(
+    async_session: AsyncSession,
+    auth0_user_id: str,
+    expected_roles: Set[Tuple[str, str]],
+):
     db_roles = (
         (
             await async_session.execute(
                 sa.select(User)  # type: ignore
-                .options(joinedload(User.user_roles, innerjoin=True).options(  # type: ignore
-                         joinedload(UserRole.group, innerjoin=True),  # type: ignore
-                         joinedload(UserRole.role, innerjoin=True))  # type: ignore
+                .options(
+                    joinedload(User.user_roles, innerjoin=True).options(  # type: ignore
+                        joinedload(UserRole.group, innerjoin=True),  # type: ignore
+                        joinedload(UserRole.role, innerjoin=True),
+                    )  # type: ignore
                 )
                 .filter(User.auth0_user_id == auth0_user_id)  # type: ignore
             )
@@ -39,6 +52,8 @@ async def check_roles(async_session: AsyncSession, auth0_user_id: str, expected_
     for user in db_roles:
         for user_role in user.user_roles:
             actual_roles.add((user_role.group.auth0_org_id, user_role.role.name))
+    print(f"expected: {expected_roles}")
+    print(f"actual: {actual_roles}")
     assert expected_roles == actual_roles
 
 
@@ -154,26 +169,33 @@ async def test_dont_create_new_user_if_exists(
     expected_roles = {(group.auth0_org_id, "member")}
     await check_roles(async_session, userinfo["sub"], expected_roles)
 
+
 async def test_create_new_user_and_sync_roles(
     async_session: AsyncSession,
-    http_client: AsyncClient,
     auth0_apiclient: Auth0Client,
 ):
     """
-    Test creating a new auth0 user on login
+    Test creating a new auth0 user on login and syncing its roles
     """
     userinfo = {
         "sub": "user123-asdf",
-        "org_id": "123456",
+        "org_id": "group1",
         "email": "hello@czgenepi.org",
     }
-    group = group_factory(auth0_org_id=userinfo["org_id"])
-    async_session.add(group)
-    auth0_apiclient.get_org_user_roles.side_effect = [["member"]]  # type: ignore
+    group1 = group_factory(name="Group 1", auth0_org_id=userinfo["org_id"])
+    group2 = group_factory(name="Group 2", auth0_org_id="group2")
+    group3 = group_factory(name="Group 3", auth0_org_id="group3")
+    async_session.add_all([group1, group2, group3])
+    auth0_apiclient.get_org_user_roles.side_effect = [["member"], ["member"], ["admin"]]  # type: ignore
+    auth0_apiclient.get_user_orgs.side_effect = [[{"id": group1.auth0_org_id}, {"id": group3.auth0_org_id}]]  # type: ignore
     await start_new_transaction(async_session)
-    user_obj: Optional[User] = await create_user_if_not_exists(async_session, auth0_apiclient, userinfo)
+    user_obj: Optional[User] = await create_user_if_not_exists(
+        async_session, auth0_apiclient, userinfo
+    )
     assert user_obj is not None
+    await RoleManager.sync_user_roles(async_session, auth0_apiclient, user_obj)
     assert user_obj.email == userinfo["email"]
+
     await start_new_transaction(async_session)
     user = (
         (
@@ -186,6 +208,74 @@ async def test_create_new_user_and_sync_roles(
         .scalars()
         .one()
     )
-    assert user.group_id == group.id
+    assert user.group_id == group1.id
     assert user.email == userinfo["email"]
     assert user.group_admin is False
+    expected_roles = {(group1.auth0_org_id, "member"), (group3.auth0_org_id, "admin")}
+    await check_roles(async_session, userinfo["sub"], expected_roles)
+
+
+async def test_sync_complicated_roles(
+    async_session: AsyncSession,
+    auth0_apiclient: Auth0Client,
+):
+    """
+    Test Sync'ing roles.
+    """
+    groups = [
+        group_factory(name=f"Group {i}", auth0_org_id=f"group{i}") for i in range(12)
+    ]
+    # NOTE -- the groups passed to user factory are irrelevant here.
+    users = [
+        user_factory(
+            name=f"User {i}",
+            email=f"user{i}@czgenepi.org",
+            auth0_user_id=f"user{i}",
+            group=groups[0],
+        )
+        for i in range(4)
+    ]
+    async_session.add_all(users + groups)
+    await start_new_transaction(async_session)
+
+    # NOTE - DO NOT USE groups[0] in our test for fear of the SA identity map dragon!!!
+    matrix = [
+        # Add a role where there was nothing
+        [users[0], [], [(groups[1], "admin")]],
+        # leave one role intact and add another
+        [
+            users[1],
+            [(groups[2], "member")],
+            [(groups[2], "member"), (groups[3], "admin")],
+        ],
+        # wipe everything out
+        [
+            users[2],
+            [(groups[3], "member"), (groups[4], "member"), (groups[5], "member")],
+            [],
+        ],
+        # add and remove 2 of each
+        [
+            users[3],
+            [(groups[6], "member"), (groups[7], "member"), (groups[8], "member")],
+            [(groups[6], "member"), (groups[9], "admin"), (groups[10], "member")],
+        ],
+    ]
+
+    # Back to our regularly scheduled testing programming
+    for user, starting_roles, final_roles in matrix:
+        for group, role in starting_roles:
+            async_session.add(
+                await RoleManager.generate_user_role(async_session, user, group, role)
+            )
+        orgs_response = [{"id": group.auth0_org_id} for group, _ in final_roles]
+        members_responses = [[role] for _, role in final_roles]
+        auth0_apiclient.get_org_user_roles.side_effect = members_responses
+        auth0_apiclient.get_user_orgs.side_effect = [orgs_response]
+        await RoleManager.sync_user_roles(async_session, auth0_apiclient, user)
+        await start_new_transaction(async_session)
+
+        expected_roles = set(
+            [(group.auth0_org_id, role) for group, role in final_roles]
+        )
+        await check_roles(async_session, user.auth0_user_id, expected_roles)

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -3,10 +3,11 @@ import sqlalchemy as sa
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
+from typing import Set, Tuple, Optional
 
 from aspen.api.views.auth import create_user_if_not_exists
 from aspen.auth.auth0_management import Auth0Client
-from aspen.database.models import User
+from aspen.database.models import User, UserRole, Role
 from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
 # All test coroutines will be treated as marked.
@@ -17,6 +18,28 @@ async def start_new_transaction(session: AsyncSession):
     await session.commit()
     await session.close()
     session.begin()
+
+async def check_roles(async_session: AsyncSession, auth0_user_id: str, expected_roles: Set[Tuple[str, str]]):
+    db_roles = (
+        (
+            await async_session.execute(
+                sa.select(User)  # type: ignore
+                .options(joinedload(User.user_roles, innerjoin=True).options(  # type: ignore
+                         joinedload(UserRole.group, innerjoin=True),  # type: ignore
+                         joinedload(UserRole.role, innerjoin=True))  # type: ignore
+                )
+                .filter(User.auth0_user_id == auth0_user_id)  # type: ignore
+            )
+        )
+        .scalars()
+        .unique()
+        .all()
+    )
+    actual_roles = set()
+    for user in db_roles:
+        for user_role in user.user_roles:
+            actual_roles.add((user_role.group.auth0_org_id, user_role.role.name))
+    assert expected_roles == actual_roles
 
 
 async def test_create_new_admin_user_if_not_exists(
@@ -52,6 +75,8 @@ async def test_create_new_admin_user_if_not_exists(
     assert user.group_id == group.id
     assert user.email == userinfo["email"]
     assert user.group_admin is True
+    expected_roles = {(group.auth0_org_id, "admin")}
+    await check_roles(async_session, userinfo["sub"], expected_roles)
 
 
 async def test_create_new_user_if_not_exists(
@@ -87,6 +112,8 @@ async def test_create_new_user_if_not_exists(
     assert user.group_id == group.id
     assert user.email == userinfo["email"]
     assert user.group_admin is False
+    expected_roles = {(group.auth0_org_id, "member")}
+    await check_roles(async_session, userinfo["sub"], expected_roles)
 
 
 async def test_dont_create_new_user_if_exists(
@@ -124,3 +151,41 @@ async def test_dont_create_new_user_if_exists(
         .one()
     )
     assert db_user.id == original_user_id
+    expected_roles = {(group.auth0_org_id, "member")}
+    await check_roles(async_session, userinfo["sub"], expected_roles)
+
+async def test_create_new_user_and_sync_roles(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+    auth0_apiclient: Auth0Client,
+):
+    """
+    Test creating a new auth0 user on login
+    """
+    userinfo = {
+        "sub": "user123-asdf",
+        "org_id": "123456",
+        "email": "hello@czgenepi.org",
+    }
+    group = group_factory(auth0_org_id=userinfo["org_id"])
+    async_session.add(group)
+    auth0_apiclient.get_org_user_roles.side_effect = [["member"]]  # type: ignore
+    await start_new_transaction(async_session)
+    user_obj: Optional[User] = await create_user_if_not_exists(async_session, auth0_apiclient, userinfo)
+    assert user_obj is not None
+    assert user_obj.email == userinfo["email"]
+    await start_new_transaction(async_session)
+    user = (
+        (
+            await async_session.execute(
+                sa.select(User)  # type: ignore
+                .options(joinedload(User.group, innerjoin=True))  # type: ignore
+                .filter(User.auth0_user_id == userinfo["sub"])  # type: ignore
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert user.group_id == group.id
+    assert user.email == userinfo["email"]
+    assert user.group_admin is False

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -90,8 +90,6 @@ async def test_create_new_admin_user_if_not_exists(
     assert user.group_id == group.id
     assert user.email == userinfo["email"]
     assert user.group_admin is True
-    expected_roles = {(group.auth0_org_id, "admin")}
-    await check_roles(async_session, userinfo["sub"], expected_roles)
 
 
 async def test_create_new_user_if_not_exists(
@@ -127,8 +125,6 @@ async def test_create_new_user_if_not_exists(
     assert user.group_id == group.id
     assert user.email == userinfo["email"]
     assert user.group_admin is False
-    expected_roles = {(group.auth0_org_id, "member")}
-    await check_roles(async_session, userinfo["sub"], expected_roles)
 
 
 async def test_dont_create_new_user_if_exists(
@@ -166,8 +162,6 @@ async def test_dont_create_new_user_if_exists(
         .one()
     )
     assert db_user.id == original_user_id
-    expected_roles = {(group.auth0_org_id, "member")}
-    await check_roles(async_session, userinfo["sub"], expected_roles)
 
 
 async def test_create_new_user_and_sync_roles(
@@ -211,8 +205,6 @@ async def test_create_new_user_and_sync_roles(
     assert user.group_id == group1.id
     assert user.email == userinfo["email"]
     assert user.group_admin is False
-    expected_roles = {(group1.auth0_org_id, "member"), (group3.auth0_org_id, "admin")}
-    await check_roles(async_session, userinfo["sub"], expected_roles)
 
 
 async def test_sync_complicated_roles(

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -205,6 +205,8 @@ async def test_create_new_user_and_sync_roles(
     assert user.group_id == group1.id
     assert user.email == userinfo["email"]
     assert user.group_admin is False
+    expected_roles = {(group1.auth0_org_id, "member"), (group3.auth0_org_id, "admin")}
+    await check_roles(async_session, user.auth0_user_id, expected_roles)
 
 
 async def test_sync_complicated_roles(

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -36,9 +36,7 @@ def set_user_groups(user):
 
 
 @router.get("/me", response_model=UserMeResponse)
-async def get_current_user(
-    user=Depends(get_auth_user)
-) -> UserMeResponse:
+async def get_current_user(user=Depends(get_auth_user)) -> UserMeResponse:
     set_user_groups(user)
     return UserMeResponse.from_orm(user)
 

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -1,10 +1,6 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.requests import Request
-from aspen.auth.role_manager import RoleManager
-import sqlalchemy as sa
 
 from aspen.api.authn import (
     get_admin_user,
@@ -41,8 +37,9 @@ def set_user_groups(user):
 
 @router.get("/me", response_model=UserMeResponse)
 async def get_current_user(
-    user=Depends(get_auth_user),
+    user=Depends(get_auth_user)
 ) -> UserMeResponse:
+    set_user_groups(user)
     return UserMeResponse.from_orm(user)
 
 

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -41,12 +41,8 @@ def set_user_groups(user):
 
 @router.get("/me", response_model=UserMeResponse)
 async def get_current_user(
-    request: Request, db: AsyncSession = Depends(get_db), user=Depends(get_auth_user),
-    auth0_mgmt: Auth0Client = Depends(get_auth0_apiclient),
+    user=Depends(get_auth_user),
 ) -> UserMeResponse:
-    user = (await(db.execute(sa.select(User).where(User.id == 1)))).scalars().one()
-    await RoleManager.sync_user_roles(db, auth0_mgmt, user)
-    await db.commit()
     return UserMeResponse.from_orm(user)
 
 

--- a/src/backend/aspen/auth/auth0_management.py
+++ b/src/backend/aspen/auth/auth0_management.py
@@ -61,14 +61,14 @@ class Auth0Client:
 
         self.client: Auth0 = Auth0(domain=domain, token=token["access_token"])
 
-    def get_all_results(self, endpoint: Callable, key: str) -> List[Any]:
+    def get_all_results(self, endpoint: Callable, key: str, **kwargs) -> List[Any]:
         # Auth0 paginates results. We don't have a crazy amount of data in auth0 so we can
         # afford to just paginate through all the results and hold everything in memory.
         results: List[Any] = []
         page = 0
         per_page = 25
         while True:
-            resp = endpoint(page=page, per_page=per_page)
+            resp = endpoint(**kwargs, page=page, per_page=per_page)
             if len(resp[key]) == 0:
                 return results
             results.extend(resp[key])
@@ -99,6 +99,12 @@ class Auth0Client:
             if org["id"] == org_id:
                 return org
         raise Exception("Organization not found")
+
+    @cache
+    def get_user_orgs(self, user_id: str) -> List[Auth0Org]:
+        return self.get_all_results(
+            self.client.users.list_organizations, "organizations", id=user_id
+        )
 
     @cache
     def get_orgs(self) -> List[Auth0Org]:

--- a/src/backend/aspen/auth/role_manager.py
+++ b/src/backend/aspen/auth/role_manager.py
@@ -1,6 +1,11 @@
+import json
+from collections import defaultdict
+
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import contains_eager, joinedload
 
+from aspen.auth.auth0_management import Auth0Client
 from aspen.database.models import Group, GroupRole, Role, User, UserRole
 
 
@@ -37,3 +42,67 @@ class RoleManager:
         role = await cls.get_role_by_name(db, role_name)
         ur = UserRole(user=user, group=group, role=role)
         return ur
+
+    @classmethod
+    async def sync_user_roles(cls, db: AsyncSession, a0: Auth0Client, user: User):
+        """
+        Sync a user's auth0 organizations/roles to our db. Auth0 is the source of truth here!!
+        This might be slightly overkill, but it should help to keep auth0 and our db in sync
+        """
+        old_groups = await db.execute(
+            sa.select(Group)
+            .join(UserRole, Group.user_roles)
+            .join(Role, UserRole.role)
+            .options(  # type: ignore
+                contains_eager(Group.user_roles).contains_eager(UserRole.role),  # type: ignore
+            )
+            .filter(UserRole.user == user)
+        )
+
+        old_groups = old_groups.unique().scalars().all()
+        old_group_roles = defaultdict(dict)
+        old_groups_by_id = {}
+        for old_group in old_groups:
+            old_groups_by_id[old_group.auth0_org_id] = old_group
+            if not old_group.auth0_org_id:
+                # This really shouldn't happen, but skip groups that don't make sense.
+                continue
+            for urole in old_group.user_roles:
+                old_group_roles[old_group.auth0_org_id][urole.role.name] = urole
+
+        current_group_roles = {}
+        current_groups = a0.get_user_orgs(user.auth0_user_id)
+        for group in current_groups:
+            group_id = group["id"]
+            current_roles = set(a0.get_org_user_roles(group_id, user.auth0_user_id))
+            current_group_roles[group_id] = current_roles
+
+        # Wipe out all roles for these groups.
+        groups_to_delete = set(old_group_roles.keys()) - set(current_group_roles.keys())
+        for groupid in groups_to_delete:
+            for urole in old_group_roles[groupid].values():
+                await db.delete(urole)
+
+        # Add or update the rest.
+        for groupid, roles in current_group_roles.items():
+            existing_roles = set(old_group_roles[groupid].keys())
+            new_roles = set(roles)
+            for role in new_roles - existing_roles:
+                group = (
+                    (
+                        await db.execute(
+                            sa.select(Group).where(Group.auth0_org_id == groupid)
+                        )
+                    )
+                    .scalars()
+                    .one()
+                )
+                db.add(await cls.generate_user_role(db, user, group, role))
+            for role in existing_roles - new_roles:
+                await db.delete(old_group_roles[groupid][role])
+
+        if False:
+            for remove_role_name in old_roles - current_roles:
+                await db.delete(old_roles_by_name[remove_role_name])
+            for add_role_name in current_roles - old_roles:
+                db.add(await cls.generate_user_role(db, user, old_group, add_role_name))

--- a/src/backend/aspen/auth/role_manager.py
+++ b/src/backend/aspen/auth/role_manager.py
@@ -51,8 +51,8 @@ class RoleManager:
         This might be slightly overkill, but it should help to keep auth0 and our db in sync
         """
         old_groups = await db.execute(
-            sa.select(Group)
-            .join(UserRole, Group.user_roles)
+            sa.select(Group)  # type: ignore
+            .join(UserRole, Group.user_roles)  # type: ignore
             .join(Role, UserRole.role)  # type: ignore
             .options(  # type: ignore
                 contains_eager(Group.user_roles).contains_eager(UserRole.role),  # type: ignore
@@ -86,10 +86,10 @@ class RoleManager:
         roles_to_add = current_roles - old_roles
         for group_id, role_name in roles_to_add:
             try:
-                group = (
+                db_group = (
                     (
                         await db.execute(
-                            sa.select(Group).where(Group.auth0_org_id == group_id)
+                            sa.select(Group).where(Group.auth0_org_id == group_id)  # type: ignore
                         )
                     )
                     .scalars()
@@ -101,4 +101,4 @@ class RoleManager:
                     f"Cannot sync membership for group ({group_id})"
                 )
                 continue
-            db.add(await cls.generate_user_role(db, user, group, role_name))
+            db.add(await cls.generate_user_role(db, user, db_group, role_name))


### PR DESCRIPTION
### Summary:
- **What:** Every time someone logs in we'll download all the groups/roles they have configured in auth0 and make sure the DB is in sync.
- **Ticket:** [sc187619](https://app.shortcut.com/genepi/story/187619)

### Notes:
Users aren't forced to log in very often, so there's every possibility that data can wind up out of sync over time. But this should be a small step forward for our support team -- they can update a user's access in auth0 and then ask them to log out/in to make sure they have the correct privileges.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)