### PR TITLE
replace router path instead of adding to it when using approuting to fix the brower back button

### DIFF
--- a/src/frontend/src/common/appRouting.ts
+++ b/src/frontend/src/common/appRouting.ts
@@ -89,7 +89,7 @@ const setCurrentWorkspacePath = async (router: NextRouter) => {
 
   // don't redirect if user already viewing correct workspace
   if (router.asPath !== newPath) {
-    router.push(newPath);
+    router.replace(newPath);
   }
 };
 


### PR DESCRIPTION
### Summary
- **What:** when using app routing to modify the path (to add pathogen or group id, for example), replace the previous path instead of adding a new entry
- **Why:** Otherwise, the user cannot use the back button in the app because they would end up going to the url they originally visited, which then immediately gets redirected to the place they already are
- **Ticket:** [[sc-215224]](https://app.shortcut.com/genepi/story/215224)
- **Env:** https://maya-routing-frontend.dev.czgenepi.org/

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)