### PR TITLE
[SC-225225 generate the general viral template upload/edit

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/strings.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/CreateNSTreeModal/components/RadioLabel/strings.ts
@@ -1,5 +1,5 @@
 import { Pathogen } from "src/common/redux/types";
-import { PathogenStringsType } from "src/common/types/strings";
+import { PathogenConfigType } from "src/common/types/strings";
 
 interface RadioLabelStrings {
   nonContextualizedBestFor: string;
@@ -15,7 +15,7 @@ interface RadioLabelStrings {
   targetedGoodFor: string;
 }
 
-export const pathogenStrings: PathogenStringsType<RadioLabelStrings> = {
+export const pathogenStrings: PathogenConfigType<RadioLabelStrings> = {
   [Pathogen.COVID]: {
     nonContextualizedBestFor:
       "Best for uncovering sampling bias in your own sampling effort.",

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
@@ -1,5 +1,7 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import {
   IdColumn,
   IsPrivateTableCell,
@@ -16,6 +18,8 @@ interface Props {
 }
 
 const Table = ({ metadata }: Props): JSX.Element => {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   return (
     <Overflow>
       <form autoComplete="off">
@@ -29,13 +33,19 @@ const Table = ({ metadata }: Props): JSX.Element => {
                   <IdColumn>Private ID</IdColumn>
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId}
+                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].publicId}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate}
+                  {
+                    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionDate
+                  }
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation}
+                  {
+                    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionLocation
+                  }
                 </StyledTableCell>
                 <StyledTableCell component="div">
                   Sequencing Date

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
@@ -1,5 +1,5 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import {
   IdColumn,
   IsPrivateTableCell,
@@ -29,13 +29,13 @@ const Table = ({ metadata }: Props): JSX.Element => {
                   <IdColumn>Private ID</IdColumn>
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId}
+                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate}
+                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation}
+                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation}
                 </StyledTableCell>
                 <StyledTableCell component="div">
                   Sequencing Date

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
@@ -1,6 +1,8 @@
 import { isEmpty, pick } from "lodash";
 import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { createStringToLocationFinder } from "src/common/utils/locationUtils";
 import FilePicker from "src/components/FilePicker";
 import ImportFileWarnings, {
@@ -45,6 +47,7 @@ export default function ImportFile({
   hasImportedMetadataFile,
   onMetadataFileUploaded,
 }: Props): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
   const [missingFields, setMissingFields] = useState<string[] | null>(null);
   const [autocorrectCount, setAutocorrectCount] = useState<number>(0);
   const [filename, setFilename] = useState("");
@@ -246,7 +249,7 @@ export default function ImportFile({
         hasUnknownDataFields={hasUnknownDataFields}
         badFormatData={badFormatData}
         IdColumnNameForWarnings={
-          SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.privateId
+          SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen].privateId
         }
         metadataUploadType={MetadataUploadTypeOption.Edit}
         data-test-id="upload-import-file-warning"

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -6,9 +6,11 @@ import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { Pathogen } from "src/common/redux/types";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import {
+  EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS,
+  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
+} from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
-import { EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "src/components/WebformTable/common/constants";
 import {
   ERROR_CODE,

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -3,7 +3,7 @@ import Papa from "papaparse";
 import { HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 import { EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "src/components/WebformTable/common/constants";
@@ -87,7 +87,9 @@ function warnBadFormatMetadata(
 function getMissingHeaderFields(uploadedHeaders: string[]): Set<string> | null {
   const missingFields = new Set<string>();
   if (!uploadedHeaders.includes("currentPrivateID")) {
-    missingFields.add(SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID);
+    missingFields.add(
+      SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID
+    );
   }
   return missingFields.size !== 0 ? missingFields : null;
 }
@@ -313,7 +315,7 @@ export function parseFileEdit(
           // We only ingest file's data if user had all expected fields. and if there are no duplicate identifiers in the upload
           // find if any extraneous field data was added in the tsv
           const expectedHeaders = Object.keys(
-            SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
+            SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
           );
           const unknownFields = uploadedHeaders.filter(
             // uploaded field header is allowed to be "" (that means a user deleted a non-required column which is not a blocker)

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -361,7 +361,9 @@ export function parseFileEdit(
               rowMetadataNew.privateId = rowMetadataNew["newPrivateID"];
               sampleIdToMetadata[rowPrivateID] = pick(
                 rowMetadataNew,
-                Object.keys(SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS)
+                Object.keys(
+                  SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen]
+                )
               ) as SampleEditMetadataWebform;
               // If row had warnings, fold them into the overall warnings.
               // If row had no warnings, forEach is a no-op since no entries.

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -1,9 +1,12 @@
 import { groupBy, isEmpty, pick } from "lodash";
 import Papa from "papaparse";
-import { HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants";
+import { getHeadersToSampleEditMetadataKeys } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants";
+import { store } from "src/common/redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 import { EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "src/components/WebformTable/common/constants";
@@ -55,10 +58,6 @@ interface ParsedRowSampleEditTsv {
   // Note that we don't currently have any breaking errors at row parse level
 }
 
-const SAMPLE_EDIT_METADATA_KEYS_TO_EXTRACT = Object.values(
-  HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS
-);
-
 function warnBadFormatMetadata(
   metadata: SampleEditMetadataWebform
 ): Set<keyof SampleEditMetadataWebform> | null {
@@ -84,11 +83,14 @@ function warnBadFormatMetadata(
   return badFormatMetadata.size ? badFormatMetadata : null;
 }
 
-function getMissingHeaderFields(uploadedHeaders: string[]): Set<string> | null {
+function getMissingHeaderFields(
+  uploadedHeaders: string[],
+  pathogen: Pathogen
+): Set<string> | null {
   const missingFields = new Set<string>();
   if (!uploadedHeaders.includes("currentPrivateID")) {
     missingFields.add(
-      SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID
+      SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].currentPrivateID
     );
   }
   return missingFields.size !== 0 ? missingFields : null;
@@ -191,6 +193,9 @@ function parseRow(
   stringToLocationFinder: StringToLocationFinder,
   ignoredSampleIds: Set<string>
 ): ParsedRowSampleEditTsv {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
   const rowWarnings: ParsedRowSampleEditTsv["rowWarnings"] = new Map();
   // If row has no sampleId, we can't tie it to a sample, so we drop it.
   // Some sampleIds (ie, ones for examples) also signal we should ignore row.
@@ -205,6 +210,10 @@ function parseRow(
     // Ensure that rowMetadata will be sane even if row has no values
     ...EMPTY_METADATA,
   };
+
+  const SAMPLE_EDIT_METADATA_KEYS_TO_EXTRACT = Object.values(
+    getHeadersToSampleEditMetadataKeys(pathogen)
+  );
   // Only extract info we care about from the row. Set `rowMetadata` with it.
   SAMPLE_EDIT_METADATA_KEYS_TO_EXTRACT.forEach((key) => {
     inferMetadata({ key, row, stringToLocationFinder, rowMetadata });
@@ -254,15 +263,20 @@ function parseRow(
  * consumers previously expected for how results will be structured.)
  */
 
-function convertHeaderToMetadataKey(headerName: string): string {
-  return HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS[headerName] || headerName;
-}
-
 export function parseFileEdit(
   file: File,
   editableSampleIds: Set<string>,
   stringToLocationFinder: StringToLocationFinder
 ): Promise<ParseResult> {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
+  function convertHeaderToMetadataKey(headerName: string): string {
+    const HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS =
+      getHeadersToSampleEditMetadataKeys(pathogen);
+    return HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS[headerName] || headerName;
+  }
+
   return new Promise((resolve) => {
     Papa.parse(file, {
       header: true, // Imported file starts with a header row
@@ -284,7 +298,10 @@ export function parseFileEdit(
         >();
         const IGNORED_SAMPLE_IDS = new Set(EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS);
         let hasUnknownFields = false;
-        const missingHeaderFields = getMissingHeaderFields(uploadedHeaders);
+        const missingHeaderFields = getMissingHeaderFields(
+          uploadedHeaders,
+          pathogen
+        );
         const duplicatePublicIds = getDuplicateIds(rows, "publicId");
         const duplicatePrivateIds = getDuplicateIds(rows, "newPrivateID");
         const { extraneousSampleIds, filteredRows } = filterExtraneousSampleIds(
@@ -315,7 +332,7 @@ export function parseFileEdit(
           // We only ingest file's data if user had all expected fields. and if there are no duplicate identifiers in the upload
           // find if any extraneous field data was added in the tsv
           const expectedHeaders = Object.keys(
-            SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
+            SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
           );
           const unknownFields = uploadedHeaders.filter(
             // uploaded field header is allowed to be "" (that means a user deleted a non-required column which is not a blocker)

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants.ts
@@ -1,11 +1,15 @@
 import { Dictionary, invert } from "lodash";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { Pathogen } from "src/common/redux/types";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 
 // When parsing upload of metadata, we use a flipped version of HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS.
 // Note: there is a distinction between "real" `collectionLocation` internally
 // in app (it's an object) and user-submitted collectionLocation via metadata
 // upload (it's a string). The file parser will handle this conversion.
-export const HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS = invert(
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
-) as Dictionary<keyof SampleEditTsvMetadata>;
+export const getHeadersToSampleEditMetadataKeys = (
+  pathogen: Pathogen
+): Dictionary<keyof SampleEditTsvMetadata> => {
+  const keysToHeaders = SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen];
+  return invert(keysToHeaders) as Dictionary<keyof SampleEditTsvMetadata>;
+};

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants.ts
@@ -1,5 +1,5 @@
 import { Dictionary, invert } from "lodash";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 
 // When parsing upload of metadata, we use a flipped version of HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS.
@@ -7,5 +7,5 @@ import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/c
 // in app (it's an object) and user-submitted collectionLocation via metadata
 // upload (it's a string). The file parser will handle this conversion.
 export const HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS = invert(
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
 ) as Dictionary<keyof SampleEditTsvMetadata>;

--- a/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/utils.ts
+++ b/src/frontend/src/common/components/library/data_subview/components/EditSamplesConfirmationModal/utils.ts
@@ -1,5 +1,8 @@
 import { pick } from "lodash";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
+import { store } from "src/common/redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import {
   EMPTY_METADATA,
@@ -13,11 +16,12 @@ import {
 } from "src/components/WebformTable/common/types";
 
 export function structureInitialMetadata(
-  item: Sample
+  item: Sample,
+  pathogen: Pathogen
 ): SampleEditMetadataWebform {
   const i: SampleEditMetadataWebform = pick(
     item,
-    Object.keys(SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS)
+    Object.keys(SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen])
   );
   if (i.collectionLocation && typeof i.collectionLocation !== "string") {
     i.collectionLocation.name = stringifyGisaidLocation(i.collectionLocation);
@@ -83,9 +87,12 @@ export function initSampleMetadata(
 export function getInitialMetadata(
   samplesCanEdit: Sample[]
 ): SampleIdToEditMetadataWebform {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
   const initialMetadata: SampleIdToEditMetadataWebform = {};
   samplesCanEdit.forEach((item) => {
-    initialMetadata[item.privateId] = structureInitialMetadata(item);
+    initialMetadata[item.privateId] = structureInitialMetadata(item, pathogen);
   });
   return initialMetadata;
 }

--- a/src/frontend/src/common/types/strings.ts
+++ b/src/frontend/src/common/types/strings.ts
@@ -1,3 +1,3 @@
 import { Pathogen } from "src/common/redux/types";
 
-export type PathogenStringsType<T> = Record<Required<Pathogen>, T>;
+export type PathogenConfigType<T> = Record<Required<Pathogen>, T>;

--- a/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
@@ -59,3 +59,160 @@ export const SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS: PathogenConfigType<
   },
   [Pathogen.MONKEY_POX]: GENERAL_VIRAL_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
 };
+
+const DATE_FORMAT = "YYYY-MM-DD";
+const BOOLEAN_FORMAT = "Yes/No";
+
+export const EXAMPLE_SAMPLE_IDS = [
+  "Example Sample A",
+  "Example Sample B",
+  "Example Sample C",
+];
+
+export const EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS = [
+  "example private ID A",
+  "example private ID B",
+  "example private ID C",
+];
+
+const GENERAL_VIRAL_UPLOAD_EXAMPLE_ROWS = [
+  // Very first example row helps explain usage, but not fully valid.
+  [
+    EXAMPLE_SAMPLE_IDS[0], // sampleId
+    "Private sample name", // privateId
+    "(if available) GenBank Accession", // publicId -- here as explainer
+    DATE_FORMAT, // collectionDate -- not valid, here as explainer in template
+    "North America/USA/California/Los Angeles County", // collectionLocation
+    DATE_FORMAT, // sequencingDate -- not valid, here as explainer in template
+    BOOLEAN_FORMAT, // keepPrivate -- not valid, here as explainer in template
+  ],
+  // Subsequent example rows are mostly valid, honest-to-goodness examples...
+  // ... except for the dates. This is to avoid Excel auto "correct".
+  [
+    EXAMPLE_SAMPLE_IDS[1], // sampleId
+    "id101", // privateId
+    "", // publicId -- optional, showing that with blank use
+    DATE_FORMAT, // collectionDate
+    "San Francisco County", // collectionLocation
+    "", // sequencingDate -- optional, showing that with blank use
+    "No", // keepPrivate
+  ],
+  [
+    EXAMPLE_SAMPLE_IDS[2], // sampleId
+    "id102", // privateId
+    "USA/CA-CZB-0001/2021", // publicId
+    DATE_FORMAT, // collectionDate
+    "North America/USA/California/San Francisco County", // collectionLocation
+    DATE_FORMAT, // sequencingDate
+    "No", // keepPrivate
+  ],
+];
+
+export const UPLOAD_EXAMPLE_ROWS: PathogenConfigType<string[][]> = {
+  [Pathogen.COVID]: [
+    // Very first example row helps explain usage, but not fully valid.
+    [
+      EXAMPLE_SAMPLE_IDS[0], // sampleId
+      "Private sample name", // privateId
+      "(if available) GISAID ID", // publicId -- here as explainer
+      DATE_FORMAT, // collectionDate -- not valid, here as explainer in template
+      "North America/USA/California/Los Angeles County", // collectionLocation
+      DATE_FORMAT, // sequencingDate -- not valid, here as explainer in template
+      BOOLEAN_FORMAT, // keepPrivate -- not valid, here as explainer in template
+    ],
+    // Subsequent example rows are mostly valid, honest-to-goodness examples...
+    // ... except for the dates. This is to avoid Excel auto "correct".
+    [
+      EXAMPLE_SAMPLE_IDS[1], // sampleId
+      "id101", // privateId
+      "", // publicId -- optional, showing that with blank use
+      DATE_FORMAT, // collectionDate
+      "San Francisco County", // collectionLocation
+      "", // sequencingDate -- optional, showing that with blank use
+      "No", // keepPrivate
+    ],
+    [
+      EXAMPLE_SAMPLE_IDS[2], // sampleId
+      "id102", // privateId
+      "USA/CA-CZB-0001/2021", // publicId
+      DATE_FORMAT, // collectionDate
+      "North America/USA/California/San Francisco County", // collectionLocation
+      DATE_FORMAT, // sequencingDate
+      "No", // keepPrivate
+    ],
+  ],
+  [Pathogen.MONKEY_POX]: GENERAL_VIRAL_UPLOAD_EXAMPLE_ROWS,
+};
+
+export function getEditExampleRows(
+  pathogen: Pathogen,
+  collectionLocation?: GisaidLocation
+): string[][] {
+  // return example rows with the countys collectionLocation
+  const exampleCollectionLocation = collectionLocation
+    ? `${collectionLocation.region}/${collectionLocation.country}/${collectionLocation.division}/${collectionLocation.location}`
+    : "North America/USA/Californa/Humboldt County";
+
+  const editRows: PathogenConfigType<string[][]> = {
+    [Pathogen.COVID]: [
+      [
+        EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[0], // currentPrivateID
+        "X3421876", // newPrivateID
+        "hCoV-19/USA/demo-17806/2021", // publicId
+        DATE_FORMAT, // collectionDate,
+        exampleCollectionLocation, //collectionLocation
+        DATE_FORMAT, // sequencingDate
+        BOOLEAN_FORMAT, // keepPrivate
+      ],
+      [
+        EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[1],
+        "SOP292344X", // newPrivateID
+        "hCoV-19/USA/demo-17807/2021", // publicId
+        DATE_FORMAT, // collectionDate,
+        exampleCollectionLocation, //collectionLocation
+        DATE_FORMAT, // sequencingDate
+        BOOLEAN_FORMAT, // keepPrivate
+      ],
+      [
+        EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[2],
+        "T2348ACT", // newPrivateID
+        "hCoV-19/USA/demo-17808/2021", // publicId
+        DATE_FORMAT, // collectionDate,
+        exampleCollectionLocation, //collectionLocation
+        "Delete", // sequencingDate
+        BOOLEAN_FORMAT, // keepPrivate
+      ],
+    ],
+    [Pathogen.MONKEY_POX]: [
+      [
+        EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[0], // currentPrivateID
+        "X3421876", // newPrivateID
+        "hMpxV/USA/demo-17806/2021", // publicId
+        DATE_FORMAT, // collectionDate,
+        exampleCollectionLocation, //collectionLocation
+        DATE_FORMAT, // sequencingDate
+        BOOLEAN_FORMAT, // keepPrivate
+      ],
+      [
+        EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[1],
+        "SOP292344X", // newPrivateID
+        "hMpxV/USA/demo-17807/2021", // publicId
+        DATE_FORMAT, // collectionDate,
+        exampleCollectionLocation, //collectionLocation
+        DATE_FORMAT, // sequencingDate
+        BOOLEAN_FORMAT, // keepPrivate
+      ],
+      [
+        EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[2],
+        "T2348ACT", // newPrivateID
+        "hMpxV/USA/demo-17808/2021", // publicId
+        DATE_FORMAT, // collectionDate,
+        exampleCollectionLocation, //collectionLocation
+        "Delete", // sequencingDate
+        BOOLEAN_FORMAT, // keepPrivate
+      ],
+    ],
+  };
+
+  return editRows[pathogen];
+}

--- a/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
@@ -20,20 +20,20 @@ const GENERAL_VIRAL_SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: Record<
   keyof SampleUploadTsvMetadata,
   string
 > = {
-  privateId: "Private ID",
-  publicId: "Genbank Accession (GISAID ID)" + OPTIONAL_HEADER_MARKER,
-  sampleId: "Sample Name (from FASTA)",
   ...BASE_METADATA_HEADERS,
+  privateId: "Private ID",
+  publicId: "Genbank Accession (Public ID)" + OPTIONAL_HEADER_MARKER,
+  sampleId: "Sample Name (from FASTA)",
 };
 
 export const SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: PathogenConfigType<
   Record<keyof SampleUploadTsvMetadata, string>
 > = {
   [Pathogen.COVID]: {
+    ...BASE_METADATA_HEADERS,
     privateId: "Private ID",
     publicId: "GISAID ID (Public ID)" + OPTIONAL_HEADER_MARKER,
     sampleId: "Sample Name (from FASTA)",
-    ...BASE_METADATA_HEADERS,
   },
   [Pathogen.MONKEY_POX]: GENERAL_VIRAL_SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
 };

--- a/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
@@ -16,16 +16,13 @@ export const BASE_METADATA_HEADERS = {
   sequencingDate: "Sequencing Date" + OPTIONAL_HEADER_MARKER,
 };
 
-const PRIVATE_ID = "Private ID";
-const SAMPLE_ID = "Sample Name (from FASTA)";
-
 const GENERAL_VIRAL_SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: Record<
   keyof SampleUploadTsvMetadata,
   string
 > = {
-  privateId: PRIVATE_ID,
+  privateId: "Private ID",
   publicId: "Genbank Accession (GISAID ID)" + OPTIONAL_HEADER_MARKER,
-  sampleId: SAMPLE_ID,
+  sampleId: "Sample Name (from FASTA)",
   ...BASE_METADATA_HEADERS,
 };
 
@@ -33,20 +30,32 @@ export const SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: PathogenConfigType<
   Record<keyof SampleUploadTsvMetadata, string>
 > = {
   [Pathogen.COVID]: {
-    privateId: PRIVATE_ID,
+    privateId: "Private ID",
     publicId: "GISAID ID (Public ID)" + OPTIONAL_HEADER_MARKER,
-    sampleId: SAMPLE_ID,
+    sampleId: "Sample Name (from FASTA)",
     ...BASE_METADATA_HEADERS,
   },
   [Pathogen.MONKEY_POX]: GENERAL_VIRAL_SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
 };
 
-export const SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS: Record<
+const GENERAL_VIRAL_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS: Record<
   keyof SampleEditTsvMetadata,
   string
 > = {
   ...BASE_METADATA_HEADERS,
   currentPrivateID: "Current Private ID",
   newPrivateID: "New Private ID" + OPTIONAL_HEADER_MARKER,
-  publicId: "Public ID (GISAID ID)",
+  publicId: "GenBank Accession (Public ID)",
+};
+
+export const SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS: PathogenConfigType<
+  Record<keyof SampleEditTsvMetadata, string>
+> = {
+  [Pathogen.COVID]: {
+    ...BASE_METADATA_HEADERS,
+    currentPrivateID: "Current Private ID",
+    newPrivateID: "New Private ID" + OPTIONAL_HEADER_MARKER,
+    publicId: "Public ID (GISAID ID)",
+  },
+  [Pathogen.MONKEY_POX]: GENERAL_VIRAL_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
 };

--- a/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/common/constants.ts
@@ -1,3 +1,5 @@
+import { Pathogen } from "src/common/redux/types";
+import { PathogenConfigType } from "src/common/types/strings";
 import { SampleEditTsvMetadata, SampleUploadTsvMetadata } from "./types";
 
 // Some columns are for optional data. Below string is added to end of the
@@ -14,17 +16,32 @@ export const BASE_METADATA_HEADERS = {
   sequencingDate: "Sequencing Date" + OPTIONAL_HEADER_MARKER,
 };
 
-export const SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: Record<
+const PRIVATE_ID = "Private ID";
+const SAMPLE_ID = "Sample Name (from FASTA)";
+
+const GENERAL_VIRAL_SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: Record<
   keyof SampleUploadTsvMetadata,
   string
 > = {
+  privateId: PRIVATE_ID,
+  publicId: "Genbank Accession (GISAID ID)" + OPTIONAL_HEADER_MARKER,
+  sampleId: SAMPLE_ID,
   ...BASE_METADATA_HEADERS,
-  privateId: "Private ID",
-  publicId: "GISAID ID (Public ID)" + OPTIONAL_HEADER_MARKER,
-  sampleId: "Sample Name (from FASTA)",
 };
 
-export const SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS: Record<
+export const SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS: PathogenConfigType<
+  Record<keyof SampleUploadTsvMetadata, string>
+> = {
+  [Pathogen.COVID]: {
+    privateId: PRIVATE_ID,
+    publicId: "GISAID ID (Public ID)" + OPTIONAL_HEADER_MARKER,
+    sampleId: SAMPLE_ID,
+    ...BASE_METADATA_HEADERS,
+  },
+  [Pathogen.MONKEY_POX]: GENERAL_VIRAL_SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
+};
+
+export const SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS: Record<
   keyof SampleEditTsvMetadata,
   string
 > = {

--- a/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
@@ -14,6 +14,19 @@ export const TEMPLATE_UPDATED_DATE = "2022-02-22"; // YYYY-MM-DD
 const DATE_FORMAT = "YYYY-MM-DD";
 const BOOLEAN_FORMAT = "Yes/No";
 
+// If a future pathogen has different headers, we'll need to modify this.
+function getUploadTemplateHeaders(pathogen: Pathogen): string[] {
+  return [
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].privateId,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].publicId,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].collectionDate,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].collectionLocation,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sequencingDate,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate,
+  ];
+}
+
 export const EXAMPLE_SAMPLE_IDS = [
   "Example Sample A",
   "Example Sample B",
@@ -66,11 +79,23 @@ const SAMPLE_EDIT_INSTRUCTIONS = [
   ["# Save in .tsv .csv or .txt format"],
 ];
 
+function getEditTemplateHeaders(pathogen: Pathogen): string[] {
+  return [
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].currentPrivateID,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].newPrivateID,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].publicId,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].collectionDate,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].collectionLocation,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].sequencingDate,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate,
+  ];
+}
+
 function getEditExampleRows(collectionLocation?: GisaidLocation): string[][] {
   // return example rows with the countys collectionLocation
   const exampleCollectionLocation = collectionLocation
     ? `${collectionLocation.region}/${collectionLocation.country}/${collectionLocation.division}/${collectionLocation.location}`
-    : "North America/USA/Californa/Humbolt County";
+    : "North America/USA/Californa/Humboldt County";
 
   return [
     [
@@ -145,9 +170,8 @@ export function prepUploadMetadataTemplate(
   templateHeaders: string[];
   templateRows: string[][];
 } {
-  const TEMPLATE_HEADERS = Object.values(
-    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
-  );
+  const TEMPLATE_HEADERS = getUploadTemplateHeaders(pathogen);
+
   // Most rows in template are just empty rows for user to fill in with data.
   const EMPTY_DATA_ROW = getEmptyDataRows(TEMPLATE_HEADERS);
   const data_rows = getDataRows(sampleIds, EMPTY_DATA_ROW);
@@ -168,9 +192,7 @@ export function prepEditMetadataTemplate(
   const state = store.getState();
   const pathogen = selectCurrentPathogen(state);
 
-  const TEMPLATE_HEADERS_EDIT = Object.values(
-    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
-  );
+  const TEMPLATE_HEADERS_EDIT = getEditTemplateHeaders(pathogen);
 
   const EMPTY_DATA_ROW = getEmptyDataRows(TEMPLATE_HEADERS_EDIT);
   const data_rows = getDataRows(sampleIds, EMPTY_DATA_ROW);

--- a/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
@@ -1,9 +1,10 @@
 /**
  * Generate info for downloadable Sample Upload and Edit Metadata Templates.
  */
+import { Pathogen } from "src/common/redux/types";
 import {
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
   SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
 } from "./common/constants";
 // Should change below whenever there are material changes to upload TSV download
 export const TEMPLATE_UPDATED_DATE = "2022-02-22"; // YYYY-MM-DD
@@ -11,25 +12,17 @@ export const TEMPLATE_UPDATED_DATE = "2022-02-22"; // YYYY-MM-DD
 const DATE_FORMAT = "YYYY-MM-DD";
 const BOOLEAN_FORMAT = "Yes/No";
 
-const TEMPLATE_HEADERS = [
-  // If position for sampleId changes, update `prepMetadataTemplate` func!
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId,
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.privateId,
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.publicId,
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionDate,
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionLocation,
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sequencingDate,
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.keepPrivate,
-];
+// If position for sampleId changes, update `prepMetadataTemplate` func!
+// const TEMPLATE_HEADERS = Object.values(SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS);
 
 const TEMPLATE_HEADERS_EDIT = [
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.newPrivateID,
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId,
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate,
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation,
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.sequencingDate,
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.keepPrivate,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.newPrivateID,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.sequencingDate,
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.keepPrivate,
 ];
 
 // We also use this elsewhere: if we see one of these uploaded, filter it out.
@@ -157,10 +150,16 @@ function getDataRows(
  * of the time, users will just be able to copy that final example downward for
  * all their data rows since most samples will be their location.
  */
-export function prepUploadMetadataTemplate(sampleIds: string[]): {
+export function prepUploadMetadataTemplate(
+  sampleIds: string[],
+  pathogen: Pathogen
+): {
   templateHeaders: string[];
   templateRows: string[][];
 } {
+  const TEMPLATE_HEADERS = Object.values(
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+  );
   // Most rows in template are just empty rows for user to fill in with data.
   const EMPTY_DATA_ROW = getEmptyDataRows(TEMPLATE_HEADERS);
   const data_rows = getDataRows(sampleIds, EMPTY_DATA_ROW);

--- a/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
@@ -1,10 +1,12 @@
 /**
  * Generate info for downloadable Sample Upload and Edit Metadata Templates.
  */
+import { store } from "src/common/redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { Pathogen } from "src/common/redux/types";
 import {
+  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
   SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
 } from "./common/constants";
 // Should change below whenever there are material changes to upload TSV download
 export const TEMPLATE_UPDATED_DATE = "2022-02-22"; // YYYY-MM-DD
@@ -12,20 +14,6 @@ export const TEMPLATE_UPDATED_DATE = "2022-02-22"; // YYYY-MM-DD
 const DATE_FORMAT = "YYYY-MM-DD";
 const BOOLEAN_FORMAT = "Yes/No";
 
-// If position for sampleId changes, update `prepMetadataTemplate` func!
-// const TEMPLATE_HEADERS = Object.values(SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS);
-
-const TEMPLATE_HEADERS_EDIT = [
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.newPrivateID,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.sequencingDate,
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.keepPrivate,
-];
-
-// We also use this elsewhere: if we see one of these uploaded, filter it out.
 export const EXAMPLE_SAMPLE_IDS = [
   "Example Sample A",
   "Example Sample B",
@@ -177,6 +165,13 @@ export function prepEditMetadataTemplate(
   templateHeaders: string[];
   templateRows: string[][];
 } {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
+  const TEMPLATE_HEADERS_EDIT = Object.values(
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
+  );
+
   const EMPTY_DATA_ROW = getEmptyDataRows(TEMPLATE_HEADERS_EDIT);
   const data_rows = getDataRows(sampleIds, EMPTY_DATA_ROW);
   const EXAMPLE_ROWS_EDIT = getEditExampleRows(collectionLocation);

--- a/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
+++ b/src/frontend/src/components/DownloadMetadataTemplate/prepMetadataTemplate.ts
@@ -5,14 +5,13 @@ import { store } from "src/common/redux";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { Pathogen } from "src/common/redux/types";
 import {
+  getEditExampleRows,
   SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
   SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS,
+  UPLOAD_EXAMPLE_ROWS,
 } from "./common/constants";
 // Should change below whenever there are material changes to upload TSV download
 export const TEMPLATE_UPDATED_DATE = "2022-02-22"; // YYYY-MM-DD
-
-const DATE_FORMAT = "YYYY-MM-DD";
-const BOOLEAN_FORMAT = "Yes/No";
 
 // If a future pathogen has different headers, we'll need to modify this.
 function getUploadTemplateHeaders(pathogen: Pathogen): string[] {
@@ -26,51 +25,6 @@ function getUploadTemplateHeaders(pathogen: Pathogen): string[] {
     SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate,
   ];
 }
-
-export const EXAMPLE_SAMPLE_IDS = [
-  "Example Sample A",
-  "Example Sample B",
-  "Example Sample C",
-];
-
-export const EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS = [
-  "example private ID A",
-  "example private ID B",
-  "example private ID C",
-];
-
-const EXAMPLE_ROWS = [
-  // Very first example row helps explain usage, but not fully valid.
-  [
-    EXAMPLE_SAMPLE_IDS[0], // sampleId
-    "Private sample name", // privateId
-    "(if available) GISAID ID", // publicId -- here as explainer
-    DATE_FORMAT, // collectionDate -- not valid, here as explainer in template
-    "North America/USA/California/Los Angeles County", // collectionLocation
-    DATE_FORMAT, // sequencingDate -- not valid, here as explainer in template
-    BOOLEAN_FORMAT, // keepPrivate -- not valid, here as explainer in template
-  ],
-  // Subsequent example rows are mostly valid, honest-to-goodness examples...
-  // ... except for the dates. This is to avoid Excel auto "correct".
-  [
-    EXAMPLE_SAMPLE_IDS[1], // sampleId
-    "id101", // privateId
-    "", // publicId -- optional, showing that with blank use
-    DATE_FORMAT, // collectionDate
-    "San Francisco County", // collectionLocation
-    "", // sequencingDate -- optional, showing that with blank use
-    "No", // keepPrivate
-  ],
-  [
-    EXAMPLE_SAMPLE_IDS[2], // sampleId
-    "id102", // privateId
-    "USA/CA-CZB-0001/2021", // publicId
-    DATE_FORMAT, // collectionDate
-    "North America/USA/California/San Francisco County", // collectionLocation
-    DATE_FORMAT, // sequencingDate
-    "No", // keepPrivate
-  ],
-];
 
 const SAMPLE_EDIT_INSTRUCTIONS = [
   ["# Only fill out columns or cells where you want to update the content"],
@@ -88,43 +42,6 @@ function getEditTemplateHeaders(pathogen: Pathogen): string[] {
     SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].collectionLocation,
     SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].sequencingDate,
     SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate,
-  ];
-}
-
-function getEditExampleRows(collectionLocation?: GisaidLocation): string[][] {
-  // return example rows with the countys collectionLocation
-  const exampleCollectionLocation = collectionLocation
-    ? `${collectionLocation.region}/${collectionLocation.country}/${collectionLocation.division}/${collectionLocation.location}`
-    : "North America/USA/Californa/Humboldt County";
-
-  return [
-    [
-      EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[0], // currentPrivateID
-      "X3421876", // newPrivateID
-      "hCoV-19/USA/demo-17806/2021", // publicId
-      DATE_FORMAT, // collectionDate,
-      exampleCollectionLocation, //collectionLocation
-      DATE_FORMAT, // sequencingDate
-      BOOLEAN_FORMAT, // keepPrivate
-    ],
-    [
-      EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[1],
-      "SOP292344X", // newPrivateID
-      "hCoV-19/USA/demo-17807/2021", // publicId
-      DATE_FORMAT, // collectionDate,
-      exampleCollectionLocation, //collectionLocation
-      DATE_FORMAT, // sequencingDate
-      BOOLEAN_FORMAT, // keepPrivate
-    ],
-    [
-      EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS[2],
-      "T2348ACT", // newPrivateID
-      "hCoV-19/USA/demo-17808/2021", // publicId
-      DATE_FORMAT, // collectionDate,
-      exampleCollectionLocation, //collectionLocation
-      "Delete", // sequencingDate
-      BOOLEAN_FORMAT, // keepPrivate
-    ],
   ];
 }
 
@@ -177,7 +94,7 @@ export function prepUploadMetadataTemplate(
   const data_rows = getDataRows(sampleIds, EMPTY_DATA_ROW);
   return {
     templateHeaders: TEMPLATE_HEADERS,
-    templateRows: [...EXAMPLE_ROWS, ...data_rows],
+    templateRows: [...UPLOAD_EXAMPLE_ROWS[pathogen], ...data_rows],
   };
 }
 
@@ -196,7 +113,7 @@ export function prepEditMetadataTemplate(
 
   const EMPTY_DATA_ROW = getEmptyDataRows(TEMPLATE_HEADERS_EDIT);
   const data_rows = getDataRows(sampleIds, EMPTY_DATA_ROW);
-  const EXAMPLE_ROWS_EDIT = getEditExampleRows(collectionLocation);
+  const EXAMPLE_ROWS_EDIT = getEditExampleRows(pathogen, collectionLocation);
   return {
     templateInstructionRows: SAMPLE_EDIT_INSTRUCTIONS,
     templateHeaders: TEMPLATE_HEADERS_EDIT,

--- a/src/frontend/src/components/ImportFileWarnings/components/WarningBadLocationFormat/index.tsx
+++ b/src/frontend/src/components/ImportFileWarnings/components/WarningBadLocationFormat/index.tsx
@@ -1,7 +1,7 @@
 import { map } from "lodash";
 import { B } from "src/common/styles/basicStyle";
 import AlertAccordion from "src/components/AlertAccordion";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { ProblemTable } from "src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/ProblemTable";
 
 /**
@@ -21,7 +21,7 @@ const MessageBadLocationFormat = ({ badSamples }: BadLocationFormatProps) => {
     "You can update the data in the table below, or update your file and re-import.";
 
   const columnHeaders = [
-    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
+    SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
     "Data Column",
     "Imported Value",
     "Updated Value",

--- a/src/frontend/src/components/ImportFileWarnings/components/WarningBadLocationFormat/index.tsx
+++ b/src/frontend/src/components/ImportFileWarnings/components/WarningBadLocationFormat/index.tsx
@@ -1,7 +1,9 @@
 import { map } from "lodash";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { B } from "src/common/styles/basicStyle";
 import AlertAccordion from "src/components/AlertAccordion";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { ProblemTable } from "src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/common/ProblemTable";
 
 /**
@@ -17,11 +19,13 @@ export interface BadLocationFormatProps {
 }
 
 const MessageBadLocationFormat = ({ badSamples }: BadLocationFormatProps) => {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const tablePreamble =
     "You can update the data in the table below, or update your file and re-import.";
 
   const columnHeaders = [
-    SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID,
+    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].currentPrivateID,
     "Data Column",
     "Imported Value",
     "Updated Value",

--- a/src/frontend/src/components/WebformTable/common/constants.ts
+++ b/src/frontend/src/components/WebformTable/common/constants.ts
@@ -1,16 +1,30 @@
+import { Pathogen } from "src/common/redux/types";
+import { PathogenConfigType } from "src/common/types/strings";
 import {
   BASE_METADATA_HEADERS,
   OPTIONAL_HEADER_MARKER,
 } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditMetadataWebform } from "./types";
 
-export const SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS: Record<
+const GENERAL_VIRAL_SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS: Record<
   keyof SampleEditMetadataWebform,
   string
 > = {
   ...BASE_METADATA_HEADERS,
   privateId: "Private ID",
-  publicId: "GISAID ID (Public ID)" + OPTIONAL_HEADER_MARKER,
+  publicId: "GenBank Accession (Public ID)" + OPTIONAL_HEADER_MARKER,
+};
+
+export const SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS: PathogenConfigType<
+  Record<keyof SampleEditMetadataWebform, string>
+> = {
+  [Pathogen.COVID]: {
+    ...BASE_METADATA_HEADERS,
+    privateId: "Private ID",
+    publicId: "GISAID ID (Public ID)" + OPTIONAL_HEADER_MARKER,
+  },
+  [Pathogen.MONKEY_POX]:
+    GENERAL_VIRAL_SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS,
 };
 
 export const EMPTY_METADATA: SampleEditMetadataWebform = {

--- a/src/frontend/src/components/WebformTable/components/EditTable/index.tsx
+++ b/src/frontend/src/components/WebformTable/components/EditTable/index.tsx
@@ -1,4 +1,6 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "../../common/constants";
 import {
   IsPrivateTableCell,
@@ -17,6 +19,8 @@ export default function EditTable({
   autocorrectWarnings,
   locations,
 }: TableProps): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   return (
     <MuiTable component="div" stickyHeader>
       <TableHead component="div">
@@ -24,22 +28,31 @@ export default function EditTable({
         {/* @ts-ignore: spread types error */}
         <StyledTableRow {...({ component: "div" } as unknown)}>
           <StyledTableCell component="div">
-            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.privateId}
+            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen].privateId}
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.publicId}
+            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen].publicId}
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.collectionDate}
+            {
+              SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen]
+                .collectionDate
+            }
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.collectionLocation}
+            {
+              SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen]
+                .collectionLocation
+            }
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.sequencingDate}
+            {
+              SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen]
+                .sequencingDate
+            }
           </StyledTableCell>
           <IsPrivateTableCell align="center" component="div">
-            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.keepPrivate}
+            {SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate}
           </IsPrivateTableCell>
         </StyledTableRow>
       </TableHead>

--- a/src/frontend/src/components/WebformTable/components/UploadTable/index.tsx
+++ b/src/frontend/src/components/WebformTable/components/UploadTable/index.tsx
@@ -1,4 +1,6 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { Metadata } from "src/components/WebformTable/common/types";
 import {
@@ -35,6 +37,9 @@ export default function UploadTable({
   autocorrectWarnings,
   locations,
 }: TableProps): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
+  const SAMPLE_UPLOAD_METADATA_HEADERS =
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen];
   return (
     <MuiTable component="div" stickyHeader>
       <TableHead component="div">
@@ -42,27 +47,25 @@ export default function UploadTable({
         {/* @ts-ignore: spread types error */}
         <StyledTableRow {...({ component: "div" } as unknown)}>
           <StyledTableCell component="div">
-            <IdColumn>
-              {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId}
-            </IdColumn>
+            <IdColumn>{SAMPLE_UPLOAD_METADATA_HEADERS.sampleId}</IdColumn>
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.privateId}
+            {SAMPLE_UPLOAD_METADATA_HEADERS.privateId}
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.publicId}
+            {SAMPLE_UPLOAD_METADATA_HEADERS.publicId}
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionDate}
+            {SAMPLE_UPLOAD_METADATA_HEADERS.collectionDate}
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionLocation}
+            {SAMPLE_UPLOAD_METADATA_HEADERS.collectionLocation}
           </StyledTableCell>
           <StyledTableCell component="div">
-            {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sequencingDate}
+            {SAMPLE_UPLOAD_METADATA_HEADERS.sequencingDate}
           </StyledTableCell>
           <IsPrivateTableCell align="center" component="div">
-            {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.keepPrivate}
+            {SAMPLE_UPLOAD_METADATA_HEADERS.keepPrivate}
           </IsPrivateTableCell>
         </StyledTableRow>
       </TableHead>

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/RadioLabel/strings.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/RadioLabel/strings.ts
@@ -1,5 +1,5 @@
 import { Pathogen } from "src/common/redux/types";
-import { PathogenStringsType } from "src/common/types/strings";
+import { PathogenConfigType } from "src/common/types/strings";
 
 interface RadioLabelStrings {
   nonContextualizedBestFor: string;
@@ -15,7 +15,7 @@ interface RadioLabelStrings {
   targetedGoodFor: string;
 }
 
-export const pathogenStrings: PathogenStringsType<RadioLabelStrings> = {
+export const pathogenStrings: PathogenConfigType<RadioLabelStrings> = {
   [Pathogen.COVID]: {
     nonContextualizedBestFor:
       "Best for uncovering sampling bias in your own sampling effort.",

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
@@ -1,5 +1,7 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import {
   IdColumn,
   IsPrivateTableCell,
@@ -16,6 +18,8 @@ interface Props {
 }
 
 const Table = ({ metadata }: Props): JSX.Element => {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   return (
     <Overflow>
       <form autoComplete="off">
@@ -29,13 +33,19 @@ const Table = ({ metadata }: Props): JSX.Element => {
                   <IdColumn>Private ID</IdColumn>
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId}
+                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].publicId}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate}
+                  {
+                    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionDate
+                  }
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation}
+                  {
+                    SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionLocation
+                  }
                 </StyledTableCell>
                 <StyledTableCell component="div">
                   Sequencing Date

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/EditSamplesReviewDialog/components/Table/index.tsx
@@ -1,5 +1,5 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import {
   IdColumn,
   IsPrivateTableCell,
@@ -29,13 +29,13 @@ const Table = ({ metadata }: Props): JSX.Element => {
                   <IdColumn>Private ID</IdColumn>
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId}
+                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.publicId}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate}
+                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionDate}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation}
+                  {SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.collectionLocation}
                 </StyledTableCell>
                 <StyledTableCell component="div">
                   Sequencing Date

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/index.tsx
@@ -1,6 +1,8 @@
 import { isEmpty, pick } from "lodash";
 import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { createStringToLocationFinder } from "src/common/utils/locationUtils";
 import FilePicker from "src/components/FilePicker";
 import ImportFileWarnings, {
@@ -45,6 +47,7 @@ export default function ImportFile({
   hasImportedMetadataFile,
   onMetadataFileUploaded,
 }: Props): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
   const [missingFields, setMissingFields] = useState<string[] | null>(null);
   const [autocorrectCount, setAutocorrectCount] = useState<number>(0);
   const [filename, setFilename] = useState("");
@@ -246,7 +249,7 @@ export default function ImportFile({
         hasUnknownDataFields={hasUnknownDataFields}
         badFormatData={badFormatData}
         IdColumnNameForWarnings={
-          SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS.privateId
+          SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen].privateId
         }
         metadataUploadType={MetadataUploadTypeOption.Edit}
         data-test-id="upload-import-file-warning"

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -6,9 +6,11 @@ import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { Pathogen } from "src/common/redux/types";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import {
+  EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS,
+  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS,
+} from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
-import { EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "src/components/WebformTable/common/constants";
 import {
   ERROR_CODE,

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -3,7 +3,7 @@ import Papa from "papaparse";
 import { HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 import { EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "src/components/WebformTable/common/constants";
@@ -87,7 +87,9 @@ function warnBadFormatMetadata(
 function getMissingHeaderFields(uploadedHeaders: string[]): Set<string> | null {
   const missingFields = new Set<string>();
   if (!uploadedHeaders.includes("currentPrivateID")) {
-    missingFields.add(SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID);
+    missingFields.add(
+      SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID
+    );
   }
   return missingFields.size !== 0 ? missingFields : null;
 }
@@ -313,7 +315,7 @@ export function parseFileEdit(
           // We only ingest file's data if user had all expected fields. and if there are no duplicate identifiers in the upload
           // find if any extraneous field data was added in the tsv
           const expectedHeaders = Object.keys(
-            SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
+            SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
           );
           const unknownFields = uploadedHeaders.filter(
             // uploaded field header is allowed to be "" (that means a user deleted a non-required column which is not a blocker)

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -364,7 +364,9 @@ export function parseFileEdit(
               rowMetadataNew.privateId = rowMetadataNew["newPrivateID"];
               sampleIdToMetadata[rowPrivateID] = pick(
                 rowMetadataNew,
-                Object.keys(SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS)
+                Object.keys(
+                  SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen]
+                )
               ) as SampleEditMetadataWebform;
               // If row had warnings, fold them into the overall warnings.
               // If row had no warnings, forEach is a no-op since no entries.

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/ImportFile/parseFile.ts
@@ -1,9 +1,12 @@
 import { groupBy, isEmpty, pick } from "lodash";
 import Papa from "papaparse";
-import { HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants";
+import { getHeadersToSampleEditMetadataKeys } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/common/constants";
+import { store } from "src/common/redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 import { EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import { SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS } from "src/components/WebformTable/common/constants";
@@ -55,10 +58,6 @@ interface ParsedRowSampleEditTsv {
   // Note that we don't currently have any breaking errors at row parse level
 }
 
-const SAMPLE_EDIT_METADATA_KEYS_TO_EXTRACT = Object.values(
-  HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS
-);
-
 function warnBadFormatMetadata(
   metadata: SampleEditMetadataWebform
 ): Set<keyof SampleEditMetadataWebform> | null {
@@ -84,11 +83,14 @@ function warnBadFormatMetadata(
   return badFormatMetadata.size ? badFormatMetadata : null;
 }
 
-function getMissingHeaderFields(uploadedHeaders: string[]): Set<string> | null {
+function getMissingHeaderFields(
+  uploadedHeaders: string[],
+  pathogen: Pathogen
+): Set<string> | null {
   const missingFields = new Set<string>();
   if (!uploadedHeaders.includes("currentPrivateID")) {
     missingFields.add(
-      SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS.currentPrivateID
+      SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen].currentPrivateID
     );
   }
   return missingFields.size !== 0 ? missingFields : null;
@@ -191,6 +193,9 @@ function parseRow(
   stringToLocationFinder: StringToLocationFinder,
   ignoredSampleIds: Set<string>
 ): ParsedRowSampleEditTsv {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
   const rowWarnings: ParsedRowSampleEditTsv["rowWarnings"] = new Map();
   // If row has no sampleId, we can't tie it to a sample, so we drop it.
   // Some sampleIds (ie, ones for examples) also signal we should ignore row.
@@ -205,6 +210,10 @@ function parseRow(
     // Ensure that rowMetadata will be sane even if row has no values
     ...EMPTY_METADATA,
   };
+
+  const SAMPLE_EDIT_METADATA_KEYS_TO_EXTRACT = Object.values(
+    getHeadersToSampleEditMetadataKeys(pathogen)
+  );
   // Only extract info we care about from the row. Set `rowMetadata` with it.
   SAMPLE_EDIT_METADATA_KEYS_TO_EXTRACT.forEach((key) => {
     inferMetadata({ key, row, stringToLocationFinder, rowMetadata });
@@ -255,7 +264,12 @@ function parseRow(
  */
 
 function convertHeaderToMetadataKey(headerName: string): string {
-  return HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS[headerName] || headerName;
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
+  const HEADERS_TO_EDIT_METADATA_KEYS =
+    getHeadersToSampleEditMetadataKeys(pathogen);
+  return HEADERS_TO_EDIT_METADATA_KEYS[headerName] || headerName;
 }
 
 export function parseFileEdit(
@@ -263,6 +277,9 @@ export function parseFileEdit(
   editableSampleIds: Set<string>,
   stringToLocationFinder: StringToLocationFinder
 ): Promise<ParseResult> {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
   return new Promise((resolve) => {
     Papa.parse(file, {
       header: true, // Imported file starts with a header row
@@ -284,7 +301,10 @@ export function parseFileEdit(
         >();
         const IGNORED_SAMPLE_IDS = new Set(EXAMPLE_CURRENT_PRIVATE_IDENTIFIERS);
         let hasUnknownFields = false;
-        const missingHeaderFields = getMissingHeaderFields(uploadedHeaders);
+        const missingHeaderFields = getMissingHeaderFields(
+          uploadedHeaders,
+          pathogen
+        );
         const duplicatePublicIds = getDuplicateIds(rows, "publicId");
         const duplicatePrivateIds = getDuplicateIds(rows, "newPrivateID");
         const { extraneousSampleIds, filteredRows } = filterExtraneousSampleIds(
@@ -315,7 +335,7 @@ export function parseFileEdit(
           // We only ingest file's data if user had all expected fields. and if there are no duplicate identifiers in the upload
           // find if any extraneous field data was added in the tsv
           const expectedHeaders = Object.keys(
-            SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
+            SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen]
           );
           const unknownFields = uploadedHeaders.filter(
             // uploaded field header is allowed to be "" (that means a user deleted a non-required column which is not a blocker)

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/common/constants.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/common/constants.ts
@@ -1,11 +1,15 @@
 import { Dictionary, invert } from "lodash";
-import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { Pathogen } from "src/common/redux/types";
+import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 
 // When parsing upload of metadata, we use a flipped version of HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS.
 // Note: there is a distinction between "real" `collectionLocation` internally
 // in app (it's an object) and user-submitted collectionLocation via metadata
 // upload (it's a string). The file parser will handle this conversion.
-export const HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS = invert(
-  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
-) as Dictionary<keyof SampleEditTsvMetadata>;
+export const getHeadersToSampleEditMetadataKeys = (
+  pathogen: Pathogen
+): Dictionary<keyof SampleEditTsvMetadata> => {
+  const keysToHeaders = SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS[pathogen];
+  return invert(keysToHeaders) as Dictionary<keyof SampleEditTsvMetadata>;
+};

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/common/constants.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/components/common/constants.ts
@@ -1,5 +1,5 @@
 import { Dictionary, invert } from "lodash";
-import { SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 
 // When parsing upload of metadata, we use a flipped version of HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS.
@@ -7,5 +7,5 @@ import { SampleEditTsvMetadata } from "src/components/DownloadMetadataTemplate/c
 // in app (it's an object) and user-submitted collectionLocation via metadata
 // upload (it's a string). The file parser will handle this conversion.
 export const HEADERS_TO_SAMPLE_EDIT_METADATA_KEYS = invert(
-  SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
+  SC2_SAMPLE_EDIT_METADATA_KEYS_TO_HEADERS
 ) as Dictionary<keyof SampleEditTsvMetadata>;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/utils.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal/utils.ts
@@ -1,5 +1,8 @@
 import { pick } from "lodash";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
+import { store } from "src/common/redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { stringifyGisaidLocation } from "src/common/utils/locationUtils";
 import {
   EMPTY_METADATA,
@@ -13,11 +16,12 @@ import {
 } from "src/components/WebformTable/common/types";
 
 export function structureInitialMetadata(
-  item: Sample
+  item: Sample,
+  pathogen: Pathogen
 ): SampleEditMetadataWebform {
   const i: SampleEditMetadataWebform = pick(
     item,
-    Object.keys(SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS)
+    Object.keys(SAMPLE_EDIT_WEBFORM_METADATA_KEYS_TO_HEADERS[pathogen])
   );
   if (i.collectionLocation && typeof i.collectionLocation !== "string") {
     i.collectionLocation.name = stringifyGisaidLocation(i.collectionLocation);
@@ -83,9 +87,12 @@ export function initSampleMetadata(
 export function getInitialMetadata(
   samplesCanEdit: Sample[]
 ): SampleIdToEditMetadataWebform {
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+
   const initialMetadata: SampleIdToEditMetadataWebform = {};
   samplesCanEdit.forEach((item) => {
-    initialMetadata[item.privateId] = structureInitialMetadata(item);
+    initialMetadata[item.privateId] = structureInitialMetadata(item, pathogen);
   });
   return initialMetadata;
 }

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/warnings.tsx
@@ -1,4 +1,7 @@
+import { useSelector } from "react-redux";
 import { SampleEditIdToWarningMessages } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { B } from "src/common/styles/basicStyle";
 import { pluralize } from "src/common/utils/strUtils";
 import AlertAccordion from "src/components/AlertAccordion";
@@ -49,10 +52,14 @@ interface PropsExtraneousEntry {
   extraneousSampleIds: string[];
 }
 function MessageExtraneousEntry({ extraneousSampleIds }: PropsExtraneousEntry) {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const tablePreamble =
     "The following sample IDs in the metadata file " +
     "do not match any sample IDs imported in the previous step.";
-  const columnHeaders = [SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId];
+  const columnHeaders = [
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId,
+  ];
   const rows = extraneousSampleIds.map((sampleId) => [sampleId]);
   return (
     <ProblemTable
@@ -136,10 +143,14 @@ interface PropsAbsentSample {
   absentSampleIds: string[];
 }
 function MessageAbsentSample({ absentSampleIds }: PropsAbsentSample) {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const tablePreamble =
     "The following sample IDs were imported in the " +
     "previous step but did not match any sample IDs in the metadata file.";
-  const columnHeaders = [SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId];
+  const columnHeaders = [
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId,
+  ];
   const rows = absentSampleIds.map((sampleId) => [sampleId]);
   return (
     <ProblemTable
@@ -216,14 +227,16 @@ interface PropsMissingData {
   missingData: SampleIdToWarningMessages | SampleEditIdToWarningMessages;
 }
 function MessageMissingData({ missingData }: PropsMissingData) {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const tablePreamble =
     "You can add the required data in the table below, " +
     "or update your file and re-import.";
   const columnHeaders = [
-    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId,
+    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId,
     "Missing Data",
   ];
-  const rows = getSampleIdsWithMissingData(missingData);
+  const rows = getSampleIdsWithMissingData(missingData, pathogen);
   return (
     <ProblemTable
       tablePreamble={tablePreamble}
@@ -233,12 +246,16 @@ function MessageMissingData({ missingData }: PropsMissingData) {
   );
 }
 
-function getSampleIdsWithMissingData(missingData: SampleIdToWarningMessages) {
+function getSampleIdsWithMissingData(
+  missingData: SampleIdToWarningMessages,
+  pathogen: Pathogen
+) {
   const idsMissingData = Object.keys(missingData);
   return idsMissingData.map((sampleId) => {
     const missingHeaders = Array.from(
       missingData[sampleId],
-      (missingKey) => SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[missingKey]
+      (missingKey) =>
+        SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen][missingKey]
     );
     const missingDataDescription = missingHeaders.join(", ");
     return [sampleId, missingDataDescription];
@@ -246,14 +263,16 @@ function getSampleIdsWithMissingData(missingData: SampleIdToWarningMessages) {
 }
 
 function MessageMissingDataEdit({ missingData }: PropsMissingData) {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const tablePreamble =
     "You can add the required data in the table below, " +
     "or update your file and re-import.";
   const columnHeaders = [
-    "Sample " + SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.privateId,
+    "Sample " + SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].privateId,
     "Missing Data",
   ];
-  const rows = getSampleIdsWithMissingData(missingData);
+  const rows = getSampleIdsWithMissingData(missingData, pathogen);
   return (
     <ProblemTable
       tablePreamble={tablePreamble}
@@ -331,6 +350,8 @@ function MessageBadFormatData({
   badFormatData,
   IdColumnNameForWarnings,
 }: PropsBadFormatData) {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const tablePreamble = BadFormatDataTablePreamble;
   const columnHeaders = [
     IdColumnNameForWarnings,
@@ -340,7 +361,8 @@ function MessageBadFormatData({
   const rows = idsBadFormatData.map((sampleId) => {
     const badFormatRawHeaders = Array.from(
       badFormatData[sampleId],
-      (badFormatKey) => SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[badFormatKey]
+      (badFormatKey) =>
+        SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen][badFormatKey]
     );
     // Some headers say "optional" in them: we don't put that in description
     const badFormatPrettyHeaders = badFormatRawHeaders.map((header) => {

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
 import { ParseResult as ParseResultEdit } from "src/common/components/library/data_subview/components/EditSamplesConfirmationModal/components/ImportFile/parseFile";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { SampleUploadDownloadTemplate } from "src/components/DownloadMetadataTemplate";
 import { SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
@@ -42,6 +44,7 @@ export default function ImportFile({
   samples,
   stringToLocationFinder,
 }: Props): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
   const [isInstructionsShown, setIsInstructionsShown] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [hasImportedFile, setHasImportedFile] = useState(false);
@@ -91,7 +94,10 @@ export default function ImportFile({
   };
 
   const { templateHeaders, templateRows } = useMemo(() => {
-    return prepUploadMetadataTemplate(Object.keys(samples || EMPTY_OBJECT));
+    return prepUploadMetadataTemplate(
+      Object.keys(samples || EMPTY_OBJECT),
+      pathogen
+    );
   }, [samples]);
 
   const handleFiles = async (files: FileList | null) => {
@@ -179,7 +185,7 @@ export default function ImportFile({
         missingData={missingData}
         badFormatData={badFormatData}
         IdColumnNameForWarnings={
-          SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId
+          SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId
         }
         metadataUploadType={MetadataUploadTypeOption.Upload}
         data-test-id="upload-simport-file-warning"

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/parseFile.ts
@@ -4,11 +4,11 @@ import { store } from "src/common/redux";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { StringToLocationFinder } from "src/common/utils/locationUtils";
 import { DATE_REGEX } from "src/components/DateField/constants";
+import { EXAMPLE_SAMPLE_IDS } from "src/components/DownloadMetadataTemplate/common/constants";
 import {
   SampleEditTsvMetadata,
   SampleUploadTsvMetadata,
 } from "src/components/DownloadMetadataTemplate/common/types";
-import { EXAMPLE_SAMPLE_IDS } from "src/components/DownloadMetadataTemplate/prepMetadataTemplate";
 import {
   ERROR_CODE,
   SampleIdToMetadata,

--- a/src/frontend/src/views/Upload/components/Metadata/components/StaticTable/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/StaticTable/index.tsx
@@ -1,30 +1,34 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
-import { useEffect, useCallback, useState } from "react";
 import { Tooltip } from "czifui";
-import { SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import { useCallback, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import { EMPTY_OBJECT } from "src/common/constants/empty";
-import { Props as CommonProps } from "../../../common/types";
-import { Metadata } from "src/components/WebformTable/common/types";
-import Row from "./components/Row";
-import {
-  IdColumn,
-  PrivateTableCell,
-  Overflow,
-  StyledTableCell,
-  StyledTableContainer,
-  StyledTableRow,
-} from "./style";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { B } from "src/common/styles/basicStyle";
-import {
-  MAX_NAME_LENGTH,
-  VALID_NAME_REGEX,
-} from "src/views/Upload/components/common/constants";
 import {
   DATE_ERROR_MESSAGE,
   DATE_REGEX,
 } from "src/components/DateField/constants";
-import { object, string, number, ValidationError } from "yup";
-import { SampleIdToMetadata } from "src/components/WebformTable/common/types";
+import { SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
+import {
+  Metadata,
+  SampleIdToMetadata,
+} from "src/components/WebformTable/common/types";
+import {
+  MAX_NAME_LENGTH,
+  VALID_NAME_REGEX,
+} from "src/views/Upload/components/common/constants";
+import { number, object, string, ValidationError } from "yup";
+import { Props as CommonProps } from "../../../common/types";
+import Row from "./components/Row";
+import {
+  IdColumn,
+  Overflow,
+  PrivateTableCell,
+  StyledTableCell,
+  StyledTableContainer,
+  StyledTableRow,
+} from "./style";
 
 interface Props {
   metadata: CommonProps["metadata"];
@@ -63,6 +67,8 @@ export default function StaticTable({
   setIsValid,
   hasImportedMetadataFile,
 }: Props): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const [validationErrors, setValidationErrors] =
     useState<ValidationErrorMap>(EMPTY_OBJECT);
 
@@ -153,7 +159,7 @@ export default function StaticTable({
               >
                 <StyledTableCell>
                   <IdColumn>
-                    {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId}
+                    {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId}
                   </IdColumn>
                 </StyledTableCell>
               </Tooltip>
@@ -169,7 +175,7 @@ export default function StaticTable({
                 arrow
               >
                 <StyledTableCell>
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.privateId}
+                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].privateId}
                 </StyledTableCell>
               </Tooltip>
               <Tooltip
@@ -184,7 +190,7 @@ export default function StaticTable({
                 arrow
               >
                 <StyledTableCell>
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.publicId}
+                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].publicId}
                 </StyledTableCell>
               </Tooltip>
               <Tooltip
@@ -199,7 +205,10 @@ export default function StaticTable({
                 arrow
               >
                 <StyledTableCell>
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionDate}
+                  {
+                    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionDate
+                  }
                 </StyledTableCell>
               </Tooltip>
               <Tooltip
@@ -215,7 +224,10 @@ export default function StaticTable({
                 arrow
               >
                 <StyledTableCell>
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionLocation}
+                  {
+                    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionLocation
+                  }
                 </StyledTableCell>
               </Tooltip>
               <Tooltip
@@ -230,7 +242,10 @@ export default function StaticTable({
                 arrow
               >
                 <StyledTableCell>
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sequencingDate}
+                  {
+                    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .sequencingDate
+                  }
                 </StyledTableCell>
               </Tooltip>
               <Tooltip
@@ -245,7 +260,7 @@ export default function StaticTable({
                 arrow
               >
                 <PrivateTableCell align="center">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.keepPrivate}
+                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate}
                 </PrivateTableCell>
               </Tooltip>
             </StyledTableRow>

--- a/src/frontend/src/views/Upload/components/Review/components/Table/index.tsx
+++ b/src/frontend/src/views/Upload/components/Review/components/Table/index.tsx
@@ -1,4 +1,6 @@
 import { Table as MuiTable, TableBody, TableHead } from "@mui/material";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { Props as CommonProps } from "../../../common/types";
 import Row from "./components/Row";
@@ -16,6 +18,8 @@ interface Props {
 }
 
 export default function Table({ metadata }: Props): JSX.Element {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   return (
     <Overflow>
       <form autoComplete="off">
@@ -27,26 +31,35 @@ export default function Table({ metadata }: Props): JSX.Element {
               <StyledTableRow {...({ component: "div" } as unknown)}>
                 <StyledTableCell component="div">
                   <IdColumn>
-                    {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sampleId}
+                    {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].sampleId}
                   </IdColumn>
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.privateId}
+                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].privateId}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.publicId}
+                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].publicId}
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionDate}
+                  {
+                    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionDate
+                  }
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.collectionLocation}
+                  {
+                    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .collectionLocation
+                  }
                 </StyledTableCell>
                 <StyledTableCell component="div">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.sequencingDate}
+                  {
+                    SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen]
+                      .sequencingDate
+                  }
                 </StyledTableCell>
                 <IsPrivateTableCell align="center" component="div">
-                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS.keepPrivate}
+                  {SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen].keepPrivate}
                 </IsPrivateTableCell>
               </StyledTableRow>
             </TableHead>

--- a/src/frontend/src/views/Upload/components/Samples/strings.ts
+++ b/src/frontend/src/views/Upload/components/Samples/strings.ts
@@ -1,12 +1,12 @@
 import { Pathogen } from "src/common/redux/types";
-import { PathogenStringsType } from "src/common/types/strings";
+import { PathogenConfigType } from "src/common/types/strings";
 
 interface UploadSamplesStrings {
   header: string;
   acceptedFormats: string;
 }
 
-export const pathogenStrings: PathogenStringsType<UploadSamplesStrings> = {
+export const pathogenStrings: PathogenConfigType<UploadSamplesStrings> = {
   [Pathogen.COVID]: {
     header: "Select SARS-CoV-2 Consensus Genome Files",
     acceptedFormats:

--- a/src/frontend/src/views/Upload/components/common/constants.ts
+++ b/src/frontend/src/views/Upload/components/common/constants.ts
@@ -1,4 +1,5 @@
 import { Dictionary, invert } from "lodash";
+import { Pathogen } from "src/common/redux/types";
 import { SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS } from "src/components/DownloadMetadataTemplate/common/constants";
 import { SampleUploadTsvMetadata } from "src/components/DownloadMetadataTemplate/common/types";
 
@@ -6,9 +7,12 @@ import { SampleUploadTsvMetadata } from "src/components/DownloadMetadataTemplate
 // Note: there is a distinction between "real" `collectionLocation` internally
 // in app (it's an object) and user-submitted collectionLocation via metadata
 // upload (it's a string). The file parser will handle this conversion.
-export const HEADERS_TO_METADATA_KEYS = invert(
-  SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS
-) as Dictionary<keyof SampleUploadTsvMetadata>;
+export const getHeadersToMetadataKeys = (
+  pathogen: Pathogen
+): Dictionary<keyof SampleUploadTsvMetadata> => {
+  const keysToHeaders = SAMPLE_UPLOAD_METADATA_KEYS_TO_HEADERS[pathogen];
+  return invert(keysToHeaders) as Dictionary<keyof SampleUploadTsvMetadata>;
+};
 
 export const NEXTSTRAIN_FORMAT_HEADERS_TO_METADATA_KEYS: Record<
   string,


### PR DESCRIPTION
### Summary:
- **What:** `Refactor downloadable upload/edit template constants to work with multiple pathogens`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

**Would like some feedback on where to get the pathogen information.**  I think helper functions should take this as an argument rather than looking it up in redux directly.  However, passing the pathogen param through multiple layers of helper functions didn't seem great either.  I am currently in an inconsistent state with components getting the pathogen where they can, but some helpers also look in redux.  **Thoughts?**

### Demos:
![Screenshot 2022-11-17 at 9 28 51 AM](https://user-images.githubusercontent.com/109251328/202516528-d65182ab-5c3d-41c2-bb37-afe97dc2553b.png)
![Screenshot 2022-11-17 at 9 28 27 AM](https://user-images.githubusercontent.com/109251328/202516532-c62c7c79-d7fc-407a-928e-c308cb72bdf4.png)
![Screenshot 2022-11-17 at 9 27 08 AM](https://user-images.githubusercontent.com/109251328/202516535-cc2e74d9-89b3-4836-a971-905a2974f915.png)
![Screenshot 2022-11-17 at 9 26 48 AM](https://user-images.githubusercontent.com/109251328/202516537-0760fd13-2217-4fcf-bff5-40fefeb61a6c.png)


### Notes:
* This includes updating the webform table headers
* This does not include updating copy on the edit/upload flows

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)