### PR TITLE
disable gisaid template download if not SC2

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -43,7 +43,7 @@ const DownloadModal = ({
   const [isGenbankSelected, setGenbankSelected] = useState<boolean>(false);
   const state = store.getState();
   const pathogen = selectCurrentPathogen(state);
-  const isGisaidTemplateEnabled = pathogen === "SC2" ? true : false;
+  const isGisaidTemplateEnabled = pathogen ===Pathogen.COVID;
 
   const completedSampleIds = checkedSamples
     .filter((sample) => !failedSampleIds.includes(sample.publicId))

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import DialogActions from "src/common/components/library/Dialog/components/DialogActions";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
+import { store } from "src/common/redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import {
   StyledCloseIconButton,
   StyledCloseIconWrapper,
@@ -39,6 +41,9 @@ const DownloadModal = ({
   const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
   const [isGisaidSelected, setGisaidSelected] = useState<boolean>(false);
   const [isGenbankSelected, setGenbankSelected] = useState<boolean>(false);
+  const state = store.getState();
+  const pathogen = selectCurrentPathogen(state);
+  const isGisaidTemplateEnabled = pathogen === "SC2" ? true : false;
 
   const completedSampleIds = checkedSamples
     .filter((sample) => !failedSampleIds.includes(sample.publicId))
@@ -127,25 +132,25 @@ const DownloadModal = ({
                 Date, Sequencing Date, Lineage, GISAID Status, and ISL Accession
                 #.
               </DownloadMenuSelection>
-
-              <DownloadMenuSelection
-                id="download-gisaid-checkbox"
-                isChecked={isGisaidSelected}
-                onChange={handleGisaidClick}
-                downloadTitle="GISAID Submission Template"
-                fileTypes=".fasta, .tsv"
-              >
-                Download concatenated consensus genomes and metadata files
-                formatted to prepare samples for submission to GISAID.{" "}
-                <Link
-                  href="https://help.czgenepi.org/hc/en-us/articles/8179880474260"
-                  target="_blank"
-                  rel="noreferrer"
+              {isGisaidTemplateEnabled && (
+                <DownloadMenuSelection
+                  id="download-gisaid-checkbox"
+                  isChecked={isGisaidSelected}
+                  onChange={handleGisaidClick}
+                  downloadTitle="GISAID Submission Template"
+                  fileTypes=".fasta, .tsv"
                 >
-                  Learn More.
-                </Link>
-              </DownloadMenuSelection>
-
+                  Download concatenated consensus genomes and metadata files
+                  formatted to prepare samples for submission to GISAID.{" "}
+                  <Link
+                    href="https://help.czgenepi.org/hc/en-us/articles/8179880474260"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Learn More.
+                  </Link>
+                </DownloadMenuSelection>
+              )}
               <DownloadMenuSelection
                 id="download-genbank-checkbox"
                 isChecked={isGenbankSelected}

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -1,10 +1,11 @@
 import { Alert, Icon, Link } from "czifui";
 import { useState } from "react";
+import { useSelector } from "react-redux";
 import DialogActions from "src/common/components/library/Dialog/components/DialogActions";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
-import { store } from "src/common/redux";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import {
   StyledCloseIconButton,
   StyledCloseIconWrapper,
@@ -41,9 +42,8 @@ const DownloadModal = ({
   const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
   const [isGisaidSelected, setGisaidSelected] = useState<boolean>(false);
   const [isGenbankSelected, setGenbankSelected] = useState<boolean>(false);
-  const state = store.getState();
-  const pathogen = selectCurrentPathogen(state);
-  const isGisaidTemplateEnabled = pathogen ===Pathogen.COVID;
+  const pathogen = useSelector(selectCurrentPathogen);
+  const isGisaidTemplateEnabled = pathogen === Pathogen.COVID;
 
   const completedSampleIds = checkedSamples
     .filter((sample) => !failedSampleIds.includes(sample.publicId))


### PR DESCRIPTION
### Summary:
- **What:** disable template download for gisaid if pathogen slug is not SC2
- **Ticket:** [sc225240](https://app.shortcut.com/genepi/story/225240)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)