### PR TITLE
add date to the end of s3 prefix for ci screenshots

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -163,8 +163,9 @@ jobs:
           echo "Init complete - testing web service"
           # docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
           echo "Webserver up, running tests!"
+          export NOW=$(date +'%Y-%m-%dT%H:%M:%S')
           docker-compose logs -f frontend &
-          export S3_PREFIX=${{ secrets.CI_SCREENSHOT_PREFIX }}/${{ github.run_id }}/
+          export S3_PREFIX=${{ secrets.CI_SCREENSHOT_PREFIX }}/${{ github.run_id }}-${NOW}/
           make frontend-e2e-ci
   py-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -161,7 +161,7 @@ jobs:
           chmod a+rwx src/frontend/build # TODO temp hack - need a better plan for the build dir.
           make local-init
           echo "Init complete - testing web service"
-          # docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
+          docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
           echo "Webserver up, running tests!"
           export NOW=$(date +'%Y-%m-%dT%H:%M:%S')
           docker-compose logs -f frontend &

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -161,7 +161,7 @@ jobs:
           chmod a+rwx src/frontend/build # TODO temp hack - need a better plan for the build dir.
           make local-init
           echo "Init complete - testing web service"
-          docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
+          # docker-compose exec -T frontend wget -T 10 --tries 20 localhost:8000/
           echo "Webserver up, running tests!"
           export NOW=$(date +'%Y-%m-%dT%H:%M:%S')
           docker-compose logs -f frontend &

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,7 @@ frontend-e2e-ci: .env.ecr ## Run e2e tests with s3 screenshot wrapper.
 	test_container=$$(docker ps -a | grep -i frontend_run | cut -d ' ' -f 1 | head -n 1); \
 	docker cp $${test_container}:/tmp/screenshots .; \
 	docker rm $${test_container}; \
+	ls screenshots
 	echo copying screenshots to ${S3_PREFIX}
 	aws s3 cp --recursive ./screenshots ${S3_PREFIX}; \
 	exit $$exit_status

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ frontend-e2e-ci: .env.ecr ## Run e2e tests with s3 screenshot wrapper.
 	test_container=$$(docker ps -a | grep -i frontend_run | cut -d ' ' -f 1 | head -n 1); \
 	docker cp $${test_container}:/tmp/screenshots .; \
 	docker rm $${test_container}; \
-	aws s3 cp --recursive ./screenshots $${S3_PREFIX}; \
+	echo copying screenshots to $S3_PREFIX
+	aws s3 cp --recursive ./screenshots $S3_PREFIX; \
 	exit $$exit_status
 
 ### WDL ###################################################

--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,8 @@ frontend-e2e-ci: .env.ecr ## Run e2e tests with s3 screenshot wrapper.
 	test_container=$$(docker ps -a | grep -i frontend_run | cut -d ' ' -f 1 | head -n 1); \
 	docker cp $${test_container}:/tmp/screenshots .; \
 	docker rm $${test_container}; \
-	echo copying screenshots to $S3_PREFIX
-	aws s3 cp --recursive ./screenshots $S3_PREFIX; \
+	echo copying screenshots to ${S3_PREFIX}
+	aws s3 cp --recursive ./screenshots ${S3_PREFIX}; \
 	exit $$exit_status
 
 ### WDL ###################################################

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ frontend-%: .env.ecr ## Run make commands in the frontend container (src/fronten
 # this needs to be here so we can access docker and aws (which are not installed in the frontend container)
 .PHONY: frontend-e2e-ci
 frontend-e2e-ci: .env.ecr ## Run e2e tests with s3 screenshot wrapper.
-	$(docker_compose) run -e CI=true --no-deps frontend make e2e; \
+	$(docker_compose) run -e CI=true --no-deps frontend make e2e-ci; \
 	exit_status=$$?; \
 	test_container=$$(docker ps -a | grep -i frontend_run | cut -d ' ' -f 1 | head -n 1); \
 	docker cp $${test_container}:/tmp/screenshots .; \

--- a/src/frontend/Makefile
+++ b/src/frontend/Makefile
@@ -12,12 +12,6 @@ test: # run ts unit test
 
 e2e-ci: # run e2e tests
 	npm --prefix . run e2e
-	exit_status=$$?; \
-	test_container=$$(docker ps -a | grep -i frontend_run | cut -d ' ' -f 1 | head -n 1); \
-	docker cp $${test_container}:/tmp/screenshots .; \
-	docker rm $${test_container}; \
-	aws --profile $(AWS_DEV_PROFILE) s3 cp --recursive ./screenshots $${S3_PREFIX}; \
-	exit $$exit_status
 
 test-build:
 	npm --prefix . run build

--- a/src/frontend/e2e/setup/local.config.ts
+++ b/src/frontend/e2e/setup/local.config.ts
@@ -29,7 +29,7 @@ const config: PlaywrightTestConfig = {
     baseURL: "https://staging.czgenepi.org",
     headless: true,
     ignoreHTTPSErrors: true,
-    screenshot: "only-on-failure",
+    // screenshot: "only-on-failure",
     storageState: "/tmp/state.json",
     trace: "on-first-retry",
     viewport: { width: 1280, height: 720 },

--- a/src/frontend/e2e/setup/staging.config.ts
+++ b/src/frontend/e2e/setup/staging.config.ts
@@ -28,7 +28,7 @@ const config: PlaywrightTestConfig = {
     actionTimeout: 0,
     baseURL: "https://staging.czgenepi.org",
     ignoreHTTPSErrors: true,
-    screenshot: "only-on-failure",
+    // screenshot: "only-on-failure",
     storageState: "/tmp/state.json",
     trace: "on-first-retry",
     viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)