### PR TITLE
Make it clearer what size instances to launch.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -183,8 +183,7 @@ module gisaid_sfn_config {
   image    = local.gisaid_image
   # This job is actually constrained by *DISK SPACE* and swipe currently only supports NVME-mounted storage
   # so we're requesting more vcpu's than necessary in order to bump the instance size to: 2 x 900 NVMe SSD
-  vcpus    = 48
-  memory   = 128000
+  memory   = 384000
   wdl_path = "workflows/gisaid.wdl"
   custom_stack_name     = local.custom_stack_name
   deployment_stage      = local.deployment_stage
@@ -249,8 +248,7 @@ module nextstrain_autorun_sfn_config {
   image    = local.backend_image
   # This job is actually constrained by *DISK SPACE* and swipe currently only supports NVME-mounted storage
   # so we're requesting more vcpu's than necessary in order to bump the instance size to: 2 x 300 NVMe SSD
-  vcpus    = 16
-  memory   = 64000
+  memory   = 16000
   wdl_path = "workflows/nextstrain-autorun.wdl"
   custom_stack_name     = local.custom_stack_name
   deployment_stage      = local.deployment_stage
@@ -277,7 +275,6 @@ module nextstrain_ondemand_template_sfn_config {
   source   = "../sfn_config"
   app_name = "nextstrain-ondemand-sfn"
   image    = local.nextstrain_image
-  vcpus    = 8
   memory   = 64000
   wdl_path = "workflows/nextstrain-ondemand.wdl"
   custom_stack_name     = local.custom_stack_name

--- a/.happy/terraform/modules/sfn_config/main.tf
+++ b/.happy/terraform/modules/sfn_config/main.tf
@@ -8,8 +8,8 @@ locals {
       )
     }
     OutputPrefix = "s3://${var.swipe_comms_bucket}/swipe${var.remote_dev_prefix}/${var.app_name}/results",
-    RunSPOTMemory = var.memory,
-    RunEC2Memory = var.memory,
+    RunSPOTMemory = var.memory - 2000,
+    RunEC2Memory = var.memory - 2000,
     RunSPOTVcpu = var.vcpus,
     RunEC2Vcpu = var.vcpus,
     RUN_WDL_URI = "s3://${aws_s3_bucket_object.wdl.bucket}${aws_s3_bucket_object.wdl.key}",


### PR DESCRIPTION
### Notes:
I did some investigation into what's going on with our batch job sizing and learned a few things:
- Using *both* vcpu *and* memory parameters to specify what size instance to launch is confusing for humans, it's easy to update one forget to update the other so it's not always clear what instance class is getting launched.
- It's more than just confusing for humans. It looks like swipe is in some cases basically ignoring the vcpu parameter. I have some time set aside next sprint to look into this, but in the meantime we can work around it by just using memory values.
- I did some testing in staging and for more ambiguous reasons, when we ask for 384000 mib of memory, we get an r5d.16xlarge instance, but when we ask for 382000 mib of memory, we get the r5d.12xlarge instance size we were aiming for. I'm not sure why this happens, but I added a "- 2000" to our terraform code to work around this.

Basically launching instances that are larger than we expected / planned for allowed AWS to schedule more jobs to the same host, which caused disk space contention. This PR *hopefully* means that all of our instances will be right-sized to each run on their own host for the moment.

There are a lot of improvements/changes we plan to take on in the future to make all this better, but I'm hoping this keeps jobs stable for now.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)