### PR TITLE
sort members alphabetically, as a human reads

### DIFF
--- a/src/frontend/src/common/utils/strUtils.ts
+++ b/src/frontend/src/common/utils/strUtils.ts
@@ -17,7 +17,7 @@ export const pluralizeVerb = (str: string, count: number): string => {
   return str;
 };
 
-type SortReponse = -1 | 0 | 1;
+type SortResponse = -1 | 0 | 1;
 export const caseInsensitiveSort = (a: string, b: string): SortReponse => {
   return a.toLowerCase() > b.toLowerCase() ? 1 : -1;
 };

--- a/src/frontend/src/common/utils/strUtils.ts
+++ b/src/frontend/src/common/utils/strUtils.ts
@@ -16,3 +16,8 @@ export const pluralizeVerb = (str: string, count: number): string => {
   if (WORDS_TO_PLURALIZE[str]) return WORDS_TO_PLURALIZE[str];
   return str;
 };
+
+type SortReponse = -1 | 0 | 1;
+export const caseInsensitiveSort = (a: string, b: string): SortReponse => {
+  return a.toLowerCase() > b.toLowerCase() ? 1 : -1;
+};

--- a/src/frontend/src/common/utils/strUtils.ts
+++ b/src/frontend/src/common/utils/strUtils.ts
@@ -18,6 +18,6 @@ export const pluralizeVerb = (str: string, count: number): string => {
 };
 
 type SortResponse = -1 | 0 | 1;
-export const caseInsensitiveSort = (a: string, b: string): SortReponse => {
+export const caseInsensitiveSort = (a: string, b: string): SortResponse => {
   return a.toLowerCase() > b.toLowerCase() ? 1 : -1;
 };

--- a/src/frontend/src/views/GroupMembersPage/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/index.tsx
@@ -5,6 +5,7 @@ import { useProtectedRoute, useUserInfo } from "src/common/queries/auth";
 import { useGroupInfo, useGroupMembersInfo } from "src/common/queries/groups";
 import { ROUTES } from "src/common/routes";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
+import { caseInsensitiveSort } from "src/common/utils/strUtils";
 import { GroupDetailsTab } from "./components/GroupDetailsTab";
 import { MembersTab, SecondaryTabType } from "./components/MembersTab";
 import {
@@ -49,7 +50,7 @@ const GroupMembersPage = ({
   }, [requestedPrimaryTab]);
 
   // sort group members by name before display
-  members.sort((a, b) => (a.name > b.name ? 1 : -1));
+  members.sort((a, b) => caseInsensitiveSort(a.name, b.name));
 
   const displayLocation = stringifyGisaidLocation(location);
 


### PR DESCRIPTION
### Summary
- **What:** So a case-insensitive sort for members shown in the group members tab
- **Why:** because people aren't computers and consider A and a to be the same character
- **Env:** https://maya-sort-frontend.dev.czgenepi.org/
- **Discussion:** https://docs.google.com/document/d/1VeFOmIkHAr4_HNOVdtfM2FyN3VZYc1hmU_rXJ-QkoTY/edit#

### Demos
#### Before: 
Capitalized names all listed first
![Screen Shot 2022-07-26 at 10 50 33 AM](https://user-images.githubusercontent.com/7562933/181076504-ce0f86a1-825e-4f2c-92f5-1d0e5afe89ed.png)

#### After: 
Case-insensitive sorting of names combines upper- and lower-case names
![Screen Shot 2022-07-26 at 10 49 40 AM](https://user-images.githubusercontent.com/7562933/181076490-5ecad6f1-9da8-4678-a86f-b5df3401deb0.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)