### PR TITLE
Add gisaid_submitter_id column to users table and api support

### DIFF
--- a/src/backend/aspen/api/schemas/usergroup.py
+++ b/src/backend/aspen/api/schemas/usergroup.py
@@ -44,6 +44,7 @@ class UserUpdateRequest(BaseRequest):
     agreed_to_tos: Optional[bool] = None
     acknowledged_policy_version: Optional[datetime.date] = None
     name: Optional[str] = None
+    gisaid_submitter_id: Optional[str] = None
 
 
 class GroupRoleResponse(BaseResponse):
@@ -56,6 +57,7 @@ class GroupRoleResponse(BaseResponse):
 class UserMeResponse(UserBaseResponse):
     split_id: str
     analytics_id: str
+    gisaid_submitter_id: Optional[str]
     group: GroupResponse
     groups: List[GroupRoleResponse]
 

--- a/src/backend/aspen/api/views/tests/test_users.py
+++ b/src/backend/aspen/api/views/tests/test_users.py
@@ -34,6 +34,7 @@ async def test_users_me(http_client: AsyncClient, async_session: AsyncSession) -
         "groups": [
             {"id": group.id, "name": group.name, "roles": ["member"]},
         ],
+        "gisaid_submitter_id": None,
     }
     resp_data = response.json()
     for key in expected:
@@ -63,6 +64,7 @@ async def test_users_view_put_pass(
         {"agreed_to_tos": False},
         {"acknowledged_policy_version": "2020-07-22"},
         {"name": new_name},
+        {"gisaid_submitter_id": "alice_phd"},
     ]
     for req in requests:
         res = await http_client.put("/v2/users/me", headers=headers, json=req)
@@ -91,6 +93,8 @@ async def test_users_view_put_pass(
             )
         if "name" in req:
             assert updated_user.name == req["name"]
+        if "gisaid_submitter_id" in req:
+            assert updated_user.gisaid_submitter_id == req["gisaid_submitter_id"]
 
 
 async def test_usergroup_view_put_fail(

--- a/src/backend/aspen/api/views/users.py
+++ b/src/backend/aspen/api/views/users.py
@@ -49,16 +49,14 @@ async def update_user_info(
     user=Depends(get_auth_user),
 ) -> UserMeResponse:
     auth0_update_items = {}
+    auth0_attributes = ["name"]
 
-    if user_update_request.agreed_to_tos is not None:
-        user.agreed_to_tos = user_update_request.agreed_to_tos
-    if user_update_request.acknowledged_policy_version is not None:
-        user.acknowledged_policy_version = (
-            user_update_request.acknowledged_policy_version
-        )
-    if user_update_request.name is not None:
-        user.name = user_update_request.name
-        auth0_update_items["name"] = user_update_request.name
+    for attribute, value in user_update_request:
+        if value is not None:
+            setattr(user, attribute, value)
+            if attribute in auth0_attributes:
+                auth0_update_items[attribute] = value
+
     await db.commit()
 
     if user.auth0_user_id and len(auth0_update_items) > 0:

--- a/src/backend/aspen/database/models/usergroup.py
+++ b/src/backend/aspen/database/models/usergroup.py
@@ -102,6 +102,7 @@ class User(idbase, DictMixin):  # type: ignore
     analytics_id = Column(
         String, unique=True, nullable=False, default=generate_random_id
     )
+    gisaid_submitter_id = Column(String, nullable=True, default=None)
 
     group_id = Column(Integer, ForeignKey(Group.id), nullable=False)
     group = relationship("Group", back_populates="members")  # type: ignore

--- a/src/backend/database_migrations/versions/20220809_234732_add_gisaid_submitter_id_to_users_table.py
+++ b/src/backend/database_migrations/versions/20220809_234732_add_gisaid_submitter_id_to_users_table.py
@@ -1,0 +1,26 @@
+"""Add gisaid_submitter_id to Users table
+
+Create Date: 2022-08-09 23:47:38.212679
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220809_234732"
+down_revision = "20220808_214216"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("gisaid_submitter_id", sa.String(), nullable=True),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    raise NotImplementedError("Reversing this migration is not supported")


### PR DESCRIPTION
### Summary:
- **What:** Adds `gisaid_submitter_id` column to users table, as well as api support.
- **Ticket:** [sc209738](https://app.shortcut.com/genepi/story/209738), [sc210080](https://app.shortcut.com/genepi/story/210080
- **Env:** `<rdev link>`

### Demos:
<img width="978" alt="Screen Shot 2022-08-09 at 17 12 27" src="https://user-images.githubusercontent.com/24234461/183783117-e580fd8d-4787-4e57-a096-5276a4a6f380.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)