### PR TITLE
use pathogen slug for create and list samples

### DIFF
--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -5,6 +5,7 @@ from pydantic import constr, validator
 from pydantic.utils import GetterDict
 
 from aspen.api.schemas.base import BaseRequest, BaseResponse
+from aspen.api.schemas.pathogens import PathogenResponse
 from aspen.api.schemas.locations import LocationResponse
 from aspen.api.utils import format_sample_lineage
 
@@ -84,6 +85,7 @@ class SampleResponse(BaseResponse):
     czb_failed_genome_recovery: bool
     gisaid: Optional[SampleGisaidResponse]
     lineage: Optional[SampleLineageResponse]
+    pathogen: PathogenResponse
     private: bool
     private_identifier: Optional[str]
     public_identifier: Optional[str]

--- a/src/backend/aspen/api/schemas/samples.py
+++ b/src/backend/aspen/api/schemas/samples.py
@@ -5,8 +5,8 @@ from pydantic import constr, validator
 from pydantic.utils import GetterDict
 
 from aspen.api.schemas.base import BaseRequest, BaseResponse
-from aspen.api.schemas.pathogens import PathogenResponse
 from aspen.api.schemas.locations import LocationResponse
+from aspen.api.schemas.pathogens import PathogenResponse
 from aspen.api.utils import format_sample_lineage
 
 SEQUENCE_VALIDATION_REGEX = r"^[WSKMYRVHDBNZNATCGUwskmyrvhdbnznatcgu-]+$"
@@ -85,7 +85,7 @@ class SampleResponse(BaseResponse):
     czb_failed_genome_recovery: bool
     gisaid: Optional[SampleGisaidResponse]
     lineage: Optional[SampleLineageResponse]
-    pathogen: PathogenResponse
+    pathogen: Optional[PathogenResponse]
     private: bool
     private_identifier: Optional[str]
     public_identifier: Optional[str]

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -73,12 +73,9 @@ async def list_samples(
         selectinload(Sample.uploaded_by),
         selectinload(Sample.collection_location),
         selectinload(Sample.accessions),
-        selectinload(Sample.pathogen)
-    ).where(
-        Sample.pathogen.slug == pathogen
-    )
+        selectinload(Sample.pathogen),
+    ).filter(Sample.pathogen_id == pathogen.id)
     user_visible_samples_result = await db.execute(user_visible_samples_query)
-    import pdb; pdb.set_trace()
     user_visible_samples: List[Sample] = (
         user_visible_samples_result.unique().scalars().all()
     )
@@ -306,6 +303,7 @@ async def create_samples(
             "public_identifier": sample_input.public_identifier,
             "authors": sample_input.authors or [group.name],
             "collection_location": valid_location,
+            "pathogen": pathogen,
         }
 
         sample: Sample = Sample(**sample_args)

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -73,8 +73,12 @@ async def list_samples(
         selectinload(Sample.uploaded_by),
         selectinload(Sample.collection_location),
         selectinload(Sample.accessions),
+        selectinload(Sample.pathogen)
+    ).where(
+        Sample.pathogen.slug == pathogen
     )
     user_visible_samples_result = await db.execute(user_visible_samples_query)
+    import pdb; pdb.set_trace()
     user_visible_samples: List[Sample] = (
         user_visible_samples_result.unique().scalars().all()
     )

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -79,7 +79,7 @@ async def list_samples(
     if pathogen.slug == "SC2":
         user_visible_samples_query = user_visible_samples_query.filter(
             or_(
-                Sample.pathogen_id == pathogen.id, Sample.pathogen_id == None
+                Sample.pathogen_id == pathogen.id, Sample.pathogen_id is None
             )  # TODO: remove this once we make pathogen_id non nullable
         )
     else:

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncResult, AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.sql.expression import or_
 
 from aspen.api.authn import AuthContext, get_auth_context, get_auth_user
 from aspen.api.authz import AuthZSession, get_authz_session, require_group_privilege
@@ -74,7 +75,15 @@ async def list_samples(
         selectinload(Sample.collection_location),
         selectinload(Sample.accessions),
         selectinload(Sample.pathogen),
-    ).filter(Sample.pathogen_id == pathogen.id)
+    )
+    if pathogen.slug == "SC2":
+        user_visible_samples_query = user_visible_samples_query.filter(
+            or_(Sample.pathogen_id == pathogen.id, Sample.pathogen_id == None)  #TODO: remove this once we make pathogen_id non nullable
+        )
+    else:
+        user_visible_samples_query = user_visible_samples_query.filter(
+            Sample.pathogen_id == pathogen.id
+        )  
     user_visible_samples_result = await db.execute(user_visible_samples_query)
     user_visible_samples: List[Sample] = (
         user_visible_samples_result.unique().scalars().all()

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -78,12 +78,14 @@ async def list_samples(
     )
     if pathogen.slug == "SC2":
         user_visible_samples_query = user_visible_samples_query.filter(
-            or_(Sample.pathogen_id == pathogen.id, Sample.pathogen_id == None)  #TODO: remove this once we make pathogen_id non nullable
+            or_(
+                Sample.pathogen_id == pathogen.id, Sample.pathogen_id == None
+            )  # TODO: remove this once we make pathogen_id non nullable
         )
     else:
         user_visible_samples_query = user_visible_samples_query.filter(
             Sample.pathogen_id == pathogen.id
-        )  
+        )
     user_visible_samples_result = await db.execute(user_visible_samples_query)
     user_visible_samples: List[Sample] = (
         user_visible_samples_result.unique().scalars().all()

--- a/src/backend/aspen/api/views/tests/test_create_samples.py
+++ b/src/backend/aspen/api/views/tests/test_create_samples.py
@@ -7,7 +7,12 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from aspen.database.models import PathogenGenome, Sample, UploadedPathogenGenome, Pathogen
+from aspen.database.models import (
+    Pathogen,
+    PathogenGenome,
+    Sample,
+    UploadedPathogenGenome,
+)
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.usergroup import group_factory, userrole_factory
@@ -43,7 +48,7 @@ async def test_samples_create_different_pathogens(
 
     sc2 = await Pathogen.get_by_slug(async_session, "SC2")
     mpx = await Pathogen.get_by_slug(async_session, "MPX")
-    
+
     pathogen_specific = {sc2: range(2), mpx: range(2, 4)}
     for pathogen, id_range in pathogen_specific.items():
         data = [
@@ -58,7 +63,8 @@ async def test_samples_create_different_pathogens(
                     "sequence": VALID_SEQUENCE + "MN",
                     "sequencing_date": format_date(test_date),
                 },
-            } for i in id_range
+            }
+            for i in id_range
         ]
         auth_headers = {"user_id": user.auth0_user_id}
         res = await http_client.post(

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -1181,7 +1181,9 @@ async def test_validation_endpoint_missing_identifier(
     }
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/pathogens/SC2/samples/validate_ids/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/SC2/samples/validate_ids/",
+        json=data,
+        headers=auth_headers,
     )
 
     # request should not fail, should return list of samples that are missing from the DB

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -79,7 +79,7 @@ async def test_samples_list(
     await async_session.commit()
 
     auth_headers = {"user_id": user.auth0_user_id}
-    pathogen_specific = {
+    pathogen_specific = {  # type: ignore
         sc2: {
             "id_range": range(2),
             "url": f"/v2/orgs/{group.id}/pathogens/SC2/samples/",
@@ -94,10 +94,10 @@ async def test_samples_list(
             "url": f"/v2/orgs/{group.id}/samples/",
         },
     }
-    for pathogen, params in pathogen_specific.items():
+    for pathogen, params in pathogen_specific.items():  # type: ignore
 
         res = await http_client.get(
-            params["url"],
+            params["url"],  # type: ignore
             headers=auth_headers,
         )
         response = res.json()
@@ -158,7 +158,7 @@ async def test_samples_list(
                     },
                     "uploaded_by": {"id": user.id, "name": user.name},
                 }
-                for i in params["id_range"]
+                for i in params["id_range"]  # type: ignore
             ]
         }
         assert response == expected

--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -1,6 +1,5 @@
 import json
 from typing import Any, List, Optional, Tuple
-from backend.aspen.database.models.pathogens import Pathogen
 
 import pytest
 import sqlalchemy as sa
@@ -18,6 +17,7 @@ from aspen.database.models import (
     UploadedPathogenGenome,
     User,
 )
+from aspen.database.models.pathogens import Pathogen
 from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.location import location_factory
 from aspen.test_infra.models.sample import sample_factory
@@ -49,8 +49,9 @@ async def test_samples_list(
         "scorpio_support": "0.775",
         "qc_status": "pass",
     }
-    sc2 = Pathogen(slug="SC2", name="sars-cov-19")
-    mpx = Pathogen(slug="MPX", name="monkey-pox")
+
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
+    mpx = await Pathogen.get_by_slug(async_session, "MPX")
 
     # Make multiple samples
     samples: List[Sample] = []
@@ -65,7 +66,7 @@ async def test_samples_list(
                 private=True,
                 private_identifier=f"private{i}",
                 public_identifier=f"public{i}",
-                pathogen=pathogen
+                pathogen=pathogen,
             )
         )
         uploaded_pathogen_genomes.append(
@@ -73,65 +74,71 @@ async def test_samples_list(
                 samples[i], pangolin_output=pangolin_output
             )
         )
+
     async_session.add(group)
     await async_session.commit()
 
     auth_headers = {"user_id": user.auth0_user_id}
-    res = await http_client.get(
-        f"/v2/orgs/{group.id}/pathogens/sc2/samples/",
-        headers=auth_headers,
-    )
-    response = res.json()
-    expected = {
-        "samples": [
-            {
-                "id": samples[i].id,
-                "collection_date": str(samples[i].collection_date),
-                "collection_location": {
-                    "id": location.id,
-                    "region": location.region,
-                    "country": location.country,
-                    "division": location.division,
-                    "location": location.location,
-                },
-                "czb_failed_genome_recovery": False,
-                "gisaid": {
-                    "status": "Accepted",
-                    "gisaid_id": samples[i].accessions[0].accession,
-                },
-                "pathogen": {
-                    "id": sc2.id,
-                    "slug": sc2.slug,
-                    "name": sc2.name
-                },
-                "private_identifier": samples[i].private_identifier,
-                "public_identifier": samples[i].public_identifier,
-                "upload_date": convert_datetime_to_iso_8601(
-                    uploaded_pathogen_genomes[i].upload_date
-                ),
-                "sequencing_date": str(uploaded_pathogen_genomes[i].sequencing_date),
-                "lineage": {
-                    "lineage": uploaded_pathogen_genomes[i].pangolin_lineage,
-                    "confidence": uploaded_pathogen_genomes[i].pangolin_probability,
-                    "version": uploaded_pathogen_genomes[i].pangolin_version,
-                    "last_updated": convert_datetime_to_iso_8601(
-                        uploaded_pathogen_genomes[i].pangolin_last_updated
+    pathogen_specific = {sc2: range(2), mpx: range(2, 4)}
+    for pathogen, id_range in pathogen_specific.items():
+
+        res = await http_client.get(
+            f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/samples/",
+            headers=auth_headers,
+        )
+        response = res.json()
+        expected = {
+            "samples": [
+                {
+                    "id": samples[i].id,
+                    "collection_date": str(samples[i].collection_date),
+                    "collection_location": {
+                        "id": location.id,
+                        "region": location.region,
+                        "country": location.country,
+                        "division": location.division,
+                        "location": location.location,
+                    },
+                    "czb_failed_genome_recovery": False,
+                    "gisaid": {
+                        "status": "Accepted",
+                        "gisaid_id": samples[i].accessions[0].accession,
+                    },
+                    "pathogen": {
+                        "id": pathogen.id,
+                        "slug": pathogen.slug,
+                        "name": pathogen.name,
+                    },
+                    "private_identifier": samples[i].private_identifier,
+                    "public_identifier": samples[i].public_identifier,
+                    "upload_date": convert_datetime_to_iso_8601(
+                        uploaded_pathogen_genomes[i].upload_date
                     ),
-                    "scorpio_call": pangolin_output["scorpio_call"],
-                    "scorpio_support": float(pangolin_output["scorpio_support"]),
-                    "qc_status": pangolin_output["qc_status"],
-                },
-                "private": True,
-                "submitting_group": {
-                    "id": group.id,
-                    "name": group.name,
-                },
-                "uploaded_by": {"id": user.id, "name": user.name},
-            }
-            for i in range(2)
-        ]
-    }
-    assert response == expected
+                    "sequencing_date": str(
+                        uploaded_pathogen_genomes[i].sequencing_date
+                    ),
+                    "lineage": {
+                        "lineage": uploaded_pathogen_genomes[i].pangolin_lineage,
+                        "confidence": uploaded_pathogen_genomes[i].pangolin_probability,
+                        "version": uploaded_pathogen_genomes[i].pangolin_version,
+                        "last_updated": convert_datetime_to_iso_8601(
+                            uploaded_pathogen_genomes[i].pangolin_last_updated
+                        ),
+                        "scorpio_call": pangolin_output["scorpio_call"],
+                        "scorpio_support": float(pangolin_output["scorpio_support"]),
+                        "qc_status": pangolin_output["qc_status"],
+                    },
+                    "private": True,
+                    "submitting_group": {
+                        "id": group.id,
+                        "name": group.name,
+                    },
+                    "uploaded_by": {"id": user.id, "name": user.name},
+                }
+                for i in id_range
+            ]
+        }
+        assert response == expected
 
 
 async def test_samples_view_gisaid_rejected(
@@ -143,17 +150,19 @@ async def test_samples_view_gisaid_rejected(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    sample = sample_factory(group, user, location, accessions={})
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
+    sample = sample_factory(group, user, location, accessions={}, pathogen=sc2)
     # Test no GISAID accession logic
     uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
         sample,
     )
+
     async_session.add(group)
     await async_session.commit()
 
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/samples/",
+        f"/v2/orgs/{group.id}/pathogens/{sc2.slug}/samples/",
         headers=auth_headers,
     )
     response = res.json()
@@ -188,6 +197,7 @@ async def test_samples_view_gisaid_rejected(
                     "scorpio_support": None,
                     "qc_status": None,
                 },
+                "pathogen": {"id": sc2.id, "slug": sc2.slug, "name": sc2.name},
                 "private": False,
                 "submitting_group": {
                     "id": group.id,
@@ -209,7 +219,8 @@ async def test_samples_view_gisaid_no_info(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    sample = sample_factory(group, user, location, accessions={})
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
+    sample = sample_factory(group, user, location, accessions={}, pathogen=sc2)
     # Test no GISAID accession logic
     uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
         sample,
@@ -220,7 +231,7 @@ async def test_samples_view_gisaid_no_info(
 
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/samples/",
+        f"/v2/orgs/{group.id}/pathogens/{sc2.slug}/samples/",
         headers=auth_headers,
     )
     response = res.json()
@@ -256,6 +267,7 @@ async def test_samples_view_gisaid_no_info(
                     "scorpio_support": None,
                     "qc_status": None,
                 },
+                "pathogen": {"id": sc2.id, "slug": sc2.slug, "name": sc2.name},
                 "private": False,
                 "submitting_group": {
                     "id": group.id,
@@ -277,13 +289,16 @@ async def test_samples_view_gisaid_not_eligible(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    sample = sample_factory(group, user, location, czb_failed_genome_recovery=True)
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
+    sample = sample_factory(
+        group, user, location, czb_failed_genome_recovery=True, pathogen=sc2
+    )
     async_session.add(group)
     await async_session.commit()
 
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/samples/",
+        f"/v2/orgs/{group.id}/pathogens/{sc2.slug}/samples/",
         headers=auth_headers,
     )
     response = res.json()
@@ -317,6 +332,7 @@ async def test_samples_view_gisaid_not_eligible(
                     "scorpio_support": None,
                     "qc_status": None,
                 },
+                "pathogen": {"id": sc2.id, "slug": sc2.slug, "name": sc2.name},
                 "private": False,
                 "submitting_group": {
                     "id": group.id,
@@ -343,7 +359,8 @@ async def _test_samples_view_cansee(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    sample = sample_factory(owner_group, user, location)
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
+    sample = sample_factory(owner_group, user, location, pathogen=sc2)
     # create a private sample as well to make sure it doesn't get shown unless admin
     private_sample = sample_factory(
         owner_group,
@@ -368,7 +385,7 @@ async def _test_samples_view_cansee(
 
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{viewer_group.id}/samples/",
+        f"/v2/orgs/{viewer_group.id}/pathogens/{sc2.slug}/samples/",
         headers=auth_headers,
     )
     response = res.json()
@@ -418,6 +435,7 @@ async def test_samples_view_cansee_all(
         http_client,
         group_roles=["viewer"],
     )
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
 
     # yes private identifier in the output.
     assert response["samples"] == [
@@ -453,6 +471,7 @@ async def test_samples_view_cansee_all(
                 "scorpio_support": None,
                 "qc_status": None,
             },
+            "pathogen": {"id": sc2.id, "slug": sc2.slug, "name": sc2.name},
             "private": False,
             "submitting_group": {
                 "id": sample.submitting_group.id,
@@ -474,7 +493,8 @@ async def test_samples_view_no_pangolin(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    sample = sample_factory(group, user, location)
+    sc2 = await Pathogen.get_by_slug(async_session, "SC2")
+    sample = sample_factory(group, user, location, pathogen=sc2)
     uploaded_pathogen_genome = uploaded_pathogen_genome_factory(
         sample,
         pangolin_lineage=None,
@@ -487,7 +507,7 @@ async def test_samples_view_no_pangolin(
 
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/samples/",
+        f"/v2/orgs/{group.id}/pathogens/{sc2.slug}/samples/",
         headers=auth_headers,
     )
     response = res.json()
@@ -523,6 +543,7 @@ async def test_samples_view_no_pangolin(
                     "scorpio_support": None,
                     "qc_status": None,
                 },
+                "pathogen": {"id": sc2.id, "slug": sc2.slug, "name": sc2.name},
                 "private": False,
                 "submitting_group": {
                     "id": group.id,
@@ -583,7 +604,7 @@ async def test_bulk_delete_sample_success(
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.request(
         "DELETE",
-        f"/v2/orgs/{group.id}/samples/",
+        f"/v2/orgs/{group.id}/pathogens/SC2/samples/",
         json=body,
         headers=auth_headers,
     )
@@ -648,7 +669,7 @@ async def test_delete_sample_success(
     for sample in [samples[0], samples[1]]:
         auth_headers = {"user_id": user.auth0_user_id}
         res = await http_client.delete(
-            f"/v2/orgs/{group.id}/samples/{sample.id}",
+            f"/v2/orgs/{group.id}/pathogens/SC2/samples/{sample.id}",
             headers=auth_headers,
         )
         assert res.status_code == 200
@@ -726,7 +747,7 @@ async def test_delete_sample_failures(
     # Request this sample as a user who shouldn't be able to delete it.
     auth_headers = {"user_id": user2.auth0_user_id}
     res = await http_client.delete(
-        f"/v2/orgs/{group.id}/samples/{sample.id}",
+        f"/v2/orgs/{group.id}/pathogens/SC2/samples/{sample.id}",
         headers=auth_headers,
     )
     assert res.status_code == 403
@@ -734,7 +755,7 @@ async def test_delete_sample_failures(
     # Make sure this sample isn't found under the user's group context
     auth_headers = {"user_id": user2.auth0_user_id}
     res = await http_client.delete(
-        f"/v2/orgs/{group2.id}/samples/{sample.id}",
+        f"/v2/orgs/{group2.id}/pathogens/SC2/samples/{sample.id}",
         headers=auth_headers,
     )
     assert res.status_code == 404
@@ -749,7 +770,7 @@ async def test_delete_sample_failures(
     # https://www.python-httpx.org/compatibility/#request-body-on-http-methods
     res = await http_client.request(
         method="DELETE",
-        url=f"/v2/orgs/{group.id}/samples/",
+        url=f"/v2/orgs/{group.id}/pathogens/SC2/samples/",
         content=json.dumps({"ids": [sample.id, sample2.id]}),
         headers=auth_headers,
     )
@@ -757,7 +778,7 @@ async def test_delete_sample_failures(
 
     res = await http_client.request(
         method="DELETE",
-        url=f"/v2/orgs/{group2.id}/samples/",
+        url=f"/v2/orgs/{group2.id}/pathogens/SC2/samples/",
         content=json.dumps({"ids": [sample.id, sample2.id]}),
         headers=auth_headers,
     )
@@ -766,7 +787,7 @@ async def test_delete_sample_failures(
     # Test that our multi-delete endpoint succeeds if we only specify an owned sample
     res = await http_client.request(
         method="DELETE",
-        url=f"/v2/orgs/{group2.id}/samples/",
+        url=f"/v2/orgs/{group2.id}/pathogens/SC2/samples/",
         content=json.dumps({"ids": [sample2.id]}),
         headers=auth_headers,
     )
@@ -898,7 +919,7 @@ async def test_update_samples_success(
     async_session.expire_all()
 
     res = await http_client.put(
-        f"/v2/orgs/{group_id}/samples",
+        f"/v2/orgs/{group_id}/pathogens/SC2/samples",
         json=request_data,
         headers=auth_headers,
     )
@@ -983,7 +1004,7 @@ async def test_update_samples_access_denied(
     }
 
     res = await http_client.put(
-        f"/v2/orgs/{group.id}/samples",
+        f"/v2/orgs/{group.id}/pathogens/SC2/samples",
         json=data,
         headers=auth_headers,
     )
@@ -1083,7 +1104,7 @@ async def test_update_samples_request_failures(
         data = {"samples": [request]}
 
         res = await http_client.put(
-            f"/v2/orgs/{group.id}/samples",
+            f"/v2/orgs/{group.id}/pathogens/SC2/samples",
             json=data,
             headers=auth_headers,
         )
@@ -1129,7 +1150,7 @@ async def test_validation_endpoint(
     }
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/samples/validate_ids/",
+        f"/v2/orgs/{group.id}/pathogens/SC2/samples/validate_ids/",
         json=data,
         headers=auth_headers,
     )
@@ -1160,7 +1181,7 @@ async def test_validation_endpoint_missing_identifier(
     }
     auth_headers = {"user_id": user.auth0_user_id}
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/samples/validate_ids/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/SC2/samples/validate_ids/", json=data, headers=auth_headers
     )
 
     # request should not fail, should return list of samples that are missing from the DB


### PR DESCRIPTION
### Summary:
- **What:** use the pathogen slug to return data according to pathogen slug, or create new samples associated with correct pathogen
- **Ticket:** [sc211484](https://app.shortcut.com/genepi/story/211484)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)