### PR TITLE
Maya/223990 tsv generation

### DIFF
--- a/src/frontend/src/common/types/table.d.ts
+++ b/src/frontend/src/common/types/table.d.ts
@@ -1,6 +1,6 @@
 interface Header {
   text: string;
-  key: string | number;
+  key: string;
   sortKey: string[];
   align?: string;
   tooltip?: {

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
@@ -25,8 +25,7 @@ interface Props {
   isGenbankSelected: boolean;
   isGisaidSelected: boolean;
   isMetadataSelected: boolean;
-  nCompletedSampleIds: boolean;
-  completedSampleIds: boolean;
+  completedSampleIds: string[];
   handleCloseModal(): void;
 }
 
@@ -36,7 +35,6 @@ const DownloadButton = ({
   isGenbankSelected,
   isGisaidSelected,
   isMetadataSelected,
-  nCompletedSampleIds,
   completedSampleIds,
   handleCloseModal,
 }: Props): JSX.Element | null => {
@@ -46,10 +44,7 @@ const DownloadButton = ({
   const [tsvData, setTsvData] = useState<string[][]>([]);
 
   useEffect(() => {
-    const newTsvData = mapTsvData({
-      checkedSamples,
-    });
-
+    const newTsvData = mapTsvData(checkedSamples);
     setTsvData(newTsvData);
   }, [checkedSamples]);
 
@@ -94,7 +89,7 @@ const DownloadButton = ({
         includes_genbank_template: isGenbankSelected,
         includes_gisaid_template: isGisaidSelected,
         includes_sample_metadata: isMetadataSelected,
-        sample_count: nCompletedSampleIds,
+        sample_count: completedSampleIds.length,
         sample_public_ids: JSON.stringify(completedSampleIds),
       }
     );

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from "react";
+import { CSVLink } from "react-csv";
+import {
+  AnalyticsSamplesDownloadFile,
+  EVENT_TYPES,
+} from "src/common/analytics/eventTypes";
+import { analyticsTrackEvent } from "src/common/analytics/methods";
+import { ORG_API } from "src/common/api";
+import { useUserInfo } from "src/common/queries/auth";
+import {
+  FileDownloadResponsePayload,
+  PUBLIC_REPOSITORY_NAME,
+  useFileDownload,
+} from "src/common/queries/samples";
+import { addNotification } from "src/common/redux/actions";
+import { useDispatch } from "src/common/redux/hooks";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
+import { NotificationComponents } from "src/components/NotificationManager/components/Notification";
+import { mapTsvData } from "./mapTsvData";
+import { StyledButton } from "./style";
+
+interface Props {
+  checkedSamples: Sample[];
+  isFastaSelected: boolean;
+  isGenbankSelected: boolean;
+  isGisaidSelected: boolean;
+  isMetadataSelected: boolean;
+  nCompletedSampleIds: boolean;
+  completedSampleIds: boolean;
+  handleCloseModal(): void;
+}
+
+const DownloadButton = ({
+  checkedSamples,
+  isFastaSelected,
+  isGenbankSelected,
+  isGisaidSelected,
+  isMetadataSelected,
+  nCompletedSampleIds,
+  completedSampleIds,
+  handleCloseModal,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const { data: userInfo } = useUserInfo();
+
+  const [tsvData, setTsvData] = useState<string[][]>([]);
+
+  useEffect(() => {
+    const newTsvData = mapTsvData({
+      checkedSamples,
+    });
+
+    setTsvData(newTsvData);
+  }, [checkedSamples]);
+
+  const useFileMutationGenerator = () =>
+    useFileDownload({
+      componentOnError: () => {
+        dispatch(
+          addNotification({
+            componentKey: NotificationComponents.DOWNLOAD_FILES_FAILURE,
+            intent: "error",
+            shouldShowCloseButton: true,
+          })
+        );
+        handleCloseModal();
+      },
+      componentOnSuccess: ({ data, filename }: FileDownloadResponsePayload) => {
+        const link = document.createElement("a");
+        link.href = window.URL.createObjectURL(data);
+        link.download = filename || "file-download";
+        link.click();
+        link.remove();
+        handleCloseModal();
+      },
+    });
+
+  const downloadMutation = useFileMutationGenerator();
+
+  /**
+   * Handle firing off analytics event when a samples download is initiated.
+   *
+   * Download button kicks off download, but underlying components within it
+   * change depending on if fasta selected and/or if metadata selected.
+   * This function deals with the analytics event for downloads, but need
+   * to ensure it only gets called once, regardless of what combination
+   * of fasta/metadata selection is in place.
+   */
+  const analyticsHandleDownload = (): void => {
+    analyticsTrackEvent<AnalyticsSamplesDownloadFile>(
+      EVENT_TYPES.SAMPLES_DOWNLOAD_FILE,
+      {
+        includes_consensus_genome: isFastaSelected,
+        includes_genbank_template: isGenbankSelected,
+        includes_gisaid_template: isGisaidSelected,
+        includes_sample_metadata: isMetadataSelected,
+        sample_count: nCompletedSampleIds,
+        sample_public_ids: JSON.stringify(completedSampleIds),
+      }
+    );
+  };
+
+  // format metadata file name for download file
+  // fasta and template endpoints return the name
+  const currentGroup = getCurrentGroupFromUserInfo(userInfo);
+  const groupName = currentGroup?.name.toLowerCase().replace(/ /g, "_");
+  const downloadDate = new Date().toISOString().slice(0, 10);
+  const separator = "\t";
+  const metadataDownloadName = `${groupName}_sample_metadata_${downloadDate}.tsv`;
+
+  const isButtonDisabled = !(
+    isFastaSelected ||
+    isMetadataSelected ||
+    isGisaidSelected ||
+    isGenbankSelected
+  );
+
+  const onClick = () => {
+    // button will have different functionality depending on download type selected
+
+    if (isFastaSelected) {
+      downloadMutation.mutate({
+        endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
+        sampleIds: completedSampleIds,
+      });
+    }
+
+    if (isGisaidSelected) {
+      downloadMutation.mutate({
+        endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
+        publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
+        sampleIds: completedSampleIds,
+      });
+      downloadMutation.mutate({
+        endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
+        publicRepositoryName: PUBLIC_REPOSITORY_NAME.GISAID,
+        sampleIds: completedSampleIds,
+      });
+    }
+
+    if (isGenbankSelected) {
+      downloadMutation.mutate({
+        endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
+        publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
+        sampleIds: completedSampleIds,
+      });
+      downloadMutation.mutate({
+        endpoint: ORG_API.SAMPLES_TEMPLATE_DOWNLOAD,
+        publicRepositoryName: PUBLIC_REPOSITORY_NAME.GENBANK,
+        sampleIds: completedSampleIds,
+      });
+    }
+
+    analyticsHandleDownload();
+  };
+
+  const downloadButton = (
+    <StyledButton
+      sdsType="primary"
+      sdsStyle="rounded"
+      disabled={isButtonDisabled}
+      onClick={onClick}
+    >
+      {downloadMutation.isLoading ? "Loading" : "Download"}
+    </StyledButton>
+  );
+
+  if (!isMetadataSelected) return downloadButton;
+
+  return (
+    <CSVLink
+      data={tsvData}
+      filename={metadataDownloadName}
+      separator={separator}
+      data-test-id="download-tsv-link"
+    >
+      {downloadButton}
+    </CSVLink>
+  );
+};
+
+export { DownloadButton };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/mapTsvData.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/mapTsvData.ts
@@ -1,17 +1,12 @@
 // TODO-TR (mlila): consider moving or restructuring this blob
 import { SAMPLE_HEADERS, SAMPLE_SUBHEADERS } from "src/views/Data/headers";
 
-interface DataMapProps {
-  checkedSamples: Sample[];
-  headers: Header[];
-  subheaders: Record<string, SubHeader[]>;
-}
-
-export const mapTsvData = ({ checkedSamples }: DataMapProps): [string[][]] => {
-  const allHeaders = [
+export const mapTsvData = (checkedSamples: Sample[]): string[][] => {
+  const allHeaders: Header[] = [
     ...SAMPLE_HEADERS,
     {
       key: "CZBFailedGenomeRecovery",
+      sortKey: ["CZBFailedGenomeRecovery"],
       text: "Genome Recovery",
     },
   ];
@@ -33,10 +28,10 @@ export const mapTsvData = ({ checkedSamples }: DataMapProps): [string[][]] => {
     // for each sample, generate an array of values, one column at a time
     return allHeaders.flatMap((header) => {
       const { key } = header;
+      const value = sample[key];
 
       // break this piece of data into multiple columns, if necessary
-      if (SAMPLE_SUBHEADERS[key]) {
-        const value = sample[key];
+      if (typeof value === "object" && SAMPLE_SUBHEADERS[key]) {
         return SAMPLE_SUBHEADERS[key].map((subheader) =>
           String(value[subheader.key])
         );
@@ -44,9 +39,9 @@ export const mapTsvData = ({ checkedSamples }: DataMapProps): [string[][]] => {
 
       // otherwise, return a single value for this column
       if (key == "CZBFailedGenomeRecovery") {
-        return sample[key] ? "Failed" : "Success";
+        return value ? "Failed" : "Success";
       } else {
-        return String(sample[key]);
+        return String(value);
       }
     });
   });

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/mapTsvData.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/mapTsvData.ts
@@ -1,0 +1,55 @@
+// TODO-TR (mlila): consider moving or restructuring this blob
+import { SAMPLE_HEADERS, SAMPLE_SUBHEADERS } from "src/views/Data/headers";
+
+interface DataMapProps {
+  checkedSamples: Sample[];
+  headers: Header[];
+  subheaders: Record<string, SubHeader[]>;
+}
+
+export const mapTsvData = ({ checkedSamples }: DataMapProps): [string[][]] => {
+  const allHeaders = [
+    ...SAMPLE_HEADERS,
+    {
+      key: "CZBFailedGenomeRecovery",
+      text: "Genome Recovery",
+    },
+  ];
+
+  // define header row
+  const tsvHeaders = allHeaders.flatMap((header) => {
+    const { key, text } = header;
+
+    // create multiple columns for more complex data types (such as lineage)
+    if (SAMPLE_SUBHEADERS[key]) {
+      return SAMPLE_SUBHEADERS[key].map((subheader) => subheader.text);
+    }
+
+    return text;
+  });
+
+  // define table data
+  const tsvData = checkedSamples.map((sample) => {
+    // for each sample, generate an array of values, one column at a time
+    return allHeaders.flatMap((header) => {
+      const { key } = header;
+
+      // break this piece of data into multiple columns, if necessary
+      if (SAMPLE_SUBHEADERS[key]) {
+        const value = sample[key];
+        return SAMPLE_SUBHEADERS[key].map((subheader) =>
+          String(value[subheader.key])
+        );
+      }
+
+      // otherwise, return a single value for this column
+      if (key == "CZBFailedGenomeRecovery") {
+        return sample[key] ? "Failed" : "Success";
+      } else {
+        return String(sample[key]);
+      }
+    });
+  });
+
+  return [tsvHeaders, ...tsvData];
+};

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { Button, CommonThemeProps, getSpaces } from "czifui";
+
+export const StyledButton = styled(Button)`
+  max-width: fit-content;
+
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-top: ${spaces?.xxl}px;
+    `;
+  }}
+`;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -65,7 +65,6 @@ const DownloadModal = ({
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const tooltipRef = useCallback((node: HTMLElement) => setAnchorEl(node), []);
 
-  const [isFastaDisabled, setFastaDisabled] = useState<boolean>(false);
   const [isFastaSelected, setFastaSelected] = useState<boolean>(false);
   const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
   const [isGisaidSelected, setGisaidSelected] = useState<boolean>(false);
@@ -75,6 +74,7 @@ const DownloadModal = ({
     (id) => !failedSampleIds.includes(id)
   );
   const nCompletedSampleIds = completedSampleIds.length;
+  const isFastaDisabled = nCompletedSampleIds === 0;
 
   useEffect(() => {
     if (tsvData) {
@@ -83,14 +83,6 @@ const DownloadModal = ({
       setTsvRows(Rows);
     }
   }, [tsvData]);
-
-  useEffect(() => {
-    if (nCompletedSampleIds === 0) {
-      setFastaDisabled(true);
-    } else {
-      setFastaDisabled(false);
-    }
-  }, [nCompletedSampleIds, setFastaDisabled]);
 
   const handleMetadataClick = function () {
     setMetadataSelected(!isMetadataSelected);
@@ -137,7 +129,6 @@ const DownloadModal = ({
         handleCloseModal();
       },
       componentOnSuccess: ({ data, filename }: FileDownloadResponsePayload) => {
-        // TODO (mlila): may need to modify behavior here for gisaid/genbank multi-file download
         const link = document.createElement("a");
         link.href = window.URL.createObjectURL(data);
         link.download = filename || "file-download";
@@ -382,7 +373,7 @@ const DownloadModal = ({
         disabled={isButtonDisabled}
         onClick={onClick}
       >
-        {getDownloadButtonText()}
+        {downloadMutation.isLoading ? "Loading" : "Download"}
       </StyledButton>
     );
 
@@ -399,14 +390,6 @@ const DownloadModal = ({
         {downloadButton}
       </CSVLink>
     );
-  }
-
-  function getDownloadButtonText() {
-    if (downloadMutation.isLoading) {
-      return "Loading";
-    } else {
-      return "Download";
-    }
   }
 };
 

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -46,9 +46,10 @@ const DownloadModal = ({
   const [isGisaidSelected, setGisaidSelected] = useState<boolean>(false);
   const [isGenbankSelected, setGenbankSelected] = useState<boolean>(false);
 
-  const completedSampleIds = checkedSamples.filter(
-    (sample) => !failedSampleIds.includes(sample.id)
-  );
+  const completedSampleIds = checkedSamples
+    .filter((sample) => !failedSampleIds.includes(sample.publicId))
+    .map((s) => s.publicId);
+
   const nCompletedSampleIds = completedSampleIds.length;
   const isFastaDisabled = nCompletedSampleIds === 0;
 
@@ -230,7 +231,6 @@ const DownloadModal = ({
               isGenbankSelected={isGenbankSelected}
               isGisaidSelected={isGisaidSelected}
               isMetadataSelected={isMetadataSelected}
-              nCompletedSampleIds={nCompletedSampleIds}
               completedSampleIds={completedSampleIds}
               handleCloseModal={handleCloseModal}
             />

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/style.ts
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import {
-  Button,
   CommonThemeProps,
   fontBodyM,
   fontBodyS,

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/style.ts
@@ -116,16 +116,6 @@ export const DownloadType = styled.div`
   }}
 `;
 
-export const StyledButton = styled(Button)`
-  max-width: fit-content;
-  ${(props: CommonThemeProps) => {
-    const spaces = getSpaces(props);
-    return `
-      margin-top: ${spaces?.xxl}px;
-    `;
-  }}
-`;
-
 export const DownloadTypeInfo = styled.div`
   ${fontBodyXxs}
   width: 400px;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
@@ -68,12 +68,8 @@ const SampleTableModalManager = ({
   return (
     <>
       <DownloadModal
-        checkedSampleIds={checkedSampleIds}
+        checkedSamples={checkedSamples}
         failedSampleIds={failedSampleIds}
-        // TODO-TR (mlila): update tsvDataMap
-        // tsvData={tsvDataMap(
-        //   checkedSampleIds, tableData, headers, subheaders,
-        // )}
         open={isDownloadModalOpen}
         onClose={() => setIsDownloadModalOpen(false)}
       />

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
@@ -6,7 +6,6 @@ import { EditSamplesConfirmationModal } from "./components/EditSamplesConfirmati
 import { SampleTableActions } from "./components/SampleTableActions";
 import { UsherTreeFlow } from "./components/UsherTreeFlow";
 
-// TODO-TR (mlila): types
 interface Props {
   checkedSamples: Sample[];
   clearCheckedSamples(): void;


### PR DESCRIPTION
### Summary
- **What:**
  - rewrite the tsv data generation function to be more readable
  - break download button for the download modal into its own component
- **Why:** Ease of readability and maintainability
- **Ticket:** [[sc-223990]](https://app.shortcut.com/genepi/story/223990)
- **Env:** https://maya-tsv-frontend.dev.czgenepi.org/

### Testing
1. Select a few samples
1. Download the metadata file (second checkbox)

### Demos
![after](https://user-images.githubusercontent.com/7562933/202946747-e3c0a109-905d-4936-8804-4b0a5cc835c2.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)