### PR TITLE
Fix USHER identifier processing and add getfastaurl test

### DIFF
--- a/src/backend/aspen/api/views/sequences.py
+++ b/src/backend/aspen/api/views/sequences.py
@@ -100,7 +100,9 @@ async def getfastaurl(
         f"s3://{s3_bucket}/{s3_key}", "w", transport_params=dict(client=s3_client)
     )
     # Write selected samples to s3
-    streamer = FastaStreamer(db, az, ac, pathogen, set(sample_ids), downstream_consumer)
+    streamer = FastaStreamer(
+        db, az, ac, pathogen, set(sample_ids), downstream_consumer=downstream_consumer
+    )
     async for line in streamer.stream():
         s3_write_fh.write(line)
     s3_write_fh.close()


### PR DESCRIPTION
### Summary:
- **What:** Fixes a bug where the `downstream_consumer` in the request was not passed down to the `FastaStreamer()` class. Adds a test for the `sequences/getfastaurl` route.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)