### PR TITLE
Update pangolin version comparison

### DIFF
--- a/.happy/terraform/modules/sfn_config/pangolin.wdl
+++ b/.happy/terraform/modules/sfn_config/pangolin.wdl
@@ -40,7 +40,7 @@ task pangolin_workflow {
 
     cd /usr/src/app/aspen/workflows/pangolin
     ./update_pangolin.sh
-    /usr/local/bin/python3.9 find_samples.py
+    ./run_mass_update.sh
     >>>
 
     runtime {

--- a/src/backend/aspen/workflows/pangolin/run_mass_update.sh
+++ b/src/backend/aspen/workflows/pangolin/run_mass_update.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# TODO: fix pipefail flags to be informative
+#set -Eex pipefail
+
+# activate miniconda
+eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+conda init
+conda activate pangolin
+
+# record pangolin version:
+PANGOLIN_VERSION=$(pangolin -pv)
+
+/usr/local/bin/python3.9 find_samples.py \
+  --pangolin-version "$PANGOLIN_VERSION"


### PR DESCRIPTION
### Summary:
- **What:** Sources current pangolin version from updated program running on the container, not from github. Compares pangolin version with version strings stored in database while keeping PangoLEARN / PUSHER information.
- **Ticket:** [sc191868](https://app.shortcut.com/genepi/story/191868)
- **Env:** [https://pangov4-frontend.dev.czgenepi.org](https://pangov4-frontend.dev.czgenepi.org)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)