### PR TITLE
Restart oidc server when generating a new cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ oauth/pkcs12/certificate.pfx:
 	# On Linux, the pkcs12 directory gets written to with root permission. Force ownership to our user.
 	sudo chown -R $$(id -u):$$(id -g) $(PWD)/oauth/pkcs12
 	# If the OIDC server is already running, restart it to use the new certs
-	docker compose restart oidc
+	$(docker_compose) restart oidc
 
 .env.ecr:
 	export AWS_ACCOUNT_ID=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,10 @@ oauth/pkcs12/certificate.pfx:
 	# On Linux, the pkcs12 directory gets written to with root permission. Force ownership to our user.
 	sudo chown -R $$(id -u):$$(id -g) $(PWD)/oauth/pkcs12
 	# If the OIDC server is already running, restart it to use the new certs
-	$(docker_compose) restart oidc
+	if [ -n "$$(docker ps -q -f name=oidc)" ]; then \
+		echo "Restarting OIDC server"; \
+		$(docker_compose) restart oidc; \
+	fi
 
 .env.ecr:
 	export AWS_ACCOUNT_ID=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ oauth/pkcs12/certificate.pfx:
 	docker run -v $(PWD)/oauth/pkcs12:/tmp/certs --workdir /tmp/certs --rm=true --entrypoint bash soluto/oidc-server-mock:0.3.0 ./generate_pfx.sh
 	# On Linux, the pkcs12 directory gets written to with root permission. Force ownership to our user.
 	sudo chown -R $$(id -u):$$(id -g) $(PWD)/oauth/pkcs12
+	# If the OIDC server is already running, restart it to use the new certs
+	docker compose restart oidc
 
 .env.ecr:
 	export AWS_ACCOUNT_ID=$$(aws sts get-caller-identity --profile $(AWS_DEV_PROFILE) | jq -r .Account); \


### PR DESCRIPTION
### Summary:
- **What:** The sequence make local-clean and make local-sync breaks; the OIDC server launches before the Kestrel certificates are generated, so it crashes when trying to read the nonexistent certificates. This restarts the OIDC server upon generation of a new certificate.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)