### PR TITLE
Make it easier for existing users to accept invitations instead of creating a new account

### DIFF
--- a/scripts/auth0_login.sh
+++ b/scripts/auth0_login.sh
@@ -54,4 +54,4 @@ ${local_aws} secretsmanager update-secret --secret-id genepi-config --secret-str
   "AUTH0_MANAGEMENT_DOMAIN": '"${AUTH0_MANAGEMENT_DOMAIN}"'
 }' || true
 
-docker compose restart backend
+docker compose exec backend supervisorctl restart fastapi

--- a/scripts/auth0_login.sh
+++ b/scripts/auth0_login.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Fetch certain secrets that make local dev work better from *real* AWS
+# so we can feed them to localstack (fake aws)
+
+# CI doesn't support profiles right now, so work around it.
+PROFILE="--profile genepi-dev"
+# GitHub actions can't handle our remapped DNS or AWS profiles :'(
+if [ -n "${CI}" ]; then
+	PROFILE=""
+fi
+# Fetch some additional data from real-aws to populate in our fake-aws secret.
+EXTRA_SECRETS=$(aws ${PROFILE} secretsmanager get-secret-value --secret-id localdev/genepi-config-secrets --query SecretString --output text)
+
+export AWS_REGION=us-west-2
+export AWS_DEFAULT_REGION=us-west-2
+export AWS_ACCESS_KEY_ID=nonce
+export AWS_SECRET_ACCESS_KEY=nonce
+export AWS_PAGER=""
+
+export FRONTEND_URL=http://frontend.genepinet.localdev:8000
+export BACKEND_URL=http://backend.genepinet.localdev:3000
+export LOCALSTACK_URL=http://localstack.genepinet.localdev:4566
+
+
+ONETRUST_FRONTEND_KEY=$(jq -c .ONETRUST_FRONTEND_KEY <<< "${EXTRA_SECRETS}")
+PLAUSIBLE_FRONTEND_KEY=$(jq -c .PLAUSIBLE_FRONTEND_KEY <<< "${EXTRA_SECRETS}")
+AUTH0_MANAGEMENT_CLIENT_ID=$(jq -c .AUTH0_MANAGEMENT_CLIENT_ID <<< "${EXTRA_SECRETS}")
+AUTH0_MANAGEMENT_CLIENT_SECRET=$(jq -c .AUTH0_MANAGEMENT_CLIENT_SECRET <<< "${EXTRA_SECRETS}")
+AUTH0_MANAGEMENT_DOMAIN=$(jq -c .AUTH0_MANAGEMENT_DOMAIN <<< "${EXTRA_SECRETS}")
+AUTH0_CLIENT_ID=$(jq -c .AUTH0_CLIENT_ID <<< "${EXTRA_SECRETS}")
+AUTH0_CLIENT_SECRET=$(jq -c .AUTH0_CLIENT_SECRET <<< "${EXTRA_SECRETS}")
+echo "Creating secretsmanager secrets"
+local_aws="aws --no-paginate --endpoint-url=${LOCALSTACK_URL}"
+${local_aws} secretsmanager create-secret --name genepi-config &> /dev/null || true
+# AUSPICE_MAC_KEY is just the result of urlsafe_b64encode(b'auspice-mac-key')
+${local_aws} secretsmanager update-secret --secret-id genepi-config --secret-string '{
+  "AUSPICE_MAC_KEY": "YXVzcGljZS1tYWMta2V5",
+  "AUTH0_CALLBACK_URL": "'"${BACKEND_URL}"'/callback",
+  "AUTH0_CLIENT_ID": '"${AUTH0_CLIENT_ID}"',
+  "AUTH0_CLIENT_SECRET": '"${AUTH0_CLIENT_SECRET}"',
+  "AUTH0_DOMAIN": '"${AUTH0_MANAGEMENT_DOMAIN}"',
+  "AUTH0_CLIENT_KWARGS": {"scope": "openid profile email offline_access"},
+  "FLASK_SECRET": "DevelopmentKey",
+  "SPLIT_BACKEND_KEY": "localhost",
+  "DB_rw_username": "user_rw",
+  "DB_rw_password": "password_rw",
+  "DB_address": "database.genepinet.localdev",
+  "S3_external_auspice_bucket": "genepi-external-auspice-data",
+  "S3_db_bucket": "genepi-db-data",
+  "ONETRUST_FRONTEND_KEY": '"${ONETRUST_FRONTEND_KEY}"',
+  "PLAUSIBLE_FRONTEND_KEY": '"${PLAUSIBLE_FRONTEND_KEY}"',
+  "AUTH0_MANAGEMENT_CLIENT_ID": '"${AUTH0_MANAGEMENT_CLIENT_ID}"',
+  "AUTH0_MANAGEMENT_CLIENT_SECRET": '"${AUTH0_MANAGEMENT_CLIENT_SECRET}"',
+  "AUTH0_MANAGEMENT_DOMAIN": '"${AUTH0_MANAGEMENT_DOMAIN}"'
+}' || true
+
+docker compose restart backend

--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -133,7 +133,6 @@ async def login(
             organization_name,
             cookie_userid,
         )
-        print(f"Resp: {resp}")
         if resp:
             return resp
         kwargs["invitation"] = invitation
@@ -272,7 +271,6 @@ async def process_invitation(
     settings: Settings = Depends(get_settings),
     user=Depends(get_auth_user),
 ) -> Response:
-    raise ex.BadRequestException("boo")
     # Load more information about the invitation from auth0
     org: Auth0Org = {
         "id": organization,

--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -13,10 +13,10 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 import aspen.api.error.http_exceptions as ex
-from aspen.api.authn import get_auth0_apiclient
+from aspen.api.authn import get_auth0_apiclient, get_auth_user
 from aspen.api.deps import get_auth0_client, get_db, get_settings, get_splitio
 from aspen.api.settings import Settings
-from aspen.auth.auth0_management import Auth0Client
+from aspen.auth.auth0_management import Auth0Client, Auth0Invitation, Auth0Org
 from aspen.auth.role_manager import RoleManager
 from aspen.database.models import Group, User
 from aspen.util.split import SplitClient
@@ -26,23 +26,111 @@ from aspen.util.split import SplitClient
 router = APIRouter()
 
 
+def get_invitation_ticket(
+    a0: Auth0Client, organization: str, invitation: str
+) -> Optional[Auth0Invitation]:
+    org: Auth0Org = {
+        "id": organization,
+        "name": organization,
+        "display_name": organization,
+    }
+    # We can't query the auth0 org invitations api directly if we only have a ticket id,
+    # so this is the next best thing.
+    tickets = a0.get_org_invitations(org)
+    for ticket in tickets:
+        if ticket.get("ticket_id") == invitation:
+            return ticket
+
+
+async def get_invitation_redirect(
+    oauth: StarletteOAuth2App,
+    settings: Settings,
+    a0: Auth0Client,
+    db: AsyncSession,
+    request: Request,
+    invitation: str,
+    organization: str,
+    organization_name: Optional[str] = None,
+) -> Optional[Response]:
+    # If this invitation is for an email address that already exists in our db,
+    # we'll use our custom invitation acceptance flow to associate their existing
+    # account with the invitation. If we haven't seen that email address before,
+    # we'll send them to the standard auth0 "create a new acct" flow.
+
+    # Load more information about the invitation from auth0
+    ticket_info = get_invitation_ticket(a0, organization, invitation)
+    if not ticket_info:
+        return
+    # Check to see if the user is already in our db.
+    invitee = ticket_info["invitee"]["email"]
+    try:
+        (await db.execute(sa.select(User).where(User.email == invitee))).scalars().one()
+    except NoResultFound:
+        # If the user isn't in our db, proceed with regular auth0 flow.
+        return
+    # If we're already logged in as this user, just process the invitation and redirect to welcome.
+    logged_in_userid = request.session.get("profile", {}).get("user_id")
+    try:
+        user = (
+            (
+                await db.execute(
+                    sa.select(User).where(User.auth0_user_id == logged_in_userid)
+                )
+            )
+            .scalars()
+            .one()
+        )
+    except NoResultFound:
+        raise ex.UnauthorizedException("Invalid user id")
+    if invitee == user.email:
+        # Redirect to process_invitation endpoint
+        redirect_url = (
+            settings.API_URL
+            + f"/v2/auth/process_invitation?invitation={invitation}&organization={organization}&organization_name={organization_name}"
+        )
+        return RedirectResponse(redirect_url)
+    # If we're logged in as a *different* user, we'll need to stash the invitation in the session and redirect to the login page.
+    request.session["process_invitation"] = {
+        "invitation": invitation,
+        "organization": organization,
+        "organization_name": organization_name,
+    }
+    return await oauth.authorize_redirect(
+        request, settings.AUTH0_CALLBACK_URL, login_hint=invitee, prompt="login"
+    )
+
+
 @router.get("/login")
 async def login(
     request: Request,
     organization: Optional[str] = None,
     invitation: Optional[str] = None,
+    db: AsyncSession = Depends(get_db),
     organization_name: Optional[str] = None,
-    auth0: StarletteOAuth2App = Depends(get_auth0_client),
+    oauth: StarletteOAuth2App = Depends(get_auth0_client),
+    a0: Auth0Client = Depends(get_auth0_apiclient),
     settings: Settings = Depends(get_settings),
 ) -> Response:
     kwargs = {}
-    if invitation:
+    if invitation and organization:
+        resp = await get_invitation_redirect(
+            oauth,
+            settings,
+            a0,
+            db,
+            request,
+            invitation,
+            organization,
+            organization_name,
+        )
+        if resp:
+            return resp
         kwargs["invitation"] = invitation
     if organization:
         kwargs["organization"] = organization
     if organization_name:
         kwargs["organization_name"] = organization_name
-    return await auth0.authorize_redirect(
+    return await oauth.authorize_redirect(
         request, settings.AUTH0_CALLBACK_URL, **kwargs
     )
 
@@ -97,11 +185,12 @@ async def create_user_if_not_exists(
 @router.get("/callback")
 async def auth(
     request: Request,
-    auth0: StarletteOAuth2App = Depends(get_auth0_client),
+    oauth: StarletteOAuth2App = Depends(get_auth0_client),
     splitio: SplitClient = Depends(get_splitio),
     db: AsyncSession = Depends(get_db),
-    auth0_mgmt: Auth0Client = Depends(get_auth0_apiclient),
+    a0: Auth0Client = Depends(get_auth0_apiclient),
     error_description: Optional[str] = None,
+    settings: Settings = Depends(get_settings),
 ) -> Response:
     if error_description:
         # Note: Auth0 sends the message "invitation not found or already used" for *both* expired and
@@ -116,7 +205,7 @@ async def auth(
                 os.getenv("FRONTEND_URL", "") + "/auth/invite/expired"
             )
     try:
-        token = await auth0.authorize_access_token(request)
+        token = await oauth.authorize_access_token(request)
     except OAuthError:
         raise ex.UnauthorizedException("Invalid token")
     userinfo = token.get("userinfo")
@@ -128,22 +217,108 @@ async def auth(
         "user_id": userinfo["sub"],
         "name": userinfo["name"],
     }
-    user, newuser_group = await create_user_if_not_exists(db, auth0_mgmt, userinfo)
+    user, newuser_group = await create_user_if_not_exists(db, a0, userinfo)
     # Always re-sync auth0 groups to our db on login!
     # Make sure the user is in auth0 before sync'ing roles.
     #  ex: User1 in local dev doesn't exist in auth0
     sync_roles = splitio.get_flag("sync_auth0_roles", user)
     if sync_roles == "on":
         if user.auth0_user_id.startswith("auth0|"):
-            await RoleManager.sync_user_roles(db, auth0_mgmt, user)
+            await RoleManager.sync_user_roles(db, a0, user)
         await db.commit()
 
+    # If we saved an org invitation in the users's session, redirect the user to the endpoint
+    # that can process the invitation, and clear out the invitation info in their session.
+    if request.session.get("process_invitation"):
+        saved_invitation = request.session.get("process_invitation", {})
+        invitation = saved_invitation.get("invitation")
+        organization = saved_invitation.get("organization")
+        organization_name = saved_invitation.get("organization_name")
+        redirect_url = (
+            settings.API_URL
+            + f"/v2/auth/process_invitation?invitation={invitation}&organization={organization}&organization_name={organization_name}"
+        )
+        del request.session["process_invitation"]
+        return RedirectResponse(redirect_url)
     if userinfo.get("org_id") and newuser_group:
         return RedirectResponse(
             os.getenv("FRONTEND_URL", "") + f"/welcome/{newuser_group.id}"
         )
     else:
         return RedirectResponse(os.getenv("FRONTEND_URL", "") + "/data/samples")
+
+
+@router.get("/process_invitation")
+async def process_invitation(
+    request: Request,
+    organization: str,
+    invitation: str,
+    db: AsyncSession = Depends(get_db),
+    splitio: SplitClient = Depends(get_splitio),
+    organization_name: Optional[str] = None,
+    oauth: StarletteOAuth2App = Depends(get_auth0_client),
+    a0: Auth0Client = Depends(get_auth0_apiclient),
+    settings: Settings = Depends(get_settings),
+    user=Depends(get_auth_user),
+) -> Response:
+    # Load more information about the invitation from auth0
+    org: Auth0Org = {
+        "id": organization,
+        "name": organization,
+        "display_name": organization,
+    }
+    ticket_info = get_invitation_ticket(a0, organization, invitation)
+    if not ticket_info:
+        # Let Auth0 complain about the invalid invitation.
+        kwargs = {
+            "invitation": invitation,
+            "organization": organization,
+            "organization_name": organization_name,
+        }
+        return await oauth.authorize_redirect(
+            request, settings.AUTH0_CALLBACK_URL, **kwargs
+        )
+
+    # Check to see if the user is the same as the one we're logged in as
+    invitee = ticket_info["invitee"]["email"]
+    if invitee != user.email:
+        raise ex.BadRequestException("email address mismatch")
+
+    # If we made it to this point, just process the invitation and redirect to welcome.
+
+    # Tell auth0 to make this user a member of the group and assign roles.
+    org: Auth0Org = {
+        "id": ticket_info["organization_id"],
+        "name": "",
+        "display_name": "",
+    }
+    a0.add_org_member(org, user.auth0_user_id, ticket_info["roles"], False)
+    # and our invitation is moot, delete it.
+    a0.delete_organization_invitation(ticket_info["organization_id"], ticket_info["id"])
+
+    # ok, now sync a0 roles to the db.
+    sync_roles = splitio.get_flag("sync_auth0_roles", user)
+    if sync_roles == "on":
+        await RoleManager.sync_user_roles(db, a0, user)
+        await db.commit()
+
+    try:
+        # redirect to the welcome page.
+        group = (
+            (
+                await db.execute(
+                    sa.select(Group).where(
+                        Group.auth0_org_id == ticket_info["organization_id"]
+                    )
+                )
+            )
+            .scalars()
+            .one()
+        )
+        return RedirectResponse(os.getenv("FRONTEND_URL", "") + f"/welcome/{group.id}")
+    except NoResultFound:
+        # This really shouldn't have happened, but send them to the frontend.
+        return RedirectResponse(os.getenv("FRONTEND_URL", "") + f"/data/samples")
 
 
 @router.get("/logout")

--- a/src/backend/aspen/api/views/tests/data/auth0_mock_responses.py
+++ b/src/backend/aspen/api/views/tests/data/auth0_mock_responses.py
@@ -13,6 +13,7 @@ DEFAULT_AUTH0_USER: Auth0User = {
 }
 DEFAULT_AUTH0_INVITATION: Auth0OrgInvitation = {
     "id": "inv_id",
+    "created_at": "",
     "expires_at": "2022-06-01",
     "inviter": {"name": "Bob"},
     "invitee": {"email": "invitee@czgenepi.org"},

--- a/src/backend/aspen/api/views/tests/data/auth0_mock_responses.py
+++ b/src/backend/aspen/api/views/tests/data/auth0_mock_responses.py
@@ -1,4 +1,4 @@
-from aspen.auth.auth0_management import Auth0Invitation, Auth0Org, Auth0User
+from aspen.auth.auth0_management import Auth0Org, Auth0OrgInvitation, Auth0User
 
 DEFAULT_AUTH0_ORG: Auth0Org = {
     "id": "testid",
@@ -11,10 +11,15 @@ DEFAULT_AUTH0_USER: Auth0User = {
     "name": "test user",
     "email": "test@czgenepi.org",
 }
-DEFAULT_AUTH0_INVITATION: Auth0Invitation = {
+DEFAULT_AUTH0_INVITATION: Auth0OrgInvitation = {
     "id": "inv_id",
-    "created_at": "2022-01-01",
     "expires_at": "2022-06-01",
     "inviter": {"name": "Bob"},
     "invitee": {"email": "invitee@czgenepi.org"},
+    "organization_id": "org-1234",
+    "invitation_url": "",
+    "roles": ["member"],
+    "ticket_id": "ticket_id",
+    "client_id": "",
+    "connection_id": "",
 }

--- a/src/backend/aspen/api/views/tests/test_invitation_flows.py
+++ b/src/backend/aspen/api/views/tests/test_invitation_flows.py
@@ -76,6 +76,7 @@ async def generate_invitation(
         "invitee": {"email": email},
         "inviter": {"name": ""},
         "expires_at": expiration_str,
+        "created_at": expiration_str,
         "ticket_id": "ticket_1",
         "roles": ["member"],
         "client_id": "",

--- a/src/backend/aspen/api/views/tests/test_invitation_flows.py
+++ b/src/backend/aspen/api/views/tests/test_invitation_flows.py
@@ -1,0 +1,229 @@
+from datetime import datetime, timedelta
+from typing import Dict, Optional, Tuple
+from urllib.parse import parse_qsl, urlparse
+
+import pytest
+from authlib.integrations.starlette_client import StarletteOAuth2App
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from aspen.api.middleware.session import SessionMiddleware
+from aspen.auth.auth0_management import Auth0Client, Auth0OrgInvitation
+from aspen.database.models import Group, User
+from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.util.split import SplitClient
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+async def setup_invitation_flows(
+    async_session: AsyncSession,
+    auth0_apiclient: Auth0Client,
+    auth0_oauth: StarletteOAuth2App,
+    split_client: SplitClient,
+):
+    """
+    Test most of the flows that lead to accepting organization invitations
+    """
+    group = group_factory(auth0_org_id="test_org")
+    user1 = user_factory(
+        name="Existing User",
+        email="existing_user@czgenepi.org",
+        auth0_user_id="existing_user",
+        group=group,
+    )
+    user2 = user_factory(
+        name="Another User",
+        email="another_user@czgenepi.org",
+        auth0_user_id="another_user",
+        group=group,
+    )
+    async_session.add_all([group, user1, user2])
+    await async_session.commit()
+
+    # todo fix this
+    userinfo = {
+        "sub": "user123-asdf",
+        "org_id": "123456",
+        "email": "hello@czgenepi.org",
+    }
+
+    split_client.get_flag.return_value = "on"  # type: ignore
+    auth0_apiclient.get_org_user_roles.side_effect = [["admin"]]  # type: ignore
+    auth0_oauth.authorize_access_token.side_effect = [{"userinfo": userinfo}]  # type: ignore
+    auth0_apiclient.get_user_orgs.side_effect = [[]]  # type: ignore
+    return user1, user2, group
+
+
+async def generate_invitation(
+    auth0_apiclient: Auth0Client,
+    group: Group,
+    email: str,
+    expires_at: Optional[datetime] = None,
+) -> Tuple[Auth0OrgInvitation, Dict]:
+    if not expires_at:
+        expires_at = datetime.now() + timedelta(days=2)
+    expiration_str = expires_at.isoformat()
+    invitation: Auth0OrgInvitation = {
+        "id": "foo",
+        "organization_id": group.auth0_org_id,
+        "created_at": "",
+        "invitee": {"email": email},
+        "inviter": {"email": ""},
+        "expires_at": expiration_str,
+        "ticket_id": "ticket_1",
+        "roles": ["member"],
+        "client_id": "",
+    }
+    login_params = {
+        "invitation": invitation["ticket_id"],
+        "organization": group.auth0_org_id,
+        "organization_name": group.name,
+    }
+    print("get org invitations setting -- ")
+    auth0_apiclient.get_org_invitations.return_value = [invitation]  # type: ignore
+    return invitation, login_params
+
+
+async def make_login_request(
+    http_client: AsyncClient, login_params: Dict, auth_user: Optional[User] = None
+) -> Response:
+    auth_headers = {}
+    if auth_user:
+        auth_headers = {"user_id": auth_user.auth0_user_id}
+    print(auth_headers)
+    res = await http_client.get(
+        f"/v2/auth/login",
+        params=login_params,
+        headers=auth_headers,
+        allow_redirects=False,
+    )
+    return res
+
+
+async def test_redirect_without_prompt(
+    async_session: AsyncSession,
+    auth0_apiclient: Auth0Client,
+    auth0_oauth: StarletteOAuth2App,
+    http_client: AsyncClient,
+    split_client: SplitClient,
+):
+    """
+    Invitation is expired but address is in db, or email doesn't exist in the db (redirect to auth0 w/o prompt)
+    """
+    user, _, group = await setup_invitation_flows(
+        async_session=async_session,
+        auth0_apiclient=auth0_apiclient,
+        auth0_oauth=auth0_oauth,
+        split_client=split_client,
+    )
+
+    auth_user = None
+    test_cases = [
+        [user.email, datetime.now() - timedelta(days=2)],
+        ["zzyzx@czgenepi.org", None],
+    ]
+
+    auth0_oauth.authorize_redirect.side_effect = [RedirectResponse("/auth0_test"), RedirectResponse("/auth0_test")]  # type: ignore
+    for test_case in test_cases:
+        invitation_email, expires_at = test_case
+        invitation, login_params = await generate_invitation(
+            auth0_apiclient, group=group, email=invitation_email, expires_at=expires_at
+        )
+        res = await make_login_request(http_client, login_params, auth_user)
+
+        assert res.headers["Location"] == "/auth0_test"
+        redirect_kwargs = auth0_oauth.authorize_redirect.call_args.kwargs
+        assert redirect_kwargs["invitation"] == invitation["ticket_id"]
+        assert redirect_kwargs["organization"] == group.auth0_org_id
+        assert redirect_kwargs["organization_name"] == group.name
+
+
+async def test_invitation_valid_and_logged_in(
+    async_session: AsyncSession,
+    auth0_apiclient: Auth0Client,
+    auth0_oauth: StarletteOAuth2App,
+    http_client: AsyncClient,
+    split_client: SplitClient,
+):
+    """
+    Email exists and we're logged in as the right user (expect redirect to process_invitation)
+    """
+    user, _, group = await setup_invitation_flows(
+        async_session=async_session,
+        auth0_apiclient=auth0_apiclient,
+        auth0_oauth=auth0_oauth,
+        split_client=split_client,
+    )
+
+    auth_user = user
+    invitation_email = user.email
+    expires_at = None
+
+    invitation, login_params = await generate_invitation(
+        auth0_apiclient, group=group, email=invitation_email, expires_at=expires_at
+    )
+
+    res = await make_login_request(http_client, login_params, auth_user)
+
+    _, _, path, _, query, _ = urlparse(res.headers["Location"])
+    query_params = dict(parse_qsl(query))
+    assert "process_invitation" in path
+    assert query_params["invitation"] == invitation["ticket_id"]
+    assert query_params["organization"] == group.auth0_org_id
+
+
+async def get_cookie(api: FastAPI, client: AsyncClient, response: Response):
+    """
+    Get the cookie from a response
+    """
+    cookie = client.cookies.get("session")
+    sess_args = [
+        mw.options for mw in api.user_middleware if mw.cls == SessionMiddleware
+    ][0]
+    sessionmanager = SessionMiddleware(api, **sess_args)
+    return sessionmanager.decode_flask_cookie(cookie)
+
+
+async def test_redirect_with_prompt(
+    async_session: AsyncSession,
+    auth0_apiclient: Auth0Client,
+    auth0_oauth: StarletteOAuth2App,
+    http_client: AsyncClient,
+    split_client: SplitClient,
+    api: FastAPI,
+):
+    """
+    if the email exists and we're either not logged in, or logged in as a different user, redirect to auth0 with a prompt
+    """
+    user1, user2, group = await setup_invitation_flows(
+        async_session=async_session,
+        auth0_apiclient=auth0_apiclient,
+        auth0_oauth=auth0_oauth,
+        split_client=split_client,
+    )
+
+    invitation_email = user2.email
+    expires_at = None
+
+    invitation, login_params = await generate_invitation(
+        auth0_apiclient, group=group, email=invitation_email, expires_at=expires_at
+    )
+    auth0_oauth.authorize_redirect.side_effect = [RedirectResponse("/auth0_test"), RedirectResponse("/auth0_test")]  # type: ignore
+    for auth_user in [user1, None]:
+        res = await make_login_request(http_client, login_params, auth_user)
+
+        assert res.headers["Location"] == "/auth0_test"
+        redirect_kwargs = auth0_oauth.authorize_redirect.call_args.kwargs
+        assert redirect_kwargs["prompt"] == "login"
+        assert redirect_kwargs["login_hint"] == invitation_email
+        session_values = await get_cookie(api, http_client, res)
+        assert session_values["process_invitation"] == {
+            "invitation": invitation["ticket_id"],
+            "organization": group.auth0_org_id,
+            "organization_name": group.name,
+        }

--- a/src/backend/aspen/auth/auth0_management.py
+++ b/src/backend/aspen/auth/auth0_management.py
@@ -40,6 +40,7 @@ class Auth0Invitee(TypedDict):
 class Auth0OrgInvitation(TypedDict):
     id: str
     organization_id: str
+    created_at: Optional[str]
     inviter: Auth0Inviter
     invitee: Auth0Invitee
     invitation_url: Optional[str]

--- a/src/backend/aspen/auth/auth0_management.py
+++ b/src/backend/aspen/auth/auth0_management.py
@@ -1,7 +1,7 @@
 import random
 import string
 from functools import cache, partial
-from typing import Any, Callable, Dict, List, Optional, TypedDict
+from typing import Any, Callable, List, Optional, TypedDict
 
 from auth0.v3 import authentication as auth0_authentication
 from auth0.v3.management import Auth0
@@ -11,18 +11,6 @@ class Auth0Org(TypedDict):
     id: str
     name: str
     display_name: str
-
-
-class Auth0OrgInvitation(TypedDict):
-    id: str
-    organization_id: str
-    inviter: Dict[str, str]
-    inviteee: Dict[str, str]
-    invitation_url: str
-    roles: List[str]
-    ticket_id: str
-    client_id: str
-    connection_id: str
 
 
 class Auth0User(TypedDict):
@@ -49,12 +37,17 @@ class Auth0Invitee(TypedDict):
     email: str
 
 
-class Auth0Invitation(TypedDict):
+class Auth0OrgInvitation(TypedDict):
     id: str
-    created_at: str
-    expires_at: str
+    organization_id: str
     inviter: Auth0Inviter
     invitee: Auth0Invitee
+    invitation_url: Optional[str]
+    roles: List[str]
+    ticket_id: str
+    client_id: Optional[str]
+    connection_id: Optional[str]
+    expires_at: str
 
 
 def generate_password(length: int = 22) -> str:

--- a/src/backend/etc/split.yml
+++ b/src/backend/etc/split.yml
@@ -9,7 +9,7 @@
 - test_feature:
     treatment: "on"
     keys: ["split_id_1", "split_id_2"]
-- sync_roles:
+- sync_auth0_roles:
     treatment: "on"
 - test_feature:
     treatment: "off"

--- a/src/backend/etc/split.yml
+++ b/src/backend/etc/split.yml
@@ -9,5 +9,7 @@
 - test_feature:
     treatment: "on"
     keys: ["split_id_1", "split_id_2"]
+- sync_roles:
+    treatment: "on"
 - test_feature:
     treatment: "off"


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc208570](https://app.shortcut.com/genepi/story/208570)
- **Env:** https://acceptinvitation-frontend.dev.czgenepi.org

### Notes:
Alright, this PR does a few things:
- Adds a setup script to convert local dev to relying 100% on our localdev auth0 tenant for auth
- Updates local dev to enable the "sync roles" feature flag by default
- Adds a new endpoint for processing a user's invitation (basically trying to duplicate what auth0 does when processing an invitation acceptance 😢 )
- Updates the login endpoint to check whether an invitation is for a user that already exists in the db. If it does, it tries to encourage the user to *log in* instead of using the default auth0 flow which prompts users to *create a new account* by default.
- Updates the callback endpoint to read session parameters that might be set by the login endpoint, to redirect the user to the "process invitation" endpoint if necessary.

The flow diagram is here: https://lucid.app/lucidchart/77a5ba77-7e05-4987-847c-2250ded9ddfa/edit?invitationId=inv_7ac1d716-e2a0-4936-9928-8af7cd55a8b0&page=0_0#

I'm happy to go over this in person if anyone's interested!

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)