### PR TITLE
Write Sample Lineages

### DIFF
--- a/src/backend/aspen/workflows/pangolin/save.py
+++ b/src/backend/aspen/workflows/pangolin/save.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from typing import Mapping, Optional, Union
 
 import click
+import sqlalchemy as sa
+from sqlalchemy.orm import contains_eager
+from sqlalchemy.sql.expression import and_
 
 from aspen.config.config import Config
 from aspen.database.connection import (
@@ -12,7 +15,12 @@ from aspen.database.connection import (
     session_scope,
     SqlAlchemyInterface,
 )
-from aspen.database.models import PathogenGenome, UploadedPathogenGenome
+from aspen.database.models import (
+    LineageType,
+    Sample,
+    SampleLineage,
+    UploadedPathogenGenome,
+)
 
 
 def get_probability(row: dict) -> Optional[int]:
@@ -40,7 +48,11 @@ def get_probability(row: dict) -> Optional[int]:
 )
 def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
     interface: SqlAlchemyInterface = init_db(get_db_uri(Config()))
+    # This script is SC2 only, which uses pangolin for lineage calls.
+    lineage_type = LineageType.PANGOLIN
 
+    commit_chunk_size = 100
+    current_chunk_size = 0
     with session_scope(interface) as session:
         pango_csv: csv.DictReader = csv.DictReader(pangolin_fh)
         taxon_to_pango_info: Mapping[
@@ -55,11 +67,29 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
             for row in pango_csv
         }
 
+        genome_query = (
+            sa.select(UploadedPathogenGenome)
+            .join(UploadedPathogenGenome.sample)
+            .outerjoin(
+                SampleLineage,
+                and_(
+                    Sample.id == SampleLineage.sample_id,
+                    SampleLineage.lineage_type == lineage_type,
+                ),
+            )
+            .options(
+                contains_eager(UploadedPathogenGenome.sample).contains_eager(
+                    Sample.lineages
+                )
+            )
+            .where(UploadedPathogenGenome.entity_id.in_(taxon_to_pango_info.keys()))
+        )
         entity_id_to_pathogen_genome: Mapping[int, UploadedPathogenGenome] = {
             pathogen_genome.entity_id: pathogen_genome
-            for pathogen_genome in session.query(PathogenGenome).filter(
-                PathogenGenome.entity_id.in_(taxon_to_pango_info.keys())
-            )
+            for pathogen_genome in session.execute(genome_query)
+            .unique()
+            .scalars()
+            .all()
         }
 
         for entity_id, pathogen_genome in entity_id_to_pathogen_genome.items():
@@ -71,7 +101,30 @@ def cli(pangolin_fh: io.TextIOBase, pangolin_last_updated: datetime):
             pathogen_genome.pangolin_probability = pango_info["probability"]  # type: ignore
             pathogen_genome.pangolin_version = pango_info["version"]  # type: ignore
             pathogen_genome.pangolin_output = pango_info["full_output"]  # type: ignore
-            session.commit()
+            current_chunk_size += 1
+
+            # Support populating the sample_lineages table.
+            if pathogen_genome.sample.lineages:
+                lineage = pathogen_genome.sample.lineages[0]
+                lineage.lineage = pango_info["lineage"]  # type: ignore
+                lineage.lineage_software_version = pango_info["version"]  # type: ignore
+                lineage.lineage_probability = pango_info["probability"]  # type: ignore
+                lineage.raw_lineage_output = pango_info["full_output"]  # type: ignore
+            else:
+                lineage = SampleLineage(
+                    sample=pathogen_genome.sample,
+                    lineage_type=lineage_type,
+                    lineage=pango_info["lineage"],  # type: ignore
+                    lineage_software_version=pango_info["version"],  # type: ignore
+                    lineage_probability=pango_info["probability"],  # type: ignore
+                    raw_lineage_output=pango_info["full_output"],  # type: ignore
+                )
+                pathogen_genome.sample.lineages.append(lineage)
+
+            if current_chunk_size > commit_chunk_size:
+                session.commit()
+                current_chunk_size = 0
+        session.commit()
 
 
 if __name__ == "__main__":

--- a/src/backend/aspen/workflows/pangolin/tests/data/lineage_report.csv
+++ b/src/backend/aspen/workflows/pangolin/tests/data/lineage_report.csv
@@ -1,3 +1,3 @@
 taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,scorpio_notes,version,pangolin_version,scorpio_version,constellation_version,is_designated,qc_status,qc_notes,note
-1,B,0.0,,,,,,PANGO-v1.2.133,4.0.1,0.3.16,v0.1.4,True,pass,Ambiguous_content:0.02,Assigned from designation hash.
-2,B,0.0,,,,,,PANGO-v1.2.133,4.0.1,0.3.16,v0.1.4,True,pass,Ambiguous_content:0.02,Assigned from designation hash.
+3,B,0.0,,,,,,PANGO-v1.2.133,4.0.1,0.3.16,v0.1.4,True,pass,Ambiguous_content:0.02,Assigned from designation hash.
+4,B,0.0,,,,,,PANGO-v1.2.133,4.0.1,0.3.16,v0.1.4,True,pass,Ambiguous_content:0.02,Assigned from designation hash.

--- a/src/backend/aspen/workflows/pangolin/tests/sample_ids.txt
+++ b/src/backend/aspen/workflows/pangolin/tests/sample_ids.txt
@@ -1,2 +1,0 @@
-public_identifier_1
-public_identifier_2

--- a/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
+++ b/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
@@ -1,9 +1,10 @@
-import os
+import random
 from datetime import datetime
 from pathlib import Path, PosixPath
 from typing import Collection
 
 from click.testing import CliRunner, Result
+from sqlalchemy.orm import undefer
 
 from aspen.database.models.sample import Sample
 from aspen.database.models.sequences import UploadedPathogenGenome
@@ -18,29 +19,25 @@ from aspen.workflows.pangolin.find_samples import find_samples
 from aspen.workflows.pangolin.save import cli as save_cli
 
 
-def create_test_data(session):
-    group: Group = group_factory()
-    pathogen = random_pathogen_factory()
-    uploaded_by_user = user_factory(group)
-    location = location_factory(
-        "North America", "USA", "California", "Santa Barbara County"
-    )
-
-    samples = []
+def create_samples_for_pathogen(session, group, user, location, pathogen):
     pathogen_genomes = []
+    samples = []
     for i in range(1, 3):
         sample: Sample = sample_factory(
             group,
-            uploaded_by_user,
+            user,
             location,
             pathogen=pathogen,
-            private_identifier=f"private_identifier_{i}",
-            public_identifier=f"public_identifier_{i}",
+            private_identifier=f"private_identifier_{pathogen.slug}_{i}",
+            public_identifier=f"public_identifier_{pathogen.slug}_{i}",
         )
         session.add(sample)
         samples.append(sample)
+        sequence = [item for item in "ATGCATGCATGCATGCATGC"]
+        random.shuffle(sequence)
         pathogen_genome: UploadedPathogenGenome = uploaded_pathogen_genome_factory(
             sample,
+            sequence="".join(sequence),
             pangolin_lineage=None,
             pangolin_probability=None,
             pangolin_version=None,
@@ -49,8 +46,29 @@ def create_test_data(session):
         session.add(pathogen_genome)
         pathogen_genomes.append(pathogen_genome)
         session.commit()
-
     return samples, pathogen_genomes
+
+
+def create_test_data(session):
+    group: Group = group_factory()
+    pathogen = random_pathogen_factory()
+    extra_pathogen = random_pathogen_factory()
+    uploaded_by_user = user_factory(group)
+    location = location_factory(
+        "North America", "USA", "California", "Santa Barbara County"
+    )
+
+    # Create samples for an unused pathogen (test that we're filtering for pathogens properly)
+    _, _ = create_samples_for_pathogen(
+        session, group, uploaded_by_user, location, extra_pathogen
+    )
+
+    # Create samples for a targeted pathogen
+    samples, pathogen_genomes = create_samples_for_pathogen(
+        session, group, uploaded_by_user, location, pathogen
+    )
+
+    return samples, pathogen_genomes, pathogen
 
 
 def mock_remote_db_uri(mocker, test_postgres_db_uri):
@@ -63,39 +81,60 @@ def mock_remote_db_uri(mocker, test_postgres_db_uri):
 
 def test_pangolin_find_samples(mocker, session, postgres_database):
 
-    samples, _ = create_test_data(session)
+    samples, _, pathogen = create_test_data(session)
     mock_remote_db_uri(mocker, postgres_database.as_uri())
 
-    found_samples: Collection[str] = find_samples()
+    found_samples: Collection[str] = find_samples(pathogen.slug)
 
     assert found_samples == [sample.public_identifier for sample in samples]
 
 
-def test_pangolin_export(mocker, session, postgres_database):
+def _write_sample_ids(pathogen):
+    found_samples: Collection[str] = find_samples(pathogen.slug)
+    ids_filename = "/tmp/sample_ids.txt"
+    with open(ids_filename, "w") as f:
+        f.write("\n".join(found_samples))
+    return ids_filename
 
-    create_test_data(session)
-    mock_remote_db_uri(mocker, postgres_database.as_uri())
 
+def _run_sample_export(ids_filename):
+    output_filename = "/tmp/test.fa"
     runner = CliRunner()
     result = runner.invoke(
         export_cli,
-        [
-            "--sequences",
-            "test.fa",
-            "--sample-ids-file",
-            f"{str(os.path.dirname(os.path.realpath(__file__)))}/sample_ids.txt",
-        ],
+        ["--sequences", output_filename, "--sample-ids-file", ids_filename],
     )
     assert result.exit_code == 0
-    with open("test.fa", "r") as fh:
+    return output_filename
+
+
+def test_pangolin_export(mocker, session, postgres_database):
+
+    samples, pathogen_genomes, pathogen = create_test_data(session)
+    mock_remote_db_uri(mocker, postgres_database.as_uri())
+    ids_filename = _write_sample_ids(pathogen)
+    sequence_fasta = _run_sample_export(ids_filename)
+
+    sequences = (
+        session.query(UploadedPathogenGenome)
+        .options(undefer(UploadedPathogenGenome.sequence))
+        .where(UploadedPathogenGenome.sample_id.in_([sample.id for sample in samples]))
+        .all()
+    )
+    expected = (
+        "\n".join([f">{sequence.id}\n{sequence.sequence}" for sequence in sequences])
+        + "\n"
+    )
+    with open(sequence_fasta, "r") as fh:
         lines = fh.read()
-        assert lines == ">1\nTCGGCG\n>2\nTCGGCG\n"
+        assert lines == expected
 
 
 def test_pangolin_save(mocker, session, postgres_database):
 
-    create_test_data(session)
+    _, _, pathogen = create_test_data(session)
     mock_remote_db_uri(mocker, postgres_database.as_uri())
+    pathogen_slug = pathogen.slug
 
     pangolin_csv: PosixPath = Path(Path(__file__).parent, "data", "lineage_report.csv")
 
@@ -112,9 +151,20 @@ def test_pangolin_save(mocker, session, postgres_database):
     session.begin()
 
     for pathogen_genome in session.query(UploadedPathogenGenome).all():
+        sample = pathogen_genome.sample
+        if sample.pathogen.slug != pathogen_slug:
+            assert pathogen_genome.pangolin_lineage is None
+            assert pathogen_genome.pangolin_version is None
+            assert len(pathogen_genome.sample.lineages) == 0
+            continue
         assert pathogen_genome.pangolin_lineage == "B"
         assert pathogen_genome.pangolin_probability == 100.0
         assert pathogen_genome.pangolin_last_updated == datetime.strptime(
             "05-03-2021", "%m-%d-%Y"
         )
         assert pathogen_genome.pangolin_version == "PANGO-v1.2.133"
+
+        sample_lineage = pathogen_genome.sample.lineages[0]
+        assert sample_lineage.lineage == "B"
+        assert sample_lineage.lineage_probability == 100.0
+        assert sample_lineage.lineage_software_version == "PANGO-v1.2.133"


### PR DESCRIPTION
### Summary:
- **What:** Have the Pangolin job write pangolin lineage data to `sample_lineages`
- **Ticket:** [sc226127](https://app.shortcut.com/genepi/story/226127)

### Notes:
There's not a lot to see here, this PR does what it says on the tin. The major changes are:
- Update the nightly pangolin job to only fetch SC2 samples
- Create-or-update SampleLineage rows for each sample we do a lineage call on, as well as updating the `pathogen_genome.pango*` columns, for reverse compatibility
- Update the tests to generate samples for multiple pathogens, to make sure filtering/etc works. The tests rely much less on hardcoded values now, but I couldn't find a reasonable way to avoid hardcoded ID's in the `lineage_report.csv` file, so maybe we can take another stab at that later.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)