### PR TITLE
remove public id prefix

### DIFF
--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
@@ -58,11 +58,6 @@ const GroupDetailsTab = ({
             <InfoTooltip title="Group’s full Nextstrain location ID. CZ GEN EPI uses this as the default location parameters when building trees for this group." />
           </DetailSubheader>
           <DetailDisplay>{displayLocation}</DetailDisplay>
-          <DetailSubheader>
-            Sample Public ID Prefix
-            <InfoTooltip title="Set of characters used when auto-generating unique Public IDs for samples uploaded to this Group if a Public or GISAID ID is not provided." />
-          </DetailSubheader>
-          <DetailDisplay>{prefix}</DetailDisplay>
         </DetailSection>
         <DetailSection>
           <DetailHeader>GISAID Submission Details</DetailHeader>

--- a/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
+++ b/src/frontend/src/views/GroupMembersPage/components/GroupDetailsTab/index.tsx
@@ -24,7 +24,7 @@ const GroupDetailsTab = ({
 }: Props): JSX.Element | null => {
   if (!group) return null;
 
-  const { address, name, prefix, location } = group;
+  const { address, name, location } = group;
   const displayLocation = stringifyGisaidLocation(location);
 
   const InfoTooltip = ({ title }: { title: string }) => (


### PR DESCRIPTION
### Summary
- **What:** Remove sample prefix section from group details page
- **Why:** part of decovidify work
- **Ticket:** [[sc-210129]](https://app.shortcut.com/genepi/story/210129)
- **Env:** https://maya-prefix-frontend.dev.czgenepi.org/

### Demos
#### Before: 
![Screen Shot 2022-08-25 at 10 38 41 AM](https://user-images.githubusercontent.com/7562933/186732910-a0c9d513-43e9-4b5a-b4f6-7ef7b21d5137.png)
![Screen Shot 2022-08-25 at 10 38 46 AM](https://user-images.githubusercontent.com/7562933/186732925-5c1df892-df52-4d9d-a3fa-2e80c3573cf9.png)

#### After: 
![Screen Shot 2022-08-25 at 10 37 15 AM](https://user-images.githubusercontent.com/7562933/186732977-ec4ee733-a583-400a-81f4-712dd0674f90.png)
![Screen Shot 2022-08-25 at 10 37 20 AM](https://user-images.githubusercontent.com/7562933/186732990-e6f6e3b8-d163-4c74-84b6-3c7db373b883.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)