### PR TITLE
Fix template args test for phylo tree creation

### DIFF
--- a/src/backend/aspen/workflows/pangolin/find_samples.py
+++ b/src/backend/aspen/workflows/pangolin/find_samples.py
@@ -17,7 +17,7 @@ from aspen.database.models import Sample
 
 def check_latest_pangolin_version() -> str:
     contents = urllib.request.urlopen(
-        "https://github.com/cov-lineages/pangolin-data/releases/latest"
+        "https://github.com/cov-lineages/pangoLEARN/releases/latest"
     )
     # get latest version from redirected url:
     redirected_url: str = contents.url

--- a/src/backend/aspen/workflows/pangolin/find_samples.py
+++ b/src/backend/aspen/workflows/pangolin/find_samples.py
@@ -17,7 +17,7 @@ from aspen.database.models import Sample
 
 def check_latest_pangolin_version() -> str:
     contents = urllib.request.urlopen(
-        "https://github.com/cov-lineages/pangoLEARN/releases/latest"
+        "https://github.com/cov-lineages/pangolin-data/releases/latest"
     )
     # get latest version from redirected url:
     redirected_url: str = contents.url


### PR DESCRIPTION
### Summary:
- **What:** Fixes the `test_create_phylo_run_with_template_args` to match what is now expected from the endpoint, since the values in the `filter_pango_lineages` list won't necessarily be returned in the same order, since they are converted to a set as an intermediary.
- **Ticket:** [sc199195](https://app.shortcut.com/genepi/story/199195)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)