### PR TITLE
don't show current group in dropdown

### DIFF
--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/GroupDetailsDropdown/index.tsx
@@ -3,6 +3,8 @@ import { useRouter } from "next/router";
 import React from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
+import { useSelector } from "src/common/redux/hooks";
+import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import { pluralize } from "src/common/utils/strUtils";
@@ -31,6 +33,7 @@ const GroupDetailsDropdown = ({
 }: Props): JSX.Element | null => {
   const router = useRouter();
 
+  const currentGroupId = useSelector(selectCurrentGroup);
   const { data: userInfo } = useUserInfo();
   const { data: members = [] } = useGroupMembersInfo();
   const { data: groupInfo } = useGroupInfo();
@@ -99,9 +102,11 @@ const GroupDetailsDropdown = ({
       </CurrentGroup>
       {groups.length > 1 && (
         <GroupList>
-          {groups.map((group) => (
-            <GroupMenuItem key={group.id} id={group.id} name={group.name} />
-          ))}
+          {groups
+            .filter((group) => group.id !== currentGroupId)
+            .map((group) => (
+              <GroupMenuItem key={group.id} id={group.id} name={group.name} />
+            ))}
         </GroupList>
       )}
     </Dropdown>


### PR DESCRIPTION
### Summary
- **What:** Don't show current group in navbar dropdown
- **Why:** Might be confusing to see details on top and the option to select it on the bottom
- **Env:** https://maya-dropdown-frontend.dev.czgenepi.org/
- **Discussion:** https://docs.google.com/document/d/1VeFOmIkHAr4_HNOVdtfM2FyN3VZYc1hmU_rXJ-QkoTY/edit#

### Demos
#### Before: 
![Screen Shot 2022-07-21 at 1 17 05 PM](https://user-images.githubusercontent.com/7562933/180307400-016be4ae-e0bc-493b-82d1-2f00029c049e.png)

#### After: 
![Screen Shot 2022-07-21 at 1 16 53 PM](https://user-images.githubusercontent.com/7562933/180307441-efb10589-d579-486b-872a-40cc8b4a74e4.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)