### PR TITLE
Maya/211276 split pathogen traffic

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/SampleFiltering/index.tsx
@@ -3,10 +3,14 @@ import { createFilterOptions } from "@mui/material/Autocomplete";
 import { DefaultMenuSelectOption, Icon } from "czifui";
 import { isEqual } from "lodash";
 import { noop } from "src/common/constants/empty";
+import { useSelector } from "src/common/redux/hooks";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import {
   MENU_OPTIONS_COLLECTION_DATE,
   MENU_OPTION_ALL_TIME,
 } from "src/components/DateFilterMenu/constants";
+import { SplitPathogenWrapper } from "src/components/Split/SplitPathogenWrapper";
+import { PATHOGEN_FEATURE_FLAGS } from "src/components/Split/types";
 import { StyledTooltip } from "../../style";
 import { CollectionDateFilter } from "./components/CollectionDateFilter";
 import {
@@ -186,6 +190,7 @@ export function SampleFiltering({
   setStartDate,
   setEndDate,
 }: Props): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
   const lineageDropdownOptions = generateLineageDropdownOptions(
     selectedLineages,
     availableLineages
@@ -309,21 +314,23 @@ export function SampleFiltering({
       </StyledExplainerTitle>
 
       <StyledFiltersSection>
-        <StyledFilterGroup>
-          <StyledFilterGroupName>Lineage</StyledFilterGroupName>
-          <StyledDropdown
-            label={lineageDropdownLabel}
-            onChange={handleLineageDropdownChange}
-            options={lineageDropdownOptions}
-            value={lineageDropdownValue}
-            multiple
-            search
-            DropdownMenuProps={lineageDropdownMenuProps}
-            InputDropdownProps={InputDropdownProps}
-            PopperComponent={BottomPlacementDropdownPopper}
-            data-test-id="lineage-dropdown"
-          />
-        </StyledFilterGroup>
+        <SplitPathogenWrapper pathogen={pathogen} feature={PATHOGEN_FEATURE_FLAGS.lineage_filter_enabled}>
+          <StyledFilterGroup>
+            <StyledFilterGroupName>Lineage</StyledFilterGroupName>
+            <StyledDropdown
+              label={lineageDropdownLabel}
+              onChange={handleLineageDropdownChange}
+              options={lineageDropdownOptions}
+              value={lineageDropdownValue}
+              multiple
+              search
+              DropdownMenuProps={lineageDropdownMenuProps}
+              InputDropdownProps={InputDropdownProps}
+              PopperComponent={BottomPlacementDropdownPopper}
+              data-test-id="lineage-dropdown"
+            />
+          </StyledFilterGroup>
+        </SplitPathogenWrapper>
         <StyledFilterGroup>
           <StyledFilterGroupName>Collection Date</StyledFilterGroupName>
           <CollectionDateFilter

--- a/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/DownloadModal/index.tsx
@@ -27,7 +27,7 @@ import { pluralize } from "src/common/utils/strUtils";
 import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import Dialog from "src/components/Dialog";
 import { NotificationComponents } from "src/components/NotificationManager/components/Notification";
-import { isFlagOn } from "src/components/Split";
+import { isUserFlagOn } from "src/components/Split";
 import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { TooltipDescriptionText, TooltipHeaderText } from "../../style";
 import {
@@ -74,7 +74,7 @@ const DownloadModal = ({
   const [isGenbankSelected, setGenbankSelected] = useState<boolean>(false);
 
   const flag = useTreatments([USER_FEATURE_FLAGS.prep_files]);
-  const isPrepFilesFlagOn = isFlagOn(flag, USER_FEATURE_FLAGS.prep_files);
+  const isPrepFilesFlagOn = isUserFlagOn(flag, USER_FEATURE_FLAGS.prep_files);
 
   const completedSampleIds = checkedSampleIds.filter(
     (id) => !failedSampleIds.includes(id)

--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { API } from "src/common/api";
 import ENV from "src/common/constants/ENV";
 import { ROUTES } from "src/common/routes";
-import { isFlagOn } from "src/components/Split";
+import { isUserFlagOn } from "src/components/Split";
 import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { StyledNavButton, StyledNavIconWrapper } from "./style";
 
@@ -32,7 +32,7 @@ const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
   };
 
   const flag = useTreatments([USER_FEATURE_FLAGS.prep_files]);
-  const isPrepFilesFlagOn = isFlagOn(flag, USER_FEATURE_FLAGS.prep_files);
+  const isPrepFilesFlagOn = isUserFlagOn(flag, USER_FEATURE_FLAGS.prep_files);
 
   return (
     <>

--- a/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
+++ b/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
@@ -37,7 +37,7 @@ const SplitPathogenWrapper = ({ children, feature, pathogen }: Props): JSX.Eleme
       <SplitTreatments names={[feature]}>
         {({ isReady, treatments }) => {
           if (isReady) {
-            const treatment = treatments[feature]?.treatment;
+            const { treatment } = treatments[feature];
             return treatment === SPLIT_SIMPLE_FLAG.ON ? (<div>{children}</div>) : null;
           }
 

--- a/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
+++ b/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
@@ -37,8 +37,10 @@ const SplitPathogenWrapper = ({ children, feature, pathogen }: Props): JSX.Eleme
       <SplitTreatments names={[feature]}>
         {({ isReady, treatments }) => {
           if (isReady) {
-            console.log(treatments); // eslint-disable-line
-            return <div>{children}</div>;
+            console.log("treatments", treatments); // eslint-disable-line
+            const treatment = treatments[feature]?.treatment;
+            console.log("treatment", treatment); // eslint-disable-line
+            return treatment === SPLIT_SIMPLE_FLAG.ON ? (<div>{children}</div>) : null;
           }
 
           // wait until treatments are loaded to show anything

--- a/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
+++ b/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
@@ -1,0 +1,52 @@
+import { SplitClient, SplitTreatments } from "@splitsoftware/splitio-react";
+import { ReactNode, useEffect, useState } from "react";
+import { isLocalSplitEnv } from "./util";
+import { createPathogenFlagsForLocal, CurrentPathogenFlagMapping } from "./pathogenSplitConfig";
+import { PATHOGEN_FEATURE_FLAGS, SPLIT_SIMPLE_FLAG } from "./types";
+import { Pathogen } from "src/common/redux/types";
+
+interface Props {
+  children: ReactNode;
+  pathogen: Pathogen;
+  feature: PATHOGEN_FEATURE_FLAGS;
+}
+
+const SplitPathogenWrapper = ({ children, feature, pathogen }: Props): JSX.Element | null => {
+  const [localFlags, setLocalFlags] = useState<CurrentPathogenFlagMapping>();
+
+  // if pathogen changes, make sure to update whether pathogen-dependent feature flags
+  // are adjusted as well
+  useEffect(() => {
+    const flags = createPathogenFlagsForLocal(pathogen);
+    setLocalFlags(flags);
+  }, [pathogen]);
+
+  // if working locally, use local mocked flags to determine what to show or hide.
+  if (isLocalSplitEnv) {
+    if (localFlags?.[feature] === SPLIT_SIMPLE_FLAG.ON) {
+      return <>{children}</>;
+    }
+
+    return null;
+  }
+
+  // in any non-local environment, use the actual values from split.io to determine which
+  // components to show or hide.
+  return (
+    <SplitClient splitKey={pathogen} trafficType="pathogen">
+      <SplitTreatments names={[feature]}>
+        {({ isReady, treatments }) => {
+          if (isReady) {
+            console.log(treatments); // eslint-disable-line
+            return <div>{children}</div>;
+          }
+
+          // wait until treatments are loaded to show anything
+          return null;
+        }}
+      </SplitTreatments>
+    </SplitClient>
+  );
+};
+
+export { SplitPathogenWrapper };

--- a/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
+++ b/src/frontend/src/components/Split/SplitPathogenWrapper.tsx
@@ -37,9 +37,7 @@ const SplitPathogenWrapper = ({ children, feature, pathogen }: Props): JSX.Eleme
       <SplitTreatments names={[feature]}>
         {({ isReady, treatments }) => {
           if (isReady) {
-            console.log("treatments", treatments); // eslint-disable-line
             const treatment = treatments[feature]?.treatment;
-            console.log("treatment", treatment); // eslint-disable-line
             return treatment === SPLIT_SIMPLE_FLAG.ON ? (<div>{children}</div>) : null;
           }
 

--- a/src/frontend/src/components/Split/index.tsx
+++ b/src/frontend/src/components/Split/index.tsx
@@ -26,8 +26,8 @@
  *        const flag = useTreatments([USER_FEATURE_FLAGS.my_flag_name]);
  *   3) If the flag is just a simple "on"/"off" type flag, helper to get bool
  *        << ... in addition what's in (2) above ... >>>
- *        import { isFlagOn } from <<This file right here>>;
- *        const isMyFlagOn = isFlagOn(flag, USER_FEATURE_FLAGS.my_flag_name);
+ *        import { isUserFlagOn } from <<This file right here>>;
+ *        const isMyFlagOn = isUserFlagOn(flag, USER_FEATURE_FLAGS.my_flag_name);
  */
 import { SplitFactory } from "@splitsoftware/splitio-react";
 import { TreatmentsWithConfig } from "@splitsoftware/splitio/types/splitio";
@@ -56,7 +56,7 @@ const createUserFlagsForLocal = () => {
 };
 
 /**
- * Helper to check if a given Split feature flag is "on" (enabled; true).
+ * Helper to check if a given User-based Split feature flag is "on" (enabled; true).
  *
  * Note that this function will NOT work on any flag this is using a more
  * complicated set of values than just "on" for enabled. For example, if
@@ -67,8 +67,7 @@ const createUserFlagsForLocal = () => {
  * of all the flags in the array. However, we generally only use a single
  * feature flag at once, so this helper only examines one flag at a time.
  */
-// TODO (mlila):figure out if this works with traffictype=pathogen
-export function isFlagOn(
+export function isUserFlagOn(
   splitTreatments: TreatmentsWithConfig,
   featureFlagName: string
 ): boolean {
@@ -110,6 +109,7 @@ const SplitInitializer = ({ children }: Props): JSX.Element | null => {
         trafficType: "user",
       },
     };
+
     if (isLocalSplitEnv) {
       const mockedFeatureFlags = createUserFlagsForLocal();
       splitConf.features = mockedFeatureFlags;

--- a/src/frontend/src/components/Split/pathogenSplitConfig.ts
+++ b/src/frontend/src/components/Split/pathogenSplitConfig.ts
@@ -31,8 +31,7 @@ const pathogenTrafficFlagConfig: PathogenTrafficFlagConfig = {
   },
 };
 
-
-type CurrentPathogenFlagMapping = Record<PATHOGEN_FEATURE_FLAGS, SPLIT_SIMPLE_FLAG>;
+export type CurrentPathogenFlagMapping = Record<PATHOGEN_FEATURE_FLAGS, SPLIT_SIMPLE_FLAG>;
 
 /**
  * Creates a `features` object for when Split is running in "localhost" mode.
@@ -45,7 +44,7 @@ export const createPathogenFlagsForLocal = (pathogen: Pathogen): CurrentPathogen
 
   forEach(pathogenTrafficFlagConfig, (value, key) => {
     const flag = value?.[pathogen];
-    localFeatures[key as PATHOGEN_FEATURE_FLAGS] = flag ?? SPLIT_SIMPLE_FLAG.ON;
+    localFeatures[key as PATHOGEN_FEATURE_FLAGS] = flag ?? SPLIT_SIMPLE_FLAG.OFF;
   });
 
   return localFeatures;

--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -26,8 +26,8 @@ export enum USER_FEATURE_FLAGS {
  * One enum per traffic type (currently, we have `user` and `pathogen` types)
  */
 export enum PATHOGEN_FEATURE_FLAGS {
-  galago_linkout = "galago_linkout",
-  lineage_filter_enabled = "lineage_filter_enabled",
-  public_repository = "public_repository",
-  usher_linkout = "usher_linkout",
+  galago_linkout = "PATHOGEN_galago_linkout",
+  lineage_filter_enabled = "PATHOGEN_lineage_filter_enabled",
+  public_repository = "PATHOGEN_public_repository",
+  usher_linkout = "PATHOGEN_usher_linkout",
 }

--- a/src/frontend/src/components/Split/util.ts
+++ b/src/frontend/src/components/Split/util.ts
@@ -1,0 +1,7 @@
+import ENV from "src/common/constants/ENV";
+
+// Keyword to tell Split client it's running in local-only mode.
+const SPLIT_LOCALHOST_ONLY_MODE = "localhost";
+
+export const isLocalSplitEnv = ENV.SPLIT_FRONTEND_KEY === SPLIT_LOCALHOST_ONLY_MODE;
+

--- a/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/TreeActionMenu/index.tsx
@@ -1,5 +1,5 @@
 import { useTreatments } from "@splitsoftware/splitio-react";
-import { isFlagOn } from "src/components/Split";
+import { isUserFlagOn } from "src/components/Split";
 import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { MoreActionsMenu } from "./components/MoreActionsMenu";
 import { OpenInGalagoButton } from "./components/OpenInGalagoButton";
@@ -38,7 +38,7 @@ const TreeActionMenu = ({
   userInfo,
 }: Props): JSX.Element => {
   const flag = useTreatments([USER_FEATURE_FLAGS.galago_integration]);
-  const isGalagoIntegrationFlagOn = isFlagOn(
+  const isGalagoIntegrationFlagOn = isUserFlagOn(
     flag,
     USER_FEATURE_FLAGS.galago_integration
   );


### PR DESCRIPTION
### Summary
- **What:**
  - Add a frontend component that can wrap new features and optionally show them depending on whether the feature is enabled for the active workspace pathogen
  - Rename `isFlagOn` to indicate it's only for use with user based flags
  - Don't pass pathogen flags to the factory locally (this is now handled by the wrapper component)
  - Hide lineage filter for non-covid pathogens
- **Why:** Optionally show features in the future
- **Ticket:**
  - [[sc-211276]](https://app.shortcut.com/genepi/story/211276)
  - [[sc-211446]](https://app.shortcut.com/genepi/story/211446)
- **Env:** https://maya-splittwo-frontend.dev.czgenepi.org/

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)