### PR TITLE
show the correct number of deleted samples

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DeleteSamplesConfirmationModal/index.tsx
@@ -1,5 +1,4 @@
 import { isEmpty } from "lodash";
-import { useState } from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { useDeleteSamples } from "src/common/queries/samples";
 import { addNotification } from "src/common/redux/actions";

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DeleteSamplesConfirmationModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DeleteSamplesConfirmationModal/index.tsx
@@ -23,9 +23,12 @@ const DeleteSamplesConfirmationModal = ({
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
 
-  const [numDeletedSamples, setNumDeletedSamples] = useState<number>(0);
   const { data: userInfo } = useUserInfo();
   const currentGroup = getCurrentGroupFromUserInfo(userInfo);
+
+  const samplesToDelete = checkedSamples
+    .filter((sample) => sample.submittingGroup?.name === currentGroup?.name)
+    .map((sample) => sample.id);
 
   const deleteSampleMutation = useDeleteSamples({
     componentOnError: () => {
@@ -39,6 +42,8 @@ const DeleteSamplesConfirmationModal = ({
       );
     },
     componentOnSuccess: () => {
+      const numDeletedSamples = samplesToDelete.length;
+
       dispatch(
         addNotification({
           autoDismiss: true,
@@ -55,12 +60,7 @@ const DeleteSamplesConfirmationModal = ({
 
   if (!open) return null;
 
-  const samplesToDelete = checkedSamples
-    .filter((sample) => sample.submittingGroup?.name === currentGroup?.name)
-    .map((sample) => sample.id);
-
   const onDelete = () => {
-    setNumDeletedSamples(samplesToDelete.length);
     deleteSampleMutation.mutate({
       samplesToDelete,
     });


### PR DESCRIPTION
### Summary
- **What:** Fix count in the notification that confirms sample deletion
- **Why:** The state containing the deleted sample count was updated after the notification text was written to a variable, so it showed the number of samples you deleted *last time* instead of *this time* (ie: state was one tick behind)

### Demos (pending upload)
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/203447703-a486a634-2d32-4d1a-beb2-5325b8334663.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/203447710-10184b79-ea64-4e25-a684-a0266d672302.gif)

### Notes
Not caused by the sample refactor, but I noticed the bug during this morning's feedback session.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)