### PR TITLE
Fix test url's to use org-namespaces

### DIFF
--- a/src/backend/aspen/api/views/auspice.py
+++ b/src/backend/aspen/api/views/auspice.py
@@ -73,7 +73,7 @@ async def generate_auspice_string(
     mac_tag = digest_maker.hexdigest()
 
     return GenerateAuspiceMagicLinkResponse(
-        url=f'{request.url.netloc}/v2/orgs/{ac.group.id}/auspice/access/{message.decode("utf8")}.{mac_tag}'
+        url=f'{request.url.netloc}/v2/orgs/{ac.group.id}/auspice/access/{message.decode("utf8")}.{mac_tag}'  # type: ignore
     )
 
 

--- a/src/backend/aspen/api/views/auspice.py
+++ b/src/backend/aspen/api/views/auspice.py
@@ -8,7 +8,14 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
-from aspen.api.authn import get_auth_user, magic_link_payload, MagicLinkPayload
+from aspen.api.authn import (
+    AuthContext,
+    get_auth_context,
+    get_auth_user,
+    magic_link_payload,
+    MagicLinkPayload,
+    require_group_membership,
+)
 from aspen.api.authz import AuthZSession, get_authz_session
 from aspen.api.deps import get_db, get_settings
 from aspen.api.error import http_exceptions as ex
@@ -18,7 +25,7 @@ from aspen.api.schemas.auspice import (
 )
 from aspen.api.settings import Settings
 from aspen.api.utils import process_phylo_tree, verify_and_access_phylo_tree
-from aspen.database.models import User
+from aspen.database.models import Group, User
 
 router = APIRouter()
 
@@ -34,6 +41,8 @@ async def generate_auspice_string(
     settings: Settings = Depends(get_settings),
     az: AuthZSession = Depends(get_authz_session),
     user: User = Depends(get_auth_user),
+    ac: AuthContext = Depends(get_auth_context),
+    group: Group = Depends(require_group_membership),
 ):
     request_body = await request.json()
     validated_body = GenerateAuspiceMagicLinkRequest.parse_obj(request_body)
@@ -64,7 +73,7 @@ async def generate_auspice_string(
     mac_tag = digest_maker.hexdigest()
 
     return GenerateAuspiceMagicLinkResponse(
-        url=f'{request.url.netloc}/v2/auspice/access/{message.decode("utf8")}.{mac_tag}'
+        url=f'{request.url.netloc}/v2/orgs/{ac.group.id}/auspice/access/{message.decode("utf8")}.{mac_tag}'
     )
 
 

--- a/src/backend/aspen/api/views/phylo_trees.py
+++ b/src/backend/aspen/api/views/phylo_trees.py
@@ -70,7 +70,6 @@ async def _get_selected_samples(db: AsyncSession, phylo_tree_id: int):
         sample = uploaded_pathogen_genome.sample
         selected_samples.add(prefix_regex.sub("", sample.public_identifier))
         selected_samples.add(sample.private_identifier)
-    print(selected_samples)
     return selected_samples
 
 

--- a/src/backend/aspen/api/views/tests/test_auspice.py
+++ b/src/backend/aspen/api/views/tests/test_auspice.py
@@ -28,14 +28,16 @@ async def test_valid_auspice_link_generation(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
     )
 
     assert res.status_code == 200
     response = res.json()
     assert response.get("url", None) is not None
     magic_link = response["url"]
-    valid_pattern = re.compile(r"\/v2\/auspice\/access\/[a-zA-Z\d\-_=]+\.[a-z\d]+")
+    valid_pattern = re.compile(
+        r"\/v2\/orgs\/\d+\/auspice\/access\/[a-zA-Z\d\-_=]+\.[a-z\d]+"
+    )
     assert valid_pattern.search(magic_link) is not None
 
 
@@ -63,7 +65,7 @@ async def test_valid_auspice_link_access(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
     )
 
     assert generate_res.status_code == 200
@@ -107,7 +109,9 @@ async def test_unauth_user_auspice_link_generation(
     auth_headers = {"user_id": user_that_did_not_make_tree.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group_that_did_not_make_tree.id}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
     assert res.status_code == 400
 
@@ -124,7 +128,7 @@ async def test_tampered_magic_link(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
     )
 
     assert generate_res.status_code == 200
@@ -144,7 +148,7 @@ async def test_tampered_magic_link(
     tampered_payload_plus_tag = f"{tampered_message.decode('utf8')}.{tag}"
 
     access_res = await http_client.get(
-        f"/v2/auspice/access/{tampered_payload_plus_tag}"
+        f"/v2/orgs/{group.id}/auspice/access/{tampered_payload_plus_tag}"
     )
     assert access_res.status_code == 400
     res_json = access_res.json()
@@ -191,7 +195,7 @@ async def test_country_color_labeling(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
     )
 
     assert generate_res.status_code == 200
@@ -280,7 +284,7 @@ async def test_division_color_labeling(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
     )
 
     assert generate_res.status_code == 200
@@ -368,7 +372,7 @@ async def test_location_color_labeling(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        "/v2/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
     )
 
     assert generate_res.status_code == 200

--- a/src/backend/aspen/api/views/tests/test_auspice.py
+++ b/src/backend/aspen/api/views/tests/test_auspice.py
@@ -136,7 +136,7 @@ async def test_tampered_magic_link(
     magic_link = generate_response["url"]
 
     # Now we tamper with the link! We want to see a different tree!
-    payload_plus_tag = magic_link.removeprefix("test/v2/auspice/access/")
+    payload_plus_tag = magic_link.removeprefix("test/v2/orgs/1/auspice/access/")
     payload, tag = payload_plus_tag.split(".")
     decoded_payload = urlsafe_b64decode(payload).decode("utf8")
     recovered_payload = json.loads(decoded_payload)

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -38,7 +38,9 @@ async def test_create_phylo_run(
         "tree_type": "targeted",
         "samples": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 200
     response = res.json()
     assert response["template_args"] == {}
@@ -75,7 +77,9 @@ async def test_create_phylo_run_with_failed_sample(
         "tree_type": "targeted",
         "samples": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 400
 
 
@@ -124,7 +128,7 @@ async def test_create_phylo_run_with_invalid_args(
     for args in requests:
         request_body["template_args"] = args  # type: ignore
         res = await http_client.post(
-            "/v2/phylo_runs/", json=request_body, headers=auth_headers
+            f"/v2/orgs/{group.id}/phylo_runs/", json=request_body, headers=auth_headers
         )
         assert res.status_code == 422
 
@@ -180,7 +184,9 @@ async def test_create_phylo_run_with_template_args(
         },
     ]
     for data in requests:
-        res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+        res = await http_client.post(
+            f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        )
         assert res.status_code == 200
         response = res.json()
         assert response["template_args"] == data["template_args"]
@@ -216,7 +222,9 @@ async def test_create_phylo_run_with_gisaid_ids(
         "tree_type": "non_contextualized",
         "samples": [sample.public_identifier, gisaid_sample.strain],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 200
     response = res.json()
     assert response["template_args"] == {}
@@ -252,7 +260,9 @@ async def test_create_phylo_run_with_epi_isls(
         "tree_type": "non_contextualized",
         "samples": [sample.public_identifier, gisaid_isl_sample.gisaid_epi_isl],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 200
     response = res.json()
     assert response["template_args"] == {}
@@ -286,7 +296,9 @@ async def test_create_invalid_phylo_run_name(
         "tree_type": "targeted",
         "samples": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 422
 
 
@@ -315,7 +327,9 @@ async def test_create_invalid_phylo_run_tree_type(
         "tree_type": "global",
         "samples": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 422
 
 
@@ -344,7 +358,9 @@ async def test_create_invalid_phylo_run_bad_sample_id(
         "tree_type": "non_contextualized",
         "samples": [sample.public_identifier, "bad_sample_identifier"],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 400
 
 
@@ -389,35 +405,40 @@ async def test_create_invalid_phylo_run_sample_cannot_see(
         "tree_type": "non_contextualized",
         "samples": [sample.public_identifier, sample2.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
     assert res.status_code == 400
 
 
-async def test_create_phylo_run_unauthorized_access_redirect(
+async def test_create_phylo_run_unauthorized(
     async_session: AsyncSession,
     http_client: AsyncClient,
 ):
     """
-    Test a request from an outside, unauthorized source.
+    Make sure a user can't create runs in a group they don't have access to.
     """
     group = group_factory()
-    user = await userrole_factory(async_session, group)
+    user_group = group_factory(name="User's group")
+    user = await userrole_factory(async_session, user_group)
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
     sample = sample_factory(group, user, location)
-
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
     async_session.add(group)
+    async_session.add(user_group)
     async_session.add(gisaid_dump)
     await async_session.commit()
 
+    auth_headers = {"user_id": user.auth0_user_id}
     data = {
         "name": "test phylorun",
-        "tree_type": "non_contextualized",
+        "tree_type": "targeted",
         "samples": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data)
-    # No authorization header, so we should be prompted to log in.
-    assert res.status_code == 401
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+    )
+    assert res.status_code == 403

--- a/src/backend/aspen/api/views/tests/test_create_samples.py
+++ b/src/backend/aspen/api/views/tests/test_create_samples.py
@@ -69,7 +69,7 @@ async def test_samples_create_view_pass_no_public_id(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )
@@ -110,6 +110,46 @@ async def test_samples_create_view_pass_no_public_id(
     assert sample_1.uploaded_pathogen_genome.num_missing_alleles == 1
 
 
+async def test_authz_failure(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    no_access_group = group_factory(name="Unauthorized")
+    group = group_factory()
+    user = await userrole_factory(async_session, group)
+    location = location_factory(
+        "North America", "USA", "California", "Santa Barbara County"
+    )
+    async_session.add(no_access_group)
+    async_session.add(group)
+    async_session.add(location)
+    await async_session.commit()
+    test_date = datetime.datetime.now()
+
+    data = [
+        {
+            "sample": {
+                "private_identifier": "private",
+                "public_identifier": "public",
+                "collection_date": format_date(test_date),
+                "location_id": location.id,
+                "private": True,
+            },
+            "pathogen_genome": {
+                "sequence": VALID_SEQUENCE,
+                "sequencing_date": "",
+            },
+        },
+    ]
+    auth_headers = {"user_id": user.auth0_user_id}
+    res = await http_client.post(
+        f"/v2/orgs/{no_access_group.id}/samples/",
+        json=data,
+        headers=auth_headers,
+    )
+    assert res.status_code == 403
+
+
 async def test_stripping_whitespace(
     async_session: AsyncSession,
     http_client: AsyncClient,
@@ -141,7 +181,7 @@ async def test_stripping_whitespace(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )
@@ -213,7 +253,7 @@ async def test_samples_create_view_pass_no_sequencing_date(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )
@@ -289,7 +329,7 @@ async def test_samples_create_view_invalid_sequence(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )
@@ -354,7 +394,7 @@ async def test_samples_create_view_fail_duplicate_ids(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )
@@ -413,7 +453,7 @@ async def test_samples_create_view_fail_duplicate_ids_in_request_data(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )
@@ -463,7 +503,7 @@ async def test_samples_create_view_fail_missing_required_fields(
     ]
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        "/v2/samples/",
+        f"/v2/orgs/{group.id}/samples/",
         json=data,
         headers=auth_headers,
     )

--- a/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
@@ -68,16 +68,25 @@ async def test_delete_phylo_run_matrix(
     cases = [
         {
             "user": user.auth0_user_id,
+            "group": group,
             "status_code": 200,
             "tree": tree1.producing_workflow_id,
         },
         {
             "user": user2.auth0_user_id,
+            "group": group2,
             "status_code": 404,
             "tree": tree2.producing_workflow_id,
         },
         {
+            "user": user2.auth0_user_id,
+            "group": group,
+            "status_code": 403,
+            "tree": tree2.producing_workflow_id,
+        },
+        {
             "user": user.auth0_user_id,
+            "group": group,
             "status_code": 400,
             "tree": tree2.producing_workflow_id,
         },
@@ -85,8 +94,10 @@ async def test_delete_phylo_run_matrix(
     for case in cases:
         print(case)
         auth_headers = {"user_id": str(case["user"])}
+        # We want to be able to fetch the tree that belongs to `group`
         res = await http_client.delete(
-            f"/v2/phylo_runs/{case['tree']}", headers=auth_headers
+            f"/v2/orgs/{case['group'].id}/phylo_runs/{case['tree']}",
+            headers=auth_headers,
         )
         assert res.status_code == case["status_code"]
         if case["status_code"] == 200:

--- a/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_delete_phylo_runs.py
@@ -96,7 +96,7 @@ async def test_delete_phylo_run_matrix(
         auth_headers = {"user_id": str(case["user"])}
         # We want to be able to fetch the tree that belongs to `group`
         res = await http_client.delete(
-            f"/v2/orgs/{case['group'].id}/phylo_runs/{case['tree']}",
+            f"/v2/orgs/{case['group'].id}/phylo_runs/{case['tree']}",  # type: ignore
             headers=auth_headers,
         )
         assert res.status_code == case["status_code"]

--- a/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
+++ b/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
@@ -52,7 +52,8 @@ async def test_phylo_tree_can_see(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/phylo_trees/{phylo_tree.entity_id}/download", headers=auth_headers
+        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/download",
+        headers=auth_headers,
     )
     returned_tree = result.json()
     assert returned_tree["tree"] == matching_mapped_json["tree"]
@@ -81,7 +82,7 @@ async def test_phylo_tree_id_style_public(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/phylo_trees/{phylo_tree.entity_id}/download?id_style=public",
+        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/download?id_style=public",
         headers=auth_headers,
     )
     returned_tree = result.json()
@@ -129,6 +130,7 @@ async def test_phylo_tree_no_can_see(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/phylo_trees/{phylo_tree.entity_id}/download", headers=auth_headers
+        f"/v2/orgs/{viewer_group.id}/phylo_trees/{phylo_tree.entity_id}/download",
+        headers=auth_headers,
     )
     assert result.json() == expected_response

--- a/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
+++ b/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
@@ -247,7 +247,7 @@ async def test_tree_metadata_replaces_all_ids(
     )
 
     extra_sample = sample_factory(
-        user.group,
+        group,
         user,
         samples[0].collection_location,
         public_identifier=str(uuid.uuid4()),
@@ -292,7 +292,7 @@ async def test_public_tree_metadata_replaces_all_ids(
     )
 
     extra_sample = sample_factory(
-        user.group,
+        group,
         user,
         samples[0].collection_location,
         public_identifier=str(uuid.uuid4()),

--- a/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
@@ -134,7 +134,8 @@ async def test_phylo_tree_rename(
 
     auth_headers = {"user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/phylo_trees/{phylo_tree.entity_id}/download", headers=auth_headers
+        f"/v2/orgs/{viewer_group.id}/phylo_trees/{phylo_tree.entity_id}/download",
+        headers=auth_headers,
     )
 
     tree = result.json()

--- a/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
@@ -23,13 +23,18 @@ TEST_TREE = {
         "colorings": [],
     },
     "tree": {
-        "name": "public_identifier_1",
+        "name": "public_identifier_0",
         "children": [
-            {"name": "public_identifier_2"},
-            {"name": "public_identifier_3"},
+            {"name": "public_identifier_can_see_0"},
+            {"name": "public_identifier_can_see_1"},
             {
-                "name": "public_identifier_4",
-                "children": [{"name": "public_identifier_5"}],
+                "name": "public_identifier_wrong_0",
+                "children": [
+                    {"name": "public_identifier_1"},
+                    {"name": "public_identifier_wrong_1"},
+                    {"name": "public_identifier_nosee_0"},
+                    {"name": "public_identifier_nosee_1"},
+                ],
             },
         ],
     },
@@ -65,39 +70,51 @@ async def test_phylo_tree_rename(
         "North America", "USA", "California", "Santa Barbara County"
     )
 
-    local_sample = sample_factory(
-        viewer_group,
-        user,
-        location,
-        private_identifier="private_identifier_1",
-        public_identifier="public_identifier_1",
-    )
+    local_samples = [
+        sample_factory(
+            viewer_group,
+            user,
+            location,
+            private_identifier=f"private_identifier_{i}",
+            public_identifier=f"public_identifier_{i}",
+        )
+        for i in range(2)
+    ]
     # NOTE - our test user *can see* private identifiers for samples from this group!
-    can_see_sample = sample_factory(
-        can_see_group,
-        user,
-        location,
-        private_identifier="private_identifier_2",
-        public_identifier="public_identifier_2",
-    )
-    wrong_can_see_sample = sample_factory(
-        wrong_can_see_group,
-        user,
-        location,
-        private_identifier="private_identifer_3",
-        public_identifier="public_identifier_3",
-    )
-    no_can_see_sample = sample_factory(
-        no_can_see_group,
-        user,
-        location,
-        private_identifier="private_identifer_4",
-        public_identifier="public_identifier_4",
-    )
+    can_see_samples = [
+        sample_factory(
+            can_see_group,
+            user,
+            location,
+            private_identifier=f"private_identifier_can_see_{i}",
+            public_identifier=f"public_identifier_can_see_{i}",
+        )
+        for i in range(2)
+    ]
+    wrong_can_see_samples = [
+        sample_factory(
+            wrong_can_see_group,
+            user,
+            location,
+            private_identifier=f"private_identifer_wrong_{i}",
+            public_identifier=f"public_identifier_wrong_{i}",
+        )
+        for i in range(2)
+    ]
+    no_can_see_samples = [
+        sample_factory(
+            no_can_see_group,
+            user,
+            location,
+            private_identifier=f"private_identifer_nosee_{i}",
+            public_identifier=f"public_identifier_nosee_{i}",
+        )
+        for i in range(2)
+    ]
 
     phylo_tree = phylotree_factory(
         phylorun_factory(viewer_group),
-        [local_sample, can_see_sample, wrong_can_see_sample, no_can_see_sample],
+        local_samples + can_see_samples + wrong_can_see_samples + no_can_see_samples,
     )
 
     # Create the bucket if it doesn't exist in localstack.
@@ -122,14 +139,28 @@ async def test_phylo_tree_rename(
 
     tree = result.json()
     assert tree["tree"] == {
-        "name": "private_identifier_1",
-        "GISAID_ID": "public_identifier_1",
+        "name": "private_identifier_0",
+        "GISAID_ID": "public_identifier_0",
         "children": [
-            {"GISAID_ID": "public_identifier_2", "name": "private_identifier_2"},
-            {"name": "public_identifier_3"},
             {
-                "name": "public_identifier_4",
-                "children": [{"name": "public_identifier_5"}],
+                "GISAID_ID": "public_identifier_can_see_0",
+                "name": "private_identifier_can_see_0",
+            },
+            {
+                "GISAID_ID": "public_identifier_can_see_1",
+                "name": "private_identifier_can_see_1",
+            },
+            {
+                "name": "public_identifier_wrong_0",
+                "children": [
+                    {
+                        "GISAID_ID": "public_identifier_1",
+                        "name": "private_identifier_1",
+                    },
+                    {"name": "public_identifier_wrong_1"},
+                    {"name": "public_identifier_nosee_0"},
+                    {"name": "public_identifier_nosee_1"},
+                ],
             },
         ],
     }

--- a/src/backend/aspen/api/views/tests/test_sequences.py
+++ b/src/backend/aspen/api/views/tests/test_sequences.py
@@ -43,7 +43,7 @@ async def test_prepare_sequences_download(
         f"/v2/orgs/{group.id}/sequences/", headers=auth_headers, json=data
     )
     assert res.status_code == 200
-    expected_filename = f"{user.group.name}_sample_sequences.fasta"
+    expected_filename = f"{group.name}_sample_sequences.fasta"
     assert (
         res.headers["Content-Disposition"]
         == f"attachment; filename={expected_filename}"
@@ -249,7 +249,7 @@ async def test_access_matrix(
         )
 
         assert res.status_code == 200
-        expected_filename = f"{user.group.name}_sample_sequences.fasta"
+        expected_filename = f"{viewer_group.name}_sample_sequences.fasta"
         assert (
             res.headers["Content-Disposition"]
             == f"attachment; filename={expected_filename}"

--- a/src/backend/aspen/api/views/tests/test_sequences.py
+++ b/src/backend/aspen/api/views/tests/test_sequences.py
@@ -39,7 +39,9 @@ async def test_prepare_sequences_download(
     data = {
         "sample_ids": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/sequences/", headers=auth_headers, json=data)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/sequences/", headers=auth_headers, json=data
+    )
     assert res.status_code == 200
     expected_filename = f"{user.group.name}_sample_sequences.fasta"
     assert (
@@ -83,7 +85,9 @@ async def test_prepare_sequences_download_no_access(
     data = {
         "sample_ids": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/sequences/", headers=auth_headers, json=data)
+    res = await http_client.post(
+        f"/v2/orgs/{viewer_group.id}/sequences/", headers=auth_headers, json=data
+    )
     assert res.status_code == 200
     assert res.content == b""
 
@@ -112,7 +116,9 @@ async def test_prepare_sequences_download_viewer_no_access(
     data = {
         "sample_ids": [sample.public_identifier],
     }
-    res = await http_client.post("/v2/sequences/", headers=auth_headers, json=data)
+    res = await http_client.post(
+        f"/v2/orgs/{viewer_group.id}/sequences/", headers=auth_headers, json=data
+    )
 
     assert res.status_code == 200
     assert res.content == b""
@@ -186,7 +192,9 @@ async def test_access_matrix(
     # Make sure sample owners can see their own (shared & private) samples.
     owner_headers = {"name": owner.name, "user_id": owner.auth0_user_id}
     data = {"sample_ids": [sample1.public_identifier, sample4.public_identifier]}
-    res = await http_client.post("/v2/sequences/", headers=owner_headers, json=data)
+    res = await http_client.post(
+        f"/v2/orgs/{owner_group1.id}/sequences/", headers=owner_headers, json=data
+    )
 
     assert res.status_code == 200
     file_contents = str(res.content, encoding="UTF-8")
@@ -236,7 +244,9 @@ async def test_access_matrix(
         data = {
             "sample_ids": case["samples"],
         }
-        res = await http_client.post("/v2/sequences/", headers=user_headers, json=data)
+        res = await http_client.post(
+            f"/v2/orgs/{viewer_group.id}/sequences/", headers=user_headers, json=data
+        )
 
         assert res.status_code == 200
         expected_filename = f"{user.group.name}_sample_sequences.fasta"

--- a/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
+++ b/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
@@ -64,7 +64,9 @@ async def test_update_phylo_tree(
     auth_headers = {"user_id": user.auth0_user_id}
     data = {"name": "new_name"}
     res = await http_client.put(
-        f"/v2/phylo_runs/{phylo_run.id}", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/phylo_runs/{phylo_run.id}",
+        json=data,
+        headers=auth_headers,
     )
 
     assert res.status_code == 200
@@ -93,7 +95,9 @@ async def test_update_phylo_run_no_trees(
     auth_headers = {"user_id": user.auth0_user_id}
     data = {"name": "new_name"}
     res = await http_client.put(
-        f"/v2/phylo_runs/{phylo_run.id}", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/phylo_runs/{phylo_run.id}",
+        json=data,
+        headers=auth_headers,
     )
 
     assert res.status_code == 200
@@ -134,7 +138,9 @@ async def test_update_phylo_tree_wrong_group(
     auth_headers = {"user_id": user_that_did_not_make_tree.auth0_user_id}
     data = {"name": "new_name"}
     res = await http_client.put(
-        f"/v2/phylo_runs/{phylo_run.id}", json=data, headers=auth_headers
+        f"/v2/orgs/{group_that_did_not_make_tree.id}/phylo_runs/{phylo_run.id}",
+        json=data,
+        headers=auth_headers,
     )
 
     assert res.status_code == 404

--- a/src/backend/aspen/util/split.py
+++ b/src/backend/aspen/util/split.py
@@ -2,6 +2,8 @@ from splitio import get_factory
 from splitio.client.client import Client as SplitioClient
 from splitio.exceptions import TimeoutException
 
+from aspen.database.models import Group, User
+
 
 class SplitClient:
     split_config = {
@@ -22,11 +24,13 @@ class SplitClient:
         self.split_factory = factory
         self.split_client: SplitioClient = factory.client()
 
-    def generate_parameters(self, user):
-        user_parameters = {"user_id": user.id, "group_id": user.group.id}
+    def generate_parameters(self, user, group):
+        user_parameters = {"user_id": user.split_id, "group_id": group.id}
         return user_parameters
 
-    def get_flag(self, user, treatment):
-        parameters = self.generate_parameters(user)
-        treatment = self.split_client.get_treatment(user.id, treatment, parameters)
+    def get_flag(self, user: User, group: Group, treatment):
+        parameters = self.generate_parameters(user, group)
+        treatment = self.split_client.get_treatment(
+            user.split_id, treatment, parameters
+        )
         return treatment


### PR DESCRIPTION
### Summary:
There are 3 main changes here:
1. Update the auspice endpoints to use org namespaces in the URL's they generate
2. Fix the assumptions in the (currently unused) split.io integration to not assume users have a directly attached group
3. Fix all the test URL's to use org namespace'd url's, plus add a little more related test coverage.


### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)