### PR TITLE
Dynamic tree link out based on destination

### DIFF
--- a/src/frontend/src/views/Data/components/GalagoConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/GalagoConfirmationModal/index.tsx
@@ -33,6 +33,7 @@ export const GalagoConfirmationModal = ({
   const confirmButton = (
     <ConfirmButton
       treeId={treeId}
+      outgoingDestination="galago"
       onClick={() =>
         analyticsTrackEvent<AnalyticsTreeViewGalago>(
           EVENT_TYPES.TREE_VIEW_GALAGO,

--- a/src/frontend/src/views/Data/components/GalagoConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/GalagoConfirmationModal/index.tsx
@@ -5,8 +5,6 @@ import {
 import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { RedirectConfirmationModal } from "src/common/components/library/data_subview/components/RedirectConfirmationModal";
 import galagoLogo from "src/common/images/galago-logo-beta.png";
-// TODO: (ehoops) - This button will change when we create the galago URL in sc-214181
-// currently this is just using the nextstrain url as a placeholder
 import { ConfirmButton } from "src/common/utils/TreeModal/ConfirmButton";
 
 interface Props {

--- a/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/NextstrainConfirmationModal/index.tsx
@@ -31,6 +31,7 @@ const NextstrainConfirmationModal = ({
   const confirmButton = (
     <ConfirmButton
       treeId={treeId}
+      outgoingDestination="nextstrain"
       onClick={() =>
         analyticsTrackEvent<AnalyticsTreeViewNextstrain>(
           EVENT_TYPES.TREE_VIEW_NEXTSTRAIN,


### PR DESCRIPTION
### Summary:
- **What:** Adds dynamic creation of URL for tree linking out based on destination (Galago or Nextstrain)
- **Ticket:** [sc<214181>](https://app.shortcut.com/genepi/story/<214181>) + [sc<214165>](https://app.shortcut.com/genepi/story/<214165>)
- **Env:** None -- Can't actually test this in an rdev because rdevs have added security where Okta will block request from Galago to fetch the tree data. Have to test in Staging. I'll do that tomorrow once it's merged.

### Demos:

<img width="934" alt="image" src="https://user-images.githubusercontent.com/89553795/191384391-935edd54-cdca-4e85-a763-e609076a4800.png">

Working locally (I hardcoded the locally running Galago URL for local test, not present in code for this PR)


### Checklist:
- [x] I started on latest `trunk` and finished before any changes had come in
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)