### PR TITLE
Change nextstrain workdir to /nextstrain

### DIFF
--- a/.happy/terraform/modules/sfn_config/nextstrain-autorun.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-autorun.wdl
@@ -47,8 +47,7 @@ task nextstrain_workflow {
     ncov_git_rev=""
 
     # run main workflow
-    cd /usr/src/app/aspen/workflows/nextstrain_run
-    ./run_nextstrain_autorun.sh
+    /usr/src/app/aspen/workflows/nextstrain_run/run_nextstrain_autorun.sh
 
     # error handling
     if [[ $? != 0 ]]; then

--- a/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
@@ -48,8 +48,7 @@ task nextstrain_workflow {
     ncov_git_rev=""
 
     # run main workflow
-    cd /usr/src/app/aspen/workflows/nextstrain_run
-    ./run_nextstrain_ondemand.sh
+    cd /usr/src/app/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
 
     # error handling
     if [[ $? != 0 ]]; then

--- a/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
+++ b/.happy/terraform/modules/sfn_config/nextstrain-ondemand.wdl
@@ -48,7 +48,7 @@ task nextstrain_workflow {
     ncov_git_rev=""
 
     # run main workflow
-    cd /usr/src/app/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+    /usr/src/app/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
 
     # error handling
     if [[ $? != 0 ]]; then

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -63,3 +63,5 @@ ENV PYTHONPATH=.
 COPY . .
 # Install the aspen package
 RUN poetry install
+
+WORKDIR /nextstrain


### PR DESCRIPTION
### Summary:
- **What:** Our nextstrain images are failing to push in CI because they are failing tests; they are failing tests because the `nextstrain` user doesn't have write access to `/usr/src/app`. `/usr` and its subdirectories should never be used as working directories anyways, so this changes the working directory to `/nextstrain`, which is `$HOME` for the nextstrain user. 
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:
In the longer term, we should make sure the working directories for all our dockerfiles are not in `/usr` or its subdirectories, not run things as root, and make sure everything works with those changes.

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)