### PR TITLE
Fix tree metadata export bug re: printing accessions

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -308,8 +308,8 @@ def write_sequences_files(session, pathogen_genomes, sequences_fh, metadata_fh):
         aspen_metadata_row: MutableMapping[str, Any] = {
             "strain": sample.public_identifier,
             "virus": "ncov",
-            "gisaid_epi_isl": gisaid_accession.accession or "",
-            "genbank_accession": genbank_accession.accession or "",
+            "gisaid_epi_isl": getattr(gisaid_accession, "accession", None) or "",
+            "genbank_accession": getattr(genbank_accession, "accession", None) or "",
             "date": sample.collection_date.strftime("%Y-%m-%d"),
             "date_submitted": upload_date,
             "region": sample.collection_location.region,

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -308,8 +308,8 @@ def write_sequences_files(session, pathogen_genomes, sequences_fh, metadata_fh):
         aspen_metadata_row: MutableMapping[str, Any] = {
             "strain": sample.public_identifier,
             "virus": "ncov",
-            "gisaid_epi_isl": gisaid_accession or "",
-            "genbank_accession": genbank_accession or "",
+            "gisaid_epi_isl": gisaid_accession.accession or "",
+            "genbank_accession": genbank_accession.accession or "",
             "date": sample.collection_date.strftime("%Y-%m-%d"),
             "date_submitted": upload_date,
             "region": sample.collection_location.region,

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -1,3 +1,4 @@
+import csv
 from io import StringIO
 from typing import List, Optional
 
@@ -126,6 +127,11 @@ def test_build_config(mocker, session, postgres_database):
         assert nextstrain_config["files"]["description"].endswith(".md")
         assert len(sequences.splitlines()) == 20  # 10 county samples @2 lines each
         assert len(metadata.splitlines()) == 11  # 10 samples + 1 header line
+        # Test that we are careful with printing data from our models
+        metadata_reader = csv.DictReader(StringIO(metadata), delimiter="\t")
+        for row in metadata_reader:
+            for value in row.values():
+                assert not value.startswith("<aspen.database.models")
 
 
 # Make sure that configs specific to an Overview tree are working.

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -130,8 +130,10 @@ def test_build_config(mocker, session, postgres_database):
         # Test that we are careful with printing data from our models
         metadata_reader = csv.DictReader(StringIO(metadata), delimiter="\t")
         for row in metadata_reader:
-            for value in row.values():
+            for key, value in row.items():
                 assert not value.startswith("<aspen.database.models")
+                if key == "gisaid_epi_isl":
+                    assert value.startswith("EPI_ISL_")
 
 
 # Make sure that configs specific to an Overview tree are working.


### PR DESCRIPTION
### Summary:
- **What:** Fixes a bug where the tree metadata export was printing a pointer to a Python object instead of the actual accession string.
- **Ticket:** [sc208850](https://app.shortcut.com/genepi/story/208850)
- **Env:** [https://tree-metadata-frontend.dev.czgenepi.org](https://tree-metadata-frontend.dev.czgenepi.org)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)