### PR TITLE
SC 209481 Username does not show in nav

### DIFF
--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
@@ -1,21 +1,9 @@
-import { Button } from "@material-ui/core";
-import { createStyles, makeStyles } from "@material-ui/styles";
-import { AppThemeOptions, Icon, Menu, MenuItem } from "czifui";
+import { Icon, Menu, MenuItem } from "czifui";
 import React from "react";
 import { API } from "src/common/api";
 import ENV from "src/common/constants/ENV";
 import { ROUTES } from "src/common/routes";
-import { StyledNavIconWrapper } from "./style";
-
-const useStyles = makeStyles((theme: AppThemeOptions) => {
-  const palette = theme.palette;
-
-  return createStyles({
-    text: {
-      color: palette?.common?.white,
-    },
-  });
-});
+import { StyledNavButton, StyledNavIconWrapper } from "./style";
 
 interface UserMenuProps {
   user: string | undefined;
@@ -23,8 +11,6 @@ interface UserMenuProps {
 
 const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
-
-  const classes = useStyles();
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
     setAnchorEl(event.currentTarget);
@@ -36,10 +22,9 @@ const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
 
   return (
     <>
-      <Button
+      <StyledNavButton
         data-test-id="nav-user-menu"
         onClick={handleClick}
-        classes={classes}
         endIcon={
           <StyledNavIconWrapper>
             <Icon sdsIcon="chevronDown" sdsSize="xs" sdsType="static" />
@@ -47,7 +32,7 @@ const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
         }
       >
         {user}
-      </Button>
+      </StyledNavButton>
       <Menu
         anchorEl={anchorEl}
         keepMounted

--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/style.ts
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/style.ts
@@ -1,5 +1,15 @@
 import styled from "@emotion/styled";
+import { Button, CommonThemeProps, getPalette } from "czifui";
 import { iconFillWhite } from "src/common/styles/iconStyle";
+
+export const StyledNavButton = styled(Button)`
+  ${(props: CommonThemeProps) => {
+    const palette = getPalette(props);
+    return `
+      color: ${palette?.common?.white};
+    `;
+  }}
+`;
 
 export const StyledNavIconWrapper = styled.div`
   ${iconFillWhite}


### PR DESCRIPTION
### Summary:
- **What:** `Make username white so we can see it on the black nav background`
- **Ticket:** [sc209481](https://app.shortcut.com/genepi/story/209481/username-text-color-is-black-should-be-white)
- **Env:** `none`

### Demos:
![Screen Shot 2022-08-01 at 12 55 32 PM](https://user-images.githubusercontent.com/109251328/182234085-203e9e6a-d688-47bc-809f-ead72aa43d7a.png)

### Notes:
The user menu isn't keyboard accessible.  Going to look into this in a separate PR.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)