### PR TITLE
Change missing required fields error severity when importing metadata

### DIFF
--- a/src/frontend/src/components/ImportFileWarnings/index.tsx
+++ b/src/frontend/src/components/ImportFileWarnings/index.tsx
@@ -9,12 +9,12 @@ import Error from "src/views/Upload/components/Metadata/components/ImportFile/co
 import Success from "src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Success";
 import {
   ErrorBadFormatData,
+  ErrorMissingData,
   WarningAbsentSample,
   WarningAbsentSampleEdit,
   WarningAutoCorrect,
   WarningExtraneousEntry,
   WarningExtraneousEntrySampleEdit,
-  WarningMissingData,
   WarningMissingDataEdit,
 } from "src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings";
 import {
@@ -114,9 +114,7 @@ export default function ImportFileWarnings({
         )}
 
       {metadataUploadType == MetadataUploadTypeOption.Upload &&
-        !isEmpty(missingData) && (
-          <WarningMissingData missingData={missingData} />
-        )}
+        !isEmpty(missingData) && <ErrorMissingData missingData={missingData} />}
 
       {metadataUploadType == MetadataUploadTypeOption.Edit &&
         !isEmpty(missingData) && (

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -9,6 +9,7 @@ import {
 import { SampleIdToWarningMessages } from "../../parseFile";
 import { ProblemTable } from "./common/ProblemTable";
 
+const ERROR_SEVERITY = "error";
 const WARNING_SEVERITY = "warning";
 
 /**
@@ -263,7 +264,7 @@ function MessageMissingDataEdit({ missingData }: PropsMissingData) {
   );
 }
 
-export function WarningMissingData({
+export function ErrorMissingData({
   missingData,
 }: PropsMissingData): JSX.Element {
   const count = Object.keys(missingData).length;
@@ -276,7 +277,7 @@ export function WarningMissingData({
     <AlertAccordion
       title={<B>{title}</B>}
       collapseContent={<MessageMissingData missingData={missingData} />}
-      intent={WARNING_SEVERITY}
+      intent={ERROR_SEVERITY}
     />
   );
 }
@@ -378,7 +379,7 @@ export function ErrorBadFormatData({
           IdColumnNameForWarnings={IdColumnNameForWarnings}
         />
       }
-      intent="error"
+      intent={ERROR_SEVERITY}
     />
   );
 }


### PR DESCRIPTION
### Summary:
- **What:** Affects the sample upload flow. Changes the severity of the alert raised when an imported metadata file has missing data for required fields from  warning to error.
- **Ticket:** [sc<177079>](https://app.shortcut.com/genepi/story/177079)
- **Env:** `<rdev link>`

### Demos:
<img width="1801" alt="Screenshot 2022-11-14 at 10 43 01" src="https://user-images.githubusercontent.com/24234461/201749655-c454bc96-a075-47f2-a3a5-6168c956468d.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)