### PR TITLE
Maya/welcome group update

### DIFF
--- a/src/frontend/pages/welcome/[groupId].tsx
+++ b/src/frontend/pages/welcome/[groupId].tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import Welcome from "src/views/Welcome";
+
+const Page = (): JSX.Element => <Welcome />;
+
+export default Page;

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -125,7 +125,7 @@ export function useProtectedRoute(): UseQueryResult<User, unknown> {
         router.push(ROUTES.HOMEPAGE);
       } else if (!agreedToTOS && router.asPath !== ROUTES.AGREE_TERMS) {
         router.push(ROUTES.AGREE_TERMS);
-      } else if (!userInfo.groups.includes(currentGroup)) {
+      } else if (!userInfo.groups.find((g) => g.id === currentGroup)) {
         // user is not authorized to view the group set in their cache. Set it to one they can see.
         setValidGroup();
       } // else case: User is logged in, in a valid group, and has agreed to ToS. Leave them be.

--- a/src/frontend/src/common/redux/index.ts
+++ b/src/frontend/src/common/redux/index.ts
@@ -1,8 +1,8 @@
 import { AnyAction, applyMiddleware, createStore } from "redux";
 import { composeWithDevTools } from "redux-devtools-extension";
-import { fetchUserInfo } from "../queries/auth";
+import { setValidGroup } from "../utils/groupUtils";
 import { getLocalStorage } from "../utils/localStorage";
-import { setGroup, setPathogen } from "./actions";
+import { setPathogen } from "./actions";
 import { setGroupMiddleware, setPathogenMiddleware } from "./middleware";
 import { CZGEReduxActions, Pathogen, ReduxPersistenceTokens } from "./types";
 
@@ -87,14 +87,7 @@ const setDefaults = async () => {
 
   // set user group
   if (group === FALLBACK_GROUP_ID) {
-    const userInfo = await fetchUserInfo();
-    const { groups } = userInfo;
-
-    if (!groups) return;
-
-    // sort groups by id to put the oldest one into the first position
-    groups.sort((a, b) => (a.id > b.id ? 1 : -1));
-    dispatch(setGroup(groups[0].id));
+    setValidGroup();
   }
 
   // set pathogen

--- a/src/frontend/src/common/utils/groupUtils.ts
+++ b/src/frontend/src/common/utils/groupUtils.ts
@@ -1,0 +1,15 @@
+import { fetchUserInfo } from "../queries/auth";
+import { store } from "../redux";
+import { setGroup } from "../redux/actions";
+
+export const setValidGroup = async (): void => {
+  const { dispatch } = store;
+  const userInfo = await fetchUserInfo();
+  const { groups } = userInfo;
+
+  if (!groups) return;
+
+  // sort groups by id to put the oldest one into the first position
+  groups.sort((a, b) => (a.id > b.id ? 1 : -1));
+  dispatch(setGroup(groups[0].id));
+};

--- a/src/frontend/src/common/utils/groupUtils.ts
+++ b/src/frontend/src/common/utils/groupUtils.ts
@@ -2,7 +2,7 @@ import { fetchUserInfo } from "../queries/auth";
 import { store } from "../redux";
 import { setGroup } from "../redux/actions";
 
-export const setValidGroup = async (): void => {
+export const setValidGroup = async (): Promise<void> => {
   const { dispatch } = store;
   const userInfo = await fetchUserInfo();
   const { groups } = userInfo;

--- a/src/frontend/src/views/Welcome/index.tsx
+++ b/src/frontend/src/views/Welcome/index.tsx
@@ -1,14 +1,11 @@
 import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { HeadAppTitle } from "src/common/components";
-import { useProtectedRoute } from "src/common/queries/auth";
 import { setGroup } from "src/common/redux/actions";
 import { useDispatch } from "src/common/redux/hooks";
 import { ROUTES } from "src/common/routes";
 
 const Welcome = (): JSX.Element => {
-  useProtectedRoute();
-
   const dispatch = useDispatch();
   const router = useRouter();
   const { groupId } = router.query;

--- a/src/frontend/src/views/Welcome/index.tsx
+++ b/src/frontend/src/views/Welcome/index.tsx
@@ -1,0 +1,28 @@
+import { useRouter } from "next/router";
+import React, { useEffect } from "react";
+import { HeadAppTitle } from "src/common/components";
+import { useProtectedRoute } from "src/common/queries/auth";
+import { setGroup } from "src/common/redux/actions";
+import { useDispatch } from "src/common/redux/hooks";
+import { ROUTES } from "src/common/routes";
+
+const Welcome = (): JSX.Element => {
+  useProtectedRoute();
+
+  const router = useRouter();
+  const { groupId } = router.query;
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (groupId) {
+      dispatch(setGroup(groupId));
+    }
+
+    router.push(ROUTES.DATA);
+  }, [groupId, dispatch, router]);
+
+  return <HeadAppTitle subTitle="Welcome to CZ Gen Epi!" />;
+};
+
+export default Welcome;

--- a/src/frontend/src/views/Welcome/index.tsx
+++ b/src/frontend/src/views/Welcome/index.tsx
@@ -9,18 +9,18 @@ import { ROUTES } from "src/common/routes";
 const Welcome = (): JSX.Element => {
   useProtectedRoute();
 
+  const dispatch = useDispatch();
   const router = useRouter();
   const { groupId } = router.query;
-
-  const dispatch = useDispatch();
+  const groupIdInt = parseInt(groupId as string);
 
   useEffect(() => {
-    if (groupId) {
-      dispatch(setGroup(groupId));
+    if (groupIdInt) {
+      dispatch(setGroup(groupIdInt));
     }
 
     router.push(ROUTES.DATA);
-  }, [groupId, dispatch, router]);
+  }, [groupIdInt, dispatch, router]);
 
   return <HeadAppTitle subTitle="Welcome to CZ Gen Epi!" />;
 };


### PR DESCRIPTION
### Summary
- **What:** 
  - Add a page that plops a user into a new group when they accept an invite
  - Have a fallback on protected pages that ensures the user is in a group they are authorized to see
- **Why:** ✨ 
- **Ticket:** [[sc-187623]](https://app.shortcut.com/genepi/story/187623)
- **Env:** https://maya-welcome-frontend.dev.czgenepi.org/

### Testing
1. Test `/welcome/[group id]`
1. You can try it with groups you are a part of
2. You can try it with groups you aren't a part of
3. You can try it with non groups (ie: `abc` as group id)

### Demos
![after](https://user-images.githubusercontent.com/7562933/181139433-29b7606e-45ee-4818-a994-52a6f72826bf.gif)

### Notes
At some point there was a ticket to show a welcome modal, which would also be a part of this work, but iirc that was nice to have and we cut it.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)