### PR TITLE
Stub out Lineage&QC image test

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -217,11 +217,9 @@ jobs:
           - dockerfile: src/backend/Dockerfile.pangolin
             context: ./src/backend/
             name: genepi-pangolin
-          # TODO [Vince]: Disabling build of QC image until ready for use.
-          # (Was creating issues with failing tests and infra problems)
-          # - dockerfile: src/backend/Dockerfile.lineage_qc
-          #   context: ./src/backend/
-          #   name: genepi-lineage-qc
+          - dockerfile: src/backend/Dockerfile.lineage_qc
+            context: ./src/backend/
+            name: genepi-lineage-qc
           - dockerfile: src/backend/Dockerfile
             context: ./src/backend/
             name: genepi-backend

--- a/src/backend/aspen/workflows/test-lineage-qc.sh
+++ b/src/backend/aspen/workflows/test-lineage-qc.sh
@@ -1,0 +1,1 @@
+echo "TODO write a real test for Lineage and QC."


### PR DESCRIPTION
### Summary:
- **What:** GH Action did not play well with infra when Lineage&QC image totally missing. Just stubbing out the test to avoid things blowing up in weird ways. I hope.
- **Ticket:** None
- **Env:** None

### Notes:

It's hard to tell, but I'm pretty sure the errors I saw were the infra code expecting an image for each service (including lineage-qc), but because I dropped it in the previous PR, it just broke. Putting it back in and stubbing the test that was causing it to fail when it was missing.

### Checklist:
- [ ] I merged latest `trunk`
~ [ ] I manually verified the change~ (will watch GH Action for expected result)
- [x] I added labels to my PR
