### PR TITLE
Fix nextstrain output paths

### DIFF
--- a/src/backend/aspen/util/swipe.py
+++ b/src/backend/aspen/util/swipe.py
@@ -77,7 +77,7 @@ class NextstrainJob(SwipeJob):
     def run(self, run: PhyloRun, run_type: str):
         group = run.group
         now = datetime.datetime.now()
-        output_suffix = f"{group.name}/{str(now)}"
+        output_suffix = f"/{group.name}/{str(now)}"
         execution_name = f"{group.prefix}-{self.job_type}-nextstrain-{str(now)}"
         extra_params = {
             "s3_filestem": f"{group.location}/{run.tree_type}",


### PR DESCRIPTION
### Summary:
- **What:** Make sure nextstrain output paths have a separator between prefix and suffix.


### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)