### PR TITLE
update uploads page with group name

### DIFF
--- a/src/frontend/src/views/Upload/components/Review/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox } from "czifui";
+import { Button } from "czifui";
 import NextLink from "next/link";
 import React, { useState } from "react";
 import { HeadAppTitle } from "src/common/components";
@@ -6,6 +6,7 @@ import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
+import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
 import Progress from "../common/Progress";
 import {
@@ -24,6 +25,7 @@ import {
   ContentTitle,
   ContentTitleWrapper,
   StyledButton,
+  StyledCheckbox,
 } from "./style";
 
 export default function Review({
@@ -32,15 +34,23 @@ export default function Review({
   cancelPrompt,
 }: Props): JSX.Element {
   const { data: userInfo } = useUserInfo();
+  const [isGroupConfirmationChecked, setIsGroupConfirmationChecked] =
+    useState<boolean>(false);
   const [isConsentChecked, setIsConsentChecked] = useState(false);
 
   const group = userInfo?.group;
 
   const numOfSamples = Object.keys(samples || EMPTY_OBJECT).length;
 
-  function handleConsentCheck() {
-    setIsConsentChecked((prevState: boolean) => !prevState);
-  }
+  const toggleState = (prevState: boolean) => !prevState;
+
+  const handleConsentCheck = () => {
+    setIsConsentChecked(toggleState);
+  };
+
+  const handleGroupConfCheck = () => {
+    setIsGroupConfirmationChecked(toggleState);
+  };
 
   return (
     <>
@@ -50,7 +60,7 @@ export default function Review({
           <Title>Review</Title>
           <Subtitle>
             Uploading {numOfSamples} {pluralize("Sample", numOfSamples)} to{" "}
-            {group?.name}
+            <B>{group?.name}</B>
           </Subtitle>
         </div>
         <Progress step="3" />
@@ -77,8 +87,19 @@ export default function Review({
         <Table metadata={metadata} />
 
         <CheckboxWrapper>
+          <CheckboxText onClick={handleGroupConfCheck}>
+            <StyledCheckbox
+              checked={isGroupConfirmationChecked}
+              stage={isGroupConfirmationChecked ? "checked" : "unchecked"}
+            />
+            <span>
+              I confirm that this data should be uploaded to {group?.name}, and
+              acknowledge that by uploading to this group this data will be
+              accessible to all group members.
+            </span>
+          </CheckboxText>
           <CheckboxText onClick={handleConsentCheck}>
-            <Checkbox
+            <StyledCheckbox
               checked={isConsentChecked}
               stage={isConsentChecked ? "checked" : "unchecked"}
             />
@@ -99,7 +120,7 @@ export default function Review({
           <Upload
             samples={samples}
             metadata={metadata}
-            isDisabled={!isConsentChecked}
+            isDisabled={!isGroupConfirmationChecked || !isConsentChecked}
             cancelPrompt={cancelPrompt}
           />
           <NextLink href={ROUTES.UPLOAD_STEP2} passHref>

--- a/src/frontend/src/views/Upload/components/Review/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import {
   Button,
+  Checkbox,
   fontBodyXs,
   fontHeaderL,
   fontHeaderXs,
@@ -18,11 +19,22 @@ export const ContentTitleWrapper = styled.div`
   align-items: center;
 `;
 
+export const StyledCheckbox = styled(Checkbox)`
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      padding: 0;
+      margin-right: ${spaces?.m}px;
+    `;
+  }}
+`;
+
 export const CheckboxText = styled.div`
   ${fontBodyXs}
 
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 
   &:hover {
     cursor: pointer;
@@ -30,9 +42,11 @@ export const CheckboxText = styled.div`
 
   ${(props) => {
     const colors = getColors(props);
+    const spaces = getSpaces(props);
 
     return `
       color: ${colors?.gray[600]};
+      margin-bottom: ${spaces?.m}px;
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Tweaks to upload review page to confirm which group user uploading to
- **Why:** Avoid uploading samples to the wrong group
- **Ticket:** [[sc-188169]](https://app.shortcut.com/genepi/story/188169)
- **Env:** https://maya-groupupload-frontend.dev.czgenepi.org/
- **Design:** https://www.figma.com/file/SALQZGfIJntBes0HvIzVeX/Onboarding-New-Users-V0?node-id=280%3A48892

### Demos
#### Before: 
![Screen Shot 2022-07-14 at 12 53 24 PM](https://user-images.githubusercontent.com/7562933/179071688-cdfcdfbf-30a6-4a4b-b055-b32d8feedf31.png)
![Screen Shot 2022-07-14 at 12 53 28 PM](https://user-images.githubusercontent.com/7562933/179071691-095d9cf6-7881-4160-9f82-eb40b15ed7b8.png)

#### After: 
![Screen Shot 2022-07-14 at 12 52 58 PM](https://user-images.githubusercontent.com/7562933/179071666-7d7896fc-92c2-4efb-9690-a7869f17f248.png)
![Screen Shot 2022-07-14 at 12 53 04 PM](https://user-images.githubusercontent.com/7562933/179071667-970dc177-e581-4bdb-af60-de195996aa93.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)