### PR TITLE
sc190571 - don't include optional fields in missing headers

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
@@ -78,7 +78,10 @@ function getMissingHeaderFields(
   for (const [headerField, metadataKey] of Object.entries(
     headersToMetadataKeys
   )) {
-    if (!uploadedHeaders.includes(metadataKey)) {
+    if (
+      !uploadedHeaders.includes(metadataKey) &&
+      !headerField.includes("Optional")
+    ) {
       missingFields.add(headerField);
     }
   }


### PR DESCRIPTION
### Summary:
- **What:** don't throw error in metadata upload if user removed optional field
- **Ticket:** [sc190571](https://app.shortcut.com/genepi/story/190571)
- **Env:** no rdev since this was relatively small

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)