### PR TITLE
Write to `pathogen_lineages` alongside `pango_lineages`

### DIFF
--- a/src/backend/aspen/workflows/import_pango_lineages/load_lineages.py
+++ b/src/backend/aspen/workflows/import_pango_lineages/load_lineages.py
@@ -91,6 +91,7 @@ def get_lineages(lineage_notes_file: io.TextIOBase) -> list[str]:
     ]
 
 
+# TODO this function is only here for reverse-compatibility. We'll remove it soon
 def load_old_lineages_data(lineages: list[str]) -> None:
     """Loads all the lineages into DB.
 
@@ -220,7 +221,7 @@ def cli(
         return  # End here to avoid importing to DB
 
     print("Loading Pango lineages to DB...")
-    # load_old_lineages_data(lineages)
+    load_old_lineages_data(lineages)
     load_lineages_data(lineages)
     print("Loading Pango lineages complete!")
 

--- a/src/backend/aspen/workflows/import_pango_lineages/load_lineages.py
+++ b/src/backend/aspen/workflows/import_pango_lineages/load_lineages.py
@@ -2,6 +2,7 @@ import io
 from typing import Optional
 
 import click
+import sqlalchemy as sa
 
 from aspen.config.config import Config
 from aspen.database.connection import (
@@ -10,7 +11,7 @@ from aspen.database.connection import (
     session_scope,
     SqlAlchemyInterface,
 )
-from aspen.database.models import PangoLineage
+from aspen.database.models import PangoLineage, Pathogen, PathogenLineage
 from aspen.workflows.shared_utils.database import (
     create_temp_table,
     drop_temp_table,
@@ -90,7 +91,7 @@ def get_lineages(lineage_notes_file: io.TextIOBase) -> list[str]:
     ]
 
 
-def load_lineages_data(lineages: list[str]) -> None:
+def load_old_lineages_data(lineages: list[str]) -> None:
     """Loads all the lineages into DB.
 
     Approach to this is basically duplicating what's in
@@ -120,6 +121,57 @@ def load_lineages_data(lineages: list[str]) -> None:
 
         # Final sanity check before we commit
         count_db_lineages = session.query(dest_table).count()
+        print(f"Imported {count_db_lineages} lineage rows")
+        if len(lineages) != count_db_lineages:
+            raise RuntimeError("Something went wrong loading DB. Abort!")
+            # This exception will bubble up, end session, cause rollback.
+
+        session.commit()
+
+
+def load_lineages_data(lineages: list[str]) -> None:
+    """Loads all the lineages into DB.
+
+    Approach to this is basically duplicating what's in
+        backend/aspen/workflows/import_gisaid/save.py
+    Idea is to load all the data into a temp table with same structure,
+    then once all loaded, drop the rows from "real" table, move the new data
+    over from the temp table, and finally drop the temp table to wrap up.
+
+    Original GISAID import deals with a lot more data, so that has some
+    performance-specific bits that are not included in this version.
+    """
+    LINEAGE_COL_NAME = "lineage"
+
+    interface: SqlAlchemyInterface = init_db(get_db_uri(Config()))
+    with session_scope(interface) as session:
+        pathogen = session.execute(sa.select(Pathogen).where(Pathogen.slug == "SC2")).scalars().one()  # type: ignore
+
+        dest_table = PathogenLineage.__table__
+        temp_table = create_temp_table(session, dest_table)
+
+        # Load data into temp_table
+        lineage_objects = [
+            {LINEAGE_COL_NAME: lineage, "pathogen_id": pathogen.id}
+            for lineage in lineages
+        ]
+        session.execute(temp_table.insert(), lineage_objects)
+
+        # Replace previous data with new data from temp_table
+        mv_table_contents(
+            session,
+            temp_table,
+            dest_table,
+            [(PathogenLineage.pathogen_id == pathogen.id)],
+        )
+        drop_temp_table(session, temp_table)
+
+        # Final sanity check before we commit
+        count_db_lineages = (
+            session.query(dest_table)
+            .filter(PathogenLineage.pathogen_id == pathogen.id)
+            .count()
+        )
         print(f"Imported {count_db_lineages} lineage rows")
         if len(lineages) != count_db_lineages:
             raise RuntimeError("Something went wrong loading DB. Abort!")
@@ -168,6 +220,7 @@ def cli(
         return  # End here to avoid importing to DB
 
     print("Loading Pango lineages to DB...")
+    # load_old_lineages_data(lineages)
     load_lineages_data(lineages)
     print("Loading Pango lineages complete!")
 

--- a/src/backend/aspen/workflows/shared_utils/database.py
+++ b/src/backend/aspen/workflows/shared_utils/database.py
@@ -1,9 +1,12 @@
 import re
 import uuid
+from typing import Iterable, Optional
 
+import sqlalchemy as sa
 from sqlalchemy import Column, MetaData, Table
 from sqlalchemy.orm.session import Session
 from sqlalchemy.schema import CreateTable, DropTable
+from sqlalchemy.sql.elements import ClauseElement
 
 # Used in names of temp tables to show intention to be temporary.
 TEMPORARY_INDICATOR = "temporary"
@@ -34,16 +37,29 @@ def create_temp_table(session: Session, source_table: Table) -> Table:
     return table_object
 
 
-def mv_table_contents(session: Session, source_table: Table, dest_table: Table) -> None:
+def mv_table_contents(
+    session: Session,
+    source_table: Table,
+    dest_table: Table,
+    filters: Optional[Iterable[ClauseElement]] = None,
+) -> None:
     """Deletes contents of dest, copies in contents from source to dest.
 
     WARNING: This function is destructive for the data in dest_table.
     All the data that dest_table starts with will be dropped as part
     of copying in the incoming data from source_table.
     """
-    cols = [col.name for col in dest_table.columns]
-    session.execute(dest_table.delete())
-    session.execute(dest_table.insert().from_select(cols, source_table.select()))
+    dest_cols = [col.name for col in dest_table.columns if col.name != "id"]
+    source_cols = [col for col in source_table.columns if col.name != "id"]
+    delete_query = dest_table.delete()
+    if filters is not None:
+        delete_query = delete_query.where(*filters)
+    session.execute(delete_query)
+    print(dest_table.insert().from_select(dest_cols, sa.select(source_cols)))
+    import pdb
+
+    pdb.set_trace()
+    session.execute(dest_table.insert().from_select(dest_cols, sa.select(source_cols)))
 
 
 def drop_temp_table(

--- a/src/backend/aspen/workflows/shared_utils/database.py
+++ b/src/backend/aspen/workflows/shared_utils/database.py
@@ -2,7 +2,6 @@ import re
 import uuid
 from typing import Iterable, Optional
 
-import sqlalchemy as sa
 from sqlalchemy import Column, MetaData, Table
 from sqlalchemy.orm.session import Session
 from sqlalchemy.schema import CreateTable, DropTable
@@ -49,17 +48,12 @@ def mv_table_contents(
     All the data that dest_table starts with will be dropped as part
     of copying in the incoming data from source_table.
     """
-    dest_cols = [col.name for col in dest_table.columns if col.name != "id"]
-    source_cols = [col for col in source_table.columns if col.name != "id"]
+    cols = [col.name for col in dest_table.columns]
     delete_query = dest_table.delete()
     if filters is not None:
         delete_query = delete_query.where(*filters)
     session.execute(delete_query)
-    print(dest_table.insert().from_select(dest_cols, sa.select(source_cols)))
-    import pdb
-
-    pdb.set_trace()
-    session.execute(dest_table.insert().from_select(dest_cols, sa.select(source_cols)))
+    session.execute(dest_table.insert().from_select(cols, source_table.select()))
 
 
 def drop_temp_table(


### PR DESCRIPTION
### Summary:
- **What:** Update our pango-lineage import script to write to both old & new lineage tables
- **Ticket:** [sc226101](https://app.shortcut.com/genepi/story/226101)

### Notes:
I duplicated the existing "write data to `pango_lineages`" function instead of doing something more clever to make it easier to delete it later (since that table is going away) but open to other suggestions if we think there's a better way to manage table migrations and duplicated code.

Since the `pathogen_lineages` table supports multiple pathogens, our old "delete data from destination table and insert data from temp table" library had to be modified to support a `where` clause to **selectively** delete rows before copying in updated data.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)