### PR TITLE
use given subtree size when generating usher links

### DIFF
--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -290,15 +290,16 @@ def usher():
 
 @usher.command(name="get-link")
 @click.argument("sample_ids", nargs=-1)
+@click.argument("sample_count", nargs=1)
 @click.pass_context
-def get_link(ctx, sample_ids):
+def get_link(ctx, sample_ids, sample_count = 50):
     api_client = ctx.obj["api_client"]
     payload = {"samples": sample_ids, "downstream_consumer": "USHER"}
     resp = api_client.post_with_org("/v2/sequences/getfastaurl", json=payload)
     resp_info = resp.json()
     s3_url = resp_info["url"]
     print(
-        f"https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile={quote(s3_url)}"
+        f"https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&subtreeSize={sample_count}&remoteFile={quote(s3_url)}"
     )
 
 

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -8,6 +8,7 @@ import {
   getUsherOptions,
   useFastaFetch,
 } from "src/common/queries/trees";
+import { ROUTES } from "src/common/routes";
 import {
   StyledCloseIconButton,
   StyledCloseIconWrapper,
@@ -44,7 +45,7 @@ interface Props {
   failedSampleIds: string[];
   open: boolean;
   onClose: () => void;
-  onLinkCreateSuccess(url: string, treeType: string): void;
+  onLinkCreateSuccess(url: string, treeType: string, sampleCount: number): void;
 }
 
 interface DropdownOptionProps extends DefaultMenuSelectOption {
@@ -79,6 +80,9 @@ export const UsherPlacementModal = ({
   const [isUsherDisabled, setUsherDisabled] = useState<boolean>(false);
   const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(false);
   const [treeType, setTreeType] = useState<string>("");
+  const [numSamplesPerSubtree, setNumSamplesPerSubtree] = useState<number>(
+    SUGGESTED_MIN_SAMPLES
+  );
 
   const defaultNumSamples = getDefaultNumSamplesPerSubtree(
     checkedSampleIds?.length
@@ -120,7 +124,7 @@ export const UsherPlacementModal = ({
     },
     componentOnSuccess: (data: FastaResponseType) => {
       const url = data?.url;
-      if (url) onLinkCreateSuccess(data.url, treeType);
+      if (url) onLinkCreateSuccess(data.url, treeType, numSamplesPerSubtree);
       setIsLoading(false);
     },
   });
@@ -140,9 +144,7 @@ export const UsherPlacementModal = ({
   const MAIN_USHER_TOOLTIP_TEXT = (
     <div>
       UShER is a third-party tool and has its own policies.{" "}
-      <NewTabLink href="https://genome.ucsc.edu/cgi-bin/hgPhyloPlace">
-        Learn more about UShER.
-      </NewTabLink>
+      <NewTabLink href={ROUTES.USHER}>Learn more about UShER.</NewTabLink>
     </div>
   );
 
@@ -180,6 +182,7 @@ export const UsherPlacementModal = ({
     (e) => {
       const numSamples = e?.target?.value;
       const showWarning = !numSamples || numSamples < SUGGESTED_MIN_SAMPLES;
+      setNumSamplesPerSubtree(numSamples);
       setShouldShowWarning(showWarning);
     },
     ONE_SECOND,

--- a/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/UsherTreeFlow/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { EVENT_TYPES } from "src/common/analytics/eventTypes";
 import { analyticsTrackEvent } from "src/common/analytics/methods";
+import { ROUTES } from "src/common/routes";
 import Notification from "src/components/Notification";
 import { UsherConfirmationModal } from "./components/UsherConfirmationModal";
 import { UsherPlacementModal } from "./components/UsherPlacementModal";
@@ -12,13 +13,26 @@ interface Props {
   shouldStartUsherFlow: boolean;
 }
 
-const generateUsherLink = (remoteFile: string, treeType: string) => {
-  const USHER_URL =
-    "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&remoteFile=";
-  const USHER_TREE_TYPE_QUERY = "&phyloPlaceTree=";
+const generateUsherLink = (
+  remoteFile: string,
+  treeType: string,
+  sampleCount: number
+) => {
   const encodedFileLink = encodeURIComponent(remoteFile);
 
-  return `${USHER_URL}${encodedFileLink}${USHER_TREE_TYPE_QUERY}${treeType}`;
+  const DB_PARAM = `db=wuhCor1`;
+  const FILE_PARAM = `remoteFile=${encodedFileLink}`;
+  const TREE_TYPE_PARAM = `phyloPlaceTree=${treeType}`;
+  const SAMPLE_COUNT_PARAM = `subtreeSize=${sampleCount}`;
+
+  const queryParams = [
+    DB_PARAM,
+    FILE_PARAM,
+    TREE_TYPE_PARAM,
+    SAMPLE_COUNT_PARAM,
+  ].join("&");
+
+  return `${ROUTES.USHER}?${queryParams}`;
 };
 
 const UsherTreeFlow = ({
@@ -46,8 +60,12 @@ const UsherTreeFlow = ({
     link.remove();
   };
 
-  const onLinkCreateSuccess = (url: string, treeType: string) => {
-    const usherLink = generateUsherLink(url, treeType);
+  const onLinkCreateSuccess = (
+    url: string,
+    treeType: string,
+    sampleCount: number
+  ) => {
+    const usherLink = generateUsherLink(url, treeType, sampleCount);
     setUsherLink(usherLink);
     setIsConfirmOpen(true);
   };


### PR DESCRIPTION
### Summary
- **What:** Actually use the subtree size given by the user when generating usher trees (including in cli!)
- **Why:** It's confusing when a user gets a tree that isn't the size they specified
- **Ticket:** [[sc-210283]](https://app.shortcut.com/genepi/story/210283)
- **Env:** https://maya-usher-frontend.dev.czgenepi.org/

### Testing
1. Choose a sample to make a placement
1. Set a custom tree size (besides 50)
2. Ensure the resulting placement contains the number of samples per subtree you gave it.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)