### PR TITLE
BE handles custom location for tree builds

### DIFF
--- a/src/backend/aspen/api/schemas/phylo_runs.py
+++ b/src/backend/aspen/api/schemas/phylo_runs.py
@@ -19,6 +19,7 @@ class TemplateArgsRequest(BaseRequest):
     filter_start_date: Optional[datetime.date]
     filter_end_date: Optional[datetime.date]
     filter_pango_lineages: Optional[List[constr(regex=r"^[0-9A-Za-z. *\/]+$")]]  # type: ignore # noqa
+    location_id: Optional[int]  # if not specified, will use group default
 
 
 class PhyloRunRequest(BaseRequest):

--- a/src/backend/aspen/api/views/phylo_runs.py
+++ b/src/backend/aspen/api/views/phylo_runs.py
@@ -30,6 +30,7 @@ from aspen.api.utils import (
 from aspen.database.models import (
     AlignedGisaidDump,
     Group,
+    Location,
     Pathogen,
     PathogenGenome,
     PhyloRun,
@@ -131,7 +132,13 @@ async def kick_off_phylo_run(
                 value = value.strftime("%Y-%m-%d")
             if key == "filter_pango_lineages":
                 value = await expand_lineage_wildcards(db, value)
+            if key == "location_id":
+                # Verify it's a real location before starting workflow with it
+                location = await Location.get_by_id(db, value)
+                if location is None:
+                    raise ex.BadRequestException(f"location_id {value} not found")
             template_args[key] = value
+
     workflow: PhyloRun = PhyloRun(
         start_datetime=start_datetime,
         workflow_status=WorkflowStatusType.STARTED,

--- a/src/backend/aspen/workflows/nextstrain_run/build_plugins/type_plugins.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_plugins/type_plugins.py
@@ -15,7 +15,7 @@ class TreeTypePlugin(BaseConfigPlugin):
     def _update_config_params(self, config):
         build = config["builds"]["aspen"]
 
-        location = self.group.default_tree_location
+        location = self.template_args["location"]
         # Make a shortcut to decide whether this is a location vs division vs country level build
         if not location.division:
             self.tree_build_level = "country"

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -11,9 +11,9 @@ from aspen.config.config import Config
 from aspen.database.connection import (
     get_db_uri,
     init_db,
+    Session,
     session_scope,
     SqlAlchemyInterface,
-    Session,
 )
 from aspen.database.models import (
     Accession,
@@ -177,7 +177,9 @@ def export_run_config(
         }
 
         # Some template args need to be resolved before ready to use.
-        resolved_template_args = resolve_template_args(session, phylo_run.template_args, group)
+        resolved_template_args = resolve_template_args(
+            session, phylo_run.template_args, group
+        )
 
         builder: TemplateBuilder = TemplateBuilder(
             phylo_run.tree_type,
@@ -234,7 +236,9 @@ def get_phylo_run(session, phylo_run_id):
     return phylo_run
 
 
-def resolve_template_args(session: Session, template_args: Dict[str, Any], group: Group) -> Dict[str, Any]:
+def resolve_template_args(
+    session: Session, template_args: Dict[str, Any], group: Group
+) -> Dict[str, Any]:
     """Takes raw template_args and interprets them so ready for downstream use.
 
     Some of the raw args from upstream (eg, `location_id`) need to resolved
@@ -250,12 +254,14 @@ def resolve_template_args(session: Session, template_args: Dict[str, Any], group
     resolved_location = group.default_tree_location
     custom_location_id = template_args.get("location_id")
     if custom_location_id:
-        resolved_location = session.query(Location).filter(
-            Location.id == custom_location_id).one()
+        resolved_location = (
+            session.query(Location).filter(Location.id == custom_location_id).one()
+        )
 
     # Avoid mutating original template_args; resolved args handled special.
-    resolved_template_args = {key: template_args[key] for key in template_args
-        if key not in NON_PASSTHRU_ARGS}
+    resolved_template_args = {
+        key: template_args[key] for key in template_args if key not in NON_PASSTHRU_ARGS
+    }
     resolved_template_args["location"] = resolved_location
     return resolved_template_args
 


### PR DESCRIPTION
### Summary:
- **What:** Allow BE phylo tree kick offs to take a custom location, not just use group's default location
- **Ticket:** [sc<216099>](https://app.shortcut.com/genepi/story/<216099>)
- **Env:** None yet. I'd like to put one together, but haven't gotten around to it yet. Because this tweaks tree kick offs and it appears that tree kicks offs are currently broken in rdevs, I need to work on that before there would be any value to making an rdev for this PR.

### Notes:
The `resolve_template_args` portion is overcomplicated for what it does right now, but I'm planning to expand that in the next chunk of work for handling the "Details" of a tree build when returning the list for trees table. More processing will happen there with that PR. 

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
~I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)~ none needed