### PR TITLE
Fix group endpoint authz.

### DIFF
--- a/src/backend/aspen/api/authz.py
+++ b/src/backend/aspen/api/authz.py
@@ -1,11 +1,13 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import Optional
 
 from fastapi import Depends
 from oso import AsyncOso, Relation
 from polar.data.adapter.async_sqlalchemy2_adapter import AsyncSqlAlchemyAdapter
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.exc import NoResultFound
+from starlette.requests import Request
 
 from aspen.api.authn import AuthContext, get_auth_context
 from aspen.api.deps import get_db
@@ -219,21 +221,25 @@ def require_group_privilege(
 
 
 class AuthorizedRow:
-    def __init__(self, privilege: str, model: idbase):
+    def __init__(self, privilege: str, model: idbase, id_field: Optional[str] = None):
         self.privilege = privilege
         self.model = model
+        if not id_field:
+            id_field = "row_id"
+        self.id_field = id_field
 
     async def __call__(
         self,
-        row_id: int,
+        request: Request,
         auth_context: AuthContext = Depends(get_auth_context),
         session: AsyncSession = Depends(get_db),
     ) -> idbase:
         authz_session = AuthZSession(session, auth_context)
         query = await authz_session.authorized_query(self.privilege, self.model)
+        id_value = int(request.path_params[self.id_field])
         try:
             res = (
-                (await (session.execute(query.where(self.model.id == row_id))))
+                (await (session.execute(query.where(self.model.id == id_value))))
                 .scalars()
                 .one()
             )
@@ -242,11 +248,10 @@ class AuthorizedRow:
             raise ex.UnauthorizedException("unauthorized")
 
 
-# NOTE - any endpoint that uses `fetch_authorized_row` must use "row_id" as the path
-#        parameter name to identify the row to be fetched.
 @lru_cache
 def fetch_authorized_row(
     privilege: str,
     model: idbase,
+    id_field: Optional[str] = None,
 ) -> idbase:
-    return AuthorizedRow(privilege, model)
+    return AuthorizedRow(privilege, model, id_field)

--- a/src/backend/aspen/api/views/tests/test_groups.py
+++ b/src/backend/aspen/api/views/tests/test_groups.py
@@ -8,6 +8,7 @@ from aspen.api.views.tests.data.auth0_mock_responses import (
     DEFAULT_AUTH0_ORG,
 )
 from aspen.auth.auth0_management import Auth0Client
+from aspen.auth.role_manager import RoleManager
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.usergroup import group_factory, userrole_factory
 
@@ -40,6 +41,7 @@ async def test_list_members(
     )
     async_session.add(group)
     async_session.add(user3)
+    async_session.add(user2)
     async_session.add(group2)
     await async_session.commit()
 
@@ -65,6 +67,70 @@ async def test_list_members(
                 "agreed_to_tos": True,
                 "acknowledged_policy_version": None,
                 "email": user.email,
+                "group_admin": False,
+                "role": "member",
+            },
+        ]
+    }
+    resp_data = response.json()
+    for key in expected:
+        assert resp_data[key] == expected[key]
+
+
+async def test_list_members_secondary_group(
+    http_client: AsyncClient, async_session: AsyncSession
+) -> None:
+    group = group_factory()
+    group2 = group_factory(name="test_group2")
+    user = await userrole_factory(
+        async_session, group, name="Bob", auth0_user_id="testid02", email="bob@dph.org"
+    )
+    user2 = await userrole_factory(
+        async_session,
+        group,
+        name="Alice",
+        auth0_user_id="testid01",
+        email="alice@dph.org",
+        roles=["admin"],
+    )
+    user3 = await userrole_factory(
+        async_session,
+        group2,
+        name="Jane",
+        auth0_user_id="testid03",
+        email="jane@dph.org",
+    )
+    async_session.add(
+        await RoleManager.generate_user_role(async_session, user, group2, "member")
+    )
+    async_session.add(group)
+    async_session.add(user2)
+    async_session.add(user3)
+    async_session.add(group2)
+    await async_session.commit()
+
+    response = await http_client.get(
+        f"/v2/groups/{group2.id}/members/", headers={"user_id": user.auth0_user_id}
+    )
+    assert response.status_code == 200
+    # TODO - this response isn't sorted, so our test should handle unordered results.
+    expected = {
+        "members": [
+            {
+                "id": user.id,
+                "name": user.name,
+                "agreed_to_tos": True,
+                "acknowledged_policy_version": None,
+                "email": user.email,
+                "group_admin": False,
+                "role": "member",
+            },
+            {
+                "id": user3.id,
+                "name": user3.name,
+                "agreed_to_tos": True,
+                "acknowledged_policy_version": None,
+                "email": user3.email,
                 "group_admin": False,
                 "role": "member",
             },


### PR DESCRIPTION
### Notes:
I broke the authz for the group membership endpoints when I switched to `row_id` -- this fixes the breakage and adds a test for multi-group-membership.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)