### PR TITLE
[SC-211770] bug - TOS requires multiple clicks to close

### DIFF
--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -16,11 +16,7 @@ import { selectCurrentGroup } from "../redux/selectors";
 import { ensureValidGroup } from "../redux/utils/groupUtils";
 import { ROUTES } from "../routes";
 import { ENTITIES } from "./entities";
-import {
-  USE_GROUP_INFO,
-  USE_GROUP_INVITATION_INFO,
-  USE_GROUP_MEMBER_INFO,
-} from "./groups";
+import { GROUP_QUERY_PREFIX } from "./groups";
 
 const { API_URL } = ENV;
 
@@ -75,12 +71,10 @@ export function useUpdateUserInfo(): UseMutationResult<
 
   return useMutation(updateUserInfo, {
     onSuccess: async () => {
-      await queryClient.invalidateQueries([
-        USE_USER_INFO,
-        USE_GROUP_INFO,
-        USE_GROUP_INVITATION_INFO,
-        USE_GROUP_MEMBER_INFO,
-      ]);
+      // invalidateQueries only works for multiple queries if they start with the same key
+      // https://github.com/TanStack/query/discussions/2057#discussioncomment-549333
+      await queryClient.invalidateQueries([USE_USER_INFO]);
+      await queryClient.invalidateQueries([GROUP_QUERY_PREFIX]);
     },
   });
 }

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -16,7 +16,7 @@ import { selectCurrentGroup } from "../redux/selectors";
 import { ensureValidGroup } from "../redux/utils/groupUtils";
 import { ROUTES } from "../routes";
 import { ENTITIES } from "./entities";
-import { GROUP_QUERY_PREFIX } from "./groups";
+import { GROUP_QUERY_ID_PREFIX } from "./groups";
 
 const { API_URL } = ENV;
 
@@ -74,7 +74,7 @@ export function useUpdateUserInfo(): UseMutationResult<
       // invalidateQueries only works for multiple queries if they start with the same key
       // https://github.com/TanStack/query/discussions/2057#discussioncomment-549333
       await queryClient.invalidateQueries([USE_USER_INFO]);
-      await queryClient.invalidateQueries([GROUP_QUERY_PREFIX]);
+      await queryClient.invalidateQueries([GROUP_QUERY_ID_PREFIX]);
     },
   });
 }

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -78,6 +78,12 @@ export const mapGroupMemberData = (obj: RawGroupMemberRequest): GroupMember => {
 };
 
 /**
+ * starting all group-related queries with "group" allows us to invalidate
+ * all of the queries in a single call to queryClient.invalidateQueries(["group"])
+ */
+export const GROUP_QUERY_PREFIX = "group";
+
+/**
  * fetch group info
  */
 export const USE_GROUP_INFO = {

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -81,14 +81,14 @@ export const mapGroupMemberData = (obj: RawGroupMemberRequest): GroupMember => {
  * starting all group-related queries with "group" allows us to invalidate
  * all of the queries in a single call to queryClient.invalidateQueries(["group"])
  */
-export const GROUP_QUERY_PREFIX = "group";
+export const GROUP_QUERY_ID_PREFIX = "group";
 
 /**
  * fetch group info
  */
 export const USE_GROUP_INFO = {
   entities: [ENTITIES.GROUP_INFO],
-  id: "groupInfo",
+  id: `${GROUP_QUERY_ID_PREFIX}Info`,
 };
 
 export function useGroupInfo(): UseQueryResult<GroupDetails, unknown> {
@@ -117,7 +117,7 @@ interface GroupMembersFetchResponseType {
 
 export const USE_GROUP_MEMBER_INFO = {
   entities: [ENTITIES.GROUP_MEMBER_INFO],
-  id: "groupMemberInfo",
+  id: `${GROUP_QUERY_ID_PREFIX}MemberInfo`,
 };
 
 export function useGroupMembersInfo(): UseQueryResult<GroupMember[], unknown> {
@@ -149,7 +149,7 @@ interface FetchInvitationResponseType {
 
 export const USE_GROUP_INVITATION_INFO = {
   entities: [ENTITIES.GROUP_INVITATION_INFO],
-  id: "groupInvitationInfo",
+  id: `${GROUP_QUERY_ID_PREFIX}InvitationInfo`,
 };
 
 export function useGroupInvitations(): UseQueryResult<Invitation[], unknown> {

--- a/src/frontend/src/views/AgreeTerms/index.tsx
+++ b/src/frontend/src/views/AgreeTerms/index.tsx
@@ -13,7 +13,7 @@ import { useUpdateUserInfo, useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
 import { CURRENT_POLICY_VERSION } from "src/components/AcknowledgePolicyChanges";
 import { PageContent } from "../../common/styles/mixins/global";
-import { Details, SpacedBold, Title } from "./style";
+import { Details, SpacedBold, StyledIcon, Title } from "./style";
 
 export default function AgreeTerms(): JSX.Element | null {
   // `isTosViewable` -- Should user see ToS page?
@@ -135,6 +135,11 @@ export default function AgreeTerms(): JSX.Element | null {
           <DialogActions>
             <Button
               disabled={isUpdatingUserInfo}
+              startIcon={
+                isUpdatingUserInfo && (
+                  <StyledIcon sdsIcon="loading" sdsSize="l" sdsType="static" />
+                )
+              }
               sdsType="primary"
               sdsStyle="rounded"
               autoFocus
@@ -142,15 +147,15 @@ export default function AgreeTerms(): JSX.Element | null {
             >
               Accept
             </Button>
-            <a href={ENV.API_URL + API.LOG_OUT}>
-              <Button
-                disabled={isUpdatingUserInfo}
-                sdsType="secondary"
-                sdsStyle="rounded"
-              >
-                Decline
-              </Button>
-            </a>
+            <Button
+              component="a"
+              href={ENV.API_URL + API.LOG_OUT}
+              disabled={isUpdatingUserInfo}
+              sdsType="secondary"
+              sdsStyle="rounded"
+            >
+              Decline
+            </Button>
           </DialogActions>
         </Dialog>
       </PageContent>

--- a/src/frontend/src/views/AgreeTerms/style.tsx
+++ b/src/frontend/src/views/AgreeTerms/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { fontBodyS, fontHeaderXl, getSpaces } from "czifui";
+import { fontBodyS, fontHeaderXl, getColors, getSpaces, Icon } from "czifui";
 
 export const Title = styled.div`
   ${fontHeaderXl}
@@ -19,4 +19,14 @@ export const Details = styled.p`
 
 export const SpacedBold = styled.b`
   padding: 0 0.3em;
+`;
+
+export const StyledIcon = styled(Icon)`
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      fill: ${colors?.gray[500]};
+    `;
+  }}
 `;

--- a/src/frontend/src/views/AgreeTerms/style.tsx
+++ b/src/frontend/src/views/AgreeTerms/style.tsx
@@ -26,7 +26,7 @@ export const StyledIcon = styled(Icon)`
     const colors = getColors(props);
 
     return `
-      fill: ${colors?.gray[500]};
+      fill: ${colors?.gray[400]};
     `;
   }}
 `;


### PR DESCRIPTION
### Summary:
- **What:** `Use multiple invalidateQueries calls. Add icon loading to button.`
- **Ticket:** [sc211770](https://app.shortcut.com/genepi/story/211770/agree-to-terms-of-service-requires-double-agree-click)
- **Env:** `<rdev link>`

### Demos:
![TOS-one-click](https://user-images.githubusercontent.com/109251328/187789336-f176c091-1cc2-4650-8e55-9fb65d1055b5.gif)

### Notes:
This bug looked like an issue with the Terms of Service page.  However, the actual issue was that TOS redirected to the samples page and since the user data was not properly invalidated, the user was then redirected back to the TOS page.  This redirect loop continued until the new user data was fetched.  Invalidating (and refetching) the data fixed the issue.

The click looks a little slower now because it is actually invalidating and refetching data.  I added a spinner to the button so the user knows we're working on it.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)