### PR TITLE
Homepage accessibility

### DIFF
--- a/src/frontend/src/common/analytics/methods.ts
+++ b/src/frontend/src/common/analytics/methods.ts
@@ -140,8 +140,9 @@ export function analyticsTrackEvent<
 export function analyticsTrackEvent(
   eventType: EVENT_TYPES,
   additionalEventData?: EventData
-) {
+): void {
   const addlEventData = additionalEventData || {};
+  debugger;
   if (window.analytics && window.isCzGenEpiAnalyticsEnabled) {
     const eventData = {
       ...getCommonUserInfo(),

--- a/src/frontend/src/common/analytics/methods.ts
+++ b/src/frontend/src/common/analytics/methods.ts
@@ -142,7 +142,6 @@ export function analyticsTrackEvent(
   additionalEventData?: EventData
 ): void {
   const addlEventData = additionalEventData || {};
-  debugger;
   if (window.analytics && window.isCzGenEpiAnalyticsEnabled) {
     const eventData = {
       ...getCommonUserInfo(),

--- a/src/frontend/src/common/images/form-submit-arrow.svg
+++ b/src/frontend/src/common/images/form-submit-arrow.svg
@@ -1,3 +1,0 @@
-<svg width="7" height="10" viewBox="0 0 7 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M1.05707 1.12671L5.08221 5.15186L1.05707 9.177" stroke="white" stroke-width="1.4231"/>
-</svg>

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
@@ -15,6 +15,7 @@ import {
   HeaderMaxWidthContainer,
   HeaderTopContainer,
   HeaderTopLinks,
+  HiddenTitle,
   MobileNavClose,
   MobileNavCloseContainer,
   MobileNavLink,
@@ -115,7 +116,7 @@ export default function StaticPageNavBar(): JSX.Element {
       <HeaderMaxWidthContainer>
         <HeaderTopContainer>
           <HeaderLogoContainer href={userInfo ? ROUTES.DATA : ROUTES.HOMEPAGE}>
-            <HeaderLogo data-test-id="logo" />
+            <HeaderLogo data-test-id="logo" title="CZ Gen Epi Home" />
             {orgSplash ? <OrgSplash>{orgSplash}</OrgSplash> : null}
           </HeaderLogoContainer>
           <HeaderTopLinks>{RightNav}</HeaderTopLinks>

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
@@ -15,7 +15,6 @@ import {
   HeaderMaxWidthContainer,
   HeaderTopContainer,
   HeaderTopLinks,
-  HiddenTitle,
   MobileNavClose,
   MobileNavCloseContainer,
   MobileNavLink,

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/style.ts
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { srOnly } from "src/common/styles/accessibility";
 import { SmallerThanBreakpoint } from "src/common/styles/mixins/global";
 
 export const Bar = styled.div`
@@ -39,7 +40,7 @@ export const HeaderTopLinks = styled.div`
   `)}
 `;
 
-export const HeaderContainer = styled.div`
+export const HeaderContainer = styled.header`
   background: black;
   color: white;
 
@@ -135,6 +136,11 @@ export const MobileNavTray = styled.div`
   background-color: #ffffff;
   z-index: 10;
   transition: all 0.4s;
+  display: none;
+  ${SmallerThanBreakpoint(`
+    display: inline-block;
+    cursor: pointer;
+  `)}
 `;
 
 export const OrgSplash = styled.span`
@@ -150,4 +156,8 @@ export const OrgSplash = styled.span`
 
 export const TextLink = styled.a`
   margin: 0 10px;
+`;
+
+export const HiddenTitle = styled.title`
+  ${srOnly}
 `;

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/style.ts
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/style.ts
@@ -157,7 +157,3 @@ export const OrgSplash = styled.span`
 export const TextLink = styled.a`
   margin: 0 10px;
 `;
-
-export const HiddenTitle = styled.title`
-  ${srOnly}
-`;

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/style.ts
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/style.ts
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { srOnly } from "src/common/styles/accessibility";
 import { SmallerThanBreakpoint } from "src/common/styles/mixins/global";
 
 export const Bar = styled.div`

--- a/src/frontend/src/views/LandingPageV2/components/Hero/components/HeroEmailForm/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/Hero/components/HeroEmailForm/index.tsx
@@ -25,12 +25,13 @@ export default function EmailForm(): JSX.Element {
     <HeroEmailForm onSubmit={submitEmail}>
       <EmailInput
         placeholder="Your email address"
+        aria-labelledby="join-waitlist"
         value={enteredEmail}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           setEnteredEmail(e.target.value);
         }}
       />
-      <SubmitButton type="submit">
+      <SubmitButton id="join-waitlist" type="submit">
         Join the waitlist
         <SubmitIcon>
           <FormSubmitArrow />

--- a/src/frontend/src/views/LandingPageV2/components/Hero/components/HeroEmailForm/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/Hero/components/HeroEmailForm/index.tsx
@@ -1,5 +1,5 @@
+import { Icon } from "czifui";
 import { useState } from "react";
-import FormSubmitArrow from "src/common/images/form-submit-arrow.svg";
 import { EmailInput, HeroEmailForm, SubmitButton, SubmitIcon } from "./style";
 
 export default function EmailForm(): JSX.Element {
@@ -34,7 +34,7 @@ export default function EmailForm(): JSX.Element {
       <SubmitButton id="join-waitlist" type="submit">
         Join the waitlist
         <SubmitIcon>
-          <FormSubmitArrow />
+          <Icon sdsIcon="chevronRight" sdsSize="xs" sdsType="static" />
         </SubmitIcon>
       </SubmitButton>
     </HeroEmailForm>

--- a/src/frontend/src/views/LandingPageV2/components/Hero/components/HeroEmailForm/style.ts
+++ b/src/frontend/src/views/LandingPageV2/components/Hero/components/HeroEmailForm/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { iconFillWhite } from "src/common/styles/iconStyle";
 import { SmallerThanBreakpoint } from "src/common/styles/mixins/global";
 
 export const HeroEmailForm = styled.form`
@@ -78,4 +79,5 @@ export const SubmitButton = styled.button`
 
 export const SubmitIcon = styled.span`
   margin-left: 10px;
+  ${iconFillWhite}
 `;

--- a/src/frontend/src/views/LandingPageV2/components/Hero/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/Hero/index.tsx
@@ -28,7 +28,7 @@ export default function Hero(): JSX.Element {
           <EmailForm />
         </HeroTextSection>
         <HeroImage>
-          <HeroBackgroundSvg />
+          <HeroBackgroundSvg aria-hidden="true" />
         </HeroImage>
         <NextstrainContainer>
           <PartnershipText>In partnership with</PartnershipText>

--- a/src/frontend/src/views/LandingPageV2/components/Hero/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/Hero/index.tsx
@@ -33,7 +33,7 @@ export default function Hero(): JSX.Element {
         <NextstrainContainer>
           <PartnershipText>In partnership with</PartnershipText>
           <NextstrainLink href={ROUTES.NEXTSTRAIN} target="_blank">
-            <Image src={NextstrainLogo} alt="" />
+            <Image src={NextstrainLogo} alt="NextStrain" />
           </NextstrainLink>
         </NextstrainContainer>
       </HeroMaxWidthContainer>

--- a/src/frontend/src/views/LandingPageV2/components/QuoteSlider/components/Quote/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/QuoteSlider/components/Quote/index.tsx
@@ -8,10 +8,12 @@ export default function Quote(props: {
   return (
     <QuoteContainer>
       <QuoteIcon>
-        <QuoteIconImg />
+        <QuoteIconImg title="quote" />
       </QuoteIcon>
       <QuoteText>{props.quoteText}</QuoteText>
-      <Citation>{props.citation}</Citation>
+      <Citation aria-label={`citation ${props.citation}`}>
+        {props.citation}
+      </Citation>
     </QuoteContainer>
   );
 }

--- a/src/frontend/src/views/LandingPageV2/components/QuoteSlider/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/QuoteSlider/index.tsx
@@ -15,7 +15,7 @@ export default function QuoteSlider(): JSX.Element {
   };
 
   return (
-    <QuoteSliderContainer>
+    <QuoteSliderContainer role="region" aria-label="User Quotes">
       <Slider {...settings}>
         <Quote
           quoteText='Obtaining adequate resources in this area is a constant challenge and we would not have been able to do this otherwise. For years, we’ve watched better-resourced regions, like LA and the Bay Area, quickly bring on technological advancements that further the field. It is wonderful to finally be able to be a part of this and, through our testing for surrounding counties, support the communities in our entire region."'

--- a/src/frontend/src/views/LandingPageV2/components/UseCases/index.tsx
+++ b/src/frontend/src/views/LandingPageV2/components/UseCases/index.tsx
@@ -8,15 +8,23 @@ import {
   UseCasesImageMobile,
 } from "./style";
 
+const imageAltText = `CZ Gen Epi bridges outbreak investigation and pathogen 
+surveillance. On the left, "Outbreak investigation", includes 
+questions such as: "Do these cases share a common source?", "How are these two 
+outbreaks related?" and "Is this community transmission, or is this a new 
+introduction?".  On the rights, "Pathogen surveillance includes questions such 
+as "How has this changed over time?", "Which genotypes or variants are 
+circulating in my community?" and "When was this variant first introduced?".`;
+
 export default function UseCases(): JSX.Element {
   return (
     <UseCasesContainer>
       <UseCasesHeader>Understand the Spread of Disease</UseCasesHeader>
       <UseCasesImage>
-        <Image src={UseCasesImg} />
+        <Image alt={imageAltText} src={UseCasesImg} />
       </UseCasesImage>
       <UseCasesImageMobile>
-        <Image src={UseCasesImgMobile} />
+        <Image alt={imageAltText} src={UseCasesImgMobile} />
       </UseCasesImageMobile>
     </UseCasesContainer>
   );


### PR DESCRIPTION
### Summary:
- **What:** `Homepage accessibility - still needs some help further down the page, but this makes some progress`
- **Ticket:** none
- **Env:** `none`

### Demos:
**sound on**

https://user-images.githubusercontent.com/109251328/190477898-4c479efd-3665-4cae-8c4e-35893ffae67f.mov

### Notes:
* I wrote the description of the "Understand the spread of disease" image - lmk if I should change it.  
* Images only need descriptions if they provide meaning, so the background tree image and computer image didn't get descriptions - lmk if they should.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)