### PR TITLE
SC-194364 get rid of semantic UI

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -3521,23 +3521,6 @@
         }
       }
     },
-    "@fluentui/react-component-event-listener": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
-      "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
-      "requires": {
-        "@babel/runtime": "^7.10.4"
-      }
-    },
-    "@fluentui/react-component-ref": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
-      "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
-      "requires": {
-        "@babel/runtime": "^7.10.4",
-        "react-is": "^16.6.3"
-      }
-    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4603,20 +4586,6 @@
             "source-map": "^0.5.6"
           }
         }
-      }
-    },
-    "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
-    },
-    "@semantic-ui-react/event-stack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
-      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
-      "requires": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
       }
     },
     "@sideway/address": {
@@ -8038,11 +8007,6 @@
         "clone-regexp": "^2.1.0"
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -11026,11 +10990,6 @@
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
       "dev": true
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -11265,11 +11224,6 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.2"
       }
-    },
-    "keyboard-key": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -13135,22 +13089,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "requires": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "react-fast-compare": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-          "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-        }
-      }
-    },
     "react-query": {
       "version": "3.34.3",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.3.tgz",
@@ -13723,34 +13661,6 @@
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
-      }
-    },
-    "semantic-ui-css": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-      "requires": {
-        "jquery": "x.*"
-      }
-    },
-    "semantic-ui-react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.3.tgz",
-      "integrity": "sha512-dd2pqalMk0ycJoHf7hn4mYd0xohg0NMk7ohlpPVOigCfMLrKk2e3NZdRk0yBetvD+qJXPqZ04jA43bDwqOM5OA==",
-      "requires": {
-        "@babel/runtime": "^7.10.5",
-        "@fluentui/react-component-event-listener": "~0.63.0",
-        "@fluentui/react-component-ref": "~0.63.0",
-        "@popperjs/core": "^2.6.0",
-        "@semantic-ui-react/event-stack": "^3.1.3",
-        "clsx": "^1.1.1",
-        "keyboard-key": "^1.1.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6 || ^17.0.0 || ^18.0.0",
-        "react-popper": "^2.3.0",
-        "shallowequal": "^1.1.0"
       }
     },
     "semver": {
@@ -15045,14 +14955,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -61,8 +61,6 @@
     "react-window": "^1.8.6",
     "redux": "^4.2.0",
     "redux-devtools-extension": "^2.13.9",
-    "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "^2.0.3",
     "style-loader": "1.3.0",
     "typescript": "^4.1.3",
     "url-loader": "4.1.1",

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -5,7 +5,6 @@ import Head from "next/head";
 import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Provider } from "react-redux";
-import "semantic-ui-css/semantic.min.css";
 import { PlausibleInitializer } from "src/common/analytics/PlausibleInitializer";
 import { store } from "src/common/redux";
 import { StyledApp } from "src/common/styles/appStyle";

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -8,6 +8,7 @@ import { Provider } from "react-redux";
 import { PlausibleInitializer } from "src/common/analytics/PlausibleInitializer";
 import { store } from "src/common/redux";
 import { StyledApp } from "src/common/styles/appStyle";
+import "src/common/styles/global.css";
 import { theme } from "src/common/styles/theme";
 import { setFeatureFlagsFromQueryParams } from "src/common/utils/featureFlags";
 import Nav from "src/components/NavBar";

--- a/src/frontend/src/common/components/library/Table/components/Row/style.ts
+++ b/src/frontend/src/common/components/library/Table/components/Row/style.ts
@@ -1,15 +1,7 @@
 import styled from "@emotion/styled";
-import {
-  CommonThemeProps,
-  fontHeaderS,
-  fontHeaderXs,
-  getColors,
-  getSpaces,
-} from "czifui";
+import { fontHeaderS, fontHeaderXs, getColors } from "czifui";
 
-const sharedRowStyles = (props: CommonThemeProps) => {
-  const spaces = getSpaces(props);
-
+const sharedRowStyles = () => {
   return `
     display: flex;
     align-items: center;

--- a/src/frontend/src/common/components/library/Table/components/Row/style.ts
+++ b/src/frontend/src/common/components/library/Table/components/Row/style.ts
@@ -13,7 +13,6 @@ const sharedRowStyles = (props: CommonThemeProps) => {
   return `
     display: flex;
     align-items: center;
-    padding: ${spaces?.l}px;
   `;
 };
 
@@ -21,12 +20,12 @@ export const StyledRow = styled.div`
   ${fontHeaderXs}
   ${sharedRowStyles}
 
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-
   ${(props) => {
     const colors = getColors(props);
 
     return `
+
+      border-bottom: 1px ${colors?.gray[200]} solid;
       &:hover {
         background-color: ${colors?.primary[100]};
       }

--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/style.ts
@@ -65,7 +65,6 @@ export const StyledDialogContent = styled(DialogContent)`
   ${fontBodyS}
   ${transparentScrollbars}
 
-  width: 600px;
   padding-bottom: 0;
   overflow-y: auto;
   & > div:last-child {

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -1,3 +1,4 @@
+import { InputSearch } from "czifui";
 import { compact, escapeRegExp, filter } from "lodash";
 import React, {
   FunctionComponent,
@@ -5,7 +6,6 @@ import React, {
   useReducer,
   useState,
 } from "react";
-import { Input } from "semantic-ui-react";
 import { DataTable } from "src/common/components";
 import { VIEWNAME } from "src/common/constants/types";
 import { CreateNSTreeModal } from "./components/CreateNSTreeModal";
@@ -218,15 +218,6 @@ const DataSubview: FunctionComponent<Props> = ({
     setEditTreeConfirmationOpen(true);
   };
 
-  const onChange = (
-    _event: React.ChangeEvent<HTMLInputElement>,
-    fieldInput: InputOnChangeData
-  ) => {
-    const query = fieldInput.value;
-    searcher(query);
-    setSearchQuery(query);
-  };
-
   // search functions
   const searcher = (query: string): void => {
     if (data === undefined) {
@@ -241,6 +232,11 @@ const DataSubview: FunctionComponent<Props> = ({
     const regex = new RegExp(escapeRegExp(query), "i");
     const filteredData = filter(data, (item) => recursiveTest(item, regex));
     dispatch({ results: filteredData, searching: false });
+  };
+
+  const onSearchChange = (query: string): void => {
+    searcher(query);
+    setSearchQuery(query);
   };
 
   const DOWNLOAD_TOOLTIP_TEXT_DISABLED = (
@@ -352,11 +348,13 @@ const DataSubview: FunctionComponent<Props> = ({
         <StyledFlexChildDiv>
           <SearchBar>
             <SearchInput>
-              <Input
-                icon="search"
+              <InputSearch
+                id="sample-search"
+                label="Search samples"
+                sdsStyle="rounded"
                 placeholder="Search"
-                loading={state.searching}
-                onChange={onChange}
+                // loading={state.searching}
+                handleSubmit={onSearchChange}
                 data-test-id="search"
               />
             </SearchInput>

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -43,11 +43,6 @@ interface Props {
   dataFilterFunc?: (data: TableItem[]) => TableItem[];
 }
 
-interface InputOnChangeData {
-  [key: string]: string;
-  value: string;
-}
-
 interface SearchState {
   searching?: boolean;
   results?: TableItem[];
@@ -219,6 +214,12 @@ const DataSubview: FunctionComponent<Props> = ({
   };
 
   // search functions
+  const onSearchChange = (_event: React.ChangeEvent<HTMLInputElement>) => {
+    const query = _event.target.value;
+    searcher(query);
+    setSearchQuery(query);
+  };
+
   const searcher = (query: string): void => {
     if (data === undefined) {
       return;
@@ -232,11 +233,6 @@ const DataSubview: FunctionComponent<Props> = ({
     const regex = new RegExp(escapeRegExp(query), "i");
     const filteredData = filter(data, (item) => recursiveTest(item, regex));
     dispatch({ results: filteredData, searching: false });
-  };
-
-  const onSearchChange = (query: string): void => {
-    searcher(query);
-    setSearchQuery(query);
   };
 
   const DOWNLOAD_TOOLTIP_TEXT_DISABLED = (
@@ -349,12 +345,12 @@ const DataSubview: FunctionComponent<Props> = ({
           <SearchBar>
             <SearchInput>
               <InputSearch
-                id="sample-search"
-                label="Search samples"
+                id="search-samples"
+                label="search samples"
                 sdsStyle="rounded"
                 placeholder="Search"
-                // loading={state.searching}
-                handleSubmit={onSearchChange}
+                onChange={onSearchChange}
+                value={searchQuery}
                 data-test-id="search"
               />
             </SearchInput>

--- a/src/frontend/src/common/styles/appStyle.ts
+++ b/src/frontend/src/common/styles/appStyle.ts
@@ -4,8 +4,4 @@ export const StyledApp = styled.div`
   height: 100vh;
   flex-flow: column wrap;
   justify-content: center;
-  :not(i) {
-    font-family: Open Sans, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-      Helvetica Neue, Helvetica, Arial, sans-serif !important;
-  }
 `;

--- a/src/frontend/src/common/styles/global.css
+++ b/src/frontend/src/common/styles/global.css
@@ -1,0 +1,15 @@
+/* 
+ * Styles here replace semantic-ui global styles.
+ * We should add new styles elsewhere.
+*/
+body {
+  margin: 0;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: none;
+}

--- a/src/frontend/src/common/styles/global.css
+++ b/src/frontend/src/common/styles/global.css
@@ -4,6 +4,8 @@
 */
 body {
   margin: 0;
+  font-family: Open Sans, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    Helvetica Neue, Helvetica, Arial, sans-serif !important;
 }
 
 a {

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -154,9 +154,9 @@ const Data: FunctionComponent = () => {
   // create JSX elements from categories
   dataCategories.forEach((category) => {
     dataJSX.menuItems.push(
-      <Link href={category.to} key={category.text} passHref>
-        <a href="passHref">
-          <StyledMenuItem>
+      <StyledMenuItem>
+        <Link href={category.to} key={category.text} passHref>
+          <a href="passHref">
             <Category>
               <CategoryTitle
                 isActive={router.asPath === category.to}
@@ -166,9 +166,9 @@ const Data: FunctionComponent = () => {
               </CategoryTitle>
               <StyledCount>{Object.keys(category.data).length}</StyledCount>
             </Category>
-          </StyledMenuItem>
-        </a>
-      </Link>
+          </a>
+        </Link>
+      </StyledMenuItem>
     );
   });
 
@@ -202,7 +202,7 @@ const Data: FunctionComponent = () => {
             setShouldShowFilters(!shouldShowFilters);
           }}
         />
-        <StyledMenu secondary>{dataJSX.menuItems}</StyledMenu>
+        <StyledMenu>{dataJSX.menuItems}</StyledMenu>
       </Navigation>
       <View>
         {viewName === "Samples" && (

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -1,5 +1,6 @@
+import { Link } from "czifui";
 import { compact, map, uniq } from "lodash";
-import Link from "next/link";
+import NextLink from "next/link";
 import { useRouter } from "next/router";
 import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
 import { HeadAppTitle } from "src/common/components";
@@ -21,6 +22,7 @@ import {
   Container,
   Navigation,
   StyledCount,
+  StyledLink,
   StyledMenu,
   StyledMenuItem,
   View,
@@ -155,8 +157,8 @@ const Data: FunctionComponent = () => {
   dataCategories.forEach((category) => {
     dataJSX.menuItems.push(
       <StyledMenuItem>
-        <Link href={category.to} key={category.text} passHref>
-          <a href="passHref">
+        <NextLink href={category.to} key={category.text} passHref>
+          <StyledLink href="passHref">
             <Category>
               <CategoryTitle
                 isActive={router.asPath === category.to}
@@ -166,8 +168,8 @@ const Data: FunctionComponent = () => {
               </CategoryTitle>
               <StyledCount>{Object.keys(category.data).length}</StyledCount>
             </Category>
-          </a>
-        </Link>
+          </StyledLink>
+        </NextLink>
       </StyledMenuItem>
     );
   });

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -1,4 +1,3 @@
-import { Link } from "czifui";
 import { compact, map, uniq } from "lodash";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
@@ -22,7 +21,6 @@ import {
   Container,
   Navigation,
   StyledCount,
-  StyledLink,
   StyledMenu,
   StyledMenuItem,
   View,
@@ -158,7 +156,7 @@ const Data: FunctionComponent = () => {
     dataJSX.menuItems.push(
       <StyledMenuItem>
         <NextLink href={category.to} key={category.text} passHref>
-          <StyledLink href="passHref">
+          <a href="passHref">
             <Category>
               <CategoryTitle
                 isActive={router.asPath === category.to}
@@ -168,7 +166,7 @@ const Data: FunctionComponent = () => {
               </CategoryTitle>
               <StyledCount>{Object.keys(category.data).length}</StyledCount>
             </Category>
-          </StyledLink>
+          </a>
         </NextLink>
       </StyledMenuItem>
     );

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -8,6 +8,7 @@ import {
   fontHeaderXs,
   getColors,
   getSpaces,
+  Link,
 } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import { PageContent } from "src/common/styles/mixins/global";
@@ -194,4 +195,10 @@ export const StyledMenuItem = styled.li`
       margin: 0 ${spaces?.m}px;
     `;
   }};
+`;
+
+export const StyledLink = styled(Link)`
+  &:hover {
+    text-decoration: none;
+  }
 `;

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -196,9 +196,3 @@ export const StyledMenuItem = styled.li`
     `;
   }};
 `;
-
-export const StyledLink = styled(Link)`
-  &:hover {
-    text-decoration: none;
-  }
-`;

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -191,7 +191,7 @@ export const StyledMenuItem = styled.li`
     const spaces = getSpaces(props);
 
     return `
-      margin: 0 ${spaces?.m}px
+      margin: 0 ${spaces?.m}px;
     `;
-  }};
+  }}
 `;

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -8,7 +8,6 @@ import {
   fontHeaderXs,
   getColors,
   getSpaces,
-  Link,
 } from "czifui";
 import { RowContent } from "src/common/components/library/data_table/style";
 import { PageContent } from "src/common/styles/mixins/global";
@@ -192,7 +191,7 @@ export const StyledMenuItem = styled.li`
     const spaces = getSpaces(props);
 
     return `
-      margin: 0 ${spaces?.m}px;
+      margin: 0 ${spaces?.m}px
     `;
   }};
 `;

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -9,7 +9,6 @@ import {
   getColors,
   getSpaces,
 } from "czifui";
-import { Menu } from "semantic-ui-react";
 import { RowContent } from "src/common/components/library/data_table/style";
 import { PageContent } from "src/common/styles/mixins/global";
 
@@ -178,16 +177,21 @@ export const StyledCount = styled.div`
   }}
 `;
 
-export const StyledMenu = styled(Menu)`
+export const StyledMenu = styled.ul`
   align-items: center;
-  margin: 0 !important;
-
-  a div {
-    /* overwrite semantic-ui style */
-    padding-left: 0 !important;
-  }
+  display: flex;
+  flex-direction: row;
+  padding: 0;
 `;
 
-export const StyledMenuItem = styled(Menu.Item)`
-  height: 100%;
+export const StyledMenuItem = styled.li`
+  list-style: none;
+  padding: 0;
+  ${(props) => {
+    const spaces = getSpaces(props);
+
+    return `
+      margin: 0 ${spaces?.m}px;
+    `;
+  }};
 `;

--- a/src/frontend/src/views/Upload/components/Metadata/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "czifui";
+import { Button, Link } from "czifui";
 import NextLink from "next/link";
 import React, { useCallback, useMemo, useState } from "react";
 import { HeadAppTitle } from "src/common/components";
@@ -154,11 +154,11 @@ export default function Metadata({
             </ContinueButton>
           </NextStepWrapper>
           <NextLink href={ROUTES.UPLOAD_STEP1} passHref>
-            <a href="passHref">
+            <Link href="passHref">
               <Button sdsType="secondary" sdsStyle="rounded">
                 Back
               </Button>
-            </a>
+            </Link>
           </NextLink>
         </ButtonWrapper>
       </Content>
@@ -175,7 +175,7 @@ function NextStepWrapper({
 }): JSX.Element {
   return isValid ? (
     <NextLink href={ROUTES.UPLOAD_STEP3} passHref>
-      <a href="passHref">{children}</a>
+      <Link href="passHref">{children}</Link>
     </NextLink>
   ) : (
     <>{children}</>

--- a/src/frontend/src/views/Upload/components/Review/components/Upload/style.ts
+++ b/src/frontend/src/views/Upload/components/Review/components/Upload/style.ts
@@ -36,7 +36,6 @@ const centerContent = `
 export const StyledDialogContent = styled(DialogContent)`
   ${centerContent}
 
-  width: 600px;
   flex-direction: column;
 `;
 


### PR DESCRIPTION
### Summary:
- **What:** `Remove semantic-ui.  Use sds or custom styles instead`
- **Ticket:** [sc194364](https://app.shortcut.com/genepi/story/194364/get-rid-of-semantic-ui)
- **Env:** [rdev](https://semantic-ui-removal-frontend.dev.czgenepi.org/data/samples)

### Demos:
<img width="1148" alt="Screen Shot 2022-08-09 at 8 46 25 AM" src="https://user-images.githubusercontent.com/109251328/183698269-bbe7f95c-0393-4a3b-bd32-7611b8971225.png">

### Notes:
There should be no changes.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)