### PR TITLE
Analytics: Various events

### DIFF
--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -18,6 +18,9 @@
 export enum EVENT_TYPES {
   // User has been sent to Nextstrain to view a phylo tree
   TREE_VIEW_NEXTSTRAIN = "TREE_VIEW_NEXTSTRAIN",
+
+  // User has successfully uploaded new samples
+  SAMPLES_UPLOAD_SUCCESS = "SAMPLES_UPLOAD_SUCCESS",
 }
 
 /**
@@ -43,7 +46,7 @@ export type EventData = Record<string, EventValue | undefined>;
 
 // While we only send values of EventValue, sometimes we send a JSON string.
 // For ease of readability below, we alias string for those cases.
-// type JsonString = string; // TODO VOODOO uncomment on first use
+type JsonString = string;
 
 /**
  * Structure of additionalEventData for each EVENT_TYPES type that sends it.
@@ -87,4 +90,12 @@ export type EventData = Record<string, EventValue | undefined>;
 export type AnalyticsTreeViewNextstrain = {
   // Tree that user is being sent to view
   tree_id: number;
+};
+
+/** EVENT_TYPES.SAMPLES_UPLOAD_SUCCESS*/
+export type AnalyticsSamplesUploadSuccess = {
+  // How many samples the user just uploaded
+  sample_count: number;
+  // JSON array of all the IDs for newly created samples for this upload
+  sample_ids: JsonString;
 };

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -21,6 +21,11 @@ export enum EVENT_TYPES {
 
   // User has successfully uploaded new samples
   SAMPLES_UPLOAD_SUCCESS = "SAMPLES_UPLOAD_SUCCESS",
+
+  // User downloading data about samples to a file(s)
+  // Does not currently address success/failure, but download failures are very
+  // rare, so generally safe to not be concerned about that aspect for now.
+  SAMPLES_DOWNLOAD_FILE = "SAMPLES_DOWNLOAD_FILE",
 }
 
 /**
@@ -98,4 +103,18 @@ export type AnalyticsSamplesUploadSuccess = {
   sample_count: number;
   // JSON array of all the IDs for newly created samples for this upload
   sample_ids: JsonString;
+};
+
+/** EVENT_TYPES.SAMPLES_DOWNLOAD_FILE*/
+export type AnalyticsSamplesDownloadFile = {
+  // How many samples the user is downloading info on
+  sample_count: number;
+  // JSON array of the public identifiers for these samples
+  // Not the same as a sample PK, but it plus group_id is unique in DB
+  // (based on context of how download happens, PKs are hard to obtain)
+  sample_public_ids: JsonString;
+  // User downloaded info on consensus genome (FASTA) for these samples
+  includes_consensus_genome: boolean;
+  // User downloaded info on metadata for these samples
+  includes_sample_metadata: boolean;
 };

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -4,11 +4,87 @@
  * This exists to ensure consistency/clarity across types and to provide
  * a reference for data analysts working on CZ GE.
  *
- * - Each event type should have a plain-English description of what it means.
+ * --- REQUIREMENTS for adding new event types ---
+ * - Each event type should have a comment with a plain-English description
+ *   of what the event means.
  * - Event types should be written in SCREAMING_SNAKE_CASE
  * - Each entry in the enum should be a duplicate key/value string enum
+ * - If an event type entails sending additional data about what happened
+ *   (most events do), there should be a matching event TypeScript type below
+ *   in this file that shows the structure of the additional event data.
+ *   => The TS type should be named according to the event type as follows:
+ *      Event of `SOME_EVENT_FOO` <--> TS type of `AnalyticsSomeEventFoo`
  */
 export enum EVENT_TYPES {
   // User has been sent to Nextstrain to view a phylo tree
   TREE_VIEW_NEXTSTRAIN = "TREE_VIEW_NEXTSTRAIN",
 }
+
+/**
+ * Values we consider reasonable to send to Segment as properties of event.
+ *
+ * Note that `undefined` is also acceptable within the event properties object
+ * as a value, but it is instead interpreted as "delete this key" when Segment
+ * receives. We allow `undefined` to be passed as part of EventData, but for
+ * clarity it's not considered an EventValue since it's not a value, per se.
+ *
+ * This is a convention we are choosing to make. Segment allows us to send
+ * pretty much anything, but we want to ensure a flat structure of key-value
+ * pairs for downstream analysis since the structure of the event properties
+ * implicitly determines the schema used for the event table when Segment
+ * syncs to the the data warehouse.
+ *
+ * We enforce this structure for EventData in the `analyticsTrackEvent` method
+ * that kicks off the underlying Segment `track` by ensuring that all events
+ * extend from that base structure.
+ */
+type EventValue = string | number | boolean | null;
+export type EventData = Record<string, EventValue | undefined>;
+
+// While we only send values of EventValue, sometimes we send a JSON string.
+// For ease of readability below, we alias string for those cases.
+// type JsonString = string; // TODO VOODOO uncomment on first use
+
+/**
+ * Structure of additionalEventData for each EVENT_TYPES type that sends it.
+ *
+ * Most of the event types we track include some kind of additionalEventData
+ * beyond just which EVENT_TYPES type occurred. For those event types, we have
+ * a TypeScript type that details the structure of that data. These TS types
+ * are here to provide A) documentation for data analysts working on CZ GE and
+ * B) guardrails to prevent accidentally sending an incorrectly structured
+ * payload for a given event type.
+ *
+ * The structure of the event data object we send in `track` call determines
+ * the (implicitly created) schema that Segment makes when it lands the event
+ * in downstream data warehouse. With this in mind, it's possible to update
+ * these event TS types if/when scope expands, but it should be done carefully.
+ * Changing from one value type to another can cause data loss and changing
+ * around keys will mean a lot of NULLs showing up in the data warehouse.
+ *
+ * --- REQUIREMENTS for adding new event TS types ---
+ * - Name the TS type so it matches up with EVENT_TYPES enum. Name as follows:
+ *   => Event of `SOME_EVENT_FOO` <--> TS type of `AnalyticsSomeEventFoo`
+ * - All the keys should be in **snake_case**.
+ * - The structure should always be a **flat object**. (extends `EventData`)
+ * - If you must send more complicated info (say, an array of IDs), convert
+ *   it into a string (JSON.stringify, probably) and send the string.
+ * - Always use `type`, never `interface`. (Necessary for generic extends)
+ *   See https://github.com/microsoft/TypeScript/issues/15300#issuecomment-371353444
+ * --- RECOMMENDATIONS for adding new event TS types ---
+ * - Avoid optional keys or using value of `undefined` unless necessary.
+ * - Document what each key means in the context of that event type.
+ * - If a key holds JSON, use `JsonString` type and document what it contains.
+ * - Try to avoid sending JSON strings if you can easily break it into multiple
+ *   keys with simple values instead.
+ * - When developing, try to avoid actually sending payload to Segment until
+ *   you are confident in the structure for that event type: if you send it
+ *   prematurely, you might have to wipe out that event's corresponding table
+ *   due to schema weirdness which can be a hassle to deal with when testing.
+ */
+
+/** EVENT_TYPES.TREE_VIEW_NEXTSTRAIN */
+export type AnalyticsTreeViewNextstrain = {
+  // Tree that user is being sent to view
+  tree_id: number;
+};

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -22,6 +22,11 @@ export enum EVENT_TYPES {
   // User has kicked off the creation of a Nextstrain phylo tree
   TREE_CREATION_NEXTSTRAIN = "TREE_CREATION_NEXTSTRAIN",
 
+  // User has been sent over to UShER site. UShER will now create tree and
+  // display it on their site. External, so can't tell if tree succeeds/fails.
+  // Event has no `additionalEventData`. Just tracking occurrence right now.
+  TREE_CREATION_VIEW_USHER = "TREE_CREATION_VIEW_USHER",
+
   // User has successfully uploaded new samples
   SAMPLES_UPLOAD_SUCCESS = "SAMPLES_UPLOAD_SUCCESS",
 

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -24,8 +24,15 @@ export enum EVENT_TYPES {
 
   // User has been sent over to UShER site. UShER will now create tree and
   // display it on their site. External, so can't tell if tree succeeds/fails.
-  // Event has no `additionalEventData`. Just tracking occurrence right now.
+  // **No `additionalEventData`**. Just tracking event occurrence right now.
   TREE_CREATION_VIEW_USHER = "TREE_CREATION_VIEW_USHER",
+
+  // User has downloaded a file of the actual phylo tree
+  TREE_DOWNLOAD_TREE_FILE = "TREE_DOWNLOAD_TREE_FILE",
+
+  // User downloaded a template with sample identifiers and metadata showing
+  // which selected. User could then add more metadata to overlay on tree view.
+  TREE_DOWNLOAD_SELECTED_SAMPLES_TEMPLATE = "TREE_DOWNLOAD_SELECTED_SAMPLES_TEMPLATE",
 
   // User has successfully uploaded new samples
   SAMPLES_UPLOAD_SUCCESS = "SAMPLES_UPLOAD_SUCCESS",
@@ -112,6 +119,33 @@ export type AnalyticsTreeCreationNextstrain = {
   phylo_run_workflow_id: number;
   // Type of tree being created
   tree_type: string;
+};
+
+/** EVENT_TYPES.TREE_DOWNLOAD_TREE_FILE */
+export type AnalyticsTreeDownloadTreeFile = {
+  // Tree user is downloading.
+  // null indicates tree does not exist, but should be impossible if user
+  // is downloading it. Mostly here to make TS happy, but if we ever get null
+  // in this event for tree_id, it very likely indicates a bug with app.
+  tree_id: number | null;
+  // PK of the workflow that kicked off the creation of this tree.
+  // Should never be null, but TS for underlying item does not guarantee it, so
+  // the null possibility is mostly to keep TS happy. If null, app has a bug.
+  phylo_run_workflow_id: number | null;
+  // User can download tree with samples using either their Private IDs or
+  // their Public IDs.
+  sample_id_type: "PRIVATE" | "PUBLIC";
+};
+
+/** EVENT_TYPES.TREE_DOWNLOAD_SELECTED_SAMPLES_TEMPLATE */
+export type AnalyticsTreeDownloadSelectedSamplesTemplate = {
+  // Tree user is downloading template in regards to.
+  // Can download template before tree done or tree failed. Null indicates such
+  tree_id: number | null;
+  // PK of the workflow that kicked off the creation of this tree.
+  // Should never be null, but TS for underlying item does not guarantee it, so
+  // the null possibility is mostly to keep TS happy. If null, app has a bug.
+  phylo_run_workflow_id: number | null;
 };
 
 /** EVENT_TYPES.SAMPLES_UPLOAD_SUCCESS*/

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -19,6 +19,9 @@ export enum EVENT_TYPES {
   // User has been sent to Nextstrain to view a phylo tree
   TREE_VIEW_NEXTSTRAIN = "TREE_VIEW_NEXTSTRAIN",
 
+  // User has kicked off the creation of a Nextstrain phylo tree
+  TREE_CREATION_NEXTSTRAIN = "TREE_CREATION_NEXTSTRAIN",
+
   // User has successfully uploaded new samples
   SAMPLES_UPLOAD_SUCCESS = "SAMPLES_UPLOAD_SUCCESS",
 
@@ -95,6 +98,15 @@ type JsonString = string;
 export type AnalyticsTreeViewNextstrain = {
   // Tree that user is being sent to view
   tree_id: number;
+};
+
+/** EVENT_TYPES.TREE_CREATION_NEXTSTRAIN */
+export type AnalyticsTreeCreationNextstrain = {
+  // PK of the workflow that kicks off the creation of requested tree
+  // Note: creating a tree kicks off process, it could still fail in pipeline.
+  phylo_run_workflow_id: number;
+  // Type of tree being created
+  tree_type: string;
 };
 
 /** EVENT_TYPES.SAMPLES_UPLOAD_SUCCESS*/

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -30,8 +30,8 @@ export enum EVENT_TYPES {
   // User has downloaded a file of the actual phylo tree
   TREE_DOWNLOAD_TREE_FILE = "TREE_DOWNLOAD_TREE_FILE",
 
-  // User downloaded a template with sample identifiers and metadata showing
-  // which selected. User could then add more metadata to overlay on tree view.
+  // User downloaded a template of sample identifiers and metadata that shows
+  // the selected samples. User can add more metadata to overlay on tree view.
   TREE_DOWNLOAD_SELECTED_SAMPLES_TEMPLATE = "TREE_DOWNLOAD_SELECTED_SAMPLES_TEMPLATE",
 
   // User has successfully uploaded new samples

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/index.tsx
@@ -5,12 +5,17 @@ import Image from "next/image";
 import NextLink from "next/link";
 import React, { SyntheticEvent, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import {
+  AnalyticsTreeCreationNextstrain,
+  EVENT_TYPES,
+} from "src/common/analytics/eventTypes";
+import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import type { TreeType } from "src/common/constants/types";
 import { TreeTypes } from "src/common/constants/types";
 import GisaidLogo from "src/common/images/gisaid-logo-full.png";
 import { useLineages } from "src/common/queries/lineages";
-import { useCreateTree } from "src/common/queries/trees";
+import { RawTreeCreationWithId, useCreateTree } from "src/common/queries/trees";
 import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import { B } from "src/common/styles/basicStyle";
@@ -125,7 +130,17 @@ export const CreateNSTreeModal = ({
       setShouldShowErrorNotification(true);
       handleClose();
     },
-    componentOnSuccess: () => {
+    componentOnSuccess: (respData: RawTreeCreationWithId) => {
+      analyticsTrackEvent<AnalyticsTreeCreationNextstrain>(
+        EVENT_TYPES.TREE_CREATION_NEXTSTRAIN,
+        {
+          phylo_run_workflow_id: respData.id,
+          // Safe to assert treeType is not undefined here, can't create tree
+          // otherwise, it's just that checking happens in a child component.
+          tree_type: treeType!,
+        }
+      );
+
       setShouldShowTreeCreatedNotification(true);
       handleClose();
     },

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react";
+import { EVENT_TYPES } from "src/common/analytics/eventTypes";
+import { analyticsTrackEvent } from "src/common/analytics/methods";
 import Notification from "src/components/Notification";
 import { UsherConfirmationModal } from "./components/UsherConfirmationModal";
 import { UsherPlacementModal } from "./components/UsherPlacementModal";
@@ -58,6 +60,7 @@ const UsherTreeFlow = ({
 
   const handleConfirmationConfirm = () => {
     openUsher();
+    analyticsTrackEvent(EVENT_TYPES.TREE_CREATION_VIEW_USHER);
     setIsConfirmOpen(false);
     setIsPlacementOpen(false);
     setIsAlertShown(true);

--- a/src/frontend/src/common/queries/trees.ts
+++ b/src/frontend/src/common/queries/trees.ts
@@ -38,12 +38,26 @@ interface CreateTreeType {
   };
 }
 
-type CreateTreeCallbacks = MutationCallbacks<void>;
+/**
+ * Response from BE for creating new phylo tree.
+ *
+ * Actual response has more info than just `id` -- basically matches a single
+ * `PhyloRun` type -- but the only thing we use downstream right now is id.
+ * This is all just for analytics as of this writing, so I [Vince] am taking
+ * the easy way out and only going to care about the key needed for analytics.
+ * That said, if we ever start using the POST tree creation response more
+ * fully, this should be re-worked.
+ */
+export interface RawTreeCreationWithId {
+  id: number; // phylo_runs PK workflow_id for tree that just got kicked off
+}
+
+type CreateTreeCallbacks = MutationCallbacks<RawTreeCreationWithId>;
 
 async function createTree(
   groupId: number,
   { sampleIds, treeName, treeType, filters }: CreateTreeType
-): Promise<unknown> {
+): Promise<RawTreeCreationWithId> {
   const { startDate, endDate, lineages } = filters;
   const payload: CreateTreePayload = {
     name: treeName,
@@ -76,9 +90,9 @@ export function useCreateTree(
 
   return useMutation((toMutate) => createTree(groupId, toMutate), {
     onError: componentOnError,
-    onSuccess: async () => {
+    onSuccess: async (data: RawTreeCreationWithId) => {
       await queryClient.invalidateQueries([USE_PHYLO_RUN_INFO]);
-      componentOnSuccess();
+      componentOnSuccess(data);
     },
   });
 }

--- a/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { EVENT_TYPES } from "src/common/analytics/eventTypes";
+import {
+  AnalyticsTreeViewNextstrain,
+  EVENT_TYPES,
+} from "src/common/analytics/eventTypes";
 import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { RedirectConfirmationModal } from "src/common/components/library/data_subview/components/RedirectConfirmationModal";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
@@ -30,9 +33,12 @@ const NextstrainConfirmationModal = ({
     <ConfirmButton
       treeId={treeId}
       onClick={() =>
-        analyticsTrackEvent(EVENT_TYPES.TREE_VIEW_NEXTSTRAIN, {
-          tree_id: treeId,
-        })
+        analyticsTrackEvent<AnalyticsTreeViewNextstrain>(
+          EVENT_TYPES.TREE_VIEW_NEXTSTRAIN,
+          {
+            tree_id: treeId,
+          }
+        )
       }
     />
   );

--- a/src/frontend/src/views/Data/components/TreeActionMenu/components/TreeTableDownloadMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/components/TreeTableDownloadMenu/index.tsx
@@ -1,5 +1,11 @@
 import { Menu, MenuItem, Tooltip } from "czifui";
 import React, { MouseEventHandler, ReactNode, useState } from "react";
+import {
+  AnalyticsTreeDownloadSelectedSamplesTemplate,
+  AnalyticsTreeDownloadTreeFile,
+  EVENT_TYPES,
+} from "src/common/analytics/eventTypes";
+import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { TREE_STATUS } from "src/common/constants/types";
 import DownloadIcon from "src/common/icons/IconDownloadSmall.svg";
@@ -7,7 +13,7 @@ import { stringGuard } from "src/common/utils";
 import { StyledIcon, StyledIconWrapper } from "../../style";
 
 interface Props {
-  item: TableItem;
+  item: PhyloRun;
 }
 
 const TreeTableDownloadMenu = ({ item }: Props): JSX.Element => {
@@ -17,8 +23,39 @@ const TreeTableDownloadMenu = ({ item }: Props): JSX.Element => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  // Close download menu. Making any download choice should close menu.
+  const baseHandleClose = () => {
     setAnchorEl(null);
+  };
+
+  // Tree download: close menu and fire analytics event.
+  // Note that you need to pass an arg of the tree's ID type.
+  const handleCloseWithTreeAnalytics = (
+    sampleIdType: AnalyticsTreeDownloadTreeFile["sample_id_type"]
+  ) => {
+    const { treeId, phyloRunWorkflowId } = analyticsGetData(item);
+    analyticsTrackEvent<AnalyticsTreeDownloadTreeFile>(
+      EVENT_TYPES.TREE_DOWNLOAD_TREE_FILE,
+      {
+        tree_id: treeId || null,
+        phylo_run_workflow_id: phyloRunWorkflowId || null,
+        sample_id_type: sampleIdType,
+      }
+    );
+    baseHandleClose();
+  };
+
+  // TSV template download: close menu and fire analytics event.
+  const handleCloseWithTsvAnalytics = () => {
+    const { treeId, phyloRunWorkflowId } = analyticsGetData(item);
+    analyticsTrackEvent<AnalyticsTreeDownloadSelectedSamplesTemplate>(
+      EVENT_TYPES.TREE_DOWNLOAD_SELECTED_SAMPLES_TEMPLATE,
+      {
+        tree_id: treeId || null,
+        phylo_run_workflow_id: phyloRunWorkflowId || null,
+      }
+    );
+    baseHandleClose();
   };
 
   const jsonLinkIdStylePrivateIdentifiers = stringGuard(
@@ -73,30 +110,55 @@ const TreeTableDownloadMenu = ({ item }: Props): JSX.Element => {
           }}
           keepMounted
           open={open}
-          onClose={handleClose}
+          onClose={baseHandleClose}
           getContentAnchorEl={null}
         >
           <NewTabLink href={jsonLinkIdStylePrivateIdentifiers}>
             <MenuItemTooltip>
-              <MenuItem disabled={disabled} onClick={handleClose}>
+              <MenuItem
+                disabled={disabled}
+                onClick={() => handleCloseWithTreeAnalytics("PRIVATE")}
+              >
                 {"Tree file with Private IDs (.json)"}
               </MenuItem>
             </MenuItemTooltip>
           </NewTabLink>
           <NewTabLink href={jsonLinkIdStylePublicIdentifiers}>
             <MenuItemTooltip>
-              <MenuItem disabled={disabled} onClick={handleClose}>
+              <MenuItem
+                disabled={disabled}
+                onClick={() => handleCloseWithTreeAnalytics("PUBLIC")}
+              >
                 {"Tree file with Public IDs (.json)"}
               </MenuItem>
             </MenuItemTooltip>
           </NewTabLink>
           <NewTabLink href={tsvDownloadLink}>
-            <MenuItem onClick={handleClose}>{"Private IDs (.tsv)"}</MenuItem>
+            <MenuItem onClick={handleCloseWithTsvAnalytics}>
+              {"Private IDs (.tsv)"}
+            </MenuItem>
           </NewTabLink>
         </Menu>
       )}
     </>
   );
 };
+
+/**
+ * Pulls data necessary to send analytics event regarding tree/TSV download.
+ *
+ * For the most part, both values will exist when downloading. However, either
+ * below could be `undefined`. The `treeId` could be undefined if tree is still
+ * processing or failed. I think `phyloRunWorkflowId` actually can not ever be
+ * undefined if it shows up in the table, but according to the TS type for the
+ * row item, it could be missing/undefined. In either case, downstream event
+ * sending handles what to do when one/both undefined.
+ */
+function analyticsGetData(item: Props["item"]) {
+  return {
+    treeId: item.phyloTree?.id,
+    phyloRunWorkflowId: item.id,
+  };
+}
 
 export default TreeTableDownloadMenu;

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/index.tsx
@@ -2,8 +2,13 @@ import { AlertTitle } from "@material-ui/lab";
 import { Alert, Button } from "czifui";
 import NextLink from "next/link";
 import React, { useState } from "react";
+import {
+  AnalyticsSamplesUploadSuccess,
+  EVENT_TYPES,
+} from "src/common/analytics/eventTypes";
+import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
-import { useCreateSamples } from "src/common/queries/samples";
+import { RawSamplesWithId, useCreateSamples } from "src/common/queries/samples";
 import { useSelector } from "src/common/redux/hooks";
 import { selectCurrentGroup } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
@@ -40,7 +45,18 @@ export default function Upload({
   const { mutate, isLoading, isSuccess, isError, error } = useCreateSamples(
     groupId,
     {
-      componentOnSuccess: () => {
+      componentOnSuccess: (respData: RawSamplesWithId) => {
+        // Analytics event: successful upload of samples
+        const createdSamples = respData.samples;
+        const createdIds = createdSamples.map((sample) => sample.id);
+        analyticsTrackEvent<AnalyticsSamplesUploadSuccess>(
+          EVENT_TYPES.SAMPLES_UPLOAD_SUCCESS,
+          {
+            sample_count: createdIds.length,
+            sample_ids: JSON.stringify(createdIds),
+          }
+        );
+
         cancelPrompt();
       },
     }


### PR DESCRIPTION
### Summary:
- **What:** Adds in majority of analytics events for initial version of analytics
- **Ticket:** [sc<199706>](https://app.shortcut.com/genepi/story/<199706>)
- **Env:** None. Have tested locally. Planning to do an rdev once analytics is basically wrapped and ready for trunk merge.

### Demos:
All the events added have been checked with Segment debugger, payloads are landing as expected for each. This is just a screenshot from checking one of the event types, not all of them.

<img width="1857" alt="image" src="https://user-images.githubusercontent.com/89553795/183479905-eae0e97f-c52e-4fc6-9c2c-05691d1137f9.png">


### Notes:
When reviewing, I recommend reading through the additions to `eventTypes.ts` first, as the documentation for the various new events will give you context for all the code changes to support and send those events.

There is a lot of documentation here -- probably too much -- and some annoyingly fancy TS stuff to try to bake in a certain pattern for handling analytics events in code. This was the result of a lot of thinking about making events that are easy to understand for data analysts and hard to break with code changes elsewhere. The documentation on `analyticsTrackEvent` goes into detail.

### Checklist:
- [x] I merged latest `vince/analytics`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests