### PR TITLE
Remove deprecated tables/columns

### DIFF
--- a/src/backend/database_migrations/versions/20221021_175601_drop_unused_tables.py
+++ b/src/backend/database_migrations/versions/20221021_175601_drop_unused_tables.py
@@ -1,0 +1,34 @@
+"""drop unused tables
+
+Create Date: 2022-10-21 17:56:08.895818
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20221021_175601"
+down_revision = "20221010_201517"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("can_see", schema="aspen")
+    op.drop_table("data_types", schema="aspen")
+    op.create_unique_constraint(
+        op.f("uq_sample_qc_metrics_qc_score"),
+        "sample_qc_metrics",
+        ["qc_score"],
+        schema="aspen",
+    )
+    op.drop_constraint(
+        "fk_users_group_id_groups", "users", schema="aspen", type_="foreignkey"
+    )
+    op.drop_column("users", "group_admin", schema="aspen")
+    op.drop_column("users", "group_id", schema="aspen")
+
+
+def downgrade():
+    raise NotImplementedError("Downgrade not implemented.")

--- a/src/backend/database_migrations/versions/20221021_175601_drop_unused_tables.py
+++ b/src/backend/database_migrations/versions/20221021_175601_drop_unused_tables.py
@@ -3,8 +3,6 @@
 Create Date: 2022-10-21 17:56:08.895818
 
 """
-import enumtables  # noqa: F401
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/backend/database_migrations/versions/20221021_175601_drop_unused_tables.py
+++ b/src/backend/database_migrations/versions/20221021_175601_drop_unused_tables.py
@@ -17,12 +17,6 @@ depends_on = None
 def upgrade():
     op.drop_table("can_see", schema="aspen")
     op.drop_table("data_types", schema="aspen")
-    op.create_unique_constraint(
-        op.f("uq_sample_qc_metrics_qc_score"),
-        "sample_qc_metrics",
-        ["qc_score"],
-        schema="aspen",
-    )
     op.drop_constraint(
         "fk_users_group_id_groups", "users", schema="aspen", type_="foreignkey"
     )


### PR DESCRIPTION
### Summary:
- **What:** Remove old columns (user.group_id, and user.group_admin) and tables (can_see) related to our old authorization system. We haven't used these in a while and leaving them in place is confusing

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)