### PR TITLE
Clean up analytics user info process

### DIFF
--- a/src/frontend/src/common/analytics/SegmentInitializer.tsx
+++ b/src/frontend/src/common/analytics/SegmentInitializer.tsx
@@ -47,10 +47,8 @@ const INITIAL_SCRIPT_TYPE = "text/plain";
  *      (it finds the script to flip via class `ONETRUST_ENABLING_CLASS`)
  *   2) There must be a truth-y value present for the SEGMENT_FRONTEND_KEY.
  *      We default to empty string when no env var present.
- *      As of right now, during initial development, there is no Segment key
- *      in Prod (we've also avoided creating a Prod integration on the Segment
- *      side for now). This means that, even if this code gets to Prod,
- *      no analytics will run right now on Prod.
+ *   3) The user/group info must be finished with initialization, as we use
+ *      some of that info during Segment load (see below).
  *
  * In addition to initializing the Segment analytics framework, the init script
  * also kicks off an initial `page` call to record what page the user starts on
@@ -76,6 +74,11 @@ export function SegmentInitializer(): JSX.Element | null {
   // that the user info we pass to segmentInitScript and use there matches
   // the structure of what is sent in the `analyticsSendUserInfo` function.
   const analyticsUserInfo = extractAnalyticsUserInfo(userInfo);
+  // `analyticsUserInfo` will be false-y if user/group info not done with init
+  if (!analyticsUserInfo) return null;
+
+  // If we've made it here and have a SEGMENT_WRITE_KEY, we are ready to load
+  // Segment and fire first events (if user opts-in to analytics via OneTrust).
   return SEGMENT_WRITE_KEY ? (
     <Script
       id={SEGMENT_SCRIPT_TAG_ID}

--- a/src/frontend/src/common/analytics/eventTypes.ts
+++ b/src/frontend/src/common/analytics/eventTypes.ts
@@ -41,6 +41,9 @@ export enum EVENT_TYPES {
   // Does not currently address success/failure, but download failures are very
   // rare, so generally safe to not be concerned about that aspect for now.
   SAMPLES_DOWNLOAD_FILE = "SAMPLES_DOWNLOAD_FILE",
+
+  // User is in multiple groups and is changing which group they are acting in.
+  ACTIVE_GROUP_CHANGE = "ACTIVE_GROUP_CHANGE",
 }
 
 /**
@@ -168,4 +171,15 @@ export type AnalyticsSamplesDownloadFile = {
   includes_consensus_genome: boolean;
   // User downloaded info on metadata for these samples
   includes_sample_metadata: boolean;
+};
+
+/** EVENT_TYPES.ACTIVE_GROUP_CHANGE*/
+export type AnalyticsActiveGroupChange = {
+  // The group ID user had been actively viewing before changing groups.
+  // NOTE: the `group_id` common analytics field should be identical to this
+  // previous_group_id because we fire event at start of change. Nonetheless,
+  // we track it as an explicit field to avoid any ambiguity.
+  previous_group_id: number;
+  // The group ID that the user is switching to viewing/acting as.
+  new_group_id: number;
 };

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -35,6 +35,7 @@ export interface RawUserRequest {
   agreed_to_tos: boolean;
   acknowledged_policy_version: string | null; // Date or null in DB. ISO 8601: "YYYY-MM-DD"
   split_id: string;
+  analytics_id: string;
   group_admin: boolean;
 }
 
@@ -42,6 +43,7 @@ export const mapUserData = (obj: RawUserRequest): User => {
   return {
     acknowledgedPolicyVersion: obj.acknowledged_policy_version,
     agreedToTos: obj.agreed_to_tos,
+    analyticsId: obj.analytics_id,
     groups: obj.groups,
     id: obj.id,
     name: obj.name,
@@ -84,6 +86,7 @@ export function useUpdateUserInfo(): UseMutationResult<
 // to analytics as a way to easily catch any changes to user info over time.
 function mapUserDataAndHandleAnalytics(obj: RawUserRequest): User {
   const user = mapUserData(obj);
+  // Downstream will handle figuring out group info (and if it's ready yet).
   analyticsSendUserInfo(user);
   return user;
 }

--- a/src/frontend/src/common/redux/middleware/index.ts
+++ b/src/frontend/src/common/redux/middleware/index.ts
@@ -5,8 +5,10 @@
  */
 
 import { AnyAction, Middleware } from "redux";
+import { analyticsSendUserInfo } from "src/common/analytics/methods";
 import { expireAllCaches } from "src/common/queries/groups";
 import { setLocalStorage } from "src/common/utils/localStorage";
+import { getCurrentUserInfo } from "src/common/utils/userInfo";
 import { selectCurrentGroup } from "../selectors";
 import { CZGEReduxActions, ReduxPersistenceTokens } from "../types";
 
@@ -23,6 +25,12 @@ export const setGroupMiddleware: Middleware =
       const state = getState();
       if (selectCurrentGroup(state) !== payload) {
         expireAllCaches();
+        // Need to update analytics with the group user is changing to
+        const currentUserInfo = getCurrentUserInfo();
+        if (currentUserInfo) {
+          // Need to use latest group ID explicitly since redux is updating
+          analyticsSendUserInfo(currentUserInfo, payload);
+        }
       }
     }
 

--- a/src/frontend/src/common/types/user.d.ts
+++ b/src/frontend/src/common/types/user.d.ts
@@ -22,6 +22,7 @@ type BaseUser = {
 interface User extends BaseUser {
   groups: UserGroup[];
   splitId: string;
+  analyticsId: string;
 }
 
 type GroupRole = "member" | "admin";

--- a/src/frontend/src/common/utils/userInfo.ts
+++ b/src/frontend/src/common/utils/userInfo.ts
@@ -1,21 +1,60 @@
 import { find } from "lodash";
+import { queryClient } from "pages/_app";
+import {
+  mapUserData,
+  RawUserRequest,
+  USE_USER_INFO,
+} from "src/common/queries/auth";
 import { store } from "../redux";
 import { selectCurrentGroup } from "../redux/selectors";
+
+// Pulls UserGroup info for the specified groupId. If userInfo `undefined` or
+// group missing from the user's available groups, returns `undefined`.
+export const getUserGroupInfoByGroupId = (
+  userInfo: User | undefined,
+  groupId: number
+): UserGroup | undefined => {
+  return find(userInfo?.groups, (g) => g.id === groupId);
+};
 
 /**
  * Takes the stored id for the current group and returns the available details about that group
  * from /me response
+ *
+ * If no group has been loaded for user yet (i.e., still on FALLBACK_GROUP_ID),
+ * or if the group is missing for some reason, returns `undefined`.
  */
 export const getCurrentGroupFromUserInfo = (
   userInfo?: User
 ): UserGroup | undefined => {
   const state = store.getState();
   const currentGroupId = selectCurrentGroup(state);
-  return find(userInfo?.groups, (g) => g.id === currentGroupId);
+  return getUserGroupInfoByGroupId(userInfo, currentGroupId);
 };
 
 export const getIsGroupAdminFromUserInfo = (userInfo?: User): boolean => {
   const currentGroup = getCurrentGroupFromUserInfo(userInfo);
   const roles: GroupRole[] = currentGroup?.roles ?? [];
   return roles.includes("admin");
+};
+
+/**
+ * WARNING -- please AVOID using unless you have no choice but to use it.
+ *
+ * Gets the currently cached data for user info.
+ * Generally, you **should** be using `useUserInfo` to get access to user info,
+ * but that will only work within React components. If you find yourself in a
+ * situation where you need access to user info, but you are outside of a React
+ * component and there is no reasonable way to pass that info down to where
+ * your code is happening, you can call this and it will return the currently
+ * held info or `undefined` if user info not pulled yet or there was an error.
+ *
+ * Note that this implementation is also a bit brittle since we must manually
+ * map the raw response data from the user info request into the JS object keys
+ * we use in FE app. That's normally taken care of by `useUserInfo` because
+ * of how it's set up, but we must manually call that func here.
+ */
+export const getCurrentUserInfo = (): User | undefined => {
+  const rawUser = queryClient.getQueryData<RawUserRequest>([USE_USER_INFO]);
+  return rawUser && mapUserData(rawUser);
 };


### PR DESCRIPTION
### Summary:
- **What:** Cleans up the user/group info process with analytics: uses the new de-identified `analytics_id` field we have for users and also handles changes to currently active group
- **Ticket:** [sc<199706>](https://app.shortcut.com/genepi/story/<199706>)
- **Env:** None, tested locally and will do major rdev for analytics testing all features at once soon

### Demos:
From Segment debugger

<img width="1531" alt="image" src="https://user-images.githubusercontent.com/89553795/184077250-a4d38816-a2a3-483a-8c43-b6e62e48f660.png">

^^^ Can see the active group change event, and then a new track event fired to record change for what user's current group is.

### Checklist:
- [x] I merged latest `vince/analytics`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests