### PR TITLE
turn off set -x when dealing with setting/reading secrets config

### DIFF
--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -175,8 +175,12 @@ task TransformGISAID {
     aspen_creation_rev=$COMMIT_SHA
 
     # fetch aspen config
+    set +x  # don't echo secrets
+    echo "* set \$genepi_config"
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
+    echo "* set \$aspen_s3_db_bucket"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
+    set -x
 
     # get the bucket/key from the object id
     raw_gisaid_location=$(python3 /usr/src/app/aspen/workflows/transform_gisaid/lookup_raw_gisaid_object.py --raw-gisaid-object-id "~{raw_gisaid_object_id}")
@@ -256,8 +260,12 @@ task AlignGISAID {
     fi
 
     # fetch aspen config
+    set +x  # don't echo secrets
+    echo "* set \$genepi_config"
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
+    echo "* set \$aspen_s3_db_bucket"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
+    set -x
 
     # get the bucket/key from the object id
     processed_gisaid_location=$(python3 /usr/src/app/aspen/workflows/align_gisaid/lookup_processed_gisaid_object.py --processed-gisaid-object-id "~{processed_gisaid_object_id}")

--- a/.happy/terraform/modules/sfn_config/gisaid.wdl
+++ b/.happy/terraform/modules/sfn_config/gisaid.wdl
@@ -176,7 +176,7 @@ task TransformGISAID {
 
     # fetch aspen config
     set +x  # don't echo secrets
-    echo "* set \$genepi_config"
+    echo "* set \$genepi_config (not printing value because contains secrets)"
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
     echo "* set \$aspen_s3_db_bucket"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
@@ -261,7 +261,7 @@ task AlignGISAID {
 
     # fetch aspen config
     set +x  # don't echo secrets
-    echo "* set \$genepi_config"
+    echo "* set \$genepi_config (not printing value because contains secrets)"
     genepi_config="$(aws secretsmanager get-secret-value --secret-id ~{genepi_config_secret_name} --query SecretString --output text)"
     echo "* set \$aspen_s3_db_bucket"
     aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_autorun.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_autorun.sh
@@ -24,7 +24,7 @@ fi
 
 # fetch aspen config
 set +x  # don't echo secrets
-echo "* set \$genepi_config"
+echo "* set \$genepi_config (not printing value because contains secrets)"
 genepi_config="$($aws secretsmanager get-secret-value --secret-id $GENEPI_CONFIG_SECRET_NAME --query SecretString --output text)"
 echo "* set \$aspen_s3_db_bucket"
 aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -24,8 +24,13 @@ else
 fi
 
 # fetch aspen config
+set +x  # don't echo secrets
+echo "* set \$genepi_config"
 genepi_config="$($aws secretsmanager get-secret-value --secret-id $GENEPI_CONFIG_SECRET_NAME --query SecretString --output text)"
+echo "* set \$aspen_s3_db_bucket"
 aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
+set -x
+
 key_prefix="phylo_run/${S3_FILESTEM}/${WORKFLOW_ID}"
 s3_prefix="s3://${aspen_s3_db_bucket}/${key_prefix}"
 

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -25,7 +25,7 @@ fi
 
 # fetch aspen config
 set +x  # don't echo secrets
-echo "* set \$genepi_config"
+echo "* set \$genepi_config (not printing value because contains secrets)"
 genepi_config="$($aws secretsmanager get-secret-value --secret-id $GENEPI_CONFIG_SECRET_NAME --query SecretString --output text)"
 echo "* set \$aspen_s3_db_bucket"
 aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"


### PR DESCRIPTION
### Summary:
- **What:** stop printing out genepi_config to std out
- **Ticket:** [sc212583](https://app.shortcut.com/genepi/story/212583>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)