### PR TITLE
SC-194965 Add callout if download will use multiple files.

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -29,6 +29,7 @@ import {
   DownloadTypeInfo,
   Header,
   StyledButton,
+  StyledCallout,
   StyledCheckbox,
   StyledFileTypeItem,
   Title,
@@ -288,6 +289,14 @@ const DownloadModal = ({
                     still be included in your Sample Metadata download.
                   </DownloadTypeInfo>
                 </Alert>
+              )}
+            {checkedSampleIds.length - failedSampleIds.length > 999 &&
+              (isGisaidSelected || isGenbankSelected) && (
+                <StyledCallout intent="info" autoDismiss={false}>
+                  Your submission template download will be generated in
+                  multiple files of up to 999 samples in order to comply with
+                  GISAID/GenBank upload limits.
+                </StyledCallout>
               )}
             {getDownloadButton()}
           </Content>

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import {
   Button,
+  Callout,
   Checkbox,
   CommonThemeProps,
   fontBodyM,
@@ -18,6 +19,8 @@ export const Header = styled.div`
 `;
 
 export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
   ${fontBodyS}
   ${(props) => {
     const colors = getColors(props);
@@ -68,6 +71,7 @@ export const Container = styled.ul`
   list-style-type: none;
   display: grid;
   padding: 0;
+  margin: 0;
 `;
 
 interface StyledFileTypeItemProps extends CommonThemeProps {
@@ -89,10 +93,13 @@ export const StyledFileTypeItem = styled.li`
       : "transparent"; // Default to "transparent if not disabled or selected"
 
     return `
-      margin-bottom: ${spaces?.xxs}px;
       background-color: ${backgroundColor};
       &:hover {
         background-color: ${colors?.gray[100]};
+      }
+      margin-bottom: ${spaces?.xxs}px;
+      &:last-child {
+        margin-bottom: 0;
       }
     `;
   }}
@@ -111,6 +118,7 @@ export const DownloadType = styled.div`
 `;
 
 export const StyledButton = styled(Button)`
+  max-width: fit-content;
   ${(props) => {
     const spaces = getSpaces(props);
     return `
@@ -132,4 +140,17 @@ export const StyledCheckbox = styled(Checkbox)`
       background-color: transparent;
     }
   }
+`;
+
+export const StyledCallout = styled(Callout)`
+  ${fontBodyXxs}
+  width: 100%;
+  max-width: 434px;
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.xl}px;
+      margin-bottom: 0;
+    `;
+  }}
 `;


### PR DESCRIPTION
### Summary:
- **What:** `If the user selects more than 999 samples for gisaid or genbank download, then let them know that the download will be chopped into multiple files.`
- **Ticket:** [sc194965](https://app.shortcut.com/genepi/story/194965/as-a-user-if-i-select-more-than-999-samples-i-want-to-be-notified-that-my-template-files-will-be-chopped-up)
- **Env:** `none`

### Demos:
![Screen Shot 2022-08-02 at 2 49 18 PM](https://user-images.githubusercontent.com/109251328/182480435-6579e0c3-74c9-45d7-8632-9f34c4c81e08.png)

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)