### PR TITLE
Use server date for GISAID/GenBank submission template

### DIFF
--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -178,6 +178,5 @@ class CreateSamplesResponse(BaseResponse):
 
 class SubmissionTemplateRequest(BaseRequest):
     sample_ids: List[str]
-    date: datetime.date
     public_repository_name: str
     page: Optional[int]

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -409,7 +409,7 @@ async def fill_submission_template(
     ]
     if request.public_repository_name.lower() == "gisaid":
         metadata_rows = sample_info_to_gisaid_rows(
-            submission_information, datetime.date.today().strftime("%Y%m%d")
+            submission_information, prefix, datetime.date.today().strftime("%Y%m%d")
         )
         metadata_rows.sort(key=lambda row: row.get("covv_virus_name"))  # type: ignore
         filename = get_submission_template_filename("GISAID")

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -355,6 +355,12 @@ async def create_samples(
     return result
 
 
+def get_submission_template_filename(public_repository_name):
+    # get filename depending on public_repository
+    todays_date = datetime.date.today().strftime("%Y%m%d")
+    return f"{todays_date}_{public_repository_name}_metadata.tsv"
+
+
 @router.post("/submission_template")
 async def fill_submission_template(
     request_data: SubmissionTemplateRequest,
@@ -390,15 +396,18 @@ async def fill_submission_template(
     ]
     if request_data.public_repository_name.lower() == "gisaid":
         metadata_rows = sample_info_to_gisaid_rows(
-            submission_information, request_data.date.strftime("%Y%m%d")
+            submission_information, datetime.date.today().strftime("%Y%m%d")
         )
         metadata_rows.sort(key=lambda row: row.get("covv_virus_name"))  # type: ignore
-        filename = f"{request_data.date.strftime('%Y%m%d')}_GISAID_metadata.csv"  # yes, we want a TSV with a .csv extension
+        filename = get_submission_template_filename("GISAID")
+        filename = filename.replace(
+            ".tsv", ".csv"
+        )  # yes, we want a TSV with a .csv extension
         tsv_streamer = GisaidSubmissionFormTSVStreamer
     elif request_data.public_repository_name.lower() == "genbank":
         metadata_rows = sample_info_to_genbank_rows(submission_information)
         metadata_rows.sort(key=lambda row: row.get("Sequence_ID"))  # type: ignore
-        filename = f"{request_data.date.strftime('%Y%m%d')}_GenBank_metadata.tsv"
+        filename = get_submission_template_filename("GenBank")
         tsv_streamer = GenBankSubmissionFormTSVStreamer
 
     if request_data.page:

--- a/src/backend/aspen/api/views/tests/test_submission_templates.py
+++ b/src/backend/aspen/api/views/tests/test_submission_templates.py
@@ -70,7 +70,6 @@ async def test_submission_template_download_gisaid(
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     request_data = {
         "sample_ids": [sample.public_identifier for sample in samples],
-        "date": today.strftime("%Y-%m-%d"),
         "public_repository_name": "GISAID",
     }
     res = await http_client.post(
@@ -153,7 +152,6 @@ async def test_submission_template_download_genbank(
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     request_data = {
         "sample_ids": [sample.public_identifier for sample in samples],
-        "date": today.strftime("%Y-%m-%d"),
         "public_repository_name": "GenBank",
     }
     res = await http_client.post(
@@ -232,7 +230,6 @@ async def test_submission_template_prefix_stripping(
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     request_data = {
         "sample_ids": [sample.public_identifier for sample in samples],
-        "date": today.strftime("%Y-%m-%d"),
         "public_repository_name": "GISAID",
     }
     res = await http_client.post(


### PR DESCRIPTION
### Summary:
- **What:** Uses the server date for naming GISAID/GenBank submission metadata files.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)