### PR TITLE
[SC-214164] add link out to galago from phylo tree table

### DIFF
--- a/src/frontend/src/common/styles/accessibility.ts
+++ b/src/frontend/src/common/styles/accessibility.ts
@@ -19,7 +19,8 @@ export const srOnly = (): string => {
 
 export const accessibleFocusBorder = (): string => {
   return `
-    &:focus {
+    &:focus, &:focus-within {
+      border: 1px solid blue
       outline: 5px auto Highlight;
       outline: 5px auto -webkit-focus-ring-color;
     }

--- a/src/frontend/src/common/styles/accessibility.ts
+++ b/src/frontend/src/common/styles/accessibility.ts
@@ -20,7 +20,6 @@ export const srOnly = (): string => {
 export const accessibleFocusBorder = (): string => {
   return `
     &:focus, &:focus-within {
-      border: 1px solid blue
       outline: 5px auto Highlight;
       outline: 5px auto -webkit-focus-ring-color;
     }

--- a/src/frontend/src/components/Split/index.tsx
+++ b/src/frontend/src/components/Split/index.tsx
@@ -45,6 +45,7 @@ import { useUserInfo } from "src/common/queries/auth";
  */
 export enum FEATURE_FLAGS {
   // my_flag_name = "my_flag_name", (<-- format example)
+  galago_integration = "galago_integration",
   prep_files = "prep_files",
   sample_filtering_tree_creation = "sample_filtering_tree_creation",
   user_onboarding_v0 = "user_onboarding_v0",

--- a/src/frontend/src/views/Data/components/TreeActionMenu/components/OpenInGalagoButton/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/components/OpenInGalagoButton/index.tsx
@@ -7,7 +7,7 @@ interface Props {
   item: PhyloRun;
 }
 
-const OpenInNextstrainButton = ({ item }: Props): JSX.Element => {
+const OpenInGalagoButton = ({ item }: Props): JSX.Element => {
   const [open, setOpen] = useState(false);
   const { status, phyloTree } = item;
   const treeId = phyloTree?.id;
@@ -29,25 +29,26 @@ const OpenInNextstrainButton = ({ item }: Props): JSX.Element => {
         sdsStyle={isDisabled ? "light" : "dark"}
         title={
           isDisabled
-            ? "“View in Nextstrain” is only available for completed trees."
-            : "View in Nextstrain"
+            ? "“View in Galago” is only available for completed trees."
+            : "View in Galago"
         }
         placement="top"
       >
         <span>
           <ButtonIcon
-            aria-label="view in Nextstrain"
+            aria-label="view in Galago"
             disabled={isDisabled}
             onClick={handleClickOpen}
             sdsSize="small"
             sdsType="primary"
             size="large"
           >
-            <Icon sdsIcon="treeHorizontal" sdsSize="s" sdsType="iconButton" />
+            <Icon sdsIcon="lightBulb" sdsSize="s" sdsType="iconButton" />
           </ButtonIcon>
         </span>
       </Tooltip>
       {treeId && (
+        // TODO: (ehoops): replace this with the Galago modal as part of SC-214165
         <NextstrainConfirmationModal
           open={open}
           onClose={handleClose}
@@ -58,4 +59,4 @@ const OpenInNextstrainButton = ({ item }: Props): JSX.Element => {
   );
 };
 
-export { OpenInNextstrainButton };
+export { OpenInGalagoButton };

--- a/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
@@ -1,4 +1,5 @@
 import { MoreActionsMenu } from "./components/MoreActionsMenu";
+import { OpenInGalagoButton } from "./components/OpenInGalagoButton";
 import { OpenInNextstrainButton } from "./components/OpenInNextstrainButton";
 import TreeTableDownloadMenu from "./components/TreeTableDownloadMenu";
 import { StyledActionWrapper, StyledTreeActionMenu } from "./style";
@@ -33,10 +34,13 @@ const TreeActionMenu = ({
   onEditTreeModalOpen,
   userInfo,
 }: Props): JSX.Element => (
-  <StyledTreeActionMenu>
+  <StyledTreeActionMenu role="group" aria-label={`${item?.name} tree actions`}>
     <StyledActionWrapper>
       <OpenInNextstrainButton item={item} />
     </StyledActionWrapper>
+    <StyledActionWrapper>
+      <OpenInGalagoButton item={item} />
+    </StyledActionWrapper> 
     <StyledActionWrapper>
       <TreeTableDownloadMenu item={item} />
     </StyledActionWrapper>

--- a/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
@@ -1,3 +1,5 @@
+import { useTreatments } from "@splitsoftware/splitio-react";
+import { FEATURE_FLAGS, isFlagOn } from "src/components/Split";
 import { MoreActionsMenu } from "./components/MoreActionsMenu";
 import { OpenInGalagoButton } from "./components/OpenInGalagoButton";
 import { OpenInNextstrainButton } from "./components/OpenInNextstrainButton";
@@ -33,26 +35,39 @@ const TreeActionMenu = ({
   onDeleteTreeModalOpen,
   onEditTreeModalOpen,
   userInfo,
-}: Props): JSX.Element => (
-  <StyledTreeActionMenu role="group" aria-label={`${item?.name} tree actions`}>
-    <StyledActionWrapper>
-      <OpenInNextstrainButton item={item} />
-    </StyledActionWrapper>
-    <StyledActionWrapper>
-      <OpenInGalagoButton item={item} />
-    </StyledActionWrapper>
-    <StyledActionWrapper>
-      <TreeTableDownloadMenu item={item} />
-    </StyledActionWrapper>
-    <StyledActionWrapper>
-      <MoreActionsMenu
-        item={item}
-        onDeleteTreeModalOpen={onDeleteTreeModalOpen}
-        onEditTreeModalOpen={onEditTreeModalOpen}
-        userInfo={userInfo}
-      />
-    </StyledActionWrapper>
-  </StyledTreeActionMenu>
-);
+}: Props): JSX.Element => {
+  const flag = useTreatments([FEATURE_FLAGS.galago_integration]);
+  const isGalagoIntegrationFlagOn = isFlagOn(
+    flag,
+    FEATURE_FLAGS.galago_integration
+  );
+
+  return (
+    <StyledTreeActionMenu
+      role="group"
+      aria-label={`${item?.name} tree actions`}
+    >
+      <StyledActionWrapper>
+        <OpenInNextstrainButton item={item} />
+      </StyledActionWrapper>
+      {isGalagoIntegrationFlagOn && (
+        <StyledActionWrapper>
+          <OpenInGalagoButton item={item} />
+        </StyledActionWrapper>
+      )}
+      <StyledActionWrapper>
+        <TreeTableDownloadMenu item={item} />
+      </StyledActionWrapper>
+      <StyledActionWrapper>
+        <MoreActionsMenu
+          item={item}
+          onDeleteTreeModalOpen={onDeleteTreeModalOpen}
+          onEditTreeModalOpen={onEditTreeModalOpen}
+          userInfo={userInfo}
+        />
+      </StyledActionWrapper>
+    </StyledTreeActionMenu>
+  );
+};
 
 export { TreeActionMenu };

--- a/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
@@ -40,7 +40,7 @@ const TreeActionMenu = ({
     </StyledActionWrapper>
     <StyledActionWrapper>
       <OpenInGalagoButton item={item} />
-    </StyledActionWrapper> 
+    </StyledActionWrapper>
     <StyledActionWrapper>
       <TreeTableDownloadMenu item={item} />
     </StyledActionWrapper>

--- a/src/frontend/src/views/Data/components/TreeActionMenu/style.ts
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/style.ts
@@ -1,25 +1,31 @@
 import styled from "@emotion/styled";
 import { CommonThemeProps, getSpaces } from "czifui";
+import { accessibleFocusBorder } from "src/common/styles/accessibility";
 
-export const StyledActionWrapper = styled.div`
+export const StyledActionWrapper = styled.li`
+  list-style: none;
+  ${accessibleFocusBorder}
   ${(props: CommonThemeProps) => {
     const spaces = getSpaces(props);
 
     return `
-      padding: 0 ${spaces?.m}px;
+      margin: 0 ${spaces?.xs}px;
 
       &:last-child {
-        padding-right: 0;
+        margin-right: 0;
       }
+
+      padding: ${spaces?.xxxs}px;
     `;
   }}
 `;
 
-export const StyledTreeActionMenu = styled.div`
+export const StyledTreeActionMenu = styled.ul`
   display: flex;
   align-items: center;
   justify-content: right;
   width: 150px;
+  padding: 0;
 
   ${(props: CommonThemeProps) => {
     const spaces = getSpaces(props);


### PR DESCRIPTION
### Summary:
- **What:** `Add a placeholder icon button to Galago.  Accessibility improvements.`
- **Ticket:** [sc214164](https://app.shortcut.com/genepi/story/214164/add-link-out-to-galago-from-phylo-tree-table)
- **Env:** `none`

### Demos:
sound on

https://user-images.githubusercontent.com/109251328/189738250-47f7f2fb-9f14-4476-9293-cf512d76a97e.mov

### Notes:
The button currently opens the nextstrain modal.  I will update that next as part of [214165](https://app.shortcut.com/genepi/story/214165/modal-for-users-to-confirm-sending-out-to-galago-from-cz-ge)

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)