### PR TITLE
Gisaid/Genbank download tweaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         exclude: ^src/backend/third-party/
         types: [file, python]
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0 
     hooks:
       - id: black
         files: ^src/backend/

--- a/src/backend/aspen/api/utils/tsv_streamer.py
+++ b/src/backend/aspen/api/utils/tsv_streamer.py
@@ -35,6 +35,7 @@ class FieldSeparatedStreamer:
         generator = self.stream()
         resp = StreamingResponse(generator, media_type="application/binary")
         resp.headers["Content-Disposition"] = f"attachment; filename={self.filename}"
+        resp.headers["Access-Control-Expose-Headers"] = "Content-Disposition"
         resp.headers["Content-Type"] = CONTENT_TYPE[self.delimiter]
         return resp
 

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -21,8 +21,7 @@ export enum ORG_API {
   SAMPLES = "samples/",
   SAMPLES_VALIDATE_IDS = "samples/validate_ids/",
   SAMPLES_FASTA_DOWNLOAD = "sequences/",
-  SAMPLES_GENBANK_DOWNLOAD = "samples/genbank_template",
-  SAMPLES_GISAID_DOWNLOAD = "samples/gisaid_template",
+  SAMPLES_TEMPLATE_DOWNLOAD = "samples/submission_template",
   GET_FASTA_URL = "sequences/getfastaurl",
 }
 

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -1,6 +1,5 @@
 import { useTreatments } from "@splitsoftware/splitio-react";
 import { Alert, Icon, Link, Tooltip } from "czifui";
-import { isEqual } from "lodash";
 import { useCallback, useEffect, useState } from "react";
 import { CSVLink } from "react-csv";
 import {

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -301,7 +301,8 @@ const DownloadModal = ({
                   <DownloadType>
                     {failedSampleIds.length}{" "}
                     {pluralize("sample", failedSampleIds.length)} will not be
-                    included in your Consensus Genome download
+                    included in your Consensus Genome or Submission Template
+                    downloads
                   </DownloadType>
                   <DownloadTypeInfo>
                     because they failed genome recovery. Failed samples will

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -77,9 +77,6 @@ const DownloadModal = ({
   const flag = useTreatments([FEATURE_FLAGS.prep_files]);
   const isPrepFilesFlagOn = isFlagOn(flag, FEATURE_FLAGS.prep_files);
 
-  const nCheckedSampleIds = checkedSampleIds.length;
-  const N_SAMPLES_PER_PAGE = 999;
-
   useEffect(() => {
     if (tsvData) {
       const [Headers, Rows] = tsvData;
@@ -309,14 +306,6 @@ const DownloadModal = ({
                   </DownloadTypeInfo>
                 </Alert>
               )}
-            {nCheckedSampleIds > 999 &&
-              (isGisaidSelected || isGenbankSelected) && (
-                <StyledCallout intent="info" autoDismiss={false}>
-                  Your submission template download will be generated in
-                  multiple files of up to 999 samples in order to comply with
-                  GISAID/GenBank upload limits.
-                </StyledCallout>
-              )}
             {getDownloadButton()}
           </Content>
         </DialogContent>
@@ -372,18 +361,11 @@ const DownloadModal = ({
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
           sampleIds: checkedSampleIds,
         });
-        const nPages = Math.ceil(nCheckedSampleIds / N_SAMPLES_PER_PAGE);
-        for (let page = 0; page < nPages; page++) {
-          downloadMutation.mutate({
-            endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
-            page,
-            publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
-            sampleIds: checkedSampleIds.slice(
-              page * N_SAMPLES_PER_PAGE,
-              Math.min(nCheckedSampleIds, (page + 1) * N_SAMPLES_PER_PAGE)
-            ),
-          });
-        }
+        downloadMutation.mutate({
+          endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
+          publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
+          sampleIds: checkedSampleIds,
+        });
       }
 
       if (isGenbankSelected) {
@@ -392,17 +374,11 @@ const DownloadModal = ({
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
           sampleIds: checkedSampleIds,
         });
-        const nPages = Math.ceil(nCheckedSampleIds / N_SAMPLES_PER_PAGE);
-        for (let page = 0; page < nPages; page++) {
-          downloadMutation.mutate({
-            endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
-            publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
-            sampleIds: checkedSampleIds.slice(
-              page * N_SAMPLES_PER_PAGE,
-              Math.min(nCheckedSampleIds, (page + 1) * N_SAMPLES_PER_PAGE)
-            ),
-          });
-        }
+        downloadMutation.mutate({
+          endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
+          publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
+          sampleIds: checkedSampleIds,
+        });
       }
 
       analyticsHandleDownload();

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -13,7 +13,7 @@ import DialogActions from "src/common/components/library/Dialog/components/Dialo
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import { useUserInfo } from "src/common/queries/auth";
-import { useFileDownload } from "src/common/queries/samples";
+import { FileDownloadResponsePayload, PUBLIC_REPOSITORY_NAME, useFileDownload } from "src/common/queries/samples";
 import { B } from "src/common/styles/basicStyle";
 import {
   StyledCloseIconButton,
@@ -130,7 +130,7 @@ const DownloadModal = ({
         setShouldShowError(true);
         handleCloseModal();
       },
-      componentOnSuccess: (data: Blob) => {
+      componentOnSuccess: ({data, filename}: FileDownloadResponsePayload) => {
         // TODO (mlila): may need to modify behavior here for gisaid/genbank multi-file download
         const link = document.createElement("a");
         link.href = window.URL.createObjectURL(data);
@@ -360,21 +360,20 @@ const DownloadModal = ({
       if (isFastaSelected) {
         fastaDownloadMutation.mutate({
           sampleIds: checkedSampleIds,
-          endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
         });
       }
 
       if (isGisaidSelected) {
         gisaidDownloadMutation.mutate({
           sampleIds: checkedSampleIds,
-          endpoint: ORG_API.SAMPLES_GISAID_DOWNLOAD,
+          publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
         });
       }
 
       if (isGenbankSelected) {
         genbankDownloadMutation.mutate({
           sampleIds: checkedSampleIds,
-          endpoint: ORG_API.SAMPLES_GENBANK_DOWNLOAD,
+          publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
         });
       }
 

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -13,7 +13,11 @@ import DialogActions from "src/common/components/library/Dialog/components/Dialo
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
 import { useUserInfo } from "src/common/queries/auth";
-import { FileDownloadResponsePayload, PUBLIC_REPOSITORY_NAME, useFileDownload } from "src/common/queries/samples";
+import {
+  FileDownloadResponsePayload,
+  PUBLIC_REPOSITORY_NAME,
+  useFileDownload,
+} from "src/common/queries/samples";
 import { B } from "src/common/styles/basicStyle";
 import {
   StyledCloseIconButton,
@@ -130,11 +134,11 @@ const DownloadModal = ({
         setShouldShowError(true);
         handleCloseModal();
       },
-      componentOnSuccess: ({data, filename}: FileDownloadResponsePayload) => {
+      componentOnSuccess: ({ data, filename }: FileDownloadResponsePayload) => {
         // TODO (mlila): may need to modify behavior here for gisaid/genbank multi-file download
         const link = document.createElement("a");
         link.href = window.URL.createObjectURL(data);
-        link.download = downloadFileName;
+        link.download = filename || downloadFileName;
         link.click();
         link.remove();
         handleCloseModal();

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -39,7 +39,6 @@ import {
   DownloadTypeInfo,
   Header,
   StyledButton,
-  StyledCallout,
   StyledCheckbox,
   StyledFileTypeItem,
   Title,
@@ -77,6 +76,11 @@ const DownloadModal = ({
   const flag = useTreatments([FEATURE_FLAGS.prep_files]);
   const isPrepFilesFlagOn = isFlagOn(flag, FEATURE_FLAGS.prep_files);
 
+  const completedSampleIds = checkedSampleIds.filter(
+    (id) => !failedSampleIds.includes(id)
+  );
+  const nCompletedSampleIds = completedSampleIds.length;
+
   useEffect(() => {
     if (tsvData) {
       const [Headers, Rows] = tsvData;
@@ -86,12 +90,12 @@ const DownloadModal = ({
   }, [tsvData]);
 
   useEffect(() => {
-    if (isEqual(checkedSampleIds, failedSampleIds)) {
+    if (nCompletedSampleIds === 0) {
       setFastaDisabled(true);
     } else {
       setFastaDisabled(false);
     }
-  }, [checkedSampleIds, failedSampleIds, setFastaDisabled]);
+  }, [nCompletedSampleIds, setFastaDisabled]);
 
   const handleMetadataClick = function () {
     setMetadataSelected(!isMetadataSelected);
@@ -331,8 +335,8 @@ const DownloadModal = ({
         includes_genbank_template: isGenbankSelected,
         includes_gisaid_template: isGisaidSelected,
         includes_sample_metadata: isMetadataSelected,
-        sample_count: checkedSampleIds.length,
-        sample_public_ids: JSON.stringify(checkedSampleIds),
+        sample_count: nCompletedSampleIds,
+        sample_public_ids: JSON.stringify(completedSampleIds),
       }
     );
   }
@@ -351,7 +355,7 @@ const DownloadModal = ({
       if (isFastaSelected) {
         downloadMutation.mutate({
           endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
-          sampleIds: checkedSampleIds,
+          sampleIds: completedSampleIds,
         });
       }
 
@@ -359,12 +363,12 @@ const DownloadModal = ({
         downloadMutation.mutate({
           endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
-          sampleIds: checkedSampleIds,
+          sampleIds: completedSampleIds,
         });
         downloadMutation.mutate({
           endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
-          sampleIds: checkedSampleIds,
+          sampleIds: completedSampleIds,
         });
       }
 
@@ -372,12 +376,12 @@ const DownloadModal = ({
         downloadMutation.mutate({
           endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
-          sampleIds: checkedSampleIds,
+          sampleIds: completedSampleIds,
         });
         downloadMutation.mutate({
           endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
-          sampleIds: checkedSampleIds,
+          sampleIds: completedSampleIds,
         });
       }
 

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -77,7 +77,7 @@ const DownloadModal = ({
   const flag = useTreatments([FEATURE_FLAGS.prep_files]);
   const isPrepFilesFlagOn = isFlagOn(flag, FEATURE_FLAGS.prep_files);
 
-  const nCompletedSampleIds = checkedSampleIds.length - failedSampleIds.length;
+  const nCheckedSampleIds = checkedSampleIds.length;
   const N_SAMPLES_PER_PAGE = 999;
 
   useEffect(() => {
@@ -309,7 +309,7 @@ const DownloadModal = ({
                   </DownloadTypeInfo>
                 </Alert>
               )}
-            {nCompletedSampleIds > 999 &&
+            {nCheckedSampleIds > 999 &&
               (isGisaidSelected || isGenbankSelected) && (
                 <StyledCallout intent="info" autoDismiss={false}>
                   Your submission template download will be generated in
@@ -372,13 +372,16 @@ const DownloadModal = ({
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
           sampleIds: checkedSampleIds,
         });
-        const nPages = Math.ceil(nCompletedSampleIds / N_SAMPLES_PER_PAGE);
+        const nPages = Math.ceil(nCheckedSampleIds / N_SAMPLES_PER_PAGE);
         for (let page = 0; page < nPages; page++) {
           downloadMutation.mutate({
             endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
             page,
             publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
-            sampleIds: checkedSampleIds,
+            sampleIds: checkedSampleIds.slice(
+              page * N_SAMPLES_PER_PAGE,
+              Math.min(nCheckedSampleIds, (page + 1) * N_SAMPLES_PER_PAGE)
+            ),
           });
         }
       }
@@ -389,12 +392,15 @@ const DownloadModal = ({
           publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
           sampleIds: checkedSampleIds,
         });
-        const nPages = Math.ceil(nCompletedSampleIds / N_SAMPLES_PER_PAGE);
+        const nPages = Math.ceil(nCheckedSampleIds / N_SAMPLES_PER_PAGE);
         for (let page = 0; page < nPages; page++) {
           downloadMutation.mutate({
             endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
             publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
-            sampleIds: checkedSampleIds,
+            sampleIds: checkedSampleIds.slice(
+              page * N_SAMPLES_PER_PAGE,
+              Math.min(nCheckedSampleIds, (page + 1) * N_SAMPLES_PER_PAGE)
+            ),
           });
         }
       }

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/style.ts
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import {
   Button,
-  Callout,
   Checkbox,
   CommonThemeProps,
   fontBodyM,
@@ -140,17 +139,4 @@ export const StyledCheckbox = styled(Checkbox)`
       background-color: transparent;
     }
   }
-`;
-
-export const StyledCallout = styled(Callout)`
-  ${fontBodyXxs}
-  width: 100%;
-  max-width: 434px;
-  ${(props) => {
-    const spaces = getSpaces(props);
-    return `
-      margin-top: ${spaces?.xl}px;
-      margin-bottom: 0;
-    `;
-  }}
 `;

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -35,13 +35,13 @@ interface SampleFileDownloadType {
 
 export interface FileDownloadResponsePayload {
   data: Blob;
-  filename?: string;
+  filename?: string | null;
 }
 
 type FileDownloadCallbacks = {
   componentOnError: () => void;
-  componentOnSuccess: ({data, filename}: FileDownloadResponsePayload) => void;
-}
+  componentOnSuccess: ({ data, filename }: FileDownloadResponsePayload) => void;
+};
 
 export async function downloadSamplesFile({
   publicRepositoryName,
@@ -52,16 +52,22 @@ export async function downloadSamplesFile({
     sample_ids: sampleIds,
   };
 
-  const response = await fetch(API_URL + generateOrgSpecificUrl(ORG_API.SAMPLES_FASTA_DOWNLOAD), {
-    ...DEFAULT_POST_OPTIONS,
-    body: JSON.stringify(payload),
-  });
+  const response = await fetch(
+    API_URL + generateOrgSpecificUrl(ORG_API.SAMPLES_FASTA_DOWNLOAD),
+    {
+      ...DEFAULT_POST_OPTIONS,
+      body: JSON.stringify(payload),
+    }
+  );
 
   if (response.ok) {
     // TODO: update filename when header is exposed
-    const filename = 'test';
+    const filename = response.headers
+      .get("content-disposition")
+      ?.split("filename=")[1];
+
     const data = await response.blob();
-    return {data, filename}
+    return { data, filename };
   }
 
   throw Error(`${response.statusText}: ${await response.text()}`);

--- a/src/frontend/src/views/Account/index.tsx
+++ b/src/frontend/src/views/Account/index.tsx
@@ -114,12 +114,12 @@ export default function Account(): JSX.Element {
       <StyledSection>
         <H2>Details</H2>
         <StyledRow>
-          <StyledH3>GISAID Submitter ID</StyledH3>
+          <StyledH3>GISAID User Name</StyledH3>
           <SubText>Optional</SubText>
         </StyledRow>
         <StyledRow>
           <P>
-            Your personal GISAID Submitter ID. This info is used to help prepare
+            Your personal GISAID user name. This info is used to help prepare
             samples for GISAID submission.
             <span>
               &nbsp;
@@ -135,8 +135,8 @@ export default function Account(): JSX.Element {
         </StyledRow>
         <InputText
           id="gisaid-id-input"
-          label="GISAID ID"
-          placeholder="GISAID ID"
+          label="GISAID User Name"
+          placeholder="GISAID User Name"
           hideLabel
           value={gisaidId}
           onChange={handleNewIdInput}


### PR DESCRIPTION
### Summary:
- **What:** `Update endpoint usage`
- **Ticket:** none
- **Env:** https://template-download-frontend.dev.czgenepi.org/

To get fasta file, use the `ORG_API.SAMPLES_FASTA_DOWNLOAD` endpoint and put the public repository in the request body:
```
{
        "sample_ids": [sample.public_identifier],
        "public_repository_name": "GISAID",
}
```
To get submission template, use the new `/v2/orgs/{group.id}/samples/submission_template` endpoint and pass:
```
   {
        "sample_ids": [sample.public_identifier for sample in samples],
        "date": today.strftime("%Y-%m-%d"),
        "page": "0",
        "public_repository_name": "GenBank",
    }
```
Use the "content-disposition" header to get the filename.

### Demos:

### Notes:
I added `resp.headers["Access-Control-Expose-Headers"] = "Content-Disposition"` to the submission_template endpoint for the filename to work.  Extra eyes on this would be great since I was just being a sheep and following what i thought should be there...

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)