### PR TITLE
Handle missing location information for GISAID prepfile d/l

### DIFF
--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -21,6 +21,7 @@ from aspen.database.models import (
     Accession,
     AccessionType,
     Group,
+    Location,
     Pathogen,
     PathogenRepoConfig,
     PublicRepository,
@@ -247,21 +248,17 @@ def collect_submission_information(
 
     for sample in samples:
         sample_info = {}
-        sample_location = getattr(sample, "collection_location")
-        if not sample_location:
-            sample_location = {}
+        sample_location = getattr(sample, "collection_location", Location())
         sample_info = {
-            "gisaid_submitter_id": getattr(user, "gisaid_submitter_id", ""),
+            "gisaid_submitter_id": user.gisaid_submitter_id,
             "public_identifier": sample.public_identifier,
             "collection_date": sample.collection_date,
-            "submitting_lab": getattr(group, "submitting_lab")
-            if getattr(group, "submitting_lab")
-            else group.name,
-            "group_address": getattr(group, "address", ""),
-            "region": getattr(sample_location, "region", ""),
-            "country": getattr(sample_location, "country", ""),
-            "division": getattr(sample_location, "division", ""),
-            "location": getattr(sample_location, "location", ""),
+            "submitting_lab": group.submitting_lab or group.name,
+            "group_address": group.address,
+            "region": sample_location.region,
+            "country": sample_location.country,
+            "division": sample_location.division,
+            "location": sample_location.location,
         }
         submission_information.append(sample_info)
 
@@ -273,9 +270,13 @@ def sample_info_to_gisaid_rows(
 ) -> List[Dict[str, str]]:
     gisaid_metadata_rows = []
     for sample_info in submission_information:
-        gisaid_location = " / ".join(
-            [sample_info[key] for key in ["region", "country", "division", "location"]]
-        )
+        # Concat location information to a single string in Region / Country / Division / Location format
+        location_strings = []
+        for key in ["region", "country", "division", "location"]:
+            if sample_info[key]:
+                location_strings.append(sample_info[key])
+        gisaid_location = " / ".join(location_strings)
+
         metadata_row = {
             "submitter": sample_info["gisaid_submitter_id"],
             "fn": f"{today}_GISAID_sequences.fasta",
@@ -296,6 +297,7 @@ def sample_info_to_genbank_rows(
 ) -> List[Dict[str, str]]:
     genbank_metadata_rows = []
     for sample_info in submission_information:
+        # Concat location information to a single string in Country: Division, Location format
         genbank_location = f"{sample_info['country']}: {sample_info['division']}, {sample_info['location']}"
         metadata_row = {
             "Sequence_ID": apply_pathogen_prefix_to_identifier(

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -275,6 +275,8 @@ def sample_info_to_gisaid_rows(
         for key in ["region", "country", "division", "location"]:
             if sample_info[key]:
                 location_strings.append(sample_info[key])
+            else:
+                location_strings.append("None")
         gisaid_location = " / ".join(location_strings)
 
         metadata_row = {

--- a/src/backend/aspen/api/views/tests/test_submission_templates.py
+++ b/src/backend/aspen/api/views/tests/test_submission_templates.py
@@ -348,6 +348,6 @@ async def test_submission_template_incomplete_location(
         ].collection_date.strftime("%Y-%m-%d")
         assert row["covv_subm_lab"] == group.name
         assert row["covv_subm_lab_addr"] == group.address
-        assert row["covv_location"] == "North America / USA / California"
+        assert row["covv_location"] == "North America / USA / California / None"
         row_count += 1
     assert row_count == len(samples)

--- a/src/backend/aspen/api/views/tests/test_submission_templates.py
+++ b/src/backend/aspen/api/views/tests/test_submission_templates.py
@@ -267,3 +267,87 @@ async def test_submission_template_prefix_stripping(
         assert row["covv_subm_lab_addr"] == group.address
         row_count += 1
     assert row_count == len(samples)
+
+
+async def test_submission_template_incomplete_location(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    """
+    Test a regular tsv download for samples submitted by the user's group
+    """
+    group = group_factory()
+    user = await userrole_factory(async_session, group)
+    location = location_factory("North America", "USA", "California")
+    await setup_gisaid_and_genbank_repo_configs(async_session)
+    pangolin_output = {
+        "scorpio_call": "B.1.167",
+        "scorpio_support": "0.775",
+        "qc_status": "pass",
+    }
+    # Make multiple samples
+    samples: List[Sample] = []
+    uploaded_pathogen_genomes: List[UploadedPathogenGenome] = []
+    for i in range(2):
+        samples.append(
+            sample_factory(
+                group,
+                user,
+                location,
+                private=True,
+                private_identifier=f"hCoV-19/private{i}",
+                public_identifier=f"hCoV-19/public{i}",
+            )
+        )
+        uploaded_pathogen_genomes.append(
+            uploaded_pathogen_genome_factory(
+                samples[i], pangolin_output=pangolin_output
+            )
+        )
+    samples.sort(key=lambda sample: sample.public_identifier)
+    to_add: list[Any] = [user, group, location] + samples  # type: ignore
+    async_session.add_all(to_add)
+    await async_session.commit()
+
+    today = datetime.date.today()
+    auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
+    request_data = {
+        "sample_ids": [sample.public_identifier for sample in samples],
+        "public_repository_name": "GISAID",
+    }
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/samples/submission_template",
+        headers=auth_headers,
+        json=request_data,
+    )
+    expected_filename = f"{today.strftime('%Y%m%d')}_GISAID_metadata.csv"
+    assert res.status_code == 200
+    assert res.headers["Content-Type"] == "text/tsv"
+    assert (
+        res.headers["Content-Disposition"]
+        == f"attachment; filename={expected_filename}"
+    )
+
+    file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
+    tsvreader = csv.DictReader(file_contents, delimiter="\t")
+    assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
+        GisaidSubmissionFormTSVStreamer.fields
+    )
+    tsvreader.__next__()  # skip human-readable headers
+    row_count = 0
+    for row in tsvreader:
+        assert row["fn"] == f"{today.strftime('%Y%m%d')}_GISAID_sequences.fasta"
+        assert (
+            row["covv_virus_name"]
+            == samples[
+                row_count
+            ].public_identifier  # should be the same since they have the hCoV-19 prefix in the db
+        )
+        assert row["covv_collection_date"] == samples[
+            row_count
+        ].collection_date.strftime("%Y-%m-%d")
+        assert row["covv_subm_lab"] == group.name
+        assert row["covv_subm_lab_addr"] == group.address
+        assert row["covv_location"] == "North America / USA / California"
+        row_count += 1
+    assert row_count == len(samples)


### PR DESCRIPTION
### Summary:
- **What:** Fixes a bug in submission template downloads. where a `None` field in the sample's collection location would raise an exception. Cleans up code that pulls information from sample, group, and user.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** [https://prepfile-frontend.dev.czgenepi.org/](https://prepfile-frontend.dev.czgenepi.org/)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)