### PR TITLE
Vince/initial track events

### DIFF
--- a/src/frontend/public/segmentInitScript.js
+++ b/src/frontend/public/segmentInitScript.js
@@ -5,13 +5,16 @@
   const dataset = document.querySelector('#segment-init-script').dataset;
   const segmentKey = dataset.segmentKey;
   const anonUserId = dataset.anonUserId;
-  const groupId = dataset.groupId;
+  // dataset only comes in as strings, but correct data type is number
+  const groupId = Number(dataset.groupId);
   const groupName = dataset.groupName;
-  // This is mostly verbatim from Segment-provided snippet. Only change is dynamic key.
+  // Load is mostly verbatim from Segment-provided snippet. Only change is dynamic key.
   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=segmentKey;;analytics.SNIPPET_VERSION="4.15.3";
   analytics.load(segmentKey);
-  analytics.page();
-  // Back to custom code. Send de-identified user info.
+  // Back to custom code. Send current page and de-identified user info.
+  analytics.page({
+    group_id: groupId,
+  });
   analytics.identify(anonUserId,
     {
       group_id: groupId,

--- a/src/frontend/src/common/analytics/methods.ts
+++ b/src/frontend/src/common/analytics/methods.ts
@@ -34,10 +34,14 @@ import { EVENT_TYPES } from "./eventTypes";
  * evolve to include things like current software version, etc. That said,
  * try to be sparing about adding to this collection since they have to go
  * on every message up to analytics platform.
+ *
+ * Necessary to be a `type` rather than `interface` so TS is happy with is use
+ * downstream as a generic object. See this TypeScript issue and comment:
+ * https://github.com/microsoft/TypeScript/issues/15300#issuecomment-371353444
  */
-interface CommonAnalyticsInfo {
+type CommonAnalyticsInfo = {
   group_id?: number;
-}
+};
 
 /**
  * Values we consider reasonable to send to Segment as properties of event.

--- a/src/frontend/src/common/types/windowAnalytics.d.ts
+++ b/src/frontend/src/common/types/windowAnalytics.d.ts
@@ -22,10 +22,10 @@ declare global {
     // Below **adds** to Window properties, not a replacement.
     analytics?: {
       identify: (userId?: string, traits: Record<string, unknown>) => void;
-      page: (properties: Record<string, unknown> | {}) => void;
+      page: (properties: Record<string, unknown>) => void;
       track: (eventType: string, properties: Record<string, unknown>) => void;
       // Unlike above methods, `user` only present once library finishes load
-      user?: () => {traits: () => Record<string, unknown>};
+      user?: () => { traits: () => Record<string, unknown> };
     };
     isCzGenEpiAnalyticsEnabled?: boolean;
   }

--- a/src/frontend/src/common/types/windowAnalytics.d.ts
+++ b/src/frontend/src/common/types/windowAnalytics.d.ts
@@ -22,8 +22,10 @@ declare global {
     // Below **adds** to Window properties, not a replacement.
     analytics?: {
       identify: (userId?: string, traits: Record<string, unknown>) => void;
-      page: () => void;
+      page: (properties: Record<string, unknown> | {}) => void;
       track: (eventType: string, properties: Record<string, unknown>) => void;
+      // Unlike above methods, `user` only present once library finishes load
+      user?: () => {traits: () => Record<string, unknown>};
     };
     isCzGenEpiAnalyticsEnabled?: boolean;
   }

--- a/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
@@ -29,7 +29,11 @@ const NextstrainConfirmationModal = ({
   const confirmButton = (
     <ConfirmButton
       treeId={treeId}
-      onClick={() => analyticsTrackEvent(EVENT_TYPES.TREE_VIEW_NEXTSTRAIN)}
+      onClick={
+        () => analyticsTrackEvent(
+          EVENT_TYPES.TREE_VIEW_NEXTSTRAIN, {
+            tree_id: treeId,
+          })}
     />
   );
 

--- a/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
@@ -29,11 +29,11 @@ const NextstrainConfirmationModal = ({
   const confirmButton = (
     <ConfirmButton
       treeId={treeId}
-      onClick={
-        () => analyticsTrackEvent(
-          EVENT_TYPES.TREE_VIEW_NEXTSTRAIN, {
-            tree_id: treeId,
-          })}
+      onClick={() =>
+        analyticsTrackEvent(EVENT_TYPES.TREE_VIEW_NEXTSTRAIN, {
+          tree_id: treeId,
+        })
+      }
     />
   );
 


### PR DESCRIPTION
### Summary:
- **What:** Small addition of some properties to calls, trying to get ahead of a merge conflict
- **Ticket:** [sc<199706>](https://app.shortcut.com/genepi/story/<199706>) -- only a part of it, not all
- **Env:** None

### Reason for this PR
See Notes for changes, but the reason for this PR is to break off the work I've done so far from the work I had started but that will be impacted by the recent changes merged to `trunk` around group IDs being embedded in most API urls. That looks like it's going to cause some merge conflicts, but because all this work is branched off `vince/analytics` which itself branches off and merges in `trunk`, I want to get those url changes into `vince/analytics` and handle it from there instead of trying to do `trunk` merges on both branches, which would then cause GitHub weirdness with a later PR because of how GH handles commits and merges (if prior experience is a guide, I had this happen once before and it was a hassle).

This might be unnecessary caution on my part, but it's low effort compared to the GH headache I'm worried I might get otherwise.

### Notes:
Changes in this PR are pretty minor:
- Adding in a `group_id` property to basically all analytics calls for easier downstream analysis
- Adding `tree_id` of tree being viewed to its event



### Checklist:
- [x] Based off latest `vince/analytics`
- [x] I manually verified the change (in Segment's debugger)
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
~I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)~