### PR TITLE
Dockerfile nextstrain/gisaid user root

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -4,6 +4,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer = "CZ Gen Epi"
 LABEL description = "Image for CZ Gen Epi ingest-gisaid workflow"
 
+# TODO -- Preferably want to drop to non-root user for job runs.
+# RUN commands below necessitate root for some of them. Nextstrain now has
+# a non-root user (`USER nextstrain:nextstrain) as part of its Dockerfile
+# https://github.com/nextstrain/docker-base/blob/master/Dockerfile#L259
+# Probably want to use that once we have chance to test its fine for job runs.
+USER root
+
 RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sources.list; \
     echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/98idseq; \
     echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/99idseq

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -7,6 +7,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer = "CZ Gen Epi"
 LABEL description = "Image for CZ Gen Epi nextstrain workflow"
 
+# TODO -- Preferably want to drop to non-root user for job runs.
+# RUN commands below necessitate root for some of them. Nextstrain now has
+# a non-root user (`USER nextstrain:nextstrain) as part of its Dockerfile
+# https://github.com/nextstrain/docker-base/blob/master/Dockerfile#L259
+# Probably want to use that once we have chance to test its fine for job runs.
+USER root
+
 RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sources.list; \
     echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/98idseq; \
     echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/99idseq


### PR DESCRIPTION
### Summary:
- **What:** Docker builds on `Dockerfile.nextstrain` and `Dockerfile.gisaid` currently breaking. This PR fixes.
- **Ticket:** [sc<215885>](https://app.shortcut.com/genepi/story/<215885>)
- **Env:** None

### Notes:
Nextstrain recently updated their Dockerfile to switch to a non-root user near the end -- https://github.com/nextstrain/docker-base/commit/39e4f658e4a3008d8d4e198e71a1939a6e6bd95b -- this is commendable, but our Dockerfiles that then build on that assume they'll be running as root, so some of the `RUN` commands fail due to permission issues.

This is a simple fix of just swapping back to `USER root` near the top of ours. Preferably we'll come back later and see about using a non-root user as well, but we'll need more time to test that it doesn't cause any downstream issues in jobs to be running as non-root.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)