### PR TITLE
write out include.txt

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -71,8 +71,7 @@ $aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_meta
 (cd /ncov && snakemake --printshellcmds auspice/ncov_aspen.json --profile my_profiles/aspen/ --resources=mem_mb=312320) || { $aws s3 cp /ncov/.snakemake/log/ "${s3_prefix}/logs/snakemake/" --recursive ; $aws s3 cp /ncov/logs/ "${s3_prefix}/logs/ncov/" --recursive ; }
 
 # upload the tree to S3
-key="${key_prefix}/ncov_aspen.json"
-$aws s3 cp /ncov/auspice/ncov_aspen.json "s3://${aspen_s3_db_bucket}/${key}"
+$aws s3 cp /ncov/auspice/ncov_aspen.json "${s3_prefix}/ncov_aspen.json"
 
 # update aspen
 aspen_workflow_rev=WHATEVER

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -50,6 +50,7 @@ aligned_gisaid_location=$(
 
 # Persist the build config we generated.
 $aws s3 cp /ncov/my_profiles/aspen/builds.yaml "${s3_prefix}/builds.yaml"
+$aws s3 cp /ncov/data/include.txt "${s3_prefix}/include.txt"
 
 # If we don't have any county samples, copy the reference genomes to to our county file
 if [ ! -e /ncov/data/sequences_aspen.fasta ]; then


### PR DESCRIPTION
### Summary:
- **What:** Writing out the `include.txt` into S3. 2 motivations: 
(1) Useful for general debugging. 
(2) I was testing tree run on staging, and out of the 3 samples selected, only the last one made it onto the tree. Their sequences and metadata look fine, so I was trying to see what happened. If I can see them on this staging account, this group should have access to these samples 🤔 
<img width="1384" alt="Screen Shot 2022-08-30 at 12 51 53 PM" src="https://user-images.githubusercontent.com/20667188/187712190-561c481b-8878-4bf0-8a21-f3d2df9f4b51.png">

### Demos:
I have no way to test other than on staging... but I quadruple checked spelling. 

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)