### PR TITLE
Prevent logging of sample ids in Pangolin jobs

### DIFF
--- a/.happy/terraform/modules/sfn_config/pangolin-ondemand.wdl
+++ b/.happy/terraform/modules/sfn_config/pangolin-ondemand.wdl
@@ -37,7 +37,10 @@ task pangolin_workflow {
     export SAMPLE_IDS_FILE="${HOME}/sample_ids.txt"
 
     cd /usr/src/app/aspen/workflows/pangolin
+    echo "Writing sample ids to file."
+    set +x
     echo "~{sep('\n', samples)}" > $SAMPLE_IDS_FILE
+    set -x
     ./run_pangolin.sh
     >>>
 


### PR DESCRIPTION
### Summary:
- **What:** Currently we expand the WDL input containing a list of sample ids, and they got logged to CloudWatch. This turns off bash command tracing when we do that.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [ ] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)