### PR TITLE
use new feature flag to begin table refactor

### DIFF
--- a/src/frontend/src/components/Split/index.tsx
+++ b/src/frontend/src/components/Split/index.tsx
@@ -53,6 +53,10 @@ const createUserFlagsForLocal = () => {
     simpleFlags[feature] = SPLIT_SIMPLE_FLAG.ON;
   });
 
+  // TODO-TR (mlila): leave the table refactor flag off (locally) for now, since it seriously
+  // TODO-TR          hinders use of the app and will be annoying.
+  simpleFlags.table_refactor = SPLIT_SIMPLE_FLAG.OFF;
+
   return simpleFlags;
 };
 

--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -19,6 +19,7 @@ export enum USER_FEATURE_FLAGS {
   // my_flag_name = "my_flag_name", (<-- format example)
   galago_integration = "galago_integration",
   prep_files = "prep_files",
+  table_refactor = "table_refactor",
   tree_location_filter = "tree_location_filter",
 }
 

--- a/src/frontend/src/views/Data/components/SamplesView/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/index.tsx
@@ -1,0 +1,7 @@
+const SamplesView = (): JSX.Element => {
+  return (
+    <div>test</div>
+  );
+};
+
+export { SamplesView };

--- a/src/frontend/src/views/Data/components/TreesView/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/index.tsx
@@ -1,0 +1,7 @@
+const TreesView = (): JSX.Element => {
+  return (
+    <div>test</div>
+  );
+};
+
+export { TreesView };


### PR DESCRIPTION
### Summary
- **What:**
  - Add feature flag for samples table refactor
  - Force it to be off, locally
  - Show different components when flag is on
- **Ticket:** [[sc-224035]](https://app.shortcut.com/genepi/story/224035)

### Demos
No visual changes.

### Notes
View with `?w=1` for even smaller changes!

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)