### PR TITLE
Patch up localstack persistence.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login local-hostconf
 	# Hack - CI keeps recreating localstack for some reason :'(
 	$(docker_compose) --profile $(LOCALDEV_PROFILE) up -d
 	./scripts/setup_dev_data.sh
+	$(docker_compose) restart backend
 	$(docker_compose) exec -T backend alembic upgrade head
 	$(docker_compose) exec -T backend python scripts/setup_localdata.py
 	$(docker_compose) --profile $(LOCALDEV_PROFILE) up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,16 +103,19 @@ services:
         aliases:
           - backend.genepinet.localdev
   localstack:
-    image: localstack/localstack:0.14.3
+    image: localstack/localstack:0.13.0
     profiles: [ "backend", "web", "all" ]
     ports:
       - "4566:4566"
     environment:
-      - EAGER_SERVICE_LOADING=1
       - HOSTNAME_EXTERNAL=localstack
+      - LEGACY_PERSISTENCE=1
+      - EAGER_SERVICE_LOADING=1
       - SERVICES=s3,secretsmanager,stepfunctions,ssm,iam
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - HOST_TMP_FOLDER=${TMPDIR}
       - DEFAULT_REGION=us-west-2
     volumes:
       - localstack:/tmp/localstack


### PR DESCRIPTION
### Notes:
Reverts to an older version of localstack that supports persistence and enables it, so we won't loose localstack data (secrets, s3 buckets, etc) every time the localstack container restarts.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)