### PR TITLE
[SC-190919] Metadata upload - loading spinner.

### DIFF
--- a/src/frontend/src/components/FilePicker/index.tsx
+++ b/src/frontend/src/components/FilePicker/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "czifui";
 import { useRef, useState } from "react";
 import ConfirmDialog from "../ConfirmDialog";
-import { HiddenInput } from "./style";
+import { HiddenInput, StyledIcon } from "./style";
 
 interface Props {
   handleFiles: (files: FileList | null) => void;
@@ -12,7 +12,7 @@ interface Props {
   shouldConfirm?: boolean;
   confirmTitle?: string;
   confirmContent?: string;
-  isDisabled?: boolean;
+  isLoading?: boolean;
 }
 
 export default function FilePicker({
@@ -24,7 +24,7 @@ export default function FilePicker({
   shouldConfirm,
   confirmTitle = "",
   confirmContent = "",
-  isDisabled = false,
+  isLoading = false,
 }: Props): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const hiddenFileInput = useRef<HTMLInputElement>(null);
@@ -61,9 +61,14 @@ export default function FilePicker({
         sdsType="primary"
         sdsStyle="square"
         onClick={shouldConfirm ? openDialog : handleClick}
-        disabled={isDisabled}
+        disabled={isLoading}
+        startIcon={
+          isLoading && (
+            <StyledIcon sdsIcon="loading" sdsSize="l" sdsType="static" />
+          )
+        }
       >
-        {text}
+        {isLoading ? "Loading" : text}
       </Button>
 
       <HiddenInput

--- a/src/frontend/src/components/FilePicker/index.tsx
+++ b/src/frontend/src/components/FilePicker/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "czifui";
 import { useRef, useState } from "react";
 import ConfirmDialog from "../ConfirmDialog";
-import { HiddenInput, StyledIcon } from "./style";
+import { HiddenInput } from "./style";
 
 interface Props {
   handleFiles: (files: FileList | null) => void;
@@ -62,13 +62,8 @@ export default function FilePicker({
         sdsStyle="square"
         onClick={shouldConfirm ? openDialog : handleClick}
         disabled={isLoading}
-        startIcon={
-          isLoading && (
-            <StyledIcon sdsIcon="loading" sdsSize="l" sdsType="static" />
-          )
-        }
       >
-        {isLoading ? "Loading" : text}
+        {isLoading ? "Loading..." : text}
       </Button>
 
       <HiddenInput

--- a/src/frontend/src/components/FilePicker/style.ts
+++ b/src/frontend/src/components/FilePicker/style.ts
@@ -1,5 +1,16 @@
 import styled from "@emotion/styled";
+import { CommonThemeProps, getColors, Icon } from "czifui";
 
 export const HiddenInput = styled.input`
   display: none;
+`;
+
+export const StyledIcon = styled(Icon)`
+  ${(props: CommonThemeProps) => {
+    const colors = getColors(props);
+
+    return `
+      fill: ${colors?.gray[200]};
+    `;
+  }}
 `;

--- a/src/frontend/src/components/FilePicker/style.ts
+++ b/src/frontend/src/components/FilePicker/style.ts
@@ -1,16 +1,5 @@
 import styled from "@emotion/styled";
-import { CommonThemeProps, getColors, Icon } from "czifui";
 
 export const HiddenInput = styled.input`
   display: none;
-`;
-
-export const StyledIcon = styled(Icon)`
-  ${(props: CommonThemeProps) => {
-    const colors = getColors(props);
-
-    return `
-      fill: ${colors?.gray[200]};
-    `;
-  }}
 `;

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -42,6 +42,7 @@ export default function ImportFile({
   stringToLocationFinder,
 }: Props): JSX.Element {
   const [isInstructionsShown, setIsInstructionsShown] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [hasImportedFile, setHasImportedFile] = useState(false);
   const [missingFields, setMissingFields] = useState<string[] | null>(null);
   const [hasUnknownFields, setHasUnknownFields] = useState<boolean>(false);
@@ -94,6 +95,8 @@ export default function ImportFile({
 
   const handleFiles = async (files: FileList | null) => {
     if (!files) return;
+    setIsLoading(true);
+    console.log({ isLoading });
 
     const result = await parseFile(files[0], stringToLocationFinder);
 
@@ -116,6 +119,8 @@ export default function ImportFile({
     );
 
     handleMetadata(result);
+    setIsLoading(false);
+    console.log("2", { isLoading });
   };
 
   return (
@@ -157,6 +162,7 @@ export default function ImportFile({
             "Your existing metadata will be replaced with the " +
             "information found in the new import file."
           }
+          isLoading={isLoading}
         />
       </div>
 

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -96,7 +96,6 @@ export default function ImportFile({
   const handleFiles = async (files: FileList | null) => {
     if (!files) return;
     setIsLoading(true);
-    console.log({ isLoading });
 
     const result = await parseFile(files[0], stringToLocationFinder);
 
@@ -120,7 +119,6 @@ export default function ImportFile({
 
     handleMetadata(result);
     setIsLoading(false);
-    console.log("2", { isLoading });
   };
 
   return (

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -122,11 +122,11 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
         />
         <ContentWrapper>
           <StyledFilePicker
-            text={isLoadingFile ? "Loading..." : "Select Sample Files"}
+            text={"Select Sample Files"}
             multiple
             handleFiles={handleFileChange}
             accept=".fasta,.fa,.txt,.gz,.zip"
-            isDisabled={isLoadingFile}
+            isLoading={isLoadingFile}
           />
           {parseErrors && (
             <AlertAccordion


### PR DESCRIPTION
### Summary:
- **What:** `Add a loading state to the metadata upload button`
- **Ticket:** [sc190919](https://app.shortcut.com/genepi/story/190919/add-loading-state-to-import-metadata-button-when-file-is-importing)
- **Env:** `none`

### Demos:
![loading](https://user-images.githubusercontent.com/109251328/188019695-d74cd817-7c5a-4c7e-a935-b3757d14c1d8.gif)


### Notes:
The spinner doesn't spin because the browser is busy processing the file.  Does it look more broken this way?  Alternatively we could just have the "Loading" text.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)