### PR TITLE
response content headers

### DIFF
--- a/src/backend/aspen/api/views/sequences.py
+++ b/src/backend/aspen/api/views/sequences.py
@@ -88,6 +88,7 @@ async def prepare_sequences_download(
     db.expunge_all()
     generator = stream_samples()
     resp = StreamingResponse(generator, media_type="application/binary")
+    resp.headers["Access-Control-Expose-Headers"] = "Content-Disposition"
     resp.headers["Content-Disposition"] = f"attachment; filename={fasta_filename}"
     return resp
 

--- a/src/backend/aspen/api/views/sequences.py
+++ b/src/backend/aspen/api/views/sequences.py
@@ -88,6 +88,7 @@ async def prepare_sequences_download(
     db.expunge_all()
     generator = stream_samples()
     resp = StreamingResponse(generator, media_type="application/binary")
+    # Access-Control-Expose-Headers needed for FE to read Content-Disposition to get filename
     resp.headers["Access-Control-Expose-Headers"] = "Content-Disposition"
     resp.headers["Content-Disposition"] = f"attachment; filename={fasta_filename}"
     return resp


### PR DESCRIPTION
### Summary:
- **What:** add Access-Control-Expose-Headers so FE can read filename from Content-Disposition
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)