### PR TITLE
Remove support for samples without an associated pathogen.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,8 +43,8 @@
                     "ms-python.vscode-pylance",
                     "ms-toolsai.jupyter",
                     "ms-toolsai.jupyter-keymap",
-                    "ms-toolsai.jupyter-renderers"
-
+                    "ms-toolsai.jupyter-renderers",
+		    "GitHub.copilot"
                 ]
             }
         }

--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -173,13 +173,6 @@ def get_app() -> FastAPI:
             dependencies=[Depends(require_group_membership)],
         )
 
-        # old urls (TODO: remove this soonish?)
-        _app.include_router(
-            router,
-            prefix="/v2/" + suffix,
-            dependencies=[Depends(require_group_membership)],
-        )
-
     return _app
 
 

--- a/src/backend/aspen/api/utils/sample.py
+++ b/src/backend/aspen/api/utils/sample.py
@@ -92,11 +92,7 @@ async def samples_by_identifiers(
         .outerjoin(private_samples_query, Sample.id == private_samples_query.c.id)  # type: ignore
         .where(
             and_(
-                or_(
-                    # TODO - DECOVIDIFY - remove the None check!
-                    Sample.pathogen == pathogen,  # noqa: E711
-                    Sample.pathogen_id == None,  # noqa: E711
-                ),
+                Sample.pathogen == pathogen,  # noqa: E711
                 or_(
                     public_samples_query.c.id != None,  # noqa: E711
                     private_samples_query.c.id != None,  # noqa: E711

--- a/src/backend/aspen/api/views/samples.py
+++ b/src/backend/aspen/api/views/samples.py
@@ -9,7 +9,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncResult, AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.sql.expression import or_
 
 from aspen.api.authn import AuthContext, get_auth_context, get_auth_user
 from aspen.api.authz import AuthZSession, get_authz_session, require_group_privilege
@@ -76,16 +75,9 @@ async def list_samples(
         selectinload(Sample.accessions),
         selectinload(Sample.pathogen),
     )
-    if pathogen.slug == "SC2":
-        user_visible_samples_query = user_visible_samples_query.filter(
-            or_(
-                Sample.pathogen_id == pathogen.id, Sample.pathogen_id is None
-            )  # TODO: remove this once we make pathogen_id non nullable
-        )
-    else:
-        user_visible_samples_query = user_visible_samples_query.filter(
-            Sample.pathogen_id == pathogen.id
-        )
+    user_visible_samples_query = user_visible_samples_query.filter(
+        Sample.pathogen_id == pathogen.id
+    )
     user_visible_samples_result = await db.execute(user_visible_samples_query)
     user_visible_samples: List[Sample] = (
         user_visible_samples_result.unique().scalars().all()


### PR DESCRIPTION
### Notes:
- Adds GitHub Copilot plugin while working on the backend in vscode
- Removes any code that allowed for `sample.pathogen_id` to be `null`
- Removes support for "default" org ID's for endpoints. All `sequences`, `phylo_runs`, `phylo_trees`, and `samples` endpoints *must be called* with an `/orgs/1234` path prefix (cc @ehoops-zz for attention)

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)