### PR TITLE
[SC-212962] Strip spaces from NS tree name

### DIFF
--- a/src/frontend/src/components/TreeNameInput/index.tsx
+++ b/src/frontend/src/components/TreeNameInput/index.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "czifui";
-import { useEffect, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import {
   StyledTextField,
   TextFieldAlert,
@@ -66,6 +66,22 @@ const TreeNameInput = ({
     <StyledInstructions items={items} title={"Instructions"} />
   );
 
+  // While the user is typing, don't allow spaces before other characters
+  const onChangeTreeName = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setTreeName(e.target.value?.trimStart());
+  };
+
+  // While the user is typing, we don't want to remove end spaces - otherwise
+  // they won't be able to have multi-word tree names.  However, we
+  // do want to remove trailing spaces when the user is done typing.
+  const onBlurTreeName = () => {
+    if (treeName) {
+      setTreeName(treeName?.trim());
+    }
+  };
+
   return (
     <div>
       {instructions}
@@ -79,7 +95,8 @@ const TreeNameInput = ({
         variant="outlined"
         value={treeName}
         size="small"
-        onChange={(e) => setTreeName(e.target.value)}
+        onBlur={onBlurTreeName}
+        onChange={onChangeTreeName}
         multiline={isTextInputMultiLine ? true : false}
         maxRows={isTextInputMultiLine ? 3 : undefined}
       />


### PR DESCRIPTION
### Summary:
- **What:** `User is allowed to proceed with tree creation if the tree name contains only blank spaces. (backend refuses to start tree run, but we should still disable this in the tree name checks)`
- **Ticket:** [sc212962](https://app.shortcut.com/genepi/story/212962/create-tree-tree-name-input-accepts-blank-spaces-as-valid-name)
- **Env:** `none`

### Notes:
Now we strip initial spaces from the input right away.  When the user is done typing, we strip trailing spaces - this allows for multi-word tree names.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)