### PR TITLE
avoid console warning about props forwarded to div

### DIFF
--- a/src/frontend/src/components/CollapsibleInstructions/style.ts
+++ b/src/frontend/src/components/CollapsibleInstructions/style.ts
@@ -26,7 +26,12 @@ interface InstructionTitleProps extends HeaderProps {
   marginBottom?: SizeType;
 }
 
-const doNotForwardProps = ["buttonSize", "headerSize", "listPadding"];
+const doNotForwardProps = [
+  "buttonSize",
+  "headerSize",
+  "listPadding",
+  "marginBottom",
+];
 
 const headerSize = (props: HeaderProps) => {
   const { headerSize } = props;


### PR DESCRIPTION
Remove this warning from console.

<img width="1569" alt="Screen Shot 2022-08-25 at 8 32 25 PM" src="https://user-images.githubusercontent.com/7562933/186811795-45d51b3d-e0cb-4577-be13-382d64110c5d.png">