### PR TITLE
Maya/group switch flake b gone

### DIFF
--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -14,7 +14,7 @@ import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
 import Nav from "src/components/NavBar";
 import SplitInitializer from "src/components/Split";
 
-const queryClient = new QueryClient();
+export const queryClient = new QueryClient();
 setFeatureFlagsFromQueryParams();
 
 const App = ({ Component, pageProps }: AppProps): JSX.Element => {

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -11,6 +11,7 @@ export enum API {
   LOCATIONS = "/v2/locations/",
   PANGO_LINEAGES = "/v2/lineages/pango",
   GROUPS = "/v2/groups/",
+  ORGS = "/v2/orgs/",
 }
 
 export enum ORG_API {
@@ -213,7 +214,7 @@ export const fetchSamples = (): Promise<SampleResponse> =>
   apiResponse<SampleResponse>(
     ["samples"],
     [SAMPLE_MAP],
-    generateGroupSpecificUrl(ORG_API.SAMPLES)
+    generateOrgSpecificUrl(ORG_API.SAMPLES)
   );
 
 export interface PhyloRunResponse extends APIResponse {
@@ -231,5 +232,5 @@ export const fetchPhyloRuns = (): Promise<PhyloRunResponse> =>
   apiResponse<PhyloRunResponse>(
     ["phylo_runs"],
     [PHYLO_RUN_MAP],
-    generateGroupSpecificUrl(ORG_API.PHYLO_RUNS)
+    generateOrgSpecificUrl(ORG_API.PHYLO_RUNS)
   );

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -1,5 +1,7 @@
 import ENV from "src/common/constants/ENV";
 import { jsonToType } from "src/common/utils";
+import { store } from "../redux";
+import { selectCurrentGroup } from "../redux/selectors";
 
 export enum API {
   USERDATA = "/v2/users/me",
@@ -20,11 +22,14 @@ export enum ORG_API {
   GET_FASTA_URL = "sequences/getfastaurl",
 }
 
-export const generateGroupSpecificUrl = (
-  path: ORG_API,
-  groupId: number
-): string => {
-  return `/v2/orgs/${groupId}/${path}`;
+export const generateOrgSpecificUrl = (path: ORG_API): string => {
+  const groupId = selectCurrentGroup(store.getState());
+  return `${API.ORGS}${groupId}/${path}`;
+};
+
+export const generateGroupSpecificUrl = (path: string): string => {
+  const groupId = selectCurrentGroup(store.getState());
+  return `${API.GROUPS}${groupId}/${path}`;
 };
 
 export const DEFAULT_HEADERS_MUTATION_OPTIONS: RequestInit = {
@@ -204,11 +209,11 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
   ["czb_failed_genome_recovery", "CZBFailedGenomeRecovery"],
 ]);
 
-export const fetchSamples = (groupId: number): Promise<SampleResponse> =>
+export const fetchSamples = (): Promise<SampleResponse> =>
   apiResponse<SampleResponse>(
     ["samples"],
     [SAMPLE_MAP],
-    generateGroupSpecificUrl(ORG_API.SAMPLES, groupId)
+    generateGroupSpecificUrl(ORG_API.SAMPLES)
   );
 
 export interface PhyloRunResponse extends APIResponse {
@@ -222,9 +227,9 @@ const PHYLO_RUN_MAP = new Map<string, keyof PhyloRun>([
   ["workflow_id", "workflowId"],
   ["workflow_status", "status"],
 ]);
-export const fetchPhyloRuns = (groupId: number): Promise<PhyloRunResponse> =>
+export const fetchPhyloRuns = (): Promise<PhyloRunResponse> =>
   apiResponse<PhyloRunResponse>(
     ["phylo_runs"],
     [PHYLO_RUN_MAP],
-    generateGroupSpecificUrl(ORG_API.PHYLO_RUNS, groupId)
+    generateGroupSpecificUrl(ORG_API.PHYLO_RUNS)
   );

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -5,8 +5,6 @@ import {
   SampleValidationResponseType,
   useValidateSampleIds,
 } from "src/common/queries/samples";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { pluralize } from "src/common/utils/strUtils";
 import { InputInstructions } from "./components/InputInstructions";
 import {
@@ -75,11 +73,9 @@ const SampleIdInput = ({
     return compact(trimmedTokens);
   }, [inputValue]);
 
-  const groupId = useSelector(selectCurrentGroup);
-
   // TODO (mlila): we don't actually surface this error to the user anywhere, but in the
   // TODO          future we probably should if this happens with any frequency.
-  const validateSampleIdentifiersMutation = useValidateSampleIds(groupId, {
+  const validateSampleIdentifiersMutation = useValidateSampleIds({
     componentOnError: () => {
       setValidating(false);
       setShowAddButton(false);

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -4,14 +4,12 @@ import { uniq } from "lodash";
 import Image from "next/image";
 import NextLink from "next/link";
 import React, { SyntheticEvent, useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import type { TreeType } from "src/common/constants/types";
 import { TreeTypes } from "src/common/constants/types";
 import GisaidLogo from "src/common/images/gisaid-logo-full.png";
 import { useLineages } from "src/common/queries/lineages";
 import { useCreateTree } from "src/common/queries/trees";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
@@ -119,8 +117,7 @@ export const CreateNSTreeModal = ({
   const treeNameLength = treeName.length;
   const hasValidName = treeNameLength > 0 && treeNameLength <= 128;
 
-  const groupId = useSelector(selectCurrentGroup);
-  const mutation = useCreateTree(groupId, {
+  const mutation = useCreateTree({
     componentOnError: () => {
       setShouldShowErrorNotification(true);
       handleClose();

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -2,8 +2,6 @@ import { isEmpty } from "lodash";
 import React, { useState } from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { useDeleteSamples } from "src/common/queries/samples";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
 import { DeleteDialog } from "src/components/DeleteDialog";
@@ -33,8 +31,7 @@ const DeleteSamplesConfirmationModal = ({
     .filter((sample) => sample.submittingGroup?.name === userGroup?.name)
     .map((sample) => sample.id);
 
-  const groupId = useSelector(selectCurrentGroup);
-  const deleteSampleMutation = useDeleteSamples(groupId, {
+  const deleteSampleMutation = useDeleteSamples({
     componentOnError: () => {
       setShouldShowErrorNotification(true);
     },

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteSamplesConfirmationModal/index.tsx
@@ -4,6 +4,7 @@ import { useUserInfo } from "src/common/queries/auth";
 import { useDeleteSamples } from "src/common/queries/samples";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import { DeleteDialog } from "src/components/DeleteDialog";
 import Notification from "src/components/Notification";
 import { StyledCallout } from "./style";
@@ -25,10 +26,10 @@ const DeleteSamplesConfirmationModal = ({
     useState<boolean>(false);
   const [numDeletedSamples, setNumDeletedSamples] = useState<number>(0);
   const { data: userInfo } = useUserInfo();
-  const { group: userGroup } = userInfo ?? {};
+  const currentGroup = getCurrentGroupFromUserInfo(userInfo);
 
   const samplesToDelete = checkedSamples
-    .filter((sample) => sample.submittingGroup?.name === userGroup?.name)
+    .filter((sample) => sample.submittingGroup?.name === currentGroup?.name)
     .map((sample) => sample.id);
 
   const deleteSampleMutation = useDeleteSamples({

--- a/src/frontend/src/common/components/library/data_subview/components/DeleteTreeConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DeleteTreeConfirmationModal/index.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
 import { useDeletePhyloRun } from "src/common/queries/phyloRuns";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { DeleteDialog } from "src/components/DeleteDialog";
 import Notification from "src/components/Notification";
 
@@ -21,9 +19,7 @@ const DeleteTreeConfirmationModal = ({
   const [shouldShowSuccessNotification, setShouldShowSuccessNotification] =
     useState<boolean>(false);
 
-  const groupId = useSelector(selectCurrentGroup);
-
-  const deletePhyloRunMutation = useDeletePhyloRun(groupId, {
+  const deletePhyloRunMutation = useDeletePhyloRun({
     componentOnSuccess: () => {
       setShouldShowSuccessNotification(true);
     },

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -8,8 +8,6 @@ import DialogContent from "src/common/components/library/Dialog/components/Dialo
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import { useUserInfo } from "src/common/queries/auth";
 import { useFastaDownload } from "src/common/queries/samples";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
 import Dialog from "src/components/Dialog";
@@ -96,8 +94,7 @@ const DownloadModal = ({
     onClose();
   };
 
-  const groupId = useSelector(selectCurrentGroup);
-  const fastaDownloadMutation = useFastaDownload(groupId, {
+  const fastaDownloadMutation = useFastaDownload({
     componentOnError: () => {
       setShouldShowError(true);
       handleCloseModal();

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -10,6 +10,7 @@ import { useUserInfo } from "src/common/queries/auth";
 import { useFastaDownload } from "src/common/queries/samples";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import Dialog from "src/components/Dialog";
 import Notification from "src/components/Notification";
 import { TooltipDescriptionText, TooltipHeaderText } from "../../style";
@@ -45,7 +46,8 @@ const DownloadModal = ({
   onClose,
 }: Props): JSX.Element => {
   const { data: userInfo } = useUserInfo();
-  const groupName = userInfo?.group?.name.toLowerCase().replace(/ /g, "_"); // format group name for sequences download file
+  const currentGroup = getCurrentGroupFromUserInfo(userInfo);
+  const groupName = currentGroup?.name.toLowerCase().replace(/ /g, "_"); // format group name for sequences download file
   const downloadDate = new Date();
   const separator = "\t";
   const fastaDownloadName = `${groupName}_sample_sequences_${downloadDate

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/index.tsx
@@ -1,10 +1,8 @@
 import { Checkbox } from "czifui";
 import { map, pickBy } from "lodash";
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { useEditSamples } from "src/common/queries/samples";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { B } from "src/common/styles/basicStyle";
 import { getIdFromCollectionLocation } from "src/common/utils/locationUtils";
@@ -45,8 +43,7 @@ const EditSamplesReviewDialog = ({
   onSaveSuccess,
 }: Props): JSX.Element => {
   const [isChecked, setChecked] = useState<boolean>(false);
-  const groupId = useSelector(selectCurrentGroup);
-  const editSampleMutation = useEditSamples(groupId, {
+  const editSampleMutation = useEditSamples({
     componentOnSuccess: () => {
       onSaveSuccess();
     },

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/index.tsx
@@ -9,6 +9,7 @@ import { useUserInfo } from "src/common/queries/auth";
 import { useNamedLocations } from "src/common/queries/locations";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import { StyledCallout } from "src/components/AlertAccordion/style";
 import { Content, Title } from "src/components/BaseDialog/style";
 import Dialog from "src/components/Dialog";
@@ -85,11 +86,11 @@ const EditSamplesConfirmationModal = ({
   const [autocorrectWarnings, setAutocorrectWarnings] =
     useState<SampleIdToWarningMessages>(EMPTY_OBJECT);
   const [userEditableSamples, setUserEditableSamples] = useState<Sample[]>([]);
-  const { data: userInfo } = useUserInfo();
-  const { group: userGroup } = userInfo ?? {};
   const [statusModalView, setStatusModalView] = useState<StatusModalView>(
     StatusModalView.NONE
   );
+  const { data: userInfo } = useUserInfo();
+  const currentGroup = getCurrentGroupFromUserInfo(userInfo);
 
   const { data: namedLocationsData } = useNamedLocations();
   const namedLocations: NamedGisaidLocation[] =
@@ -98,10 +99,10 @@ const EditSamplesConfirmationModal = ({
 
   useEffect(() => {
     const samplesToEdit = checkedSamples.filter(
-      (sample) => sample.submittingGroup?.id === userGroup?.id
+      (sample) => sample.submittingGroup?.id === currentGroup?.id
     );
     setUserEditableSamples(samplesToEdit);
-  }, [checkedSamples, userGroup?.name]);
+  }, [checkedSamples, currentGroup?.name]);
 
   useEffect(() => {
     // continue button should only be active if the user has metadata

--- a/src/frontend/src/common/components/library/data_subview/components/EditTreeConfirmationModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditTreeConfirmationModal/index.tsx
@@ -1,8 +1,6 @@
 import { Button, Icon } from "czifui";
 import React, { useEffect, useState } from "react";
 import { useEditTree } from "src/common/queries/trees";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import BaseDialog from "src/components/BaseDialog";
 import Notification from "src/components/Notification";
 import { TreeNameInput } from "src/components/TreeNameInput";
@@ -47,8 +45,7 @@ export const EditTreeConfirmationModal = ({
     setShouldShowErrorNotification,
   ]);
 
-  const groupId = useSelector(selectCurrentGroup);
-  const editTreeMutation = useEditTree(groupId, {
+  const editTreeMutation = useEditTree({
     componentOnSuccess: () => {
       setShouldShowSuccessNotification(true);
     },

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -8,8 +8,6 @@ import {
   getUsherOptions,
   useFastaFetch,
 } from "src/common/queries/trees";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { pluralize } from "src/common/utils/strUtils";
 import Dialog from "src/components/Dialog";
 import {
@@ -112,8 +110,7 @@ export const UsherPlacementModal = ({
     setUsherDisabled(shouldDisable);
   }, [checkedSampleIds, failedSampleIds, isLoading]);
 
-  const groupId = useSelector(selectCurrentGroup);
-  const fastaFetch = useFastaFetch(groupId, {
+  const fastaFetch = useFastaFetch({
     componentOnError: () => {
       setIsLoading(false);
       onClose();

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -12,8 +12,6 @@ import { API, DEFAULT_PUT_OPTIONS, getBackendApiJson } from "../api";
 import { ROUTES } from "../routes";
 import { ENTITIES } from "./entities";
 import {
-  mapGroupData,
-  RawGroupRequest,
   USE_GROUP_INFO,
   USE_GROUP_INVITATION_INFO,
   USE_GROUP_MEMBER_INFO,
@@ -29,7 +27,6 @@ export const USE_USER_INFO = {
 export interface RawUserRequest {
   id: number;
   name: string;
-  group: RawGroupRequest;
   groups: UserGroup[];
   agreed_to_tos: boolean;
   acknowledged_policy_version: string | null; // Date or null in DB. ISO 8601: "YYYY-MM-DD"
@@ -41,10 +38,8 @@ export const mapUserData = (obj: RawUserRequest): User => {
   return {
     acknowledgedPolicyVersion: obj.acknowledged_policy_version,
     agreedToTos: obj.agreed_to_tos,
-    group: mapGroupData(obj.group),
     groups: obj.groups,
     id: obj.id,
-    isGroupAdmin: obj.group_admin,
     name: obj.name,
     splitId: obj.split_id,
   };

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -246,7 +246,7 @@ export async function expireAllCaches(): Promise<void> {
   ];
 
   forEach(queriesToRefetch, async (q) => {
-    await queryClient.fetchQuery([q]);
     await queryClient.invalidateQueries([q]);
+    await queryClient.fetchQuery([q]);
   });
 }

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -233,3 +233,20 @@ export function useSendGroupInvitations({
     },
   });
 }
+
+/**
+ * expire all group-specific caches when group is changed in UI.
+ * this will not expire caches such as lists of locations
+ * or lineages because those won't change or vary depending on
+ * which group you are viewing
+ */
+export function expireAllCaches(): void {
+  const queryClient = new QueryClient();
+  queryClient.invalidateQueries([
+    USE_PHYLO_RUN_INFO,
+    USE_SAMPLE_INFO,
+    USE_GROUP_INFO,
+    USE_GROUP_INVITATION_INFO,
+    USE_GROUP_MEMBER_INFO,
+  ]);
+}

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -15,6 +15,7 @@ import { API_URL } from "../constants/ENV";
 import { store } from "../redux";
 import { selectCurrentGroup } from "../redux/selectors";
 import { ENTITIES } from "./entities";
+import { USE_PHYLO_RUN_INFO } from "./phyloRuns";
 import { USE_SAMPLE_INFO } from "./samples";
 import { MutationCallbacks } from "./types";
 
@@ -72,7 +73,6 @@ export const mapGroupMemberData = (obj: RawGroupMemberRequest): GroupMember => {
     createdAt: obj.created_at,
     email: obj.email,
     id: obj.id,
-    isGroupAdmin: obj.group_admin,
     name: obj.name,
     role: obj.role,
   };

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -236,7 +236,7 @@ export function useSendGroupInvitations({
  * or lineages because those won't change or vary depending on
  * which group you are viewing
  */
-export async function expireAllCaches(): void {
+export async function expireAllCaches(): Promise<void> {
   const queriesToRefetch = [
     USE_PHYLO_RUN_INFO,
     USE_SAMPLE_INFO,

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -6,7 +6,11 @@ import {
   useQueryClient,
   UseQueryResult,
 } from "react-query";
-import { API, DEFAULT_FETCH_OPTIONS, DEFAULT_POST_OPTIONS } from "../api";
+import {
+  DEFAULT_FETCH_OPTIONS,
+  DEFAULT_POST_OPTIONS,
+  generateGroupSpecificUrl,
+} from "../api";
 import { API_URL } from "../constants/ENV";
 import { store } from "../redux";
 import { selectCurrentGroup } from "../redux/selectors";
@@ -91,8 +95,7 @@ export function useGroupInfo(): UseQueryResult<GroupDetails, unknown> {
 }
 
 export async function fetchGroup(): Promise<RawGroupRequest> {
-  const groupId = selectCurrentGroup(store);
-  const response = await fetch(API_URL + API.GROUPS + groupId + "/", {
+  const response = await fetch(API_URL + generateGroupSpecificUrl(""), {
     ...DEFAULT_FETCH_OPTIONS,
   });
 
@@ -125,8 +128,7 @@ export function useGroupMembersInfo(): UseQueryResult<GroupMember[], unknown> {
 }
 
 export async function fetchGroupMembers(): Promise<GroupMembersFetchResponseType> {
-  const groupId = selectCurrentGroup(store);
-  const response = await fetch(API_URL + API.GROUPS + groupId + "/members/", {
+  const response = await fetch(API_URL + generateGroupSpecificUrl("members/"), {
     ...DEFAULT_FETCH_OPTIONS,
   });
 
@@ -159,9 +161,8 @@ export function useGroupInvitations(): UseQueryResult<Invitation[], unknown> {
 }
 
 export async function fetchGroupInvitations(): Promise<FetchInvitationResponseType> {
-  const groupId = selectCurrentGroup(store);
   const response = await fetch(
-    API_URL + API.GROUPS + groupId + "/invitations/",
+    API_URL + generateGroupSpecificUrl("invitations/"),
     {
       ...DEFAULT_FETCH_OPTIONS,
     }
@@ -182,7 +183,6 @@ interface InvitationPayload {
 
 interface InvitationRequestType {
   emails: string[];
-  groupId: number;
 }
 
 interface InvitationResponseType {
@@ -203,9 +203,8 @@ async function sendGroupInvitations({
     role: "member",
   };
 
-  const groupId = selectCurrentGroup(store);
   const response = await fetch(
-    API_URL + API.GROUPS + groupId + "/invitations/",
+    API_URL + generateGroupSpecificUrl("invitations/"),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),

--- a/src/frontend/src/common/queries/phyloRuns.ts
+++ b/src/frontend/src/common/queries/phyloRuns.ts
@@ -23,10 +23,8 @@ export const USE_PHYLO_RUN_INFO = {
   id: "phyloRunInfo",
 };
 
-export function usePhyloRunInfo(
-  groupId: number
-): UseQueryResult<PhyloRunResponse, unknown> {
-  return useQuery([USE_PHYLO_RUN_INFO], () => fetchPhyloRuns(groupId), {
+export function usePhyloRunInfo(): UseQueryResult<PhyloRunResponse, unknown> {
+  return useQuery([USE_PHYLO_RUN_INFO], fetchPhyloRuns, {
     retry: false,
   });
 }
@@ -47,14 +45,11 @@ interface PhyloRunDeleteResponseType {
   id: string;
 }
 
-async function deletePhyloRun(
-  groupId: number,
-  { phyloRunIdToDelete }: PhyloRunDeleteRequestType
-): Promise<PhyloRunDeleteResponseType> {
+async function deletePhyloRun({
+  phyloRunIdToDelete,
+}: PhyloRunDeleteRequestType): Promise<PhyloRunDeleteResponseType> {
   const response = await fetch(
-    API_URL +
-      generateGroupSpecificUrl(ORG_API.PHYLO_RUNS, groupId) +
-      phyloRunIdToDelete,
+    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS) + phyloRunIdToDelete,
     {
       ...DEFAULT_DELETE_OPTIONS,
     }
@@ -64,17 +59,17 @@ async function deletePhyloRun(
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
 
-export function useDeletePhyloRun(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: PhyloRunDeleteCallbacks
-): UseMutationResult<
+export function useDeletePhyloRun({
+  componentOnError,
+  componentOnSuccess,
+}: PhyloRunDeleteCallbacks): UseMutationResult<
   PhyloRunDeleteResponseType,
   unknown,
   PhyloRunDeleteRequestType,
   unknown
 > {
   const queryClient = useQueryClient();
-  return useMutation((toMutate) => deletePhyloRun(groupId, toMutate), {
+  return useMutation(deletePhyloRun, {
     onError: componentOnError,
     onSuccess: async (data) => {
       await queryClient.invalidateQueries([USE_PHYLO_RUN_INFO]);

--- a/src/frontend/src/common/queries/phyloRuns.ts
+++ b/src/frontend/src/common/queries/phyloRuns.ts
@@ -8,7 +8,7 @@ import {
 import {
   DEFAULT_DELETE_OPTIONS,
   fetchPhyloRuns,
-  generateGroupSpecificUrl,
+  generateOrgSpecificUrl,
   ORG_API,
   PhyloRunResponse,
 } from "../api";
@@ -49,7 +49,7 @@ async function deletePhyloRun({
   phyloRunIdToDelete,
 }: PhyloRunDeleteRequestType): Promise<PhyloRunDeleteResponseType> {
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS) + phyloRunIdToDelete,
+    API_URL + generateOrgSpecificUrl(ORG_API.PHYLO_RUNS) + phyloRunIdToDelete,
     {
       ...DEFAULT_DELETE_OPTIONS,
     }

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -30,19 +30,16 @@ interface SampleFastaDownloadPayload {
 
 type FastaDownloadCallbacks = MutationCallbacks<Blob>;
 
-export async function downloadSamplesFasta(
-  groupId: number,
-  {
-    sampleIds,
-  }: {
-    sampleIds: string[];
-  }
-): Promise<Blob> {
+export async function downloadSamplesFasta({
+  sampleIds,
+}: {
+  sampleIds: string[];
+}): Promise<Blob> {
   const payload = {
     sample_ids: sampleIds,
   };
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES_FASTA_DOWNLOAD, groupId),
+    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES_FASTA_DOWNLOAD),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -53,11 +50,16 @@ export async function downloadSamplesFasta(
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
 
-export function useFastaDownload(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: FastaDownloadCallbacks
-): UseMutationResult<Blob, unknown, SampleFastaDownloadPayload, unknown> {
-  return useMutation((toMutate) => downloadSamplesFasta(groupId, toMutate), {
+export function useFastaDownload({
+  componentOnError,
+  componentOnSuccess,
+}: FastaDownloadCallbacks): UseMutationResult<
+  Blob,
+  unknown,
+  SampleFastaDownloadPayload,
+  unknown
+> {
+  return useMutation(downloadSamplesFasta, {
     onError: componentOnError,
     onSuccess: componentOnSuccess,
   });
@@ -70,16 +72,15 @@ interface ValidateSampleIdentifiersPayload {
   sample_ids: string[];
 }
 
-export async function validateSampleIdentifiers(
-  groupId: number,
-  { sampleIdsToValidate }: SampleValidationRequestType
-): Promise<SampleValidationResponseType> {
+export async function validateSampleIdentifiers({
+  sampleIdsToValidate,
+}: SampleValidationRequestType): Promise<SampleValidationResponseType> {
   const payload: ValidateSampleIdentifiersPayload = {
     sample_ids: sampleIdsToValidate,
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES_VALIDATE_IDS, groupId),
+    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES_VALIDATE_IDS),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -101,22 +102,19 @@ export interface SampleValidationResponseType {
 type SampleValidationCallbacks =
   MutationCallbacks<SampleValidationResponseType>;
 
-export function useValidateSampleIds(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: SampleValidationCallbacks
-): UseMutationResult<
+export function useValidateSampleIds({
+  componentOnError,
+  componentOnSuccess,
+}: SampleValidationCallbacks): UseMutationResult<
   SampleValidationResponseType,
   unknown,
   SampleValidationRequestType,
   unknown
 > {
-  return useMutation(
-    (toMutate) => validateSampleIdentifiers(groupId, toMutate),
-    {
-      onError: componentOnError,
-      onSuccess: componentOnSuccess,
-    }
-  );
+  return useMutation(validateSampleIdentifiers, {
+    onError: componentOnError,
+    onSuccess: componentOnSuccess,
+  });
 }
 
 /**
@@ -139,10 +137,10 @@ interface SampleCreateRequestType {
   metadata: SampleIdToMetadata | null;
 }
 
-export async function createSamples(
-  groupId: number,
-  { samples, metadata }: SampleCreateRequestType
-): Promise<unknown> {
+export async function createSamples({
+  samples,
+  metadata,
+}: SampleCreateRequestType): Promise<unknown> {
   const payload: SamplePayload[] = [];
 
   if (!samples || !metadata) {
@@ -188,7 +186,7 @@ export async function createSamples(
   }
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES, groupId),
+    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -200,11 +198,12 @@ export async function createSamples(
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
 
-export function useCreateSamples(
-  groupId: number,
-  { componentOnSuccess }: { componentOnSuccess: () => void }
-): UseMutationResult<unknown, unknown, SampleCreateRequestType, unknown> {
-  return useMutation((toMutate) => createSamples(groupId, toMutate), {
+export function useCreateSamples({
+  componentOnSuccess,
+}: {
+  componentOnSuccess: () => void;
+}): UseMutationResult<unknown, unknown, SampleCreateRequestType, unknown> {
+  return useMutation(createSamples, {
     onSuccess: componentOnSuccess,
   });
 }
@@ -218,10 +217,8 @@ export const USE_SAMPLE_INFO = {
   id: "sampleInfo",
 };
 
-export function useSampleInfo(
-  groupId: number
-): UseQueryResult<SampleResponse, unknown> {
-  return useQuery([USE_SAMPLE_INFO], () => fetchSamples(groupId), {
+export function useSampleInfo(): UseQueryResult<SampleResponse, unknown> {
+  return useQuery([USE_SAMPLE_INFO], () => fetchSamples(), {
     retry: false,
   });
 }
@@ -236,16 +233,15 @@ interface DeleteSamplesPayload {
   ids: number[];
 }
 
-export async function deleteSamples(
-  groupId: number,
-  { samplesToDelete }: SampleDeleteRequestType
-): Promise<SampleDeleteResponseType> {
+export async function deleteSamples({
+  samplesToDelete,
+}: SampleDeleteRequestType): Promise<SampleDeleteResponseType> {
   const payload: DeleteSamplesPayload = {
     ids: samplesToDelete,
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES, groupId),
+    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES),
     {
       ...DEFAULT_DELETE_OPTIONS,
       body: JSON.stringify(payload),
@@ -267,10 +263,10 @@ export interface SampleDeleteResponseType {
 
 type SampleDeleteCallbacks = MutationCallbacks<SampleDeleteResponseType>;
 
-export function useDeleteSamples(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: SampleDeleteCallbacks
-): UseMutationResult<
+export function useDeleteSamples({
+  componentOnError,
+  componentOnSuccess,
+}: SampleDeleteCallbacks): UseMutationResult<
   SampleDeleteResponseType,
   unknown,
   SampleDeleteRequestType,
@@ -278,7 +274,7 @@ export function useDeleteSamples(
 > {
   const queryClient = useQueryClient();
   // TODO (mlila): pick less confusing name choices for callbacks/params
-  return useMutation((toMutate) => deleteSamples(groupId, toMutate), {
+  return useMutation(deleteSamples, {
     onError: componentOnError,
     onSuccess: async (data) => {
       await queryClient.invalidateQueries([USE_SAMPLE_INFO]);
@@ -336,27 +332,26 @@ interface SamplesEditResponseType {
 
 type SamplesEditCallbacks = MutationCallbacks<SamplesEditResponseType[]>;
 
-export async function editSamples(
-  groupId: number,
-  { samples }: SamplesEditRequestType
-): Promise<SamplesEditResponseType[]> {
+export async function editSamples({
+  samples,
+}: SamplesEditRequestType): Promise<SamplesEditResponseType[]> {
   return putBackendApiJson(
-    generateGroupSpecificUrl(ORG_API.SAMPLES, groupId),
+    generateGroupSpecificUrl(ORG_API.SAMPLES),
     JSON.stringify({ samples })
   );
 }
 
-export function useEditSamples(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: SamplesEditCallbacks
-): UseMutationResult<
+export function useEditSamples({
+  componentOnError,
+  componentOnSuccess,
+}: SamplesEditCallbacks): UseMutationResult<
   SamplesEditResponseType[],
   unknown,
   SamplesEditRequestType,
   unknown
 > {
   const queryClient = useQueryClient();
-  return useMutation((toMutate) => editSamples(groupId, toMutate), {
+  return useMutation(editSamples, {
     onError: componentOnError,
     onSuccess: async (data) => {
       await queryClient.invalidateQueries([USE_SAMPLE_INFO]);

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_DELETE_OPTIONS,
   DEFAULT_POST_OPTIONS,
   fetchSamples,
-  generateGroupSpecificUrl,
+  generateOrgSpecificUrl,
   ORG_API,
   putBackendApiJson,
   SampleResponse,
@@ -39,7 +39,7 @@ export async function downloadSamplesFasta({
     sample_ids: sampleIds,
   };
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES_FASTA_DOWNLOAD),
+    API_URL + generateOrgSpecificUrl(ORG_API.SAMPLES_FASTA_DOWNLOAD),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -80,7 +80,7 @@ export async function validateSampleIdentifiers({
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES_VALIDATE_IDS),
+    API_URL + generateOrgSpecificUrl(ORG_API.SAMPLES_VALIDATE_IDS),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -186,7 +186,7 @@ export async function createSamples({
   }
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES),
+    API_URL + generateOrgSpecificUrl(ORG_API.SAMPLES),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -241,7 +241,7 @@ export async function deleteSamples({
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.SAMPLES),
+    API_URL + generateOrgSpecificUrl(ORG_API.SAMPLES),
     {
       ...DEFAULT_DELETE_OPTIONS,
       body: JSON.stringify(payload),
@@ -336,7 +336,7 @@ export async function editSamples({
   samples,
 }: SamplesEditRequestType): Promise<SamplesEditResponseType[]> {
   return putBackendApiJson(
-    generateGroupSpecificUrl(ORG_API.SAMPLES),
+    generateOrgSpecificUrl(ORG_API.SAMPLES),
     JSON.stringify({ samples })
   );
 }

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -40,10 +40,12 @@ interface CreateTreeType {
 
 type CreateTreeCallbacks = MutationCallbacks<void>;
 
-async function createTree(
-  groupId: number,
-  { sampleIds, treeName, treeType, filters }: CreateTreeType
-): Promise<unknown> {
+async function createTree({
+  sampleIds,
+  treeName,
+  treeType,
+  filters,
+}: CreateTreeType): Promise<unknown> {
   const { startDate, endDate, lineages } = filters;
   const payload: CreateTreePayload = {
     name: treeName,
@@ -57,7 +59,7 @@ async function createTree(
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS, groupId),
+    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -68,13 +70,18 @@ async function createTree(
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
 
-export function useCreateTree(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: CreateTreeCallbacks
-): UseMutationResult<unknown, unknown, CreateTreeType, unknown> {
+export function useCreateTree({
+  componentOnError,
+  componentOnSuccess,
+}: CreateTreeCallbacks): UseMutationResult<
+  unknown,
+  unknown,
+  CreateTreeType,
+  unknown
+> {
   const queryClient = useQueryClient();
 
-  return useMutation((toMutate) => createTree(groupId, toMutate), {
+  return useMutation(createTree, {
     onError: componentOnError,
     onSuccess: async () => {
       await queryClient.invalidateQueries([USE_PHYLO_RUN_INFO]);
@@ -103,18 +110,19 @@ export interface FastaResponseType {
 
 type FastaFetchCallbacks = MutationCallbacks<FastaResponseType>;
 
-async function getFastaURL(
-  groupId: number,
-  { sampleIds, downstreamConsumer }: FastaRequestType
-): Promise<FastaResponseType> {
+async function getFastaURL({
+  sampleIds,
+  downstreamConsumer,
+}: FastaRequestType): Promise<FastaResponseType> {
   const payload: FastaURLPayloadType = {
     samples: sampleIds,
     // If specialty downstream consumer, set this to have FASTA generate accordingly
     // If left as undefined, will be stripped out from payload during JSON.stringify
     downstream_consumer: downstreamConsumer,
   };
+
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.GET_FASTA_URL, groupId),
+    API_URL + generateGroupSpecificUrl(ORG_API.GET_FASTA_URL),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -125,11 +133,16 @@ async function getFastaURL(
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
 
-export function useFastaFetch(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: FastaFetchCallbacks
-): UseMutationResult<FastaResponseType, unknown, FastaRequestType, unknown> {
-  return useMutation((toMutate) => getFastaURL(groupId, toMutate), {
+export function useFastaFetch({
+  componentOnError,
+  componentOnSuccess,
+}: FastaFetchCallbacks): UseMutationResult<
+  FastaResponseType,
+  unknown,
+  FastaRequestType,
+  unknown
+> {
+  return useMutation(getFastaURL, {
     onError: componentOnError,
     onSuccess: componentOnSuccess,
   });
@@ -164,17 +177,15 @@ interface TreeEditResponseType {
 
 type TreeEditCallbacks = MutationCallbacks<TreeEditResponseType>;
 
-export async function editTree(
-  groupId: number,
-  { treeIdToEdit, newTreeName }: TreeEditRequestType
-): Promise<TreeEditResponseType> {
+export async function editTree({
+  treeIdToEdit,
+  newTreeName,
+}: TreeEditRequestType): Promise<TreeEditResponseType> {
   const payload: EditTreePayloadType = {
     name: newTreeName,
   };
   const response = await fetch(
-    API_URL +
-      generateGroupSpecificUrl(ORG_API.PHYLO_RUNS, groupId) +
-      treeIdToEdit,
+    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS) + treeIdToEdit,
     {
       ...DEFAULT_PUT_OPTIONS,
       ...DEFAULT_HEADERS_MUTATION_OPTIONS,
@@ -186,17 +197,17 @@ export async function editTree(
   throw Error(`${response.statusText}: ${await response.text()}`);
 }
 
-export function useEditTree(
-  groupId: number,
-  { componentOnError, componentOnSuccess }: TreeEditCallbacks
-): UseMutationResult<
+export function useEditTree({
+  componentOnError,
+  componentOnSuccess,
+}: TreeEditCallbacks): UseMutationResult<
   TreeEditResponseType,
   unknown,
   TreeEditRequestType,
   unknown
 > {
   const queryClient = useQueryClient();
-  return useMutation((toMutate) => editTree(groupId, toMutate), {
+  return useMutation(editTree, {
     onError: componentOnError,
     onSuccess: async (data) => {
       await queryClient.invalidateQueries([USE_PHYLO_RUN_INFO]);

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_HEADERS_MUTATION_OPTIONS,
   DEFAULT_POST_OPTIONS,
   DEFAULT_PUT_OPTIONS,
-  generateGroupSpecificUrl,
+  generateOrgSpecificUrl,
   ORG_API,
 } from "../api";
 import { API_URL } from "../constants/ENV";
@@ -59,7 +59,7 @@ async function createTree({
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS),
+    API_URL + generateOrgSpecificUrl(ORG_API.PHYLO_RUNS),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -122,7 +122,7 @@ async function getFastaURL({
   };
 
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.GET_FASTA_URL),
+    API_URL + generateOrgSpecificUrl(ORG_API.GET_FASTA_URL),
     {
       ...DEFAULT_POST_OPTIONS,
       body: JSON.stringify(payload),
@@ -185,7 +185,7 @@ export async function editTree({
     name: newTreeName,
   };
   const response = await fetch(
-    API_URL + generateGroupSpecificUrl(ORG_API.PHYLO_RUNS) + treeIdToEdit,
+    API_URL + generateOrgSpecificUrl(ORG_API.PHYLO_RUNS) + treeIdToEdit,
     {
       ...DEFAULT_PUT_OPTIONS,
       ...DEFAULT_HEADERS_MUTATION_OPTIONS,

--- a/src/frontend/src/common/redux/middleware/index.ts
+++ b/src/frontend/src/common/redux/middleware/index.ts
@@ -5,14 +5,25 @@
  */
 
 import { AnyAction, Middleware } from "redux";
+import { expireAllCaches } from "src/common/queries/groups";
 import { setLocalStorage } from "src/common/utils/localStorage";
+import { selectCurrentGroup } from "../selectors";
 import { CZGEReduxActions, ReduxPersistenceTokens } from "../types";
 
 export const setGroupMiddleware: Middleware =
-  () => (next) => (action: AnyAction) => {
+  ({ getState }) =>
+  (next) =>
+  (action: AnyAction) => {
     const { type, payload } = action;
     if (type === CZGEReduxActions.SET_GROUP_ACTION_TYPE) {
       setLocalStorage(ReduxPersistenceTokens.GROUP, payload);
+
+      // if the group changes, expire caches, as samples, members
+      // and tress for new group must be fetched.
+      const state = getState();
+      if (selectCurrentGroup(state) !== payload) {
+        expireAllCaches();
+      }
     }
 
     return next(action);

--- a/src/frontend/src/common/types/user.d.ts
+++ b/src/frontend/src/common/types/user.d.ts
@@ -20,9 +20,7 @@ type BaseUser = {
 };
 
 interface User extends BaseUser {
-  group: GroupDetails;
   groups: UserGroup[];
-  isGroupAdmin: boolean;
   splitId: string;
 }
 
@@ -31,6 +29,5 @@ type GroupRole = "member" | "admin";
 interface GroupMember extends BaseUser {
   createdAt: string; // not yet returned from backend
   email: string;
-  isGroupAdmin: boolean;
-  role: GroupRole; // not yet returned from backend
+  role: GroupRole;
 }

--- a/src/frontend/src/common/utils/TreeModal/ConfirmButton/index.tsx
+++ b/src/frontend/src/common/utils/TreeModal/ConfirmButton/index.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonProps } from "czifui";
 import React, { useEffect, useState } from "react";
 import {
   DEFAULT_POST_OPTIONS,
-  generateGroupSpecificUrl,
+  generateOrgSpecificUrl,
   ORG_API,
 } from "src/common/api";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
@@ -15,7 +15,7 @@ interface Props extends ButtonProps {
 const getTreeUrl = async (treeId: number) => {
   const requestData = { tree_id: treeId };
   const result = await fetch(
-    `${ENV.API_URL}${generateGroupSpecificUrl(ORG_API.AUSPICE)}`,
+    `${ENV.API_URL}${generateOrgSpecificUrl(ORG_API.AUSPICE)}`,
     {
       body: JSON.stringify(requestData),
       ...DEFAULT_POST_OPTIONS,

--- a/src/frontend/src/common/utils/TreeModal/ConfirmButton/index.tsx
+++ b/src/frontend/src/common/utils/TreeModal/ConfirmButton/index.tsx
@@ -1,6 +1,5 @@
 import { Button, ButtonProps } from "czifui";
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import {
   DEFAULT_POST_OPTIONS,
   generateGroupSpecificUrl,
@@ -8,16 +7,15 @@ import {
 } from "src/common/api";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import ENV from "src/common/constants/ENV";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 
 interface Props extends ButtonProps {
   treeId: number;
 }
 
-const getTreeUrl = async (treeId: number, groupId: number) => {
+const getTreeUrl = async (treeId: number) => {
   const requestData = { tree_id: treeId };
   const result = await fetch(
-    `${ENV.API_URL}${generateGroupSpecificUrl(ORG_API.AUSPICE, groupId)}`,
+    `${ENV.API_URL}${generateGroupSpecificUrl(ORG_API.AUSPICE)}`,
     {
       body: JSON.stringify(requestData),
       ...DEFAULT_POST_OPTIONS,
@@ -47,12 +45,11 @@ export const ConfirmButton = (props: Props): JSX.Element => {
   const [isLoading, setIsLoading] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [url, setUrl] = useState("");
-  const groupId = useSelector(selectCurrentGroup);
 
   useEffect(() => {
     const getUrl = async () => {
       try {
-        setUrl(await getTreeUrl(treeId, groupId));
+        setUrl(await getTreeUrl(treeId));
         setIsLoading(false);
       } catch {
         setIsLoading(false);

--- a/src/frontend/src/common/utils/userInfo.ts
+++ b/src/frontend/src/common/utils/userInfo.ts
@@ -1,0 +1,21 @@
+import { find } from "lodash";
+import { store } from "../redux";
+import { selectCurrentGroup } from "../redux/selectors";
+
+/**
+ * Takes the stored id for the current group and returns the available details about that group
+ * from /me response
+ */
+export const getCurrentGroupFromUserInfo = (
+  userInfo?: User
+): UserGroup | undefined => {
+  const state = store.getState();
+  const currentGroupId = selectCurrentGroup(state);
+  return find(userInfo?.groups, (g) => g.id === currentGroupId);
+};
+
+export const getIsGroupAdminFromUserInfo = (userInfo?: User): boolean => {
+  const currentGroup = getCurrentGroupFromUserInfo(userInfo);
+  const roles: GroupRole[] = currentGroup?.roles ?? [];
+  return roles.includes("admin");
+};

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
@@ -6,6 +6,7 @@ import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import { pluralize } from "src/common/utils/strUtils";
+import { getIsGroupAdminFromUserInfo } from "src/common/utils/userInfo";
 import { GroupMenuItem } from "./components/GroupMenuItem";
 import {
   CurrentGroup,
@@ -36,7 +37,8 @@ const GroupDetailsDropdown = ({
 
   if (!open || !userInfo) return null;
 
-  const { groups, isGroupAdmin } = userInfo;
+  const { groups } = userInfo;
+  const isGroupAdmin = getIsGroupAdminFromUserInfo(userInfo);
 
   // how many people are in the current group
   const memberCount = members?.length ?? 0;

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
@@ -34,7 +34,7 @@ const GroupDetailsDropdown = ({
   const { data: members = [] } = useGroupMembersInfo();
   const { data: groupInfo } = useGroupInfo();
 
-  if (!open || !userInfo || !groupInfo) return null;
+  if (!open || !userInfo) return null;
 
   const { groups, isGroupAdmin } = userInfo;
 

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
@@ -1,10 +1,8 @@
 import { Icon } from "czifui";
 import { useRouter } from "next/router";
 import React from "react";
-import { useSelector } from "react-redux";
 import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import { pluralize } from "src/common/utils/strUtils";
@@ -32,10 +30,9 @@ const GroupDetailsDropdown = ({
 }: Props): JSX.Element | null => {
   const router = useRouter();
 
-  const groupId = useSelector(selectCurrentGroup);
   const { data: userInfo } = useUserInfo();
-  const { data: members = [] } = useGroupMembersInfo(groupId);
-  const { data: groupInfo } = useGroupInfo(groupId);
+  const { data: members = [] } = useGroupMembersInfo();
+  const { data: groupInfo } = useGroupInfo();
 
   if (!open || !userInfo || !groupInfo) return null;
 

--- a/src/frontend/src/components/NavBar/components/AppNavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/index.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import React, { MouseEventHandler, useState } from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import { FEATURE_FLAGS, isFlagOn } from "src/components/Split";
 import { InviteModal } from "src/views/GroupMembersPage/components/MembersTab/components/InviteModal";
 import RightNav from "../RightNav";
@@ -31,7 +32,7 @@ const AppNavBar = (): JSX.Element => {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const { data: userInfo } = useUserInfo();
 
-  const group = userInfo?.group;
+  const group = getCurrentGroupFromUserInfo(userInfo);
   const route = userInfo ? ROUTES.DATA : ROUTES.HOMEPAGE;
 
   const flag = useTreatments([FEATURE_FLAGS.user_onboarding_v0]);
@@ -46,10 +47,11 @@ const AppNavBar = (): JSX.Element => {
     setIsGroupDetailsDropdownOpen(!isGroupDetailsDropdownOpen);
   };
 
+  const name = group?.name;
   const orgElements = (
     <React.Fragment>
       <Separator />
-      <NavOrg>{group?.name}</NavOrg>
+      <NavOrg>{name}</NavOrg>
     </React.Fragment>
   );
 
@@ -62,7 +64,6 @@ const AppNavBar = (): JSX.Element => {
   }
 
   const orgSplash = hasOrg();
-  const name = group?.name;
 
   return (
     <NavBar data-test-id="navbar">

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
@@ -5,6 +5,7 @@ import CloseIcon from "src/common/images/close-icon.svg";
 import HeaderLogo from "src/common/images/gen-epi-logo.svg";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import UserMenu from "../RightNav/components/UserMenu";
 import {
   Bar,
@@ -40,8 +41,7 @@ export default function StaticPageNavBar(): JSX.Element {
   const { API_URL } = ENV;
 
   const { data: userInfo } = useUserInfo();
-
-  const group = userInfo?.group;
+  const group = getCurrentGroupFromUserInfo(userInfo);
 
   const orgElements = <React.Fragment>{group?.name}</React.Fragment>;
 

--- a/src/frontend/src/views/Data/components/TreeActionMenu/components/MoreActionsMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/components/MoreActionsMenu/index.tsx
@@ -3,6 +3,7 @@ import React, { MouseEventHandler, useState } from "react";
 import { TREE_STATUS } from "src/common/constants/types";
 import MoreActionsIcon from "src/common/icons/IconDotsHorizontal3Large.svg";
 import { StyledEditIcon, StyledTrashIcon } from "src/common/styles/iconStyle";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import { StyledIcon, StyledIconWrapper } from "../../style";
 import { StyledText } from "./style";
 
@@ -21,11 +22,11 @@ const MoreActionsMenu = ({
 }: Props): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
-  const { group: userGroup } = userInfo;
+  const currentGroup = getCurrentGroupFromUserInfo(userInfo);
   const { group, status } = item;
 
   const isAutoBuild = group?.name === "";
-  const isTreeInUserOrg = userGroup?.name === group?.name;
+  const isTreeInUserOrg = currentGroup?.name === group?.name;
   const canUserDeleteTree = isAutoBuild || isTreeInUserOrg;
   // FIXME: allow users to edit/delete FAILED runs once phylotrees V2 endpoint has been updated to better reflect tree status
   const isDisabled = status === TREE_STATUS.Started || !canUserDeleteTree;

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -2,12 +2,10 @@ import { compact, map, uniq } from "lodash";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
-import { useSelector } from "react-redux";
 import { HeadAppTitle } from "src/common/components";
 import { useProtectedRoute } from "src/common/queries/auth";
 import { usePhyloRunInfo } from "src/common/queries/phyloRuns";
 import { useSampleInfo } from "src/common/queries/samples";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { FilterPanel } from "src/components/FilterPanel";
 import { DataSubview } from "../../common/components";
 import { EMPTY_OBJECT } from "../../common/constants/empty";
@@ -76,9 +74,8 @@ const Data: FunctionComponent = () => {
 
   const router = useRouter();
 
-  const groupId = useSelector(selectCurrentGroup);
-  const sampleResponse = useSampleInfo(groupId);
-  const PhyloRunResponse = usePhyloRunInfo(groupId);
+  const sampleResponse = useSampleInfo();
+  const PhyloRunResponse = usePhyloRunInfo();
   const { data: sampleData, isLoading: isSampleInfoLoading } = sampleResponse;
   const { data: phyloRunData, isLoading: isTreeInfoLoading } = PhyloRunResponse;
 

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -76,14 +76,33 @@ const Data: FunctionComponent = () => {
 
   const sampleResponse = useSampleInfo();
   const PhyloRunResponse = usePhyloRunInfo();
-  const { data: sampleData, isLoading: isSampleInfoLoading } = sampleResponse;
-  const { data: phyloRunData, isLoading: isTreeInfoLoading } = PhyloRunResponse;
+  const {
+    data: sampleData,
+    isLoading: isSampleInfoLoading,
+    isFetching: isSampleInfoFetching,
+  } = sampleResponse;
+  const {
+    data: phyloRunData,
+    isLoading: isTreeInfoLoading,
+    isFetching: isTreeInfoFetching,
+  } = PhyloRunResponse;
 
   useEffect(() => {
     setIsDataLoading(true);
-    if (isTreeInfoLoading || isSampleInfoLoading) return;
+    if (
+      isTreeInfoLoading ||
+      isSampleInfoLoading ||
+      isTreeInfoFetching ||
+      isSampleInfoFetching
+    )
+      return;
     setIsDataLoading(false);
-  }, [isTreeInfoLoading, isSampleInfoLoading]);
+  }, [
+    isTreeInfoLoading,
+    isSampleInfoLoading,
+    isTreeInfoFetching,
+    isSampleInfoFetching,
+  ]);
 
   const { samples, phyloRuns } = useMemo(
     () => ({

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/components/InviteModal/index.tsx
@@ -150,7 +150,7 @@ const InviteModal = ({
     // If invalid, `validate` will alter state and cause error display
     const areAllAddressesValid = validate(emails);
     if (areAllAddressesValid) {
-      sendInvitationMutation.mutate({ emails, groupId });
+      sendInvitationMutation.mutate({ emails });
     }
   };
 

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { HeadAppTitle } from "src/common/components";
 import { useGroupInvitations } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
+import { getIsGroupAdminFromUserInfo } from "src/common/utils/userInfo";
 import { TabEventHandler } from "../../index";
 import { ActiveMembersTable } from "./components/ActiveMembersTable";
 import { InviteModal } from "./components/InviteModal";
@@ -35,6 +36,7 @@ const MembersTab = ({
   const router = useRouter();
 
   const { data: invitations = [] } = useGroupInvitations();
+  const isGroupAdmin = getIsGroupAdminFromUserInfo(userInfo);
 
   useEffect(() => {
     setTabValue(requestedSecondaryTab);
@@ -72,7 +74,7 @@ const MembersTab = ({
             count={invitations.length}
           />
         </StyledTabs>
-        {userInfo?.isGroupAdmin && (
+        {isGroupAdmin && (
           <Button
             sdsType="primary"
             sdsStyle="rounded"

--- a/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/MembersTab/index.tsx
@@ -1,10 +1,8 @@
 import { Button, Tab } from "czifui";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import { HeadAppTitle } from "src/common/components";
 import { useGroupInvitations } from "src/common/queries/groups";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { TabEventHandler } from "../../index";
 import { ActiveMembersTable } from "./components/ActiveMembersTable";
@@ -36,8 +34,7 @@ const MembersTab = ({
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const router = useRouter();
 
-  const groupId = useSelector(selectCurrentGroup);
-  const { data: invitations = [] } = useGroupInvitations(groupId);
+  const { data: invitations = [] } = useGroupInvitations();
 
   useEffect(() => {
     setTabValue(requestedSecondaryTab);

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -3,8 +3,6 @@ import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import { useProtectedRoute, useUserInfo } from "src/common/queries/auth";
 import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import { GroupDetailsTab } from "./components/GroupDetailsTab";
@@ -40,10 +38,9 @@ const GroupMembersPage = ({
   const [tabValue, setTabValue] = useState<PrimaryTabType>(requestedPrimaryTab);
   const router = useRouter();
 
-  const groupId = useSelector(selectCurrentGroup);
   const { data: userInfo } = useUserInfo();
-  const { data: members = [] } = useGroupMembersInfo(groupId);
-  const { data: groupInfo } = useGroupInfo(groupId);
+  const { data: members = [] } = useGroupMembersInfo();
+  const { data: groupInfo } = useGroupInfo();
 
   const { address, location, name, prefix } = groupInfo ?? {};
 

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
@@ -4,8 +4,6 @@ import NextLink from "next/link";
 import React, { useState } from "react";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { useCreateSamples } from "src/common/queries/samples";
-import { useSelector } from "src/common/redux/hooks";
-import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import Dialog from "src/components/Dialog";
 import { SampleIdToMetadata } from "src/components/WebformTable/common/types";
@@ -35,16 +33,12 @@ export default function Upload({
   cancelPrompt,
 }: Props): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
-  const groupId = useSelector(selectCurrentGroup);
 
-  const { mutate, isLoading, isSuccess, isError, error } = useCreateSamples(
-    groupId,
-    {
-      componentOnSuccess: () => {
-        cancelPrompt();
-      },
-    }
-  );
+  const { mutate, isLoading, isSuccess, isError, error } = useCreateSamples({
+    componentOnSuccess: () => {
+      cancelPrompt();
+    },
+  });
 
   return (
     <>

--- a/src/frontend/src/views/Upload/components/Review/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/index.tsx
@@ -8,6 +8,7 @@ import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import Progress from "../common/Progress";
 import {
   ButtonWrapper,
@@ -38,7 +39,7 @@ export default function Review({
     useState<boolean>(false);
   const [isConsentChecked, setIsConsentChecked] = useState(false);
 
-  const group = userInfo?.group;
+  const group = getCurrentGroupFromUserInfo(userInfo);
 
   const numOfSamples = Object.keys(samples || EMPTY_OBJECT).length;
 


### PR DESCRIPTION
### Summary
- **What:**
  - be smarter about where groupId is really required for cache subscription (ie: remove the need to pass groupId in to custom hooks which calls apis that return different data depending which group you are viewing)
  - if user's current group ends up in a weird state, don't prevent the group dropdown from opening
  - pull user's current role and available groups from /me
  -  When user changes group, expire all user-related caches
- **Why:** 
  - easier to subscribe to fe cache if you dont have to give a group id, and the id was only used to generate the url anyway
  - Allows user to get out of wonky group state themselves
  - shape of api response is changing
  - update samples table, group info, etc for new group
- **Env:** https://maya-multigroup-frontend.dev.czgenepi.org/

### Demos
No visual changes, besides dropdown in navbar should work again.

### Notes
I did a bad thing and made a very large PR. Please review each of the commits individually with `?w=1` for easier review.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)