### PR TITLE
Use keyword parameter for FastaStreamer in prepare sequences

### DIFF
--- a/src/backend/aspen/api/views/sequences.py
+++ b/src/backend/aspen/api/views/sequences.py
@@ -59,7 +59,7 @@ async def prepare_sequences_download(
 
     async def stream_samples():
         sample_ids = request.sample_ids
-        streamer = FastaStreamer(db, az, ac, pathogen, set(sample_ids), prefix)
+        streamer = FastaStreamer(db, az, ac, pathogen, set(sample_ids), prefix=prefix)
         async for line in streamer.stream():
             yield line
 


### PR DESCRIPTION
### Summary:
- **What:** When initializing a `FastaStreamer`, there are currently 5 positional parameters (`db`, `az`, `ac`, `pathogen`, `sample_ids`) and 2 keyword parameters (`prefix`, `downstream_consumer`). We just encountered a bug that stemmed from calling `FastaStreamer` with the argument for a keyword parameter used as a positional one. This also occurs in the `prepare_sequences` route but since the keyword parameter being called is right after the positional parameters, Python conveniently passes the argument to the right parameter, so we observe the correct behavior for this route. I think it's best we don't rely on this behavior for keyword parameters though, so I have changed the initialization call to explicitly use the keyword.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:
Perhaps the number of parameters themselves has become unwieldy, but it's not clear what the easiest fix would be.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)