### PR TITLE
make gisaid metadata truly csv

### DIFF
--- a/src/backend/aspen/api/utils/__init__.py
+++ b/src/backend/aspen/api/utils/__init__.py
@@ -26,6 +26,6 @@ from aspen.api.utils.sample import (  # noqa: F401
 from aspen.api.utils.tsv_streamer import (  # noqa: F401
     FieldSeparatedStreamer,
     GenBankSubmissionFormTSVStreamer,
-    GisaidSubmissionFormTSVStreamer,
+    GisaidSubmissionFormCSVStreamer,
     MetadataTSVStreamer,
 )

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -307,7 +307,9 @@ def sample_info_to_genbank_rows(
             ),
             "collection-date": sample_info["collection_date"].strftime("%Y-%m-%d"),
             "country": genbank_location,
-            "isolate": f"SARS-CoV-2/{sample_info['public_identifier']}",
+            "isolate": apply_pathogen_prefix_to_identifier(
+                sample_info["public_identifier"], pathogen_prefix
+            ),
         }
         genbank_metadata_rows.append(metadata_row)
     return genbank_metadata_rows

--- a/src/backend/aspen/api/utils/tsv_streamer.py
+++ b/src/backend/aspen/api/utils/tsv_streamer.py
@@ -73,7 +73,7 @@ class MetadataTSVStreamer(FieldSeparatedStreamer):
         return data
 
 
-class GisaidSubmissionFormTSVStreamer(FieldSeparatedStreamer):
+class GisaidSubmissionFormCSVStreamer(FieldSeparatedStreamer):
     computer_fields = [
         "submitter",
         "fn",
@@ -148,7 +148,7 @@ class GisaidSubmissionFormTSVStreamer(FieldSeparatedStreamer):
     }
 
     def __init__(self, filename: str, data: Iterable):
-        super().__init__("\t", filename, data)
+        super().__init__(",", filename, data)
 
     def generate_row(self, item):
         data: Mapping[str, Any] = {}

--- a/src/backend/aspen/api/utils/tsv_streamer.py
+++ b/src/backend/aspen/api/utils/tsv_streamer.py
@@ -175,7 +175,7 @@ class GenBankSubmissionFormTSVStreamer(FieldSeparatedStreamer):
     ]
 
     preset_fields = {
-        "host": "Homo Sapiens",
+        "host": "Homo sapiens",
         "isolation-source": "Nasal/oral swab",
     }
 

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -38,7 +38,7 @@ from aspen.api.utils import (
     get_matching_gisaid_ids_by_epi_isl,
     get_missing_and_found_sample_ids,
     get_public_repository_prefix,
-    GisaidSubmissionFormTSVStreamer,
+    GisaidSubmissionFormCSVStreamer,
     sample_info_to_genbank_rows,
     sample_info_to_gisaid_rows,
     samples_by_identifiers,
@@ -418,7 +418,7 @@ async def fill_submission_template(
     metadata_rows: list[dict[str, str]] = []
     filename: str = ""
     tsv_streamer: Union[
-        Type[GisaidSubmissionFormTSVStreamer], Type[GenBankSubmissionFormTSVStreamer]
+        Type[GisaidSubmissionFormCSVStreamer], Type[GenBankSubmissionFormTSVStreamer]
     ]
     if request.public_repository_name.lower() == "gisaid":
         metadata_rows = sample_info_to_gisaid_rows(
@@ -428,8 +428,8 @@ async def fill_submission_template(
         filename = get_submission_template_filename("GISAID")
         filename = filename.replace(
             ".tsv", ".csv"
-        )  # yes, we want a TSV with a .csv extension
-        tsv_streamer = GisaidSubmissionFormTSVStreamer
+        )
+        tsv_streamer = GisaidSubmissionFormCSVStreamer
     elif request.public_repository_name.lower() == "genbank":
         metadata_rows = sample_info_to_genbank_rows(submission_information, prefix)
         metadata_rows.sort(key=lambda row: row.get("Sequence_ID"))  # type: ignore

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -426,9 +426,7 @@ async def fill_submission_template(
         )
         metadata_rows.sort(key=lambda row: row.get("covv_virus_name"))  # type: ignore
         filename = get_submission_template_filename("GISAID")
-        filename = filename.replace(
-            ".tsv", ".csv"
-        )
+        filename = filename.replace(".tsv", ".csv")
         tsv_streamer = GisaidSubmissionFormCSVStreamer
     elif request.public_repository_name.lower() == "genbank":
         metadata_rows = sample_info_to_genbank_rows(submission_information, prefix)

--- a/src/backend/aspen/api/views/tests/test_submission_templates.py
+++ b/src/backend/aspen/api/views/tests/test_submission_templates.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from aspen.api.utils import (
     GenBankSubmissionFormTSVStreamer,
-    GisaidSubmissionFormTSVStreamer,
+    GisaidSubmissionFormCSVStreamer,
 )
 from aspen.database.models import Sample, UploadedPathogenGenome
 from aspen.test_infra.models.location import location_factory
@@ -79,7 +79,7 @@ async def test_submission_template_download_gisaid(
     )
     expected_filename = f"{today.strftime('%Y%m%d')}_GISAID_metadata.csv"
     assert res.status_code == 200
-    assert res.headers["Content-Type"] == "text/tsv"
+    assert res.headers["Content-Type"] == "text/csv"
     assert (
         res.headers["Content-Disposition"]
         == f"attachment; filename={expected_filename}"
@@ -88,7 +88,7 @@ async def test_submission_template_download_gisaid(
     file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
     tsvreader = csv.DictReader(file_contents, delimiter="\t")
     assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
-        GisaidSubmissionFormTSVStreamer.fields
+        GisaidSubmissionFormCSVStreamer.fields
     )
     tsvreader.__next__()  # skip human-readable headers
     row_count = 0
@@ -239,7 +239,7 @@ async def test_submission_template_prefix_stripping(
     )
     expected_filename = f"{today.strftime('%Y%m%d')}_GISAID_metadata.csv"
     assert res.status_code == 200
-    assert res.headers["Content-Type"] == "text/tsv"
+    assert res.headers["Content-Type"] == "text/csv"
     assert (
         res.headers["Content-Disposition"]
         == f"attachment; filename={expected_filename}"
@@ -248,7 +248,7 @@ async def test_submission_template_prefix_stripping(
     file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
     tsvreader = csv.DictReader(file_contents, delimiter="\t")
     assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
-        GisaidSubmissionFormTSVStreamer.fields
+        GisaidSubmissionFormCSVStreamer.fields
     )
     tsvreader.__next__()  # skip human-readable headers
     row_count = 0
@@ -322,7 +322,7 @@ async def test_submission_template_incomplete_location(
     )
     expected_filename = f"{today.strftime('%Y%m%d')}_GISAID_metadata.csv"
     assert res.status_code == 200
-    assert res.headers["Content-Type"] == "text/tsv"
+    assert res.headers["Content-Type"] == "text/csv"
     assert (
         res.headers["Content-Disposition"]
         == f"attachment; filename={expected_filename}"
@@ -331,7 +331,7 @@ async def test_submission_template_incomplete_location(
     file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
     tsvreader = csv.DictReader(file_contents, delimiter="\t")
     assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
-        GisaidSubmissionFormTSVStreamer.fields
+        GisaidSubmissionFormCSVStreamer.fields
     )
     tsvreader.__next__()  # skip human-readable headers
     row_count = 0

--- a/src/backend/aspen/api/views/tests/test_submission_templates.py
+++ b/src/backend/aspen/api/views/tests/test_submission_templates.py
@@ -86,7 +86,7 @@ async def test_submission_template_download_gisaid(
     )
 
     file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
-    tsvreader = csv.DictReader(file_contents, delimiter="\t")
+    tsvreader = csv.DictReader(file_contents, delimiter=",")
     assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
         GisaidSubmissionFormCSVStreamer.fields
     )
@@ -246,7 +246,7 @@ async def test_submission_template_prefix_stripping(
     )
 
     file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
-    tsvreader = csv.DictReader(file_contents, delimiter="\t")
+    tsvreader = csv.DictReader(file_contents, delimiter=",")
     assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
         GisaidSubmissionFormCSVStreamer.fields
     )
@@ -329,7 +329,7 @@ async def test_submission_template_incomplete_location(
     )
 
     file_contents = io.StringIO(str(res.content, encoding="UTF-8"))
-    tsvreader = csv.DictReader(file_contents, delimiter="\t")
+    tsvreader = csv.DictReader(file_contents, delimiter=",")
     assert set(list(tsvreader.fieldnames)) == set(  # type: ignore
         GisaidSubmissionFormCSVStreamer.fields
     )


### PR DESCRIPTION
### Summary:
- **What:** 
- 1. Make GISAID metadata a CSV format. 
- 2. Update GenBank `isolate` column to be identical to the Sequence_ID column w `SARS-CoV-2/human` prefix.
- 3. Lower case `Homo sapiens`

### Demos:
(I don't know how to set up remote dev, so here is from my local dev)
<img width="1404" alt="image" src="https://user-images.githubusercontent.com/20667188/189959132-5a60aba6-3e28-4b9d-8655-f1c2808213d3.png">
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/20667188/189959225-2df0bc0e-4041-45ce-a2bc-e946673a2a3e.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)