### PR TITLE
[fix] fix pangolin lineage list endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ local-init: oauth/pkcs12/certificate.pfx .env.ecr local-ecr-login local-hostconf
 	$(docker_compose) restart backend
 	$(docker_compose) exec -T backend alembic upgrade head
 	$(docker_compose) exec -T backend python scripts/setup_localdata.py
+	$(docker_compose) exec -e ASPEN_S3_DB_BUCKET=genepi-db-data -w /usr/src/app/aspen/workflows/import_pango_lineages -T backend ./entrypoint.sh
 	$(docker_compose) --profile $(LOCALDEV_PROFILE) up -d
 
 # Assumes you've already run `make local-init` to configure localstack resources!

--- a/src/backend/aspen/api/views/lineages.py
+++ b/src/backend/aspen/api/views/lineages.py
@@ -3,7 +3,6 @@ import re
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
 
 from aspen.api.deps import get_db
 from aspen.api.schemas.lineages import PathogenLineagesResponse
@@ -24,7 +23,7 @@ async def list_pango_lineages(db: AsyncSession = Depends(get_db)):
     so that's all we pull and return.
     """
     # This is specifically a *pangolin* lineages endpoint, so hardcode an SC2 filter
-    all_lineages_query = sa.select(PathogenLineage.lineage).options(joinedload(Pathogen)).where(Pathogen.slug == "SC2")  # type: ignore
+    all_lineages_query = sa.select(PathogenLineage.lineage).join(Pathogen).where(Pathogen.slug == "SC2")  # type: ignore
     result = await db.execute(all_lineages_query)
     all_lineages = set(result.scalars().all())
 

--- a/src/backend/aspen/api/views/tests/test_lineages_endpoints.py
+++ b/src/backend/aspen/api/views/tests/test_lineages_endpoints.py
@@ -1,0 +1,59 @@
+from typing import Collection, Tuple
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aspen.database.models import Group, Pathogen, PathogenLineage, User
+from aspen.test_infra.models.pathogen import pathogen_factory, random_pathogen_factory
+from aspen.test_infra.models.usergroup import group_factory, userrole_factory
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+def make_all_test_data(
+    async_session: AsyncSession,
+) -> Tuple[
+    Pathogen,
+    Pathogen,
+    Collection[PathogenLineage],
+    Collection[PathogenLineage],
+]:
+    random_pathogen: Pathogen = random_pathogen_factory()
+    sc2: Pathogen = pathogen_factory("SC2")
+
+    sc2_lineage_names = ["F.1", "G.1.1", "H.2.3.4"]
+    sc2_lineages = []
+    for lineage_name in sc2_lineage_names:
+        sc2_lineages.append(PathogenLineage(pathogen=sc2, lineage=lineage_name))
+
+    random_lineage_names = ["I.1", "J.1.1", "K.2.3.4"]
+    random_pathogen_lineages = []
+    for lineage_name in random_lineage_names:
+        random_pathogen_lineages.append(
+            PathogenLineage(pathogen=random_pathogen, lineage=lineage_name)
+        )
+
+    async_session.add_all(sc2_lineages + random_pathogen_lineages)
+    return sc2, random_pathogen, sc2_lineages, random_pathogen_lineages
+
+
+async def test_pango_lineages_list(
+    async_session,
+    http_client,
+    n_samples=5,
+    n_trees=3,
+):
+    group: Group = group_factory()
+    user: User = await userrole_factory(async_session, group)
+    sc2, _, sc2_lineages, _ = make_all_test_data(async_session)
+
+    async_session.add(group)
+    await async_session.commit()
+
+    auth_headers = {"user_id": str(user.auth0_user_id)}
+    res = await http_client.get("/v2/lineages/pango", headers=auth_headers)
+    results = res.json()["lineages"]
+    expected = ["Delta", "F*", "F.1", "G.1*", "G.1.1", "H.2.3*", "H.2.3.4", "Omicron"]
+
+    assert results == expected

--- a/src/backend/aspen/workflows/import_pango_lineages/entrypoint.sh
+++ b/src/backend/aspen/workflows/import_pango_lineages/entrypoint.sh
@@ -9,6 +9,12 @@
 set -Eeuxo pipefail
 shopt -s inherit_errexit
 
+if [ -n "${BOTO_ENDPOINT_URL-}" ]; then
+  export aws="aws --endpoint-url ${BOTO_ENDPOINT_URL}"
+else
+  export aws="aws"
+fi
+
 # Talking to Pangolin folks, they said the best canonical listing of all
 # current lineages is to use their (manually updated) lineage_notes.txt
 # https://github.com/cov-lineages/pango-designation/issues/456
@@ -25,7 +31,7 @@ wget -O $filename $CANONICAL_LINEAGES_LOCATION
 echo "Uploading a backup copy to S3"
 lineages_key="pangolin_lineages/${filename}"
 s3_destination="s3://${ASPEN_S3_DB_BUCKET}/${lineages_key}"
-aws s3 cp $filename $s3_destination
+$aws s3 cp $filename $s3_destination
 
 # Parse lineages file and load into DB
 python3 ./load_lineages.py --lineages-file $filename


### PR DESCRIPTION
### Summary:
- **What:** Fixes broken pango endpoint

### Notes:
- This fixes a query that I accidentally broke when migrating from the PangoLineages table to PathogenLineages
- I also added an endpoint test since I realized we didn't have coverage for it yet.
- I updated `make local-init` to download the latest list of pango lineages into the DB when setting up a new local dev env.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)