### PR TITLE
Add submitting_lab column to Group

### DIFF
--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -9,6 +9,7 @@ from aspen.api.schemas.locations import LocationResponse
 
 class GroupCreationRequest(BaseRequest):
     name: constr(min_length=3, max_length=128, strict=True)  # type: ignore
+    submitting_lab: Optional[constr(min_length=3, max_length=128, strict=True)]  # type: ignore
     # group prefix currently is used in the SFN name, which has max char limit
     # `prefix` cannot be arbitrarily increased until this ticket is resolved:
     # https://app.shortcut.com/genepi/story/209498
@@ -28,6 +29,7 @@ class GroupInfoResponse(GroupResponse):
     address: Optional[str]
     prefix: str
     default_tree_location: LocationResponse
+    submitting_lab: Optional[str]
 
 
 class UserBaseResponse(BaseResponse):

--- a/src/backend/aspen/api/views/groups.py
+++ b/src/backend/aspen/api/views/groups.py
@@ -43,6 +43,8 @@ async def create_group(
     )
     organization = auth0_client.add_org(auth0_safe_prefix, group_creation_request.name)
     group_values = dict(group_creation_request) | {"auth0_org_id": organization["id"]}
+    if group_values.get("submitting_lab") is None:
+        group_values["submitting_lab"] = group_values["name"]
     group = Group(**group_values)
     db.add(group)
     await db.commit()

--- a/src/backend/aspen/api/views/groups.py
+++ b/src/backend/aspen/api/views/groups.py
@@ -43,8 +43,6 @@ async def create_group(
     )
     organization = auth0_client.add_org(auth0_safe_prefix, group_creation_request.name)
     group_values = dict(group_creation_request) | {"auth0_org_id": organization["id"]}
-    if group_values.get("submitting_lab") is None:
-        group_values["submitting_lab"] = group_values["name"]
     group = Group(**group_values)
     db.add(group)
     await db.commit()

--- a/src/backend/aspen/api/views/tests/test_groups.py
+++ b/src/backend/aspen/api/views/tests/test_groups.py
@@ -300,6 +300,7 @@ async def test_create_group(
     assert resp_data["address"] == create_group_request["address"]
     assert resp_data["name"] == create_group_request["name"]
     assert resp_data["prefix"] == create_group_request["prefix"]
+    assert resp_data["submitting_lab"] == create_group_request["name"]
     assert isinstance(resp_data["id"], int)
 
     resp_loc = resp_data["default_tree_location"]

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -23,6 +23,7 @@ class Group(idbase, DictMixin):  # type: ignore
     __tablename__ = "groups"
 
     name = Column(String, unique=True, nullable=False)
+    submitting_lab = Column(String, nullable=True)
     address = Column(String, nullable=True)
     prefix = Column(
         String,

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, text
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.orm import backref, relationship
 
 from aspen.database.models.base import base, idbase
@@ -17,13 +18,18 @@ if TYPE_CHECKING:
     from aspen.database.models.cansee import CanSee
 
 
+def submitting_lab_default(context: DefaultExecutionContext) -> str:
+    # mypy complains, but yes this class has this method
+    return context.get_current_parameters()["name"]  # type: ignore
+
+
 class Group(idbase, DictMixin):  # type: ignore
     """A group of users, generally a department of public health."""
 
     __tablename__ = "groups"
 
     name = Column(String, unique=True, nullable=False)
-    submitting_lab = Column(String, nullable=True)
+    submitting_lab = Column(String, nullable=True, default=submitting_lab_default)
     address = Column(String, nullable=True)
     prefix = Column(
         String,

--- a/src/backend/database_migrations/versions/20220803_224221_add_submitting_lab_to_groups.py
+++ b/src/backend/database_migrations/versions/20220803_224221_add_submitting_lab_to_groups.py
@@ -1,0 +1,32 @@
+"""add submitting lab to groups
+
+Create Date: 2022-08-03 22:42:27.655366
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220803_224221"
+down_revision = "20220621_232148"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "groups",
+        sa.Column("submitting_lab", sa.String(), nullable=True),
+        schema="aspen",
+    )
+
+    conn = op.get_bind()
+    populate_submitting_lab_sql = sa.sql.text(
+        "UPDATE aspen.groups SET submitting_lab = name"
+    )
+    conn.execute(populate_submitting_lab_sql)
+
+
+def downgrade():
+    pass

--- a/src/backend/database_migrations/versions/20220803_224221_add_submitting_lab_to_groups.py
+++ b/src/backend/database_migrations/versions/20220803_224221_add_submitting_lab_to_groups.py
@@ -29,4 +29,4 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    raise NotImplementedError("Reversing this migration is not supported")


### PR DESCRIPTION
### Summary:
- **What:** Adds a column to the groups table, `submitting_lab`, which is a nullable string. Populates this field with the value of the `name` column in the migration. In the group creation API, defaults to using the `name` value for this field. Returns this field as part of the group info.
- **Ticket:** [sc194989](https://app.shortcut.com/genepi/story/194989), [sc194991](https://app.shortcut.com/genepi/story/194991)
- **Env:** [https://submit-lab-frontend.dev.czgenepi.org](https://submit-lab-frontend.dev.czgenepi.org)

### Demos:
<img width="1089" alt="Screen Shot 2022-08-03 at 15 51 02" src="https://user-images.githubusercontent.com/24234461/182727856-b538fa33-c604-43bc-b882-219979d01e0d.png">

<img width="572" alt="Screen Shot 2022-08-03 at 16 17 44" src="https://user-images.githubusercontent.com/24234461/182728640-654ac78f-b42d-43b9-b442-e3707dbb6fbd.png">



### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)