### PR TITLE
split pathogen support

### DIFF
--- a/src/backend/aspen/api/views/auth.py
+++ b/src/backend/aspen/api/views/auth.py
@@ -232,7 +232,7 @@ async def auth(
     # Always re-sync auth0 groups to our db on login!
     # Make sure the user is in auth0 before sync'ing roles.
     #  ex: User1 in local dev doesn't exist in auth0
-    sync_roles = splitio.get_flag("sync_auth0_roles", user)
+    sync_roles = splitio.get_usergroup_treatment("sync_auth0_roles", user)
     if sync_roles == "on":
         if user.auth0_user_id.startswith("auth0|"):
             await RoleManager.sync_user_roles(db, a0, user)
@@ -303,7 +303,7 @@ async def process_invitation(
     a0.delete_organization_invitation(ticket_info["organization_id"], ticket_info["id"])
 
     # ok, now sync a0 roles to the db.
-    sync_roles = splitio.get_flag("sync_auth0_roles", user)
+    sync_roles = splitio.get_usergroup_treatment("sync_auth0_roles", user)
     if sync_roles == "on":
         await RoleManager.sync_user_roles(db, a0, user)
         await db.commit()

--- a/src/backend/aspen/api/views/tests/test_auth.py
+++ b/src/backend/aspen/api/views/tests/test_auth.py
@@ -294,7 +294,7 @@ async def test_callback_syncs_auth0_user_roles(
     async_session.add(group)
     await async_session.commit()
 
-    split_client.get_flag.side_effect = ["on"]  # type: ignore
+    split_client.get_usergroup_treatment.side_effect = ["on"]  # type: ignore
     auth0_apiclient.get_org_user_roles.side_effect = [["admin"]]  # type: ignore
     auth0_oauth.authorize_access_token.side_effect = [{"userinfo": userinfo}]  # type: ignore
     auth0_apiclient.get_user_orgs.side_effect = [[]]  # type: ignore
@@ -351,7 +351,7 @@ async def test_callback_ff_doesnt_sync_auth0_user_roles(
     async_session.add(group)
     await async_session.commit()
 
-    split_client.get_flag.side_effect = ["control"]  # type: ignore
+    split_client.get_usergroup_treatment.side_effect = ["control"]  # type: ignore
     auth0_apiclient.get_org_user_roles.side_effect = [["admin"]]  # type: ignore
     auth0_oauth.authorize_access_token.side_effect = [{"userinfo": userinfo}]  # type: ignore
     auth0_apiclient.get_user_orgs.side_effect = [[]]  # type: ignore
@@ -423,7 +423,7 @@ async def test_redirect_to_samples_if_exists(
     async_session.add(user)
     await async_session.commit()
 
-    split_client.get_flag.side_effect = ["control"]  # type: ignore
+    split_client.get_usergroup_treatment.side_effect = ["control"]  # type: ignore
     auth0_apiclient.get_org_user_roles.side_effect = [["admin"]]  # type: ignore
     auth0_oauth.authorize_access_token.side_effect = [{"userinfo": userinfo}]  # type: ignore
     auth0_apiclient.get_user_orgs.side_effect = [[]]  # type: ignore
@@ -458,7 +458,7 @@ async def test_redirect_to_group_welcome_if_new(
     async_session.add(group)
     await async_session.commit()
 
-    split_client.get_flag.side_effect = ["control"]  # type: ignore
+    split_client.get_usergroup_treatment.side_effect = ["control"]  # type: ignore
     auth0_apiclient.get_org_user_roles.side_effect = [["admin"]]  # type: ignore
     auth0_oauth.authorize_access_token.side_effect = [{"userinfo": userinfo}]  # type: ignore
     auth0_apiclient.get_user_orgs.side_effect = [[]]  # type: ignore

--- a/src/backend/aspen/api/views/tests/test_invitation_flows.py
+++ b/src/backend/aspen/api/views/tests/test_invitation_flows.py
@@ -56,7 +56,7 @@ async def setup_invitation_flows(
         "name": "user1",
     }
 
-    split_client.get_flag.return_value = "on"  # type: ignore
+    split_client.get_usergroup_treatment.return_value = "on"  # type: ignore
     auth0_oauth.authorize_access_token.return_value = {"userinfo": userinfo}  # type: ignore
     return user1, user2, group
 

--- a/src/backend/aspen/api/views/tests/test_split.py
+++ b/src/backend/aspen/api/views/tests/test_split.py
@@ -3,10 +3,6 @@ from aspen.database.models.pathogens import Pathogen
 from aspen.util.split import SplitClient
 
 
-def create_test_pathogen():
-    return Pathogen(slug="SC2", name="SARS-CoV-2")
-
-
 def test_treatments():
     # test that treatments are returned correctly based on traffic type
     pathogen = Pathogen(slug="SC2", name="SARS-CoV-2")

--- a/src/backend/aspen/api/views/tests/test_split.py
+++ b/src/backend/aspen/api/views/tests/test_split.py
@@ -9,9 +9,9 @@ def test_treatments():
     settings = Settings()
     splitio = SplitClient(settings)
 
-    treatment = splitio.get_pathogen_flag("pathogen_feature", pathogen)
+    treatment = splitio.get_pathogen_treatment("pathogen_feature", pathogen)
     assert treatment == "on"
 
     pathogen.slug = "MPX"
-    treatment = splitio.get_pathogen_flag("pathogen_feature", pathogen)
+    treatment = splitio.get_pathogen_treatment("pathogen_feature", pathogen)
     assert treatment == "control"  # this is the default

--- a/src/backend/aspen/api/views/tests/test_split.py
+++ b/src/backend/aspen/api/views/tests/test_split.py
@@ -1,0 +1,21 @@
+from aspen.api.settings import Settings
+from aspen.database.models.pathogens import Pathogen
+from aspen.util.split import SplitClient
+
+
+def create_test_pathogen():
+    return Pathogen(slug="SC2", name="SARS-CoV-2")
+
+
+def test_treatments():
+    # test that treatments are returned correctly based on traffic type
+    pathogen = Pathogen(slug="SC2", name="SARS-CoV-2")
+    settings = Settings()
+    splitio = SplitClient(settings)
+
+    treatment = splitio.get_pathogen_flag("pathogen_feature", pathogen)
+    assert treatment == "on"
+
+    pathogen.slug = "MPX"
+    treatment = splitio.get_pathogen_flag("pathogen_feature", pathogen)
+    assert treatment == "control"  # this is the default

--- a/src/backend/aspen/database/models/__init__.py
+++ b/src/backend/aspen/database/models/__init__.py
@@ -14,12 +14,14 @@ from aspen.database.models.gisaid_dump import (  # noqa: F401
 from aspen.database.models.gisaid_metadata import GisaidMetadata  # noqa: F401
 from aspen.database.models.locations import Location  # noqa: F401
 from aspen.database.models.pango_lineages import PangoLineage  # noqa: F401
+from aspen.database.models.pathogens import Pathogen, PathogenRepoConfig
 from aspen.database.models.phylo_tree import (  # noqa: F401
     PhyloRun,
     PhyloTree,
     PhyloTreeSamples,
     TreeType,
 )
+from aspen.database.models.public_repositories import PublicRepository
 from aspen.database.models.sample import Sample  # noqa: F401
 from aspen.database.models.sequences import (  # noqa: F401
     PathogenGenome,
@@ -39,7 +41,5 @@ from aspen.database.models.workflow import (  # noqa: F401
     WorkflowStatusType,
     WorkflowType,
 )
-from aspen.database.models.pathogens import Pathogen, PathogenRepoConfig
-from aspen.database.models.public_repositories import PublicRepository
 
 configure_mappers()

--- a/src/backend/aspen/database/models/__init__.py
+++ b/src/backend/aspen/database/models/__init__.py
@@ -39,5 +39,7 @@ from aspen.database.models.workflow import (  # noqa: F401
     WorkflowStatusType,
     WorkflowType,
 )
+from aspen.database.models.pathogens import Pathogen, PathogenRepoConfig
+from aspen.database.models.public_repositories import PublicRepository
 
 configure_mappers()

--- a/src/backend/aspen/database/models/__init__.py
+++ b/src/backend/aspen/database/models/__init__.py
@@ -14,14 +14,14 @@ from aspen.database.models.gisaid_dump import (  # noqa: F401
 from aspen.database.models.gisaid_metadata import GisaidMetadata  # noqa: F401
 from aspen.database.models.locations import Location  # noqa: F401
 from aspen.database.models.pango_lineages import PangoLineage  # noqa: F401
-from aspen.database.models.pathogens import Pathogen, PathogenRepoConfig
+from aspen.database.models.pathogens import Pathogen, PathogenRepoConfig  # noqa: F401
 from aspen.database.models.phylo_tree import (  # noqa: F401
     PhyloRun,
     PhyloTree,
     PhyloTreeSamples,
     TreeType,
 )
-from aspen.database.models.public_repositories import PublicRepository
+from aspen.database.models.public_repositories import PublicRepository  # noqa: F401
 from aspen.database.models.sample import Sample  # noqa: F401
 from aspen.database.models.sequences import (  # noqa: F401
     PathogenGenome,

--- a/src/backend/aspen/util/split.py
+++ b/src/backend/aspen/util/split.py
@@ -1,4 +1,6 @@
+from inspect import Parameter
 from typing import Optional
+from aspen.database.models.pathogens import Pathogen
 
 from splitio import get_factory
 from splitio.client.client import Client as SplitioClient
@@ -32,9 +34,17 @@ class SplitClient:
             params["group_id"] = group.id
         return params
 
-    def get_flag(self, treatment: str, user: User, group: Optional[Group] = None):
+    def get_flag(self, feature: str, user: User, group: Optional[Group] = None):
+        # feature: ex: usher_enabled, a functionality block
         parameters = self.generate_parameters(user, group)
         treatment = self.split_client.get_treatment(
-            user.split_id, treatment, parameters
+            user.split_id, feature, parameters
+        )
+        return treatment
+
+    def get_pathogen_flag(self, feature: str, pathogen: Pathogen):
+        params = {} # empty for now, but we may want to make more complicated desicions with split later.
+        treatment = self.split_client.get_treatment(
+            pathogen.slug, feature, params
         )
         return treatment

--- a/src/backend/aspen/util/split.py
+++ b/src/backend/aspen/util/split.py
@@ -1,12 +1,11 @@
-from inspect import Parameter
 from typing import Optional
-from aspen.database.models.pathogens import Pathogen
 
 from splitio import get_factory
 from splitio.client.client import Client as SplitioClient
 from splitio.exceptions import TimeoutException
 
 from aspen.database.models import Group, User
+from aspen.database.models.pathogens import Pathogen
 
 
 class SplitClient:
@@ -34,17 +33,18 @@ class SplitClient:
             params["group_id"] = group.id
         return params
 
-    def get_flag(self, feature: str, user: User, group: Optional[Group] = None):
-        # feature: ex: usher_enabled, a functionality block
+    def get_usergroup_treatment(
+        self, feature: str, user: User, group: Optional[Group] = None
+    ):
+
         parameters = self.generate_parameters(user, group)
-        treatment = self.split_client.get_treatment(
-            user.split_id, feature, parameters
-        )
+        treatment = self.split_client.get_treatment(user.split_id, feature, parameters)
         return treatment
 
-    def get_pathogen_flag(self, feature: str, pathogen: Pathogen):
-        params = {} # empty for now, but we may want to make more complicated desicions with split later.
-        treatment = self.split_client.get_treatment(
-            pathogen.slug, feature, params
-        )
+    def get_pathogen_treatment(self, feature: str, pathogen: Pathogen):
+        # feature refers to a functionality block (split) ex: usher_enabled, public_repository
+        params = (
+            {}
+        )  # empty for now, but we may want to use it later to make more complicated desicions with split.
+        treatment = self.split_client.get_treatment(pathogen.slug, feature, params)
         return treatment

--- a/src/backend/aspen/util/split.py
+++ b/src/backend/aspen/util/split.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from splitio import get_factory
 from splitio.client.client import Client as SplitioClient
@@ -45,8 +45,6 @@ class SplitClient:
         # feature refers to a functionality block (split) ex: usher_enabled, public_repository
 
         # params is empty for now, but we may want to use it later to make more complicated desicions with split.
-        params = (
-            {}
-        )
+        params: Dict[str, str] = {}
         treatment = self.split_client.get_treatment(pathogen.slug, feature, params)
         return treatment

--- a/src/backend/aspen/util/split.py
+++ b/src/backend/aspen/util/split.py
@@ -43,8 +43,10 @@ class SplitClient:
 
     def get_pathogen_treatment(self, feature: str, pathogen: Pathogen):
         # feature refers to a functionality block (split) ex: usher_enabled, public_repository
+
+        # params is empty for now, but we may want to use it later to make more complicated desicions with split.
         params = (
             {}
-        )  # empty for now, but we may want to use it later to make more complicated desicions with split.
+        )
         treatment = self.split_client.get_treatment(pathogen.slug, feature, params)
         return treatment

--- a/src/backend/etc/split.yml
+++ b/src/backend/etc/split.yml
@@ -13,3 +13,6 @@
     treatment: "on"
 - test_feature:
     treatment: "off"
+- pathogen_feature:
+    treatment: "on"
+    keys: "SC2"


### PR DESCRIPTION
### Summary:
- **What:** update SplitClient to return treatments for pathogen traffic types
- **Ticket:** [sc211445](https://app.shortcut.com/genepi/story/211445)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)