### PR TITLE
Migration: user `created_at`

### DIFF
--- a/src/backend/database_migrations/versions/20221004_221741_add_created_at_for_users.py
+++ b/src/backend/database_migrations/versions/20221004_221741_add_created_at_for_users.py
@@ -1,0 +1,31 @@
+"""Add created_at for users
+
+Create Date: 2022-10-04 22:17:43.014644
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20221004_221741"
+down_revision = "20220920_223031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_column("users", "created_at", schema="aspen")

--- a/src/backend/database_migrations/versions/20221004_221741_add_created_at_for_users.py
+++ b/src/backend/database_migrations/versions/20221004_221741_add_created_at_for_users.py
@@ -20,9 +20,20 @@ def upgrade():
         sa.Column(
             "created_at",
             sa.DateTime(),
-            server_default=sa.text("now()"),
+            # We do NOT set a `server_default` on creation, because
+            # we want preexisting records to come in as NULL.
+            # server_default=sa.text("now()"),
             nullable=True,
         ),
+        schema="aspen",
+    )
+
+    # Now that column is added and prior records have a NULL created_at
+    # we come back and change the default so new records will be set correctly.
+    op.alter_column(
+        "users",
+        "created_at",
+        server_default=sa.text("now()"),
         schema="aspen",
     )
 


### PR DESCRIPTION
### Summary:
- **What:** Standalone migration PR for work from #1382

### Notes:
This extracts just the actual migration file commits to its own PR so we can merge and run the migration _before_ the changes to model so there is no break in service.

### Checklist:
- [x] I merged latest `trunk`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)