### PR TITLE
Handle end dates for all tree titles (SC 214190)

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/build_plugins/base_plugin.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_plugins/base_plugin.py
@@ -16,7 +16,7 @@ class BaseConfigPlugin:
         self.template_args = template_args
         self.template = None
         self.tree_build_level = "location"
-        # Set self.num_county_sequences, self.num_sequences, etc.
+        # Set self.num_sequences, self.run_start_datetime, etc.
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -186,6 +186,7 @@ def export_run_config(
         context = {
             "num_sequences": num_sequences,
             "num_included_samples": num_included_samples,
+            "run_start_datetime": phylo_run.start_datetime,  # can be None
         }
 
         # Some template args need to be resolved before ready to use.


### PR DESCRIPTION
### Summary:
- **What:** Always provide an end date to the tree title (for JSON tree, not the name we show on aspen trees list page)
- **Ticket:** [sc<214190>](https://app.shortcut.com/genepi/story/<214190>)
- **Env:** None -- testing this on an rdev would be attached to creating a tree, and that's currently broken on rdev

### Demos:
Phylo run with input template arg of `filter_start_date` but no `filter_end_date`, so falls back to using the phylo run's `start_datetime` to produce the title

<img width="636" alt="image" src="https://user-images.githubusercontent.com/89553795/199854001-c0097a1f-877f-4115-806d-fb50c268f878.png">

<img width="394" alt="image" src="https://user-images.githubusercontent.com/89553795/199854019-1a08806d-d148-4e40-8abe-ad53116e5c23.png">

<img width="701" alt="image" src="https://user-images.githubusercontent.com/89553795/199854078-34a810e9-1098-473e-9a7c-1806ce844ec7.png">

---

Phylo run that has no `filter_start_date`, title template language changes to only mention end date. (In this case, explicitly provided by `filter_end_date`, but would default to run `start_datetime` if that was not available.)

<img width="672" alt="image" src="https://user-images.githubusercontent.com/89553795/199854272-d8e734be-810d-4693-8211-de87c7702ea8.png">

<img width="694" alt="image" src="https://user-images.githubusercontent.com/89553795/199854347-43baeff3-82d7-4943-b214-51d7c1265e1b.png">


### Notes:

There is the possibility of an off-by-one error for the end date when it's implicitly pulled from the phylo run's `start_datetime`. This happens because the user's timezone is unknown: eg, if I live in the USA and kick off a tree build on Nov 1 at 10pm, that will be early Nov 2 in UTC time. Since all the datetimes on the server are UTC, the implicit end date given by `start_datetime` might actually be different than the date the user saw when they kicked off the tree build. I discussed this with Dan, and there's enough ambiguity around date already that this potential error seems acceptable to both of us. (If our users ever encounter it and care, we could try to implement a fix, but I don't think there's a perfect solution: imagine collaborators on opposite sides of the international date line. If one of them creates a tree, they each see the tree creation as happening on a different day, so we can't write both those dates to the tree JSON. There will have to be at least some level of compromise on this.)

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
~[ ] I added relevant unit tests~
