### PR TITLE
Add anonymized analytics_id to user data

### DIFF
--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -52,9 +52,10 @@ class GroupRoleResponse(BaseResponse):
     roles: List[str]
 
 
-# Only expose split id and groups to the user it belongs to.
+# Only expose split_id, analytics_id, and groups to the user they belong to.
 class UserMeResponse(UserBaseResponse):
     split_id: str
+    analytics_id: str
     group: GroupResponse
     groups: List[GroupRoleResponse]
 

--- a/src/backend/aspen/api/views/tests/test_users.py
+++ b/src/backend/aspen/api/views/tests/test_users.py
@@ -39,6 +39,7 @@ async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -
     for key in expected:
         assert resp_data[key] == expected[key]
     assert len(resp_data["split_id"]) == 20
+    assert len(resp_data["analytics_id"]) == 20
 
 
 async def test_users_view_put_pass(

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -71,7 +71,8 @@ class Group(idbase, DictMixin):  # type: ignore
         return f"Group <{self.name}>"
 
 
-def generate_split_id(length=20):
+def generate_random_id(length=20):
+    """Generates random id for cases we need de-identified ID for user"""
     possible_characters = string.ascii_lowercase + string.digits
     return "".join(random.choice(possible_characters) for _ in range(length))
 
@@ -90,7 +91,11 @@ class User(idbase, DictMixin):  # type: ignore
     # Date of policies (any of Privacy Policy, Terms of Service, etc, etc) the user
     # has last acknowledged. Used to display notification to user when policies change.
     acknowledged_policy_version = Column(Date, nullable=True, default=None)
-    split_id = Column(String, nullable=False, default=generate_split_id)
+    split_id = Column(String, nullable=False, default=generate_random_id)
+    # `analytics_id` used for keeping users anonymized for analytics
+    analytics_id = Column(
+        String, unique=True, nullable=False, default=generate_random_id
+    )
 
     group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     group = relationship("Group", back_populates="members")  # type: ignore

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -5,7 +5,7 @@ import string
 from collections.abc import MutableSequence
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, text
+from sqlalchemy import Boolean, Column, Date, ForeignKey, Index, Integer, String, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.orm import backref, relationship
@@ -81,6 +81,11 @@ class User(idbase, DictMixin):  # type: ignore
     """A user."""
 
     __tablename__ = "users"
+    __table_args__ = (
+        # For historical reasons, split_id uniqueness is via unique index
+        # rather than direct unique constraint on Column. Same effect though.
+        Index("uq_users_split_id", "split_id", unique=True),
+    )
 
     name = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
@@ -91,6 +96,7 @@ class User(idbase, DictMixin):  # type: ignore
     # Date of policies (any of Privacy Policy, Terms of Service, etc, etc) the user
     # has last acknowledged. Used to display notification to user when policies change.
     acknowledged_policy_version = Column(Date, nullable=True, default=None)
+    # `split_id` is unique, but set via index, rather than Column, see above.
     split_id = Column(String, nullable=False, default=generate_random_id)
     # `analytics_id` used for keeping users anonymized for analytics
     analytics_id = Column(

--- a/src/backend/database_migrations/versions/20220808_214216_set_analytics_user_ids.py
+++ b/src/backend/database_migrations/versions/20220808_214216_set_analytics_user_ids.py
@@ -1,0 +1,49 @@
+"""set analytics user ids
+
+Create Date: 2022-08-08 21:42:17.801419
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220808_214216"
+down_revision = "20220805_180409"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        # Column is NOT actually nullable
+        # Just need it to be nullable for creation through initial data setup
+        sa.Column("analytics_id", sa.String(), nullable=True),
+        schema="aspen",
+    )
+    op.create_unique_constraint(
+        op.f("uq_users_analytics_id"),
+        "users",
+        ["analytics_id"],
+        schema="aspen",
+    )
+    # Below is SQL implementation of models.usergroup.generate_random_id
+    op.execute(
+        """
+        UPDATE aspen.users set analytics_id = array_to_string(array(
+          select substr('abcdefghijklmnopqrstuvwxyz0123456789',((random()*(36-1)+1)::integer),1) from generate_series(1,20) where users.id = users.id
+        ),'');
+    """
+    )
+    # Now that data is loaded, can properly set column to nullable=False
+    op.alter_column(
+        "users",
+        "analytics_id",
+        nullable=False,
+        schema="aspen",
+    )
+
+
+def downgrade():
+    raise NotImplementedError("don't downgrade")

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -55,6 +55,7 @@ def create_test_user(session, email, group, user_id, name):
         name=name,
         auth0_user_id=user_id,
         split_id=user_id,
+        analytics_id=user_id,
         email=email,
         group_admin=True,
         system_admin=True,


### PR DESCRIPTION
### Summary:
- **What:** Adds an anonymized `analytics_id` to info about user so we can do analytics while keeping user info anonymized downstream in data warehouse
- **Ticket:** [sc<210052>](https://app.shortcut.com/genepi/story/<210052>)
- **Env:** https://vince-anon-analytics-id-frontend.dev.czgenepi.org/

### Demos:

<img width="760" alt="image" src="https://user-images.githubusercontent.com/89553795/183533524-ff218893-cd1f-4b7c-80f0-e763a0cbda38.png">

### Notes:
New field is almost exactly the same approach to how we added in `split_id`. Same purpose: want something we can differentiate users on but without leaking user info downstream. Same implementation: random string we pass back with user info at `/me` endpoint.

While working on this, I also discovered that there was a mismatch between how we had the uniqueness constraint for `split_id` set up in the DB versus what was shown in SQLAlchemy. I added a table arg to explicitly point out that it's unique and to show the name of the index, mostly for documentation at this point, but the result of the table arg would have been the same as what was manually run (via custom alembic migration) to make that unique. Uniqueness for `analytics_id` was just done via Column unique bool, although the end result of what happens in DB is the same. All this is really just to work around confusion of SQLAlchemy and an implementation detail of Postgres.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)