### PR TITLE
add gisaid prefixes to samples on trees

### DIFF
--- a/src/backend/aspen/api/utils/phylo.py
+++ b/src/backend/aspen/api/utils/phylo.py
@@ -57,9 +57,10 @@ def _rename_nodes_on_tree(
     gisaid_prefix = "hCoV-19/"
 
     # The mixed situations we're dealing with here:
-    #  - The public identifiers in our database *do not* have gisaid prefixes on them
-    #  - The samples on a tree *sometimes* do and sometimes don't have gisaid prefixes on them.
-    #  - At the end of this method, we want gisaid prefixes added to *all* tree samples.
+    #  - The public identifiers in our database *sometimes* have gisaid prefixes on them
+    #  - The samples on a tree *sometimes* have gisaid prefixes on them.
+    #  - We want to match identifiers from trees and the db with the prefix *stripped*
+    #  - At the end of this method, we want *all* tree samples to have gisaid prefixes on them.
     # So this means we have to:
     #  - Strip gisaid prefixes from tree nodes before trying to match them to db samples
     #  - Add gisaid prefixes to all public tree identifiers if they aren't already prefixed

--- a/src/backend/aspen/api/utils/phylo.py
+++ b/src/backend/aspen/api/utils/phylo.py
@@ -73,7 +73,11 @@ def _rename_nodes_on_tree(
     renamed_value = name_map.get(tree_identifier, None)
 
     # Make sure we have the gisaid prefix on this node when we output it.
-    node["name"] = f"{gisaid_prefix}{tree_identifier}"
+    node["name"] = (
+        f"{gisaid_prefix}{tree_identifier}"
+        if not tree_identifier.startswith("NODE_")
+        else tree_identifier
+    )
     if renamed_value is not None:
         # we found the replacement value! first, save the old value if the caller
         # requested.

--- a/src/backend/aspen/api/views/phylo_trees.py
+++ b/src/backend/aspen/api/views/phylo_trees.py
@@ -66,9 +66,12 @@ async def _get_selected_samples(db: AsyncSession, phylo_tree_id: int):
     # identifier check here since the process_phylo_tree method already does that
     # filtering, and this data is only used to match any identifiers that are
     # *already* on the tree.
+    gisaid_prefix = "hCoV-19/"
     for uploaded_pathogen_genome in phylo_run.inputs:
         sample = uploaded_pathogen_genome.sample
-        selected_samples.add(prefix_regex.sub("", sample.public_identifier))
+        stripped_identifier = prefix_regex.sub("", sample.public_identifier)
+        selected_samples.add(stripped_identifier)
+        selected_samples.add(f"{gisaid_prefix}{stripped_identifier}")
         selected_samples.add(sample.private_identifier)
     return selected_samples
 

--- a/src/backend/aspen/api/views/tests/test_auspice.py
+++ b/src/backend/aspen/api/views/tests/test_auspice.py
@@ -78,13 +78,13 @@ async def test_valid_auspice_link_access(
 
     assert "meta" in res_json.keys()
     assert "tree" in res_json.keys()
-    assert res_json["tree"]["name"] == "ROOT"
+    assert res_json["tree"]["name"] == "hCoV-19/ROOT"
     assert res_json["tree"]["branch_attrs"]["labels"]["clade"] == "42"
     test_children = res_json["tree"]["children"]
     for index in range(1, 2):
         child = test_children[index - 1]
         assert child["name"] == f"private_identifier_{index}"
-        assert child["GISAID_ID"] == f"public_identifier_{index}"
+        assert child["GISAID_ID"] == f"hCoV-19/public_identifier_{index}"
 
 
 async def test_unauth_user_auspice_link_generation(

--- a/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
+++ b/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
@@ -12,6 +12,7 @@ from aspen.api.views.tests.data.phylo_tree_data import TEST_TREE
 from aspen.api.views.tests.test_list_phylo_runs import make_all_test_data
 from aspen.api.views.tests.test_update_phylo_run_and_tree import make_shared_test_data
 from aspen.api.views.tests.utils.phylo_tree_utils import (
+    add_prefixes,
     align_json_with_model,
     create_id_mapped_tree,
 )
@@ -67,6 +68,8 @@ async def test_phylo_tree_id_style_public(
     user, group, samples, phylo_run, phylo_tree = await make_shared_test_data(
         async_session
     )
+    if not phylo_tree:
+        raise Exception("missing phylo tree")
 
     # Create the bucket if it doesn't exist in localstack.
     try:
@@ -85,8 +88,9 @@ async def test_phylo_tree_id_style_public(
         f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/download?id_style=public",
         headers=auth_headers,
     )
+    prefixed_tree = add_prefixes(TEST_TREE)
     returned_tree = result.json()
-    assert returned_tree["tree"] == TEST_TREE["tree"]
+    assert returned_tree["tree"] == prefixed_tree["tree"]
 
 
 async def test_phylo_tree_no_can_see(

--- a/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
+++ b/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
@@ -90,7 +90,7 @@ async def create_phylotree_with_inputs(
         samples.append(sample)
         input_entities.append(input_entity)
 
-    db_gisaid_samples = ["gisaid_identifier", "hCoV-19/gisaid_identifier2"]
+    db_gisaid_samples = ["hCoV-19/gisaid_identifier", "hCoV-19/gisaid_identifier2"]
     phylo_run = phylorun_factory(
         owner_group,
         inputs=input_entities,
@@ -100,7 +100,7 @@ async def create_phylotree_with_inputs(
         phylo_run,
         samples,
     )
-    tree_gisaid_samples = ["gisaid_identifier", "GISAID_identifier2"]
+    tree_gisaid_samples = ["gisaid_identifier", "hCoV-19/GISAID_identifier2"]
     upload_s3_file(mock_s3_resource, phylo_tree, samples, tree_gisaid_samples)
 
     async_session.add_all([phylo_tree])
@@ -158,7 +158,9 @@ async def test_tree_metadata_download(
         headers=auth_headers,
     )
     expected_filename = f"{phylo_tree.id}_sample_ids.tsv"
-    expected_document = "Sample Identifier\tSelected\r\n" "root_identifier_1	no\r\n"
+    expected_document = (
+        "Sample Identifier\tSelected\r\n" "hCoV-19/root_identifier_1	no\r\n"
+    )
     for sample in samples:
         expected_document += f"{sample.private_identifier}	no\r\n"
     file_contents = str(res.content, encoding="UTF-8")
@@ -213,12 +215,12 @@ async def test_private_id_matrix(
             "expected_status": 200,
             "expected_data": (
                 "Sample Identifier\tSelected\r\n"
-                f"root_identifier_1	no\r\n"
-                f"{samples[0].public_identifier}	yes\r\n"
-                f"{samples[1].public_identifier}	yes\r\n"
-                f"{samples[2].public_identifier}	yes\r\n"
-                f"gisaid_identifier	yes\r\n"
-                f"GISAID_identifier2	yes\r\n"
+                f"hCoV-19/root_identifier_1	no\r\n"
+                f"hCoV-19/{samples[0].public_identifier}	yes\r\n"
+                f"hCoV-19/{samples[1].public_identifier}	yes\r\n"
+                f"hCoV-19/{samples[2].public_identifier}	yes\r\n"
+                f"hCoV-19/gisaid_identifier	yes\r\n"
+                f"hCoV-19/GISAID_identifier2	yes\r\n"
             ),
         },
     ]
@@ -271,7 +273,7 @@ async def test_tree_metadata_replaces_all_ids(
     assert res.status_code == 200
     expected_data = (
         "Sample Identifier\tSelected\r\n"
-        f"root_identifier_1	no\r\n"
+        f"hCoV-19/root_identifier_1	no\r\n"
         f"{samples[0].private_identifier}	yes\r\n"
         f"{extra_sample.private_identifier}	no\r\n"
     )
@@ -316,9 +318,9 @@ async def test_public_tree_metadata_replaces_all_ids(
     assert res.status_code == 200
     expected_data = (
         "Sample Identifier\tSelected\r\n"
-        f"root_identifier_1	no\r\n"
-        f"{samples[0].public_identifier}	yes\r\n"
-        f"{extra_sample.public_identifier}	no\r\n"
+        f"hCoV-19/root_identifier_1	no\r\n"
+        f"hCoV-19/{samples[0].public_identifier}	yes\r\n"
+        f"hCoV-19/{extra_sample.public_identifier}	no\r\n"
     )
     file_contents = str(res.content, encoding="UTF-8")
     assert file_contents == expected_data

--- a/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
@@ -87,7 +87,8 @@ async def test_phylo_tree_rename(
             user,
             location,
             private_identifier=f"private_identifier_can_see_{i}",
-            public_identifier=f"public_identifier_can_see_{i}",
+            # Make sure our renaming works properly if our db samples have the gisaid prefix in them.
+            public_identifier=f"hCoV-19/public_identifier_can_see_{i}",
         )
         for i in range(2)
     ]
@@ -141,26 +142,26 @@ async def test_phylo_tree_rename(
     tree = result.json()
     assert tree["tree"] == {
         "name": "private_identifier_0",
-        "GISAID_ID": "public_identifier_0",
+        "GISAID_ID": "hCoV-19/public_identifier_0",
         "children": [
             {
-                "GISAID_ID": "public_identifier_can_see_0",
+                "GISAID_ID": "hCoV-19/public_identifier_can_see_0",
                 "name": "private_identifier_can_see_0",
             },
             {
-                "GISAID_ID": "public_identifier_can_see_1",
+                "GISAID_ID": "hCoV-19/public_identifier_can_see_1",
                 "name": "private_identifier_can_see_1",
             },
             {
-                "name": "public_identifier_wrong_0",
+                "name": "hCoV-19/public_identifier_wrong_0",
                 "children": [
                     {
-                        "GISAID_ID": "public_identifier_1",
+                        "GISAID_ID": "hCoV-19/public_identifier_1",
                         "name": "private_identifier_1",
                     },
-                    {"name": "public_identifier_wrong_1"},
-                    {"name": "public_identifier_nosee_0"},
-                    {"name": "public_identifier_nosee_1"},
+                    {"name": "hCoV-19/public_identifier_wrong_1"},
+                    {"name": "hCoV-19/public_identifier_nosee_0"},
+                    {"name": "hCoV-19/public_identifier_nosee_1"},
                 ],
             },
         ],

--- a/src/backend/aspen/api/views/tests/utils/phylo_tree_utils.py
+++ b/src/backend/aspen/api/views/tests/utils/phylo_tree_utils.py
@@ -6,9 +6,24 @@ from aspen.database.models import PhyloTree
 
 def create_id_mapped_tree(input_json: dict) -> dict:
     clone = deepcopy(input_json)
+    clone["tree"]["name"] = f"hCoV-19/{clone['tree']['name']}"
     for node in clone["tree"]["children"]:
-        node["GISAID_ID"] = node["name"]
+        node["GISAID_ID"] = f"hCoV-19/{node['name']}"
         node["name"] = node["name"].replace("public", "private")
+    return clone
+
+
+def add_subtree_prefixes(subtree):
+    for node in subtree:
+        node["name"] = f"hCoV-19/{node['name']}"
+        if "children" in node:
+            add_subtree_prefixes(node["children"])
+
+
+def add_prefixes(input_json: dict) -> dict:
+    clone = deepcopy(input_json)
+    clone["tree"]["name"] = f"hCoV-19/{clone['tree']['name']}"
+    add_subtree_prefixes(clone["tree"]["children"])
     return clone
 
 

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -508,18 +508,6 @@ def phylo_trees():
     pass
 
 
-@phylo_trees.command(name="selected-samples")
-@click.argument("tree_id")
-@click.pass_context
-def selected_samples(ctx, tree_id):
-    api_client = ctx.obj["api_client"]
-    params = {}
-    resp = api_client.get_with_org(
-        f"/v2/phylo_trees/{tree_id}/sample_ids", params=params
-    )
-    print(resp.text)
-
-
 @phylo_trees.command(name="download")
 @click.argument("tree_id")
 @click.option("--public-ids/--private-ids", is_flag=True, default=False)
@@ -535,11 +523,11 @@ def download_tree(ctx, tree_id, public_ids):
     print(resp.text)
 
 
-@phylo_trees.command(name="get-sample-ids")
+@phylo_trees.command(name="selected-samples")
 @click.argument("tree_id")
 @click.option("--public-ids/--private-ids", is_flag=True, default=False)
 @click.pass_context
-def get_tree_sample_ids(ctx, tree_id, public_ids):
+def get_selected_samples(ctx, tree_id, public_ids):
     api_client = ctx.obj["api_client"]
     params = {}
     if public_ids:

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import logging
 import os.path
 import time
 import webbrowser
@@ -147,7 +148,7 @@ class ApiClient:
     def url_with_org(self, path):
         if self.org_id:
             path = path.replace("/v2/", f"/v2/orgs/{self.org_id}/")
-        print(f"path: {path}")
+        logging.info(f"path: {path}")
         return path
 
     def get_with_org(self, path, **kwargs):


### PR DESCRIPTION
### Summary:
- **What:** Add gisaid prefix to trees
- **Ticket:** [sc209810](https://app.shortcut.com/genepi/story/209810)
- **Env:** https://gisaidids-frontend.dev.czgenepi.org

### Notes:
This PR updates our tree & metadata download endpoints so that:
- regardless of whether or not the tree json in s3 has 'hCoV-19/' as a prefix for any given sample, *all* public identifiers in the tree will be updated to include the prefix before it gets sent back to the user.
- We try to match samples on a tree to samples in our db both *with* and *without* the 'hCoV-19/' prefix.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)