### PR TITLE
Turn off build/test for Lineage&QC image

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -217,9 +217,11 @@ jobs:
           - dockerfile: src/backend/Dockerfile.pangolin
             context: ./src/backend/
             name: genepi-pangolin
-          - dockerfile: src/backend/Dockerfile.lineage_qc
-            context: ./src/backend/
-            name: genepi-lineage-qc
+          # TODO [Vince]: Disabling build of QC image until ready for use.
+          # (Was creating issues with failing tests and infra problems)
+          # - dockerfile: src/backend/Dockerfile.lineage_qc
+          #   context: ./src/backend/
+          #   name: genepi-lineage-qc
           - dockerfile: src/backend/Dockerfile
             context: ./src/backend/
             name: genepi-backend


### PR DESCRIPTION
### Summary:
- **What:** Lineage&QC image not really ready for use yet, so disabling because breaking deploy
- **Ticket:** None
- **Env:** None

### Notes:

Our build+test strategy assumes tests being ready for every image we build. I could put in a fake, always successful test for the image in question, but considering that it's not really ready for prime time use and already has various infra issues, it seemed best to me to just disable its creation/testing entirely for now.

### Checklist:
- [x] I merged latest `trunk`
~[ ] I manually verified the change~ (instead, gonna watch that GitHub Action real good)
- [x] I added labels to my PR