### PR TITLE
Fix Nextstrain image check test

### DIFF
--- a/src/backend/aspen/workflows/test-nextstrain.sh
+++ b/src/backend/aspen/workflows/test-nextstrain.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
-python3 /usr/src/app/aspen/workflows/nextstrain_run/export.py --test --phylo-run-id 1234 --builds-file test.txt --sequences test.fasta --metadata test.tsv --selected include.txt
+python3 /usr/src/app/aspen/workflows/nextstrain_run/export.py --test --phylo-run-id 1234 --builds-file test.txt --sequences test.fasta --metadata test.tsv --resolved-template-args /tmp/test.json --selected include.txt
 python3 /usr/src/app/aspen/workflows/nextstrain_run/error.py --test --phylo-run-id 1234 --end-time 1234
+# Files the `save.py` script assumes it can read from. If not present, errors.
 touch test.txt
-python3 /usr/src/app/aspen/workflows/nextstrain_run/save.py --test --aspen-workflow-rev test --aspen-creation-rev test --ncov-rev test --aspen-docker-image-version test --end-time 1234 --phylo-run-id 1234 --bucket test --key test --tree-path test.txt
+touch /tmp/test.json
+python3 /usr/src/app/aspen/workflows/nextstrain_run/save.py --test --aspen-workflow-rev test --aspen-creation-rev test --ncov-rev test --aspen-docker-image-version test --end-time 1234 --phylo-run-id 1234 --bucket test --key test --resolved-template-args /tmp/test.json --tree-path test.txt


### PR DESCRIPTION
### Summary:
- **What:** Fix: adds in missing params for Nextstrain image check run
- **Ticket:** None
- **Env:** None

### Demos:

Three success good, yes, three is magic number for success

<img width="677" alt="image" src="https://user-images.githubusercontent.com/89553795/200083730-d20dfc55-5cd0-4fbb-8219-e482d57fb4a5.png">


### Notes:
My work in #1427 added a new, required param (`--resolved-template-args`) for our Nextstrain export.py and save.py scripts, but I missed adding it to our smoke test shell script. This means that test script always failed, so deploys got blocked because it builds image then runs smoke tests as part of Staging deploy process.

I did not notice this at the time, because another, different error came up that I did fix, and I missed this one because I thought I had fixed the one and only problem. Nope! Two problems.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR