### PR TITLE
Redirect to nice error pages on invitation failure.

### DIFF
--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -376,3 +376,25 @@ async def test_callback_ff_doesnt_sync_auth0_user_roles(
         .one()
     )
     assert user.auth0_user_id == userinfo["sub"]
+
+
+async def test_callback_error_redirects(
+    http_client: AsyncClient,
+):
+    res = await http_client.get(
+        "/v2/auth/callback",
+        allow_redirects=False,
+        params={"error_description": "invitation not found or already used"},
+    )
+    assert res.status_code == 307
+    assert res.is_redirect
+    assert "already_accepted" in res.headers["Location"]
+
+    res = await http_client.get(
+        "/v2/auth/callback",
+        allow_redirects=False,
+        params={"error_description": "expired"},
+    )
+    assert res.status_code == 307
+    assert res.is_redirect
+    assert "expired" in res.headers["Location"]


### PR DESCRIPTION
### Summary:
- **What:** redirect to pretty error pages on invitation code expiration

### Notes:
Unfortunately auth0 sends the same error message to our backend if an invitation has already been used, never existed, or has expired 😭 We may want to update the text on the "already used" error page to reflect the fact that we have no way to differentiate what happened. I think we can basically redirect to a "something went wrong with your invitation" page and a general "something went wrong and we don't know what" page.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)