### PR TITLE
User needs longer max lengths

### DIFF
--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -8,11 +8,14 @@ from aspen.api.schemas.locations import LocationResponse
 
 
 class GroupCreationRequest(BaseRequest):
-    name: constr(min_length=3, max_length=128, strict=True)  # type: ignore
-    prefix: constr(min_length=2, max_length=20, strict=True)  # type: ignore
-    address: Optional[constr(min_length=1, max_length=128, strict=True)]  # type: ignore
-    division: Optional[constr(min_length=1, max_length=128, strict=True)]  # type: ignore
-    location: Optional[constr(min_length=1, max_length=128, strict=True)]  # type: ignore
+    name: constr(min_length=3, max_length=1000, strict=True)  # type: ignore
+    # group prefix currently is used in the SFN name, which has max char limit
+    # `prefix` cannot be arbitrarily increased until this ticket is resolved:
+    # https://app.shortcut.com/genepi/story/209498
+    prefix: constr(min_length=2, max_length=25, strict=True)  # type: ignore
+    address: Optional[constr(min_length=1, max_length=1000, strict=True)]  # type: ignore
+    division: Optional[constr(min_length=1, max_length=1000, strict=True)]  # type: ignore
+    location: Optional[constr(min_length=1, max_length=1000, strict=True)]  # type: ignore
     default_tree_location_id: int
 
 

--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -8,7 +8,7 @@ from aspen.api.schemas.locations import LocationResponse
 
 
 class GroupCreationRequest(BaseRequest):
-    name: constr(min_length=3, max_length=1000, strict=True)  # type: ignore
+    name: constr(min_length=3, max_length=128, strict=True)  # type: ignore
     # group prefix currently is used in the SFN name, which has max char limit
     # `prefix` cannot be arbitrarily increased until this ticket is resolved:
     # https://app.shortcut.com/genepi/story/209498


### PR DESCRIPTION
### Summary:
- **What:** Increase max length limits for certain fields pertaining to groups
- **Ticket:** [sc<209498>](https://app.shortcut.com/genepi/story/<209498>)
- **Env:** None

### Demos:

### Notes:
One of our new user groups needed longer field lengths than we currently allow for some. Since these were mostly arbitrary, bumping them up to 1000 each so we don't encounter this again.

The important exception is `prefix`, since that string gets put into SFN, which has a max length of 80 overall. We can't really go much larger than we currently have it -- 32 would be the absolute max before stuff would definitely begin breaking -- so bumping it to 25 in the meantime until we come up with some sort of shortening/truncation strategy. The referenced ticket above,  [sc<209498>](https://app.shortcut.com/genepi/story/<209498>), will be used for tracking that.

### Checklist:
- [x] I merged latest `trunk`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)