### PR TITLE
Fix: Add shebang to stub test script

### DIFF
--- a/src/backend/aspen/workflows/test-lineage-qc.sh
+++ b/src/backend/aspen/workflows/test-lineage-qc.sh
@@ -1,1 +1,2 @@
+#!/bin/bash -e
 echo "TODO write a real test for Lineage and QC."


### PR DESCRIPTION
### Summary:
- **What:** Forgot the shebang at top of the stub test script. Won't run without it.
- **Ticket:** None
 
### Demo:

After the repeated "doh" mistakes, I actually tested this one locally. It's working as expected.

<img width="670" alt="image" src="https://user-images.githubusercontent.com/89553795/200100902-d19d721f-ae9c-4c3a-b9ce-b9079108c31f.png">


### Notes:

Merging without review.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR