### PR TITLE
Maya/227588 sample table styles

### DIFF
--- a/src/frontend/src/views/Data/components/DataNavigation/index.tsx
+++ b/src/frontend/src/views/Data/components/DataNavigation/index.tsx
@@ -1,11 +1,11 @@
-import { Tab, Tabs } from "czifui";
+import { Tab } from "czifui";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useNewPhyloRunInfo as usePhyloRunInfo } from "src/common/queries/phyloRuns";
 import { useNewSampleInfo as useSampleInfo } from "src/common/queries/samples";
 import { ROUTES } from "src/common/routes";
 import { FilterPanelToggle } from "./FilterPanelToggle";
-import { Navigation } from "./style";
+import { Navigation, StyledTabs } from "./style";
 
 // either all the props for sample filter panel are passed
 // or no props are passed
@@ -78,7 +78,7 @@ const DataNavigation = ({
           onClick={toggleFilterPanel}
         />
       )}
-      <Tabs value={currentTab} sdsSize="large" onChange={handleTabClick}>
+      <StyledTabs value={currentTab} sdsSize="large" onChange={handleTabClick}>
         {tabData.map((tab) => (
           <Tab
             key={tab.to}
@@ -88,7 +88,7 @@ const DataNavigation = ({
             data-test-id={`menu-item-${tab.to}`}
           />
         ))}
-      </Tabs>
+      </StyledTabs>
     </Navigation>
   );
 };

--- a/src/frontend/src/views/Data/components/DataNavigation/style.ts
+++ b/src/frontend/src/views/Data/components/DataNavigation/style.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { CommonThemeProps, getColors, getSpaces } from "czifui";
+import { CommonThemeProps, getColors, getSpaces, Tabs } from "czifui";
 
 export const Navigation = styled.div`
   display: flex;
@@ -11,6 +11,15 @@ export const Navigation = styled.div`
 
     return `
       border-bottom: ${spaces?.xxs}px solid ${colors?.gray[200]};
+    `;
+  }}
+`;
+
+export const StyledTabs = styled(Tabs)`
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-bottom: ${spaces?.l}px;
     `;
   }}
 `;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/index.tsx
@@ -1,8 +1,8 @@
-import { Divider } from "@mui/material";
 import { IconButton } from "../IconButton";
 import { MoreActionsMenu } from "./components/MoreActionMenu";
 import { TreeSelectionMenu } from "./components/TreeSelectionMenu";
 import {
+  Divider,
   StyledChip,
   StyledSelectedCount,
   StyledWrapper,

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -209,15 +209,6 @@ const columns: ColumnDef<Sample, any>[] = [
     cell: DefaultCell,
   },
   {
-    id: "lineage",
-    accessorKey: "lineage",
-    header: ({ header }) => (
-      <SortableHeader header={header}>Lineage</SortableHeader>
-    ),
-    cell: DefaultCell,
-    enableSorting: true,
-  },
-  {
     id: "gisaid",
     accessorKey: "gisaid",
     header: ({ header }) => (

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -1,7 +1,8 @@
 import {
-  CellBasic,
+  CellComponent,
   CellHeader,
   Checkbox,
+  Icon,
   Table,
   TableHeader,
   TableRow,
@@ -19,6 +20,7 @@ import { IdMap } from "src/common/utils/dataTransforms";
 import { map } from "lodash";
 import { ReactNode, useEffect, useState } from "react";
 import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
+import { StyledCellBasic, StyledPrivateId } from "./style";
 
 // TODO-TR (mlila): types
 interface Props {
@@ -55,13 +57,13 @@ export const SortableHeader = ({ header, children }: SortableProps) => {
 const columns: ColumnDef<Sample, any>[] = [
   {
     id: "select",
+    size: 50,
     header: ({ table }) => {
       const {
         getIsAllRowsSelected,
         getIsSomeRowsSelected,
         getToggleAllRowsSelectedHandler,
       } = table;
-
       const isChecked = getIsAllRowsSelected();
       const isIndeterminate = getIsSomeRowsSelected();
       const checkboxStage = isChecked
@@ -72,7 +74,11 @@ const columns: ColumnDef<Sample, any>[] = [
 
       const onChange = getToggleAllRowsSelectedHandler();
 
-      return <Checkbox stage={checkboxStage} onChange={onChange} />;
+      return (
+        <CellComponent>
+          <Checkbox stage={checkboxStage} onChange={onChange} />
+        </CellComponent>
+      );
     },
     cell: ({ row }) => {
       const { getIsSelected, getToggleSelectedHandler } = row;
@@ -80,16 +86,36 @@ const columns: ColumnDef<Sample, any>[] = [
       const checkboxStage = getIsSelected() ? "checked" : "unchecked";
       const onChange = getToggleSelectedHandler();
 
-      return <Checkbox stage={checkboxStage} onChange={onChange} />;
+      return (
+        <CellComponent>
+          <Checkbox stage={checkboxStage} onChange={onChange} />
+        </CellComponent>
+      );
     },
   },
   {
     id: "privateId",
     accessorKey: "privateId",
+    minSize: 350,
     header: ({ header }) => (
       <SortableHeader header={header}>Private ID</SortableHeader>
     ),
-    cell: ({ getValue }) => <CellBasic primaryText={getValue()} />,
+    cell: ({ getValue, row }) => {
+      const uploader = row?.original?.uploadedBy.name;
+      return (
+        <StyledPrivateId
+          primaryText={getValue()}
+          secondaryText={uploader}
+          shouldTextWrap
+          primaryTextWrapLineCount={1}
+          icon={<Icon sdsIcon="flaskPublic" sdsSize="xl" sdsType="static" />}
+          tooltipProps={{
+            sdsStyle: "light",
+            arrow: false,
+          }}
+        />
+      );
+    },
     enableSorting: true,
   },
   {
@@ -98,8 +124,30 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Public ID</SortableHeader>
     ),
-    cell: ({ getValue }) => <CellBasic primaryText={getValue()} />,
+    cell: ({ getValue }) => (
+      <StyledCellBasic
+        shouldTextWrap
+        primaryText={getValue()}
+        primaryTextWrapLineCount={2}
+        shouldShowTooltipOnHover={false}
+      />
+    ),
     enableSorting: true,
+  },
+  {
+    id: "uploadDate",
+    accessorKey: "uploadDate",
+    header: ({ header }) => (
+      <SortableHeader header={header}>Upload Date</SortableHeader>
+    ),
+    cell: ({ getValue }) => (
+      <StyledCellBasic
+        shouldTextWrap
+        primaryText={datetimeWithTzToLocalDate(getValue())}
+        primaryTextWrapLineCount={2}
+        shouldShowTooltipOnHover={false}
+      />
+    ),
   },
   {
     id: "collectionDate",
@@ -107,7 +155,14 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Collection Date</SortableHeader>
     ),
-    cell: ({ getValue }) => <CellBasic primaryText={getValue()} />,
+    cell: ({ getValue }) => (
+      <StyledCellBasic
+        shouldTextWrap
+        primaryText={getValue()}
+        primaryTextWrapLineCount={2}
+        shouldShowTooltipOnHover={false}
+      />
+    ),
     enableSorting: true,
   },
   {
@@ -118,19 +173,15 @@ const columns: ColumnDef<Sample, any>[] = [
     ),
     cell: ({ getValue }) => {
       const { lineage } = getValue();
-      return <CellBasic primaryText={lineage} />;
+      return (
+        <StyledCellBasic
+          shouldTextWrap
+          primaryText={lineage}
+          primaryTextWrapLineCount={2}
+          shouldShowTooltipOnHover={false}
+        />
+      );
     },
-    enableSorting: true,
-  },
-  {
-    id: "uploadDate",
-    accessorKey: "uploadDate",
-    header: ({ header }) => (
-      <SortableHeader header={header}>Upload Date</SortableHeader>
-    ),
-    cell: ({ getValue }) => (
-      <CellBasic primaryText={datetimeWithTzToLocalDate(getValue())} />
-    ),
     enableSorting: true,
   },
   {
@@ -139,7 +190,14 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Collection Location</SortableHeader>
     ),
-    cell: ({ getValue }) => <CellBasic primaryText={getValue().location} />,
+    cell: ({ getValue }) => (
+      <StyledCellBasic
+        shouldTextWrap
+        primaryText={getValue().location}
+        primaryTextWrapLineCount={2}
+        shouldShowTooltipOnHover={false}
+      />
+    ),
     enableSorting: true,
   },
   {
@@ -148,7 +206,32 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Sequencing Date</SortableHeader>
     ),
-    cell: ({ getValue }) => <CellBasic primaryText={getValue()} />,
+    cell: ({ getValue }) => (
+      <StyledCellBasic
+        shouldTextWrap
+        primaryText={getValue()}
+        primaryTextWrapLineCount={2}
+        shouldShowTooltipOnHover={false}
+      />
+    ),
+  },
+  {
+    id: "lineage",
+    accessorKey: "lineage",
+    header: ({ header }) => (
+      <SortableHeader header={header}>Lineage</SortableHeader>
+    ),
+    cell: ({ getValue }) => {
+      const { lineage } = getValue();
+      return (
+        <StyledCellBasic
+          shouldTextWrap
+          primaryText={lineage}
+          primaryTextWrapLineCount={2}
+          shouldShowTooltipOnHover={false}
+        />
+      );
+    },
     enableSorting: true,
   },
   {
@@ -158,8 +241,14 @@ const columns: ColumnDef<Sample, any>[] = [
       <SortableHeader header={header}>GISAID</SortableHeader>
     ),
     cell: ({ getValue }) => {
-      const { status } = getValue();
-      return <CellBasic primaryText={status} />;
+      const { gisaid_id, status } = getValue();
+      return (
+        <StyledCellBasic
+          primaryText={status}
+          secondaryText={gisaid_id}
+          shouldShowTooltipOnHover={false}
+        />
+      );
     },
     enableSorting: true,
   },
@@ -183,6 +272,9 @@ const SamplesTable = ({
 
   const table = useReactTable({
     data: samples,
+    defaultColumn: {
+      minSize: 50,
+    },
     columns,
     enableMultiRowSelection: true,
     getCoreRowModel: getCoreRowModel(),

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -12,6 +12,7 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  Getter,
   Header,
   RowSelectionState,
   useReactTable,
@@ -35,7 +36,10 @@ interface SortableProps {
   children: ReactNode & string;
 }
 
-export const SortableHeader = ({ header, children }: SortableProps) => {
+export const SortableHeader = ({
+  header,
+  children,
+}: SortableProps): JSX.Element => {
   const { getCanSort, getIsSorted, getToggleSortingHandler } = header.column;
 
   const sortable = getCanSort();
@@ -53,6 +57,16 @@ export const SortableHeader = ({ header, children }: SortableProps) => {
     </CellHeader>
   );
 };
+
+// TODO-TR (mlila): move this default cell into its own component file
+const DefaultCell = ({ getValue }: { getValue: Getter<any> }): JSX.Element => (
+  <StyledCellBasic
+    shouldTextWrap
+    primaryText={getValue()}
+    primaryTextWrapLineCount={2}
+    shouldShowTooltipOnHover={false}
+  />
+);
 
 const columns: ColumnDef<Sample, any>[] = [
   {
@@ -124,14 +138,7 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Public ID</SortableHeader>
     ),
-    cell: ({ getValue }) => (
-      <StyledCellBasic
-        shouldTextWrap
-        primaryText={getValue()}
-        primaryTextWrapLineCount={2}
-        shouldShowTooltipOnHover={false}
-      />
-    ),
+    cell: DefaultCell,
     enableSorting: true,
   },
   {
@@ -155,14 +162,7 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Collection Date</SortableHeader>
     ),
-    cell: ({ getValue }) => (
-      <StyledCellBasic
-        shouldTextWrap
-        primaryText={getValue()}
-        primaryTextWrapLineCount={2}
-        shouldShowTooltipOnHover={false}
-      />
-    ),
+    cell: DefaultCell,
     enableSorting: true,
   },
   {
@@ -206,14 +206,7 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Sequencing Date</SortableHeader>
     ),
-    cell: ({ getValue }) => (
-      <StyledCellBasic
-        shouldTextWrap
-        primaryText={getValue()}
-        primaryTextWrapLineCount={2}
-        shouldShowTooltipOnHover={false}
-      />
-    ),
+    cell: DefaultCell,
   },
   {
     id: "lineage",
@@ -221,17 +214,7 @@ const columns: ColumnDef<Sample, any>[] = [
     header: ({ header }) => (
       <SortableHeader header={header}>Lineage</SortableHeader>
     ),
-    cell: ({ getValue }) => {
-      const { lineage } = getValue();
-      return (
-        <StyledCellBasic
-          shouldTextWrap
-          primaryText={lineage}
-          primaryTextWrapLineCount={2}
-          shouldShowTooltipOnHover={false}
-        />
-      );
-    },
+    cell: DefaultCell,
     enableSorting: true,
   },
   {

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+import { CellBasic, getFontWeights } from "czifui";
+
+export const StyledPrivateId = styled(CellBasic)`
+  /* width: 350px; */
+
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      span:first-of-type {
+        font-weight: ${fontWeights?.semibold};
+        word-break: break-all;
+      }
+    `;
+  }}
+`;
+
+export const StyledCellBasic = styled(CellBasic)`
+  /* min-width: 50px; */
+
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      span {
+        font-weight: ${fontWeights?.semibold};
+        word-break: break-word;
+      }
+    `;
+  }}
+`;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
@@ -2,8 +2,6 @@ import styled from "@emotion/styled";
 import { CellBasic, getFontWeights } from "czifui";
 
 export const StyledPrivateId = styled(CellBasic)`
-  /* width: 350px; */
-
   ${(props) => {
     const fontWeights = getFontWeights(props);
     return `
@@ -16,8 +14,6 @@ export const StyledPrivateId = styled(CellBasic)`
 `;
 
 export const StyledCellBasic = styled(CellBasic)`
-  /* min-width: 50px; */
-
   ${(props) => {
     const fontWeights = getFontWeights(props);
     return `

--- a/src/frontend/src/views/Data/components/SamplesView/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/index.tsx
@@ -10,7 +10,7 @@ import { StyledView } from "../../style";
 import { DataNavigation } from "../DataNavigation";
 import { SamplesTable } from "./components/SamplesTable";
 import { SampleTableModalManager } from "./components/SampleTableModalManager";
-import { Flex } from "./style";
+import { Flex, MaxWidth, StyledActionBar } from "./style";
 
 const SamplesView = (): JSX.Element => {
   // initialize state
@@ -79,8 +79,8 @@ const SamplesView = (): JSX.Element => {
           setDataFilterFunc={setDataFilterFunc}
           data-test-id="menu-item-sample-count"
         />
-        <div>
-          <Flex>
+        <MaxWidth>
+          <StyledActionBar>
             <SearchBar
               tableData={samples}
               onSearchComplete={setSearchResults}
@@ -89,13 +89,13 @@ const SamplesView = (): JSX.Element => {
               checkedSamples={checkedSamples}
               clearCheckedSamples={() => setCheckedSamples([])}
             />
-          </Flex>
+          </StyledActionBar>
           <SamplesTable
             isLoading={isLoading || isFetching}
             data={displayedRows}
             setCheckedSamples={setCheckedSamples}
           />
-        </div>
+        </MaxWidth>
       </Flex>
     </StyledView>
   );

--- a/src/frontend/src/views/Data/components/SamplesView/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/style.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
-import { getSpaces } from "czifui";
+import { CommonThemeProps, getSpaces } from "czifui";
 
 export const MaxWidth = styled.div`
   width: 1300px;
   margin: auto;
-  ${(props) => {
+  ${(props: CommonThemeProps) => {
     const spaces = getSpaces(props);
     return `
       padding: 0 ${spaces?.l}px;

--- a/src/frontend/src/views/Data/components/SamplesView/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/style.ts
@@ -1,4 +1,21 @@
 import styled from "@emotion/styled";
+import { getSpaces } from "czifui";
+
+export const MaxWidth = styled.div`
+  width: 1300px;
+  margin: auto;
+  ${(props) => {
+    const spaces = getSpaces(props);
+    return `
+      padding: 0 ${spaces?.l}px;
+    `;
+  }}
+`;
+
+export const StyledActionBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
 
 export const Flex = styled.div`
   display: flex;

--- a/src/frontend/src/views/Data/style.ts
+++ b/src/frontend/src/views/Data/style.ts
@@ -163,6 +163,7 @@ export const View = styled.div`
   when the viewport height is too short */
   height: calc(100% - 74px);
   display: flex;
+  width: 100%;
 `;
 
 export const StyledCount = styled.div`
@@ -198,4 +199,5 @@ export const StyledMenuItem = styled.li`
 export const StyledView = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
 `;


### PR DESCRIPTION
### Summary
- **What:** Some styling polish for the samples table
- **Ticket:** [[sc-227588]](https://app.shortcut.com/genepi/story/227588)
- **Design:** https://www.figma.com/file/BhgBQIacuxHYRGumpLJfDx/CZ-GE-Table-Refactor?node-id=0%3A1

### Demos
#### Before: 
![Screenshot 2022-11-09 at 1 24 01 PM](https://user-images.githubusercontent.com/7562933/200944751-4f6b060e-4fd4-47d6-8657-955fa5eb2657.png)

#### After: 
![Screenshot 2022-11-09 at 1 26 04 PM](https://user-images.githubusercontent.com/7562933/200945128-b1d96ad3-90ac-418e-aad4-e738f6364a98.png)

### Notes
There will need to be more styling work in the future. This is a first pass polishing.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)