### PR TITLE
Fix path to python3 to support 3.9 and 3.10

### DIFF
--- a/src/backend/aspen/workflows/test-pangolin.sh
+++ b/src/backend/aspen/workflows/test-pangolin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
-/usr/local/bin/python3.9 /usr/src/app/aspen/workflows/pangolin/find_samples.py --test --output-file dummy.txt
+/usr/local/bin/python3 /usr/src/app/aspen/workflows/pangolin/find_samples.py --test --output-file dummy.txt
 
 # Script has a required file arg, so make a dummy to be able to run smoke test
 touch test.txt
-/usr/local/bin/python3.9 /usr/src/app/aspen/workflows/import_pango_lineages/load_lineages.py --test --lineages-file test.txt
+/usr/local/bin/python3 /usr/src/app/aspen/workflows/import_pango_lineages/load_lineages.py --test --lineages-file test.txt


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)