### PR TITLE
Migration: resolved args; default loc id not NULL

### DIFF
--- a/src/backend/database_migrations/versions/20221025_234200_add_resolved_template_args_col_default_.py
+++ b/src/backend/database_migrations/versions/20221025_234200_add_resolved_template_args_col_default_.py
@@ -1,0 +1,47 @@
+"""Add resolved_template_args col, default_tree_location_id NOT NULL
+
+Create Date: 2022-10-25 23:42:02.152731
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20221025_234200"
+down_revision = "20221021_175601"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Verified before creating migration that both Prod and Staging DBs have
+    # no NULL values for default_tree_location_id in any group.
+    op.alter_column(
+        "groups",
+        "default_tree_location_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+        schema="aspen",
+    )
+    op.add_column(
+        "phylo_trees",
+        sa.Column(
+            "resolved_template_args",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        schema="aspen",
+    )
+
+
+def downgrade():
+    op.drop_column("phylo_trees", "resolved_template_args", schema="aspen")
+    op.alter_column(
+        "groups",
+        "default_tree_location_id",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+        schema="aspen",
+    )


### PR DESCRIPTION
### Summary:
- **What:** Migration: Adds new column for "Details" aspect of trees list; 
- **Ticket:** [sc<220375>](https://app.shortcut.com/genepi/story/<220375>)
- **Env:** None

### Notes:
- This migration is broken out from the larger branch of work for adding in handling info needed for "Details" section of trees listing. Probably won't have a PR for that work until start of next week, but the migration should just be this. I have updates to the corresponding models in that branch.
- Adds in a new column of `resolved_template_args` as part of work for the "Details" section of trees listing. When we initiate a tree run, we take various build args, `PhyloRun.template_args`. However, we need to track what args the user originally specified in the request to kick off the tree build versus what those args resolve into. For example, the user can specify wildcards in lineages: we want to keep the original, wildcard version, but also have a list of what those wildcards expand into. Those go into `template_args` and `resolved_template_args` respectively.
- Totally unrelated to work on "Details" section of trees listing, I noticed that while our `default_tree_location_id` is NULL-able, the code that uses it downstream always assumes that it is not NULL. It feels like it would be safer/easier to put a NOT NULL constraint on the DB than to add code for checking the edge case downstream. I posted about it in Slack and it seemed like people were on board with no one against it, so I'm just tacking that on as a bonus here.
  - I verified that Prod and Staging both have no NULL `default_tree_location_id` values in their DBs. As of right now, should be safe to add this constraint.
  - It would be better for this to be its own migration/PR, but it seems minor enough that it's not a big deal to just tack on here and have it be done.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)