### PR TITLE
Temp fix: Comment out lineage image from TF file

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -44,7 +44,8 @@ locals {
 
   # Workflow images
   pangolin_image   = join(":", [local.secret["ecrs"]["pangolin"]["url"], lookup(var.image_tags, "pangolin", var.image_tag)])
-  lineage_qc_image = join(":", [local.secret["ecrs"]["lineage-qc"]["url"], lookup(var.image_tags, "lineage-qc", var.image_tag)])
+  # TODO Fix `lineage-qc` vs `lineage_qc` mismatch between here and infra repo
+  # lineage_qc_image = join(":", [local.secret["ecrs"]["lineage-qc"]["url"], lookup(var.image_tags, "lineage-qc", var.image_tag)])
   nextstrain_image = join(":", [local.secret["ecrs"]["nextstrain"]["url"], lookup(var.image_tags, "nextstrain", var.image_tag)])
   gisaid_image     = join(":", [local.secret["ecrs"]["gisaid"]["url"], lookup(var.image_tags, "gisaid", var.image_tag)])
 


### PR DESCRIPTION
### Summary:
- **What:** There is a mismatch between infra repo and our app infra of `lineage-qc` vs `lineage_qc`. Can't be truly fixed right now because infra repo is frozen up due to other issues. For now, just commenting out the line of our app infra file about that image entirely should prevent it from erroring and allow our Staging deploys to work again.
- **Ticket:** None

### Notes:

Merging without review.

### Checklist:
- [x] I merged latest `trunk`
~ [ ] I manually verified the change~ (can't, it's gotta be seeing what happens in deploy)
- [x] I added labels to my PR