### PR TITLE
Bump GISAID ingest instance type to r5d.x16large

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -184,8 +184,8 @@ module gisaid_sfn_config {
   app_name = "gisaid-sfn"
   image    = local.gisaid_image
   # This job is actually constrained by *DISK SPACE* and swipe currently only supports NVME-mounted storage
-  # so we're requesting more vcpu's than necessary in order to bump the instance size to: 2 x 900 NVMe SSD
-  memory   = 384000
+  # so we're requesting more vcpu's than necessary in order to bump the instance size to: 4 x 600 NVMe SSD
+  memory   = 512000
   wdl_path = "workflows/gisaid.wdl"
   custom_stack_name     = local.custom_stack_name
   deployment_stage      = local.deployment_stage


### PR DESCRIPTION
### Summary:
- **What:** GISAID ingest jobs are failing due to a lack of storage space. This bumps us to an instance size with 2.4 TB storage from our current 1.8 TB.
- **Ticket:** [sc227167](https://app.shortcut.com/genepi/story/227167)
- **Env:** `<rdev link>`

### Demos:

### Notes:
This is just a quick fix. Over the long term it might be worth it to ask the SWIPE team to support storage-optimized instance types - if we want to bump up the storage capacity any more, any im4gn is going to be cheaper than an r5.x24large.

See also #1343 

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)