### PR TITLE
Install poetry via pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ local-dbconsole-profile: ## Connect to the local postgres database and profile q
 
 .PHONY: local-update-backend-deps
 local-update-backend-deps: ## Update poetry.lock to reflect pyproject.toml file changes.
-	$(docker_compose) exec backend /opt/poetry/bin/poetry update
+	$(docker_compose) exec backend poetry update
 
 .PHONY: local-update-frontend-deps
 local-update-frontend-deps: ## Update package-lock.json to reflect package.json file changes.

--- a/docs/DEV_ENV.md
+++ b/docs/DEV_ENV.md
@@ -67,7 +67,7 @@ To update frontend changes:
 
 To update backend dependencies:
 
-1. run 'docker compose exec backend /opt/poetry/bin/poetry add PACKAGE_NAME_HERE`
+1. run 'docker compose exec backend poetry add PACKAGE_NAME_HERE`
 
 ### Update Dev Data
 

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,20 +1,17 @@
 FROM python:3.9.1-slim AS build
 ENV FLASK_APP=aspen.main
 RUN apt-get update && apt-get install -y vim build-essential libdigest-sha-perl wget unzip libdigest-sha-perl
-ENV POETRY_HOME /opt/poetry/
-RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetry.py && \
-    echo "e973b3badb95a916bfe250c22eeb7253130fd87312afa326eb02b8bdcea8f4a7  get-poetry.py" > get-poetry.py.sha256 && \
-    shasum -a 256 -c get-poetry.py.sha256 && \
-    python get-poetry.py && \
-    rm get-poetry*
+ENV POETRY_VERSION=1.1.15
+RUN python3 -m pip install poetry==$POETRY_VERSION
 COPY pyproject.toml poetry.lock environment.yaml ./
 COPY third-party ./third-party
 # Install our customized sqlalchemy-oso package.
 RUN wget https://github.com/chanzuckerberg/oso/archive/czge-oso25.zip -O oso.zip && \
-    unzip oso.zip && \
+    unzip -q oso.zip && \
     mv oso-czge-oso25/languages/python/sqlalchemy-oso sqlalchemy-oso
-RUN /opt/poetry/bin/poetry config virtualenvs.create false && \
-    /opt/poetry/bin/poetry install
+
+RUN poetry config virtualenvs.create false && \
+    poetry install
 # TODO / FIXME
 # Oso's core library is a Rust binary that I can't currently compile in Docker on an ARM-based mac
 # so for the moment we're installing the upstream oso library (which installs the Rust binaries)
@@ -38,20 +35,16 @@ RUN pip install --no-cache-dir supervisor
 RUN apt install -y nginx
 
 # FASTAPI: Install poetry
-ENV POETRY_HOME /opt/poetry/
 RUN apt install -y libdigest-sha-perl
-RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetry.py && \
-    echo "e973b3badb95a916bfe250c22eeb7253130fd87312afa326eb02b8bdcea8f4a7  get-poetry.py" > get-poetry.py.sha256 && \
-    shasum -a 256 -c get-poetry.py.sha256 && \
-    python get-poetry.py && \
-    rm get-poetry*
+ENV POETRY_VERSION=1.1.15
+RUN python3 -m pip install poetry==$POETRY_VERSION
 WORKDIR /usr/src/app
 
 COPY pyproject.toml poetry.lock environment.yaml ./
 # build deps needs to exist before configuring poetry
 COPY third-party ./third-party
 COPY --from=build sqlalchemy-oso ./sqlalchemy-oso
-RUN /opt/poetry/bin/poetry config virtualenvs.create false
+RUN poetry config virtualenvs.create false
 # Copy poetry deps from the build image
 COPY --from=build /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=build \
@@ -70,5 +63,5 @@ ENV PYTHONPATH=.
 
 COPY . .
 # By default, Poetry installs deps, dev deps, and the project package (aspen)
-RUN cd aspen && /opt/poetry/bin/poetry install
+RUN cd aspen && poetry install
 CMD ["/usr/local/bin/supervisord", "-c", "/usr/src/app/etc/supervisord.conf"]

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -43,13 +43,9 @@ RUN apt-get -qq update && apt-get -qq -y install \
 ENV FLASK_ENV=development
 
 # Install poetry
-ENV POETRY_HOME /opt/poetry/
 RUN apt install -y libdigest-sha-perl
-RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetry.py && \
-    echo "e973b3badb95a916bfe250c22eeb7253130fd87312afa326eb02b8bdcea8f4a7  get-poetry.py" > get-poetry.py.sha256 && \
-    shasum -a 256 -c get-poetry.py.sha256 && \
-    python get-poetry.py && \
-    rm get-poetry*
+ENV POETRY_VERSION=1.1.15
+RUN python3 -m pip install poetry==$POETRY_VERSION
 
 RUN pip3 install nextstrain-cli csv-diff s3fs[boto3] aiobotocore[awscli,boto3] envdir fsspec pandas arrow
 
@@ -65,15 +61,15 @@ WORKDIR /usr/src/app
 COPY pyproject.toml poetry.lock environment.yaml ./
 COPY third-party ./third-party
 RUN wget https://github.com/chanzuckerberg/oso/archive/czge-oso25.zip -O oso.zip && \
-    unzip oso.zip && \
+    unzip -q oso.zip && \
     mv oso-czge-oso25/languages/python/sqlalchemy-oso sqlalchemy-oso && rm oso.zip
-RUN /opt/poetry/bin/poetry config virtualenvs.create false && \
-    /opt/poetry/bin/poetry install
+RUN poetry config virtualenvs.create false && \
+    poetry install
 ENV PYTHONPATH=.
 
 COPY . .
 # Install the aspen package
-RUN /opt/poetry/bin/poetry install
+RUN poetry install
 
 ARG HAPPY_BRANCH="unknown"
 ARG HAPPY_COMMIT="unknown"

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -24,13 +24,9 @@ RUN apt-get -qq update && apt-get -qq -y install \
     && locale-gen en_US.UTF-8
 
 # Install poetry
-ENV POETRY_HOME /opt/poetry/
 RUN apt install -y libdigest-sha-perl
-RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetry.py && \
-    echo "e973b3badb95a916bfe250c22eeb7253130fd87312afa326eb02b8bdcea8f4a7  get-poetry.py" > get-poetry.py.sha256 && \
-    shasum -a 256 -c get-poetry.py.sha256 && \
-    python get-poetry.py && \
-    rm get-poetry*
+ENV POETRY_VERSION=1.1.15
+RUN python3 -m pip install poetry==$POETRY_VERSION
 
 ENV FLASK_ENV=development
 
@@ -51,12 +47,12 @@ WORKDIR /usr/src/app
 COPY pyproject.toml poetry.lock environment.yaml ./
 COPY third-party ./third-party
 RUN wget https://github.com/chanzuckerberg/oso/archive/czge-oso25.zip -O oso.zip && \
-    unzip oso.zip && \
+    unzip -q oso.zip && \
     mv oso-czge-oso25/languages/python/sqlalchemy-oso sqlalchemy-oso && rm oso.zip
-RUN /opt/poetry/bin/poetry config virtualenvs.create false && \
-    /opt/poetry/bin/poetry install
+RUN poetry config virtualenvs.create false && \
+    poetry install
 ENV PYTHONPATH=.
 
 COPY . .
 # Install the aspen package
-RUN /opt/poetry/bin/poetry install
+RUN poetry install

--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -3,13 +3,9 @@ ENV FLASK_APP=aspen.main
 EXPOSE 3000
 
 # Install poetry
-ENV POETRY_HOME /opt/poetry/
 RUN apt update && apt install -y libdigest-sha-perl wget
-RUN wget https://raw.githubusercontent.com/python-poetry/poetry/1.1.10/get-poetry.py && \
-    echo "e973b3badb95a916bfe250c22eeb7253130fd87312afa326eb02b8bdcea8f4a7  get-poetry.py" > get-poetry.py.sha256 && \
-    shasum -a 256 -c get-poetry.py.sha256 && \
-    python get-poetry.py && \
-    rm get-poetry*
+ENV POETRY_VERSION=1.1.15
+RUN python3 -m pip install poetry==$POETRY_VERSION
 
 WORKDIR /usr/src/app
 
@@ -29,12 +25,12 @@ RUN bash install_pangolin.sh
 COPY pyproject.toml poetry.lock environment.yaml ./
 COPY third-party ./third-party
 RUN wget https://github.com/chanzuckerberg/oso/archive/czge-oso25.zip -O oso.zip && \
-    unzip oso.zip && \
+    unzip -q oso.zip && \
     mv oso-czge-oso25/languages/python/sqlalchemy-oso sqlalchemy-oso && rm oso.zip
-RUN /opt/poetry/bin/poetry config virtualenvs.create false && \
-    /opt/poetry/bin/poetry install
+RUN poetry config virtualenvs.create false && \
+    poetry install
 ENV PYTHONPATH=.
 
 COPY . .
 # Install the aspen package
-RUN /opt/poetry/bin/poetry install
+RUN poetry install


### PR DESCRIPTION
### Notes:
Poetry released a new version today that changed the hash of their installation script. We can update the hash or take any number of other measures, but I *think* installing it via pip will be the most reliable option for now

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)