### PR TITLE
optionally accept nextstrain headers for upload [sc190569]

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Instructions/index.tsx
@@ -1,5 +1,6 @@
 import { List, ListItem } from "czifui";
 import React from "react";
+import { NewTabLink } from "src/common/components/library/NewTabLink";
 import {
   ReImportDataItem,
   StyleDownloadTemplate,
@@ -23,14 +24,21 @@ export default function Instructions({ headers, rows }: Props): JSX.Element {
           included in your import file.
         </ListItem>
         <ListItem ordered fontSize="xs">
-          We recommend that you copy your metadata into our{" "}
+          We recommend that you copy your metadata into our
           <StyleDownloadTemplate headers={headers} rows={rows}>
             TSV template
           </StyleDownloadTemplate>
           , but you can use your own TSV or CSV file as well.
         </ListItem>
         <ListItem ordered fontSize="xs">
-          Make sure your column headers match our naming convention.
+          Make sure your column headers match our naming convention or the&nbsp;
+          <NewTabLink
+            href={
+              "https://docs.nextstrain.org/projects/ncov/en/latest/reference/metadata-fields.html"
+            }
+          >
+            Nextstrain defaults.
+          </NewTabLink>
         </ListItem>
         <ListItem ordered fontSize="xs">
           Make sure your metadata values are in the correct format.

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
@@ -17,6 +17,7 @@ import {
   FORBIDDEN_NAME_CHARACTERS_REGEX,
   HEADERS_TO_METADATA_KEYS,
   MAX_NAME_LENGTH,
+  NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS,
 } from "../../../common/constants";
 /**
  * (Vince) Regarding interfaces for Warnings/Errors:
@@ -63,7 +64,13 @@ interface ParsedRow {
 // Helper -- Takes column header from file, converts to internal metadata key
 // If header is unrecognized, leaves it alone (useful for warnings, etc).
 function convertHeaderToMetadataKey(headerName: string): string {
-  return HEADERS_TO_METADATA_KEYS[headerName] || headerName;
+  if (headerName in HEADERS_TO_METADATA_KEYS) {
+    return HEADERS_TO_METADATA_KEYS[headerName];
+  } else if (headerName in NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS) {
+    return NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS[headerName];
+  } else {
+    return headerName;
+  }
 }
 
 // Helper -- Returns any missing col header field names based on what header

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
@@ -63,6 +63,7 @@ interface ParsedRow {
 
 // Helper -- Takes column header from file, converts to internal metadata key
 // If header is unrecognized, leaves it alone (useful for warnings, etc).
+// User can also use Nextstrain header defaults as an alias
 function convertHeaderToMetadataKey(headerName: string): string {
   if (headerName in HEADERS_TO_METADATA_KEYS) {
     return HEADERS_TO_METADATA_KEYS[headerName];

--- a/src/frontend/src/views/Upload/components/common/constants.ts
+++ b/src/frontend/src/views/Upload/components/common/constants.ts
@@ -10,6 +10,16 @@ export const HEADERS_TO_METADATA_KEYS = invert(
   SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS
 ) as Dictionary<keyof SampleUploadTsvMetadata>;
 
+export const NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS: Record<
+  string,
+  string
+> = {
+  date: "collectionDate",
+  location: "collectionLocation",
+  gisaid_epi_isl: "publicId",
+  strain: "sampleId",
+};
+
 // We don't send all metadata keys to API. sampleId is not persisted.
 type KEYS_SENT_TO_API = Omit<SampleUploadTsvMetadata, "sampleId">;
 export const METADATA_KEYS_TO_API_KEYS: Record<keyof KEYS_SENT_TO_API, string> =


### PR DESCRIPTION
### Summary:
- **What:** accept nextstrain default metadata headers on upload
- **Ticket:** [sc190569](https://app.shortcut.com/genepi/story/190569)
- **Env:** no rdev link

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)