### PR TITLE
Send slack updates on prod success/failure.

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-        if: github.event.deployment.environment == 'prod' or failure()
+        if: github.event.deployment.environment == 'prod' || failure()
       - name: Set deployment status to failure if errors
         uses: avakar/set-deployment-status@v1
         if: failure()

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -11,6 +11,10 @@ jobs:
   upgrade:
     runs-on: ubuntu-20.04
     steps:
+      - uses: act10ns/slack@v1
+        with:
+          status: starting
+        if: github.event.deployment.environment == 'prod'
       - name: Configure AWS Prod Credentials
         uses: aws-actions/configure-aws-credentials@v1
         if: github.event.deployment.environment == 'prod'
@@ -65,6 +69,11 @@ jobs:
           state: success
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: github.event.deployment.environment == 'prod' or failure()
       - name: Set deployment status to failure if errors
         uses: avakar/set-deployment-status@v1
         if: failure()

--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -3,7 +3,7 @@ name: Scheduled Deploy
 on:
   schedule:
     # Weekly Tuesday & Thursdays @ 16:00 UTC (8am PST [winter] / 9am PDT [summer])
-     - cron: '0 16 * * 4'
+     - cron: '0 16 * * 2,4'
   workflow_dispatch:
     inputs:
       image_tag:
@@ -26,10 +26,6 @@ jobs:
   upgrade:
     runs-on: ubuntu-20.04
     steps:
-      - uses: act10ns/slack@v1
-        with:
-          status: starting
-        if: always()
       - name: Configure AWS Prod Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -62,8 +58,3 @@ jobs:
           required_contexts: ""
         env:
           GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-        if: always()


### PR DESCRIPTION
### Notes:
1. Re-enable Tues morning deploys
2. Our slack notifications for prod deploy success/failure were being sent from the wrong action, so we were getting a success message like 1min after the "starting" message, even if the deploy ultimately failed. I put the slack notifications in the action that *actually* does the deploy so we should get a success notification at the end of a deploy
3. We probably want to get failure notifications for staging deploys in our ops channel as well, so I tried to update the notification to message us on any failures instead of just prod.

I'm also not a GHA syntax expert 😬 

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)