### PR TITLE
[SC-214168] Add footer link.

### DIFF
--- a/src/frontend/src/common/routes.ts
+++ b/src/frontend/src/common/routes.ts
@@ -8,6 +8,7 @@ export enum ROUTES {
   CZI = "https://chanzuckerberg.com/",
   DATA = "/data",
   DATA_SAMPLES = "/data/samples",
+  GALAGO = "https://galago.czgenepi.org/",
   GISAID = "https://www.gisaid.org/",
   GITHUB = "https://github.com/chanzuckerberg/czgenepi/",
   GROUP = "/group",

--- a/src/frontend/src/views/LandingPageV2/components/Footer/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/Footer/index.tsx
@@ -20,6 +20,7 @@ import {
   FooterTopContainer,
   FooterTopLink,
   FooterTopLinks,
+  FooterTopListItem,
   Span,
 } from "./style";
 
@@ -42,15 +43,26 @@ export default function Footer(): JSX.Element {
           <FooterLogo />
         </FooterLogoContainer>
         <FooterTopLinks>
-          <FooterTopLink href={ROUTES.GITHUB} target="_blank">
-            Github
-          </FooterTopLink>
-          <FooterTopLink href={ROUTES.CAREERS} target="_blank">
-            Careers
-          </FooterTopLink>
-          <FooterTopLink href={ROUTES.RESOURCES} target="_blank">
-            Learning Center
-          </FooterTopLink>
+          <FooterTopListItem>
+            <FooterTopLink href={ROUTES.GITHUB} target="_blank">
+              Github
+            </FooterTopLink>
+          </FooterTopListItem>
+          <FooterTopListItem>
+            <FooterTopLink href={ROUTES.CAREERS} target="_blank">
+              Careers
+            </FooterTopLink>
+          </FooterTopListItem>
+          <FooterTopListItem>
+            <FooterTopLink href={ROUTES.RESOURCES} target="_blank">
+              Learning Center
+            </FooterTopLink>
+          </FooterTopListItem>
+          <FooterTopListItem>
+            <FooterTopLink href={ROUTES.GALAGO} target="_blank">
+              Galago (Beta)
+            </FooterTopLink>
+          </FooterTopListItem>
         </FooterTopLinks>
       </FooterTopContainer>
       <FooterBottomContainer>

--- a/src/frontend/src/views/LandingPageV2/components/Footer/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/Footer/index.tsx
@@ -59,6 +59,11 @@ export default function Footer(): JSX.Element {
             </FooterTopLink>
           </FooterTopListItem>
           <FooterTopListItem>
+            <FooterTopLink href={ROUTES.HELP_CENTER} target="_blank">
+              Help Center
+            </FooterTopLink>
+          </FooterTopListItem>
+          <FooterTopListItem>
             <FooterTopLink href={ROUTES.GALAGO} target="_blank">
               Galago (Beta)
             </FooterTopLink>

--- a/src/frontend/src/views/LandingPageV2/components/Footer/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/Footer/style.ts
@@ -85,7 +85,7 @@ const footerText = () => {
   `;
 };
 
-export const FooterContainer = styled.div`
+export const FooterContainer = styled.footer`
   background: black;
   color: white;
   padding: 64px 115px;
@@ -130,6 +130,20 @@ export const FooterTopContainer = styled.div`
   `)}
 `;
 
+export const FooterTopListItem = styled.li`
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  margin-left: 39px;
+
+  ${SmallerThanBreakpoint(`
+    width: 100%;
+    margin-left: 0;
+    margin-top: 11px;
+`)}
+`;
+
 export const FooterTopLink = styled.a`
   ${SmallerThanBreakpoint(`
     background: #262525;
@@ -137,19 +151,13 @@ export const FooterTopLink = styled.a`
     padding: 7px 14px;
     width: 100%;
     max-width: 280px;
-    text-align: center;
   `)}
 `;
 
-export const FooterTopLinks = styled.div`
-  a + a {
-    margin-left: 39px;
-
-    ${SmallerThanBreakpoint(`
-      margin-left: 0;
-      margin-top: 11px;
-    `)}
-  }
+export const FooterTopLinks = styled.ul`
+  display: flex;
+  flex-direction: row;
+  padding: 0;
 
   ${SmallerThanBreakpoint(`
     display: flex;


### PR DESCRIPTION
### Summary:
- **What:** `Add link to Galago in footer.  Add Help Center link to footer. Update some semantic html to improve accessibility.`
- **Ticket:** [sc214168](https://app.shortcut.com/genepi/story/214168/add-a-link-in-the-cz-ge-landing-page-footer-to-galago)
- **Env:** `none`

### Demos:
![Screen Shot 2022-09-13 at 10 01 53 AM](https://user-images.githubusercontent.com/109251328/189962802-b09f3ac7-803d-437a-bb0c-8ce8d3fecc1c.png)
![Screen Shot 2022-09-13 at 10 01 45 AM](https://user-images.githubusercontent.com/109251328/189962803-36a7d2a2-9e09-42c3-9df7-f91a9263313a.png)


### Notes:
The list of links in the footer was previously a div.  I changed it to a list.  This messed up some styling, which (I think) I put back.  Getting some quick eyes on this would be great.


### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)