### PR TITLE
Pin pangolin version in install_pangolin script

### DIFF
--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -19,7 +19,7 @@ RUN eval "$($HOME/miniconda/bin/conda shell.bash hook)" && conda init
 
 # install pangolin
 COPY aspen/workflows/pangolin/install_pangolin.sh .
-RUN bash install_pangolin.sh && echo "uncache"
+RUN bash install_pangolin.sh
 
 # Poetry: install app
 COPY pyproject.toml poetry.lock environment.yaml ./

--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -19,7 +19,7 @@ RUN eval "$($HOME/miniconda/bin/conda shell.bash hook)" && conda init
 
 # install pangolin
 COPY aspen/workflows/pangolin/install_pangolin.sh .
-RUN bash install_pangolin.sh
+RUN bash install_pangolin.sh && echo "uncache"
 
 # Poetry: install app
 COPY pyproject.toml poetry.lock environment.yaml ./

--- a/src/backend/aspen/workflows/pangolin/install_pangolin.sh
+++ b/src/backend/aspen/workflows/pangolin/install_pangolin.sh
@@ -4,7 +4,7 @@ eval "$($HOME/miniconda/bin/conda shell.bash hook)"
 conda init
 mkdir /pangolin
 cd /pangolin
-git clone https://github.com/cov-lineages/pangolin.git --depth 1 .
+git clone -b v4.1.3 https://github.com/cov-lineages/pangolin.git --depth 1 .
 conda env create -f environment.yml
 conda activate pangolin
 pip install .


### PR DESCRIPTION
### Summary:
- **What:** Pangolin has updated with a vital bugfix, but docker is still using a cached version. This pins the version of pangolin we use by cloning a specific tag of pangolin, which will bust the docker cache whenever we update it.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)