### PR TITLE
add backend split flags for pathogen

### DIFF
--- a/src/backend/aspen/api/views/tests/test_split.py
+++ b/src/backend/aspen/api/views/tests/test_split.py
@@ -3,15 +3,32 @@ from aspen.database.models.pathogens import Pathogen
 from aspen.util.split import SplitClient
 
 
-def test_treatments():
+def test_pathogen_treatments():
     # test that treatments are returned correctly based on traffic type
+
     pathogen = Pathogen(slug="SC2", name="SARS-CoV-2")
     settings = APISettings()
     splitio = SplitClient(settings)
 
-    treatment = splitio.get_pathogen_treatment("pathogen_feature", pathogen)
-    assert treatment == "on"
+    flag_to_treatments = {
+        "PATHOGEN_lineage_caller": {
+            "SC2": "Pangolin",
+            "MPX": "ncov",
+            # SFO entry is to check that default is returned if mystery pathogen
+            "SFO": "ncov",
+        },
+        "PATHOGEN_galago_linkout": {"SC2": "on", "MPX": "off", "SFO": "off"},
+        "PATHOGEN_lineage_filter_enabled": {"SC2": "on", "MPX": "off", "SFO": "off"},
+        "PATHOGEN_public_repository": {
+            "SC2": "GISAID",
+            "MPX": "GenBank",
+            "SFO": "GenBank",
+        },
+        "PATHOGEN_usher_linkout": {"SC2": "on", "MPX": "off", "SFO": "off"},
+    }
 
-    pathogen.slug = "MPX"
-    treatment = splitio.get_pathogen_treatment("pathogen_feature", pathogen)
-    assert treatment == "control"  # this is the default
+    for flag, slug_to_treatment in flag_to_treatments.items():
+        for slug, expected_treatment in slug_to_treatment.items():
+            pathogen.slug = slug
+            treatment = splitio.get_pathogen_treatment(flag, pathogen)
+            assert treatment == expected_treatment

--- a/src/backend/etc/split.yml
+++ b/src/backend/etc/split.yml
@@ -13,6 +13,48 @@
     treatment: "on"
 - test_feature:
     treatment: "off"
-- pathogen_feature:
+- PATHOGEN_lineage_caller:
+    treatment: "Pangolin"
+    keys: "SC2"
+- PATHOGEN_lineage_caller:
+    treatment: "ncov"
+    keys: "MPX"
+- PATHOGEN_lineage_caller:
+    # default value
+    treatment: "ncov"
+- PATHOGEN_galago_linkout:
     treatment: "on"
     keys: "SC2"
+- PATHOGEN_galago_linkout:
+    treatment: "off"
+    keys: "MPX"
+- PATHOGEN_galago_linkout:
+    # default value
+    treatment: "off"
+- PATHOGEN_lineage_filter_enabled:
+    treatment: "on"
+    keys: "SC2"
+- PATHOGEN_lineage_filter_enabled:
+    treatment: "off"
+    keys: "MPX"
+- PATHOGEN_lineage_filter_enabled:
+    # default value
+    treatment: "off"
+- PATHOGEN_public_repository:
+    treatment: "GISAID"
+    keys: "SC2" 
+- PATHOGEN_public_repository:
+    treatment: "GenBank"
+    keys: "MPX"
+- PATHOGEN_public_repository:
+    # default value
+    treatment: "GenBank"
+- PATHOGEN_usher_linkout:
+    treatment: "on"
+    keys: "SC2"
+- PATHOGEN_usher_linkout:
+    treatment: "off"
+    keys: "MPX"
+- PATHOGEN_usher_linkout:
+    # default value
+    treatment: "off"


### PR DESCRIPTION
### Summary:
- **What:** add the rest of the split flags to localdev backend config
- **Ticket:** [sc211772](https://app.shortcut.com/genepi/story/211772)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)