### PR TITLE
Add 12 week collection date check for launching scheduled tree builds

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -20,6 +20,7 @@ from aspen.database.models import (
     Group,
     Pathogen,
     PhyloRun,
+    Sample,
     TreeType,
     User,
     Workflow,
@@ -121,10 +122,14 @@ def launch_all(pathogen):
         for group in all_groups:
             schedule_expression = group.tree_parameters.get("schedule_expression", None)
             # Make sure the number of samples collected in the past 12 weeks is > 0
-            filter_interval_samples_count_query = sa.select(func.count(Sample)).where(
-                Sample.submitting_group_id == group.id,
-                func.current_date() - Sample.collection_date
-                < FILTER_START_INTERVAL_DAYS,
+            filter_interval_samples_count_query = (
+                sa.select(func.count())
+                .select_from(Sample)
+                .where(
+                    Sample.submitting_group_id == group.id,
+                    func.current_date() - Sample.collection_date
+                    < FILTER_START_INTERVAL_DAYS,
+                )
             )
             filter_interval_samples_count: int = (
                 db.execute(filter_interval_samples_count_query).scalars().one()

--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -32,6 +32,7 @@ SCHEDULED_TREE_TYPE = "OVERVIEW"
 
 TEMPLATE_ARGS = {"filter_start_date": "12 weeks ago", "filter_end_date": "now"}
 
+# This needs to match the value for "filter_start_date" in TEMPLATE_ARGS.
 FILTER_START_INTERVAL_DAYS = 12 * 7  # 12 weeks ago
 
 
@@ -122,6 +123,8 @@ def launch_all(pathogen):
         for group in all_groups:
             schedule_expression = group.tree_parameters.get("schedule_expression", None)
             # Make sure the number of samples collected in the past 12 weeks is > 0
+            # Note that in Postgres, date - date = int where the int is
+            # the intervening number of days.
             filter_interval_samples_count_query = (
                 sa.select(func.count())
                 .select_from(Sample)

--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, MutableSequence
 
 import click
 import sqlalchemy as sa
+from sqlalchemy import func
 
 from aspen.api.settings import CLISettings
 from aspen.config.config import Config
@@ -29,6 +30,8 @@ from aspen.util.swipe import NextstrainScheduledJob
 SCHEDULED_TREE_TYPE = "OVERVIEW"
 
 TEMPLATE_ARGS = {"filter_start_date": "12 weeks ago", "filter_end_date": "now"}
+
+FILTER_START_INTERVAL_DAYS = 12 * 7  # 12 weeks ago
 
 
 def create_phylo_run(
@@ -117,10 +120,19 @@ def launch_all(pathogen):
         )
         for group in all_groups:
             schedule_expression = group.tree_parameters.get("schedule_expression", None)
+            # Make sure the number of samples collected in the past 12 weeks is > 0
+            filter_interval_samples_count_query = sa.select(func.count(Sample)).where(
+                Sample.submitting_group_id == group.id,
+                func.current_date() - Sample.collection_date
+                < FILTER_START_INTERVAL_DAYS,
+            )
+            filter_interval_samples_count: int = (
+                db.execute(filter_interval_samples_count_query).scalars().one()
+            )
             if (
                 schedule_expression is None
                 or datetime.date.today().weekday() in schedule_expression
-            ):
+            ) and filter_interval_samples_count > 0:
                 workflow = create_phylo_run(
                     db, group, TEMPLATE_ARGS, tree_type, pathogen
                 )


### PR DESCRIPTION
### Summary:
- **What:** Prevents launching scheduled phylo tree jobs for groups that do not have any samples with a collection date in the last 12 weeks, which is the cutoff for inclusion in the tree anyways. Currently several groups are having trees built for them and the jobs inevitably fail due to the template args we pass. This prevents those failing jobs from ever starting in the first place. 
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:
Tested this against the local db by replacing the functional code with some print statements. Correctly, the code did not launch a tree job for Orange County, despite them having a bunch of samples in the db, because their collection date was not within the last twelve weeks.

<img width="774" alt="Screenshot 2022-11-14 at 15 25 53" src="https://user-images.githubusercontent.com/24234461/201790560-7c21f89d-3c1c-4886-8e21-0cf0b2d2d54b.png">

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)