### PR TITLE
Add pathogen to FastaStreamer() call in getfastaurl

### DIFF
--- a/src/backend/aspen/api/views/sequences.py
+++ b/src/backend/aspen/api/views/sequences.py
@@ -82,6 +82,7 @@ async def getfastaurl(
     settings: APISettings = Depends(get_settings),
     az: AuthZSession = Depends(get_authz_session),
     ac: AuthContext = Depends(get_auth_context),
+    pathogen: Pathogen = Depends(get_pathogen),
 ) -> FastaURLResponse:
     sample_ids = request.samples
     downstream_consumer = request.downstream_consumer
@@ -99,7 +100,7 @@ async def getfastaurl(
         f"s3://{s3_bucket}/{s3_key}", "w", transport_params=dict(client=s3_client)
     )
     # Write selected samples to s3
-    streamer = FastaStreamer(db, az, ac, sample_ids, downstream_consumer)
+    streamer = FastaStreamer(db, az, ac, pathogen, set(sample_ids), downstream_consumer)
     async for line in streamer.stream():
         s3_write_fh.write(line)
     s3_write_fh.close()


### PR DESCRIPTION
### Summary:
- **What:** Fixes a bug stemming from an incorrect number of arguments to the call initializing a `FastaStreamer()` class in the `sequences/getfastaurl` route.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)