### PR TITLE
Make sure localdev users can still log in.

### DIFF
--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -111,7 +111,10 @@ async def auth(
         }
         user = await create_user_if_not_exists(db, auth0_mgmt, userinfo)
         # Always re-sync auth0 groups to our db on login!
-        await RoleManager.sync_user_roles(db, auth0_mgmt, user)
+        # Make sure the user is in auth0 before sync'ing roles.
+        #  ex: User1 in local dev doesn't exist in auth0
+        if user.auth0_user_id.startswith("auth0|"):
+            await RoleManager.sync_user_roles(db, auth0_mgmt, user)
         await db.commit()
     else:
         raise ex.UnauthorizedException("No user info in token")


### PR DESCRIPTION
### Notes:
Now that the callback endpoint syncs auth0 user roles on login, any localdev users that are tied to our local OIDC service can't log in locally. This puts in an exception for users without 'auth0|' prefixes to not require a matching user in auth0.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)