### PR TITLE
Standalone migration to add gisaid_submitter_id to users table

### DIFF
--- a/src/backend/database_migrations/versions/20220809_234732_add_gisaid_submitter_id_to_users_table.py
+++ b/src/backend/database_migrations/versions/20220809_234732_add_gisaid_submitter_id_to_users_table.py
@@ -1,0 +1,26 @@
+"""Add gisaid_submitter_id to Users table
+
+Create Date: 2022-08-09 23:47:38.212679
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20220809_234732"
+down_revision = "20220808_214216"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("gisaid_submitter_id", sa.String(), nullable=True),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    raise NotImplementedError("Reversing this migration is not supported")


### PR DESCRIPTION
### Summary:
- **What:** Adds a gisaid_submitter_id to the users table
- **Ticket:** [sc209738](https://app.shortcut.com/genepi/story/209738)
- **Env:** `<rdev link>`

### Demos:
After the migration is run:
<img width="978" alt="Screen Shot 2022-08-09 at 17 12 27" src="https://user-images.githubusercontent.com/24234461/184020035-c9429a05-d7ba-425d-b9cf-d3605eb280d1.png">


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)