### PR TITLE
Update phylo runs and auspice endpoints to use pathogen info.

### DIFF
--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.sql.expression import or_
 
 from aspen.api.authn import get_auth_user
 from aspen.api.authz import AuthZSession, get_authz_session, require_group_privilege
@@ -168,10 +167,7 @@ async def get_serializable_runs(
         joinedload(PhyloRun.user),  # For Pydantic serialization
         joinedload(PhyloRun.group),  # For Pydantic serialization
     )
-    # TODO - DECOVIDIFY - remove the None check!
-    query = query.filter(
-        or_(PhyloRun.pathogen == pathogen, PhyloRun.pathogen_id == None)  # noqa: E711
-    )
+    query = query.filter(PhyloRun.pathogen == pathogen)  # noqa: E711
     if run_id:
         query = query.filter(PhyloRun.id == run_id)
     res = await db.execute(query)

--- a/src/backend/aspen/api/views/phylo_trees.py
+++ b/src/backend/aspen/api/views/phylo_trees.py
@@ -52,7 +52,6 @@ async def _get_selected_samples(db: AsyncSession, phylo_tree_id: int):
         .outerjoin(entity_alias, PhyloRun.inputs.of_type(entity_alias))  # type: ignore
         .outerjoin(Sample)  # type: ignore
         .filter(PhyloTree.entity_id == phylo_tree_id)  # type: ignore
-        .filter(PhyloTree.pathogen == pathogen)  # type: ignore
         .options(
             contains_eager(PhyloTree.producing_workflow.of_type(PhyloRun))
             .contains_eager(PhyloRun.inputs.of_type(entity_alias))

--- a/src/backend/aspen/api/views/phylo_trees.py
+++ b/src/backend/aspen/api/views/phylo_trees.py
@@ -52,6 +52,7 @@ async def _get_selected_samples(db: AsyncSession, phylo_tree_id: int):
         .outerjoin(entity_alias, PhyloRun.inputs.of_type(entity_alias))  # type: ignore
         .outerjoin(Sample)  # type: ignore
         .filter(PhyloTree.entity_id == phylo_tree_id)  # type: ignore
+        .filter(PhyloTree.pathogen == pathogen)  # type: ignore
         .options(
             contains_eager(PhyloTree.producing_workflow.of_type(PhyloRun))
             .contains_eager(PhyloRun.inputs.of_type(entity_alias))

--- a/src/backend/aspen/api/views/tests/test_auspice.py
+++ b/src/backend/aspen/api/views/tests/test_auspice.py
@@ -28,7 +28,9 @@ async def test_valid_auspice_link_generation(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
 
     assert res.status_code == 200
@@ -36,7 +38,7 @@ async def test_valid_auspice_link_generation(
     assert response.get("url", None) is not None
     magic_link = response["url"]
     valid_pattern = re.compile(
-        r"\/v2\/orgs\/\d+\/auspice\/access\/[a-zA-Z\d\-_=]+\.[a-z\d]+"
+        r"\/v2\/orgs\/\d+\/pathogens\/[0-9a-zA-Z]+\/auspice\/access\/[a-zA-Z\d\-_=]+\.[a-z\d]+"
     )
     assert valid_pattern.search(magic_link) is not None
 
@@ -65,7 +67,9 @@ async def test_valid_auspice_link_access(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
 
     assert generate_res.status_code == 200
@@ -109,7 +113,7 @@ async def test_unauth_user_auspice_link_generation(
     auth_headers = {"user_id": user_that_did_not_make_tree.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     res = await http_client.post(
-        f"/v2/orgs/{group_that_did_not_make_tree.id}/auspice/generate",
+        f"/v2/orgs/{group_that_did_not_make_tree.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
         json=request_body,
         headers=auth_headers,
     )
@@ -128,7 +132,9 @@ async def test_tampered_magic_link(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
 
     assert generate_res.status_code == 200
@@ -136,7 +142,9 @@ async def test_tampered_magic_link(
     magic_link = generate_response["url"]
 
     # Now we tamper with the link! We want to see a different tree!
-    payload_plus_tag = magic_link.removeprefix("test/v2/orgs/1/auspice/access/")
+    payload_plus_tag = magic_link.removeprefix(
+        f"test/v2/orgs/1/pathogens/{phylo_tree.pathogen.slug}/auspice/access/"
+    )
     payload, tag = payload_plus_tag.split(".")
     decoded_payload = urlsafe_b64decode(payload).decode("utf8")
     recovered_payload = json.loads(decoded_payload)
@@ -148,7 +156,7 @@ async def test_tampered_magic_link(
     tampered_payload_plus_tag = f"{tampered_message.decode('utf8')}.{tag}"
 
     access_res = await http_client.get(
-        f"/v2/orgs/{group.id}/auspice/access/{tampered_payload_plus_tag}"
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/access/{tampered_payload_plus_tag}"
     )
     assert access_res.status_code == 400
     res_json = access_res.json()
@@ -195,7 +203,9 @@ async def test_country_color_labeling(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
 
     assert generate_res.status_code == 200
@@ -284,7 +294,9 @@ async def test_division_color_labeling(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
 
     assert generate_res.status_code == 200
@@ -372,7 +384,9 @@ async def test_location_color_labeling(
     auth_headers = {"user_id": user.auth0_user_id}
     request_body = {"tree_id": phylo_tree.entity_id}
     generate_res = await http_client.post(
-        f"/v2/orgs/{group.id}/auspice/generate", json=request_body, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/auspice/generate",
+        json=request_body,
+        headers=auth_headers,
     )
 
     assert generate_res.status_code == 200

--- a/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_create_phylo_runs.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from aspen.test_infra.models.gisaid_metadata import gisaid_metadata_factory
 from aspen.test_infra.models.lineage import pango_lineage_factory
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.pathogen import pathogen_factory
+from aspen.test_infra.models.pathogen import random_pathogen_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
 from aspen.test_infra.models.usergroup import group_factory, userrole_factory
@@ -29,7 +29,7 @@ async def test_create_phylo_run(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
@@ -44,7 +44,9 @@ async def test_create_phylo_run(
         "samples": [sample.public_identifier],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 200
     response = res.json()
@@ -69,7 +71,7 @@ async def test_create_phylo_run_mpx(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
@@ -111,7 +113,7 @@ async def test_create_phylo_run_with_failed_sample(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     sample.czb_failed_genome_recovery = True
     gisaid_dump = aligned_gisaid_dump_factory()
@@ -127,7 +129,9 @@ async def test_create_phylo_run_with_failed_sample(
         "samples": [sample.public_identifier],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 400
 
@@ -144,7 +148,7 @@ async def test_create_phylo_run_with_invalid_args(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
     gisaid_dump = aligned_gisaid_dump_factory()
@@ -178,7 +182,9 @@ async def test_create_phylo_run_with_invalid_args(
     for args in requests:
         request_body["template_args"] = args  # type: ignore
         res = await http_client.post(
-            f"/v2/orgs/{group.id}/phylo_runs/", json=request_body, headers=auth_headers
+            f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+            json=request_body,
+            headers=auth_headers,
         )
         assert res.status_code == 422
 
@@ -195,7 +201,7 @@ async def test_create_phylo_run_with_template_args(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
     gisaid_dump = aligned_gisaid_dump_factory()
@@ -236,7 +242,9 @@ async def test_create_phylo_run_with_template_args(
     ]
     for data in requests:
         res = await http_client.post(
-            f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+            f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+            json=data,
+            headers=auth_headers,
         )
         assert res.status_code == 200
         response: Dict[str, Any] = res.json()
@@ -265,7 +273,7 @@ async def test_create_phylo_run_with_gisaid_ids(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
     gisaid_dump = aligned_gisaid_dump_factory()
@@ -282,7 +290,9 @@ async def test_create_phylo_run_with_gisaid_ids(
         "samples": [sample.public_identifier, gisaid_sample.strain],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 200
     response = res.json()
@@ -304,7 +314,7 @@ async def test_create_phylo_run_with_epi_isls(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
     gisaid_dump = aligned_gisaid_dump_factory()
@@ -321,7 +331,9 @@ async def test_create_phylo_run_with_epi_isls(
         "samples": [sample.public_identifier, gisaid_isl_sample.gisaid_epi_isl],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 200
     response = res.json()
@@ -343,7 +355,7 @@ async def test_create_invalid_phylo_run_name(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
@@ -358,7 +370,9 @@ async def test_create_invalid_phylo_run_name(
         "samples": [sample.public_identifier],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 422
 
@@ -375,7 +389,7 @@ async def test_create_invalid_phylo_run_tree_type(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
@@ -390,7 +404,9 @@ async def test_create_invalid_phylo_run_tree_type(
         "samples": [sample.public_identifier],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 422
 
@@ -407,7 +423,7 @@ async def test_create_invalid_phylo_run_bad_sample_id(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
@@ -422,7 +438,9 @@ async def test_create_invalid_phylo_run_bad_sample_id(
         "samples": [sample.public_identifier, "bad_sample_identifier"],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 400
 
@@ -439,7 +457,7 @@ async def test_create_invalid_phylo_run_sample_cannot_see(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
 
     group2 = group_factory(name="The Other Group")
@@ -474,7 +492,9 @@ async def test_create_invalid_phylo_run_sample_cannot_see(
         "samples": [sample.public_identifier, sample2.public_identifier],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 400
 
@@ -492,7 +512,7 @@ async def test_create_phylo_run_unauthorized(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
@@ -508,7 +528,9 @@ async def test_create_phylo_run_unauthorized(
         "samples": [sample.public_identifier],
     }
     res = await http_client.post(
-        f"/v2/orgs/{group.id}/phylo_runs/", json=data, headers=auth_headers
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
     )
     assert res.status_code == 403
 
@@ -542,12 +564,13 @@ async def test_create_phylo_run_with_lineage_aliases(
     location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     sample = sample_factory(group, user, location, pathogen=pathogen)
     gisaid_dump = aligned_gisaid_dump_factory()
     uploaded_pathogen_genome_factory(sample, sequence="ATGCAAAAAA")
     async_session.add(group)
     async_session.add(gisaid_dump)
+    async_session.add(pathogen)
     async_session.add_all(pango_lineages)
     await async_session.commit()
     auth_headers = {"user_id": user.auth0_user_id}
@@ -558,7 +581,11 @@ async def test_create_phylo_run_with_lineage_aliases(
         "samples": [sample.public_identifier],
         "template_args": {"filter_pango_lineages": ["Delta", "BA.1* / 21K", "B.1.1.7"]},
     }
-    res = await http_client.post("/v2/phylo_runs/", json=data, headers=auth_headers)
+    res = await http_client.post(
+        f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
+        json=data,
+        headers=auth_headers,
+    )
     assert res.status_code == 200
     response = res.json()
 

--- a/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
+++ b/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
@@ -107,7 +107,7 @@ async def test_phylo_tree_no_can_see(
         "North America", "USA", "California", "Santa Barbara County"
     )
 
-    _, _, trees, runs = make_all_test_data(
+    pathogen, _, _, trees, runs = make_all_test_data(
         owner_group, user, location, n_samples, n_trees
     )
 
@@ -134,7 +134,7 @@ async def test_phylo_tree_no_can_see(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/orgs/{viewer_group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/download",
+        f"/v2/orgs/{viewer_group.id}/pathogens/{pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/download",
         headers=auth_headers,
     )
     assert result.json() == expected_response

--- a/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
+++ b/src/backend/aspen/api/views/tests/test_download_phylo_tree.py
@@ -53,7 +53,7 @@ async def test_phylo_tree_can_see(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/download",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/download",
         headers=auth_headers,
     )
     returned_tree = result.json()
@@ -85,7 +85,7 @@ async def test_phylo_tree_id_style_public(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/download?id_style=public",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/download?id_style=public",
         headers=auth_headers,
     )
     prefixed_tree = add_prefixes(TEST_TREE)
@@ -134,7 +134,7 @@ async def test_phylo_tree_no_can_see(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/orgs/{viewer_group.id}/phylo_trees/{phylo_tree.entity_id}/download",
+        f"/v2/orgs/{viewer_group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/download",
         headers=auth_headers,
     )
     assert result.json() == expected_response

--- a/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
+++ b/src/backend/aspen/api/views/tests/test_download_tree_sample_ids.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from aspen.database.models import Group, Pathogen, PhyloTree, Sample
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.pathogen import pathogen_factory
+from aspen.test_infra.models.pathogen import random_pathogen_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.sequences import uploaded_pathogen_genome_factory
@@ -92,7 +92,7 @@ async def create_phylotree_with_inputs(
         input_entities.append(input_entity)
 
     db_gisaid_samples = ["hCoV-19/gisaid_identifier", "hCoV-19/gisaid_identifier2"]
-    pathogen: Pathogen = pathogen_factory()
+    pathogen: Pathogen = random_pathogen_factory()
     phylo_run = phylorun_factory(
         owner_group,
         inputs=input_entities,
@@ -132,7 +132,7 @@ async def create_phylotree(
     run_inputs = []
     if sample_as_input:
         run_inputs = [upg]
-    pathogen: Pathogen = pathogen_factory()
+    pathogen: Pathogen = random_pathogen_factory()
     phylo_tree = phylotree_factory(
         phylorun_factory(owner_group, pathogen=pathogen, inputs=run_inputs),
         samples,
@@ -158,7 +158,7 @@ async def test_tree_metadata_download(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/sample_ids",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/sample_ids",
         headers=auth_headers,
     )
     expected_filename = f"{phylo_tree.id}_sample_ids.tsv"
@@ -232,7 +232,7 @@ async def test_private_id_matrix(
         user = case["user"]
         auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
         res = await http_client.get(
-            f"/v2/orgs/{case['group'].id}/phylo_trees/{phylo_tree.entity_id}/sample_ids",
+            f"/v2/orgs/{case['group'].id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/sample_ids",
             headers=auth_headers,
         )
         assert res.status_code == case["expected_status"]
@@ -271,7 +271,7 @@ async def test_tree_metadata_replaces_all_ids(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/sample_ids",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/sample_ids",
         headers=auth_headers,
     )
     assert res.status_code == 200
@@ -316,7 +316,7 @@ async def test_public_tree_metadata_replaces_all_ids(
 
     auth_headers = {"name": user.name, "user_id": user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/sample_ids?id_style=public",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/sample_ids?id_style=public",
         headers=auth_headers,
     )
     assert res.status_code == 200
@@ -356,7 +356,7 @@ async def test_download_samples_unauthorized(
 
     auth_headers = {"name": noaccess_user.name, "user_id": noaccess_user.auth0_user_id}
     res = await http_client.get(
-        f"/v2/orgs/{group.id}/phylo_trees/{phylo_tree.entity_id}/sample_ids?id_style=public",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_tree.pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/sample_ids?id_style=public",
         headers=auth_headers,
     )
     assert res.status_code == 403

--- a/src/backend/aspen/api/views/tests/test_list_phylo_runs.py
+++ b/src/backend/aspen/api/views/tests/test_list_phylo_runs.py
@@ -86,6 +86,7 @@ def make_runs_with_no_trees(group: Group, pathogen: Pathogen) -> Collection[Phyl
 def make_all_test_data(
     group: Group, user: User, location: Location, n_samples: int, n_trees: int
 ) -> Tuple[
+    Pathogen,
     Collection[Sample],
     Collection[UploadedPathogenGenome],
     Sequence[PhyloTree],
@@ -98,14 +99,17 @@ def make_all_test_data(
     pathogen: Pathogen = random_pathogen_factory()
     trees: Sequence[PhyloTree] = make_trees(group, pathogen, samples, n_trees)
     treeless_runs: Collection[PhyloRun] = make_runs_with_no_trees(group, pathogen)
-    return samples, uploaded_pathogen_genomes, trees, treeless_runs
+    return pathogen, samples, uploaded_pathogen_genomes, trees, treeless_runs
 
 
 async def check_results(
-    http_client, user: User, group: Group, trees: Collection[PhyloTree]
+    http_client,
+    user: User,
+    group: Group,
+    pathogen: Pathogen,
+    trees: Collection[PhyloTree],
 ):
     auth_headers = {"user_id": str(user.auth0_user_id)}
-    pathogen = trees[0].pathogen
     res = await http_client.get(
         f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
         headers=auth_headers,
@@ -132,12 +136,14 @@ async def test_phylo_tree_view(
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    _, _, trees, _ = make_all_test_data(group, user, location, n_samples, n_trees)
+    pathogen, _, _, trees, _ = make_all_test_data(
+        group, user, location, n_samples, n_trees
+    )
 
     async_session.add(group)
     await async_session.commit()
 
-    await check_results(http_client, user, group, trees)
+    await check_results(http_client, user, group, pathogen, trees)
 
 
 async def test_in_progress_and_failed_trees(
@@ -151,7 +157,7 @@ async def test_in_progress_and_failed_trees(
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    _, _, trees, treeless_runs = make_all_test_data(
+    pathogen, _, _, trees, treeless_runs = make_all_test_data(
         group, user, location, n_samples, n_trees
     )
 
@@ -159,7 +165,6 @@ async def test_in_progress_and_failed_trees(
     await async_session.commit()
 
     auth_headers = {"user_id": str(user.auth0_user_id)}
-    pathogen = trees[0].pathogen
     res = await http_client.get(
         f"/v2/orgs/{group.id}/pathogens/{pathogen.slug}/phylo_runs/",
         headers=auth_headers,
@@ -209,13 +214,15 @@ async def test_phylo_trees_can_see(
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    _, _, trees, _ = make_all_test_data(owner_group, user, location, n_samples, n_trees)
+    pathogen, _, _, trees, _ = make_all_test_data(
+        owner_group, user, location, n_samples, n_trees
+    )
 
     role_objs = await grouprole_factory(async_session, owner_group, viewer_group)
     async_session.add_all(role_objs)
     await async_session.commit()
 
-    await check_results(http_client, user, viewer_group, trees)
+    await check_results(http_client, user, viewer_group, pathogen, trees)
 
 
 async def test_phylo_trees_no_can_see(
@@ -230,13 +237,14 @@ async def test_phylo_trees_no_can_see(
     location: Location = location_factory(
         "North America", "USA", "California", "Santa Barbara County"
     )
-    _, _, trees, _ = make_all_test_data(owner_group, user, location, n_samples, n_trees)
+    pathogen, _, _, trees, _ = make_all_test_data(
+        owner_group, user, location, n_samples, n_trees
+    )
 
     async_session.add_all((owner_group, viewer_group))
     await async_session.commit()
 
     auth_headers = {"user_id": str(user.auth0_user_id)}
-    pathogen = trees[0].pathogen
     res = await http_client.get(
         f"/v2/orgs/{owner_group.id}/pathogens/{pathogen.slug}/phylo_runs/",
         headers=auth_headers,

--- a/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
+++ b/src/backend/aspen/api/views/tests/test_phylo_tree_rename.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.pathogen import pathogen_factory
+from aspen.test_infra.models.pathogen import random_pathogen_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.usergroup import (
@@ -114,7 +114,7 @@ async def test_phylo_tree_rename(
         for i in range(2)
     ]
 
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     phylo_tree = phylotree_factory(
         phylorun_factory(viewer_group, pathogen=pathogen),
         local_samples + can_see_samples + wrong_can_see_samples + no_can_see_samples,
@@ -137,7 +137,7 @@ async def test_phylo_tree_rename(
 
     auth_headers = {"user_id": user.auth0_user_id}
     result = await http_client.get(
-        f"/v2/orgs/{viewer_group.id}/phylo_trees/{phylo_tree.entity_id}/download",
+        f"/v2/orgs/{viewer_group.id}/pathogens/{pathogen.slug}/phylo_trees/{phylo_tree.entity_id}/download",
         headers=auth_headers,
     )
 

--- a/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
+++ b/src/backend/aspen/api/views/tests/test_update_phylo_run_and_tree.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from aspen.database.models import Group, PhyloRun, PhyloTree, Sample, User
 from aspen.test_infra.models.location import location_factory
-from aspen.test_infra.models.pathogen import pathogen_factory
+from aspen.test_infra.models.pathogen import random_pathogen_factory
 from aspen.test_infra.models.phylo_tree import phylorun_factory, phylotree_factory
 from aspen.test_infra.models.sample import sample_factory
 from aspen.test_infra.models.usergroup import group_factory, userrole_factory
@@ -39,7 +39,7 @@ async def make_shared_test_data(
         )
         for i in range(1, 3)
     ]
-    pathogen = pathogen_factory()
+    pathogen = random_pathogen_factory()
     phylo_run = phylorun_factory(group, pathogen=pathogen)
     phylo_tree = None
     if not no_trees:
@@ -66,7 +66,7 @@ async def test_update_phylo_tree(
     auth_headers = {"user_id": user.auth0_user_id}
     data = {"name": "new_name"}
     res = await http_client.put(
-        f"/v2/orgs/{group.id}/phylo_runs/{phylo_run.id}",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_run.pathogen.slug}/phylo_runs/{phylo_run.id}",
         json=data,
         headers=auth_headers,
     )
@@ -97,7 +97,7 @@ async def test_update_phylo_run_no_trees(
     auth_headers = {"user_id": user.auth0_user_id}
     data = {"name": "new_name"}
     res = await http_client.put(
-        f"/v2/orgs/{group.id}/phylo_runs/{phylo_run.id}",
+        f"/v2/orgs/{group.id}/pathogens/{phylo_run.pathogen.slug}/phylo_runs/{phylo_run.id}",
         json=data,
         headers=auth_headers,
     )
@@ -140,7 +140,7 @@ async def test_update_phylo_tree_wrong_group(
     auth_headers = {"user_id": user_that_did_not_make_tree.auth0_user_id}
     data = {"name": "new_name"}
     res = await http_client.put(
-        f"/v2/orgs/{group_that_did_not_make_tree.id}/phylo_runs/{phylo_run.id}",
+        f"/v2/orgs/{group_that_did_not_make_tree.id}/pathogens/{phylo_run.pathogen.slug}/phylo_runs/{phylo_run.id}",
         json=data,
         headers=auth_headers,
     )


### PR DESCRIPTION
### Summary:
- **What:** Auspice and phylo runs endpoints should *use* the pathogen slug in the URL for filtering.
- **Ticket:** [sc211486](https://app.shortcut.com/genepi/story/211486)

### Notes:
I updated most/all of the phylo run and auspice-related unit tests to use randomly-generated pathogens to make sure we're not depending on any specific pathogen.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)