### PR TITLE
populate optional fields on upload (Nextstrain header support)

### DIFF
--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
@@ -66,8 +66,6 @@ interface ParsedRow {
 // If header is unrecognized, leaves it alone (useful for warnings, etc).
 // User can also use Nextstrain header defaults as an alias
 function convertHeaderToMetadataKey(headerName: string): string {
-  // console.log("headerName in convert headers", headerName); // REMOVE
-  // console.log("headerName in convertHeader", headerName); // REMOVE
   if (headerName in HEADERS_TO_METADATA_KEYS) {
     return HEADERS_TO_METADATA_KEYS[headerName];
   } else if (headerName in NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS) {
@@ -85,14 +83,14 @@ function getMissingHeaderFields(
   uploadedHeaders: string[],
   headersToMetadataKeys: Dictionary<keyof SampleUploadTsvMetadata>
 ): Set<string> | null {
-  console.log("uploadedHeaders in missingHeaders: ", uploadedHeaders); // REMOVE
   const missingFields = new Set<string>();
   for (const [headerField, metadataKey] of Object.entries(
     headersToMetadataKeys
   )) {
     if (
       !(uploadedHeaders.includes(metadataKey)) &&
-      !headerField.includes("Optional") 
+      !headerField.includes("Optional") &&
+      !(metadataKey === "keepPrivate") // TODO: rename field to have -Optional flag
     ) {
       if (
         ["privateId", "sampleId"].includes(metadataKey) && 
@@ -118,8 +116,10 @@ function hasUnknownHeaderFields(
   // Compare strings since we are checking for values that are not in our
   // defined list of headers.
   const knownHeaderFields: string[] = Object.values(headersToMetadataKeys);
+  const knownNextstrainFields: string[] = Object.values(NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS);
+  console.log("knownNextstrainFields", knownNextstrainFields); // REMOVE
   for (const headerField of uploadedHeaders) {
-    if (!knownHeaderFields.includes(headerField)) {
+    if (!knownHeaderFields.includes(headerField) && !knownNextstrainFields.includes(headerField)) {
       return true;
     }
   }

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
@@ -88,18 +88,18 @@ function getMissingHeaderFields(
     headersToMetadataKeys
   )) {
     if (
-      !(uploadedHeaders.includes(metadataKey)) &&
+      !uploadedHeaders.includes(metadataKey) &&
       !headerField.includes("Optional") &&
-      !(metadataKey === "keepPrivate") // TODO: rename field to have -Optional flag
+      metadataKey !== "keepPrivate" // TODO: rename field to have -Optional flag
     ) {
       if (
-        ["privateId", "sampleId"].includes(metadataKey) && 
-        (uploadedHeaders.includes("strain"))
-        ) {
-          // pass, use strain to populate sample and privateID
+        ["privateId", "sampleId"].includes(metadataKey) &&
+        uploadedHeaders.includes("strain")
+      ) {
+        // pass, use strain to populate sample and privateID
       } else {
         missingFields.add(headerField);
-      } 
+      }
     }
   }
   return missingFields.size !== 0 ? missingFields : null;
@@ -116,10 +116,14 @@ function hasUnknownHeaderFields(
   // Compare strings since we are checking for values that are not in our
   // defined list of headers.
   const knownHeaderFields: string[] = Object.values(headersToMetadataKeys);
-  const knownNextstrainFields: string[] = Object.values(NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS);
-  console.log("knownNextstrainFields", knownNextstrainFields); // REMOVE
+  const knownNextstrainFields: string[] = Object.values(
+    NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS
+  );
   for (const headerField of uploadedHeaders) {
-    if (!knownHeaderFields.includes(headerField) && !knownNextstrainFields.includes(headerField)) {
+    if (
+      !knownHeaderFields.includes(headerField) &&
+      !knownNextstrainFields.includes(headerField)
+    ) {
       return true;
     }
   }
@@ -349,7 +353,11 @@ export function parseFile(
         const uploadedHeaders = papaParseMeta.fields as string[]; // available b/c `header: true`
         if (uploadedHeaders.includes("strain")) {
           // User is using the nextstrain metadata template headers, populate privateId and sampleId with strain
-            rows = rows.map(obj => ({ ...obj, privateId: obj['strain'], sampleId: obj['strain'] }))
+          rows = rows.map((obj) => ({
+            ...obj,
+            privateId: obj["strain"],
+            sampleId: obj["strain"],
+          }));
         }
 
         // Init -- Will modify these in place as we work through incoming rows.

--- a/src/frontend/src/views/Upload/components/common/constants.ts
+++ b/src/frontend/src/views/Upload/components/common/constants.ts
@@ -17,7 +17,7 @@ export const NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS: Record<
   date: "collectionDate",
   location: "collectionLocation",
   gisaid_epi_isl: "publicId",
-  strain: "sampleId",
+  strain: "strain",
 };
 
 // We don't send all metadata keys to API. sampleId is not persisted.


### PR DESCRIPTION
### Summary:
- **What:** autopopulate sampleId and PrivateId with `strain` when users use the nextstrain template, remove keepPrivate from required fields
- **Ticket:** [sc208436](https://app.shortcut.com/genepi/story/208436)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)