### PR TITLE
SC-137461 Add followCursor to lineage tooltip.

### DIFF
--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -78,6 +78,7 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
 
     return hasLineage ? (
       <Tooltip
+        followCursor
         title={<LineageTooltip lineage={value as Lineage} />}
         width="wide"
       >


### PR DESCRIPTION
### Summary:
- **What:** The lineage tooltip previously displayed below the lineage cell rather than following the cursor, which was confusing.  Now the tooltip follows the cursor.
- **Ticket:** [sc137461](https://app.shortcut.com/genepi/story/137461/update-lineage-info-tooltip-container-positioning)
- **Env:** none

### Demos:
I don't know how to take a screenshot and show the cursor (if you do, please lmk!), but it was below the lower left corner of the tooltip.
![Screen Shot 2022-07-26 at 1 26 41 PM](https://user-images.githubusercontent.com/109251328/181106790-a0e56c59-c165-4b52-85dd-6a05f8210356.png)

### Notes:
Seemed too easy, so checking with Janeece that this was the point of the ticket.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)