### PR TITLE
Add an indicator so we can easily determine if an account is in the CZGE_internal segment in split.

### DIFF
--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -18,6 +18,7 @@ export enum SPLIT_SIMPLE_FLAG {
 export enum USER_FEATURE_FLAGS {
   // my_flag_name = "my_flag_name", (<-- format example)
   galago_integration = "galago_integration",
+  internal_user = "internal_user",
   multi_pathogen = "multi_pathogen",
   table_refactor = "table_refactor",
   tree_location_filter = "tree_location_filter",

--- a/src/frontend/src/views/Account/index.tsx
+++ b/src/frontend/src/views/Account/index.tsx
@@ -1,8 +1,11 @@
+import { useTreatments } from "@splitsoftware/splitio-react";
 import { Button, Icon, InputText, Link } from "czifui";
 import { useRouter } from "next/router";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useUpdateUserInfo, useUserInfo } from "src/common/queries/auth";
 import { H1, H2, P } from "src/common/styles/basicStyle";
+import { isUserFlagOn } from "src/components/Split";
+import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import {
   GrayIconWrapper,
   StyledDivider,
@@ -19,6 +22,13 @@ const UNSAVED_CHANGES_MESSAGE =
 
 export default function Account(): JSX.Element {
   const router = useRouter();
+
+  const flag = useTreatments([USER_FEATURE_FLAGS.internal_user]);
+  const isInternalUserFlagOn = isUserFlagOn(
+    flag,
+    USER_FEATURE_FLAGS.internal_user
+  );
+
   const { data: userInfo } = useUserInfo();
   const { mutate: updateUserInfo } = useUpdateUserInfo();
 
@@ -142,6 +152,12 @@ export default function Account(): JSX.Element {
           onChange={handleNewIdInput}
         />
       </StyledSection>
+      {isInternalUserFlagOn && (
+        <StyledSection>
+          <StyledH3>CZGE Internal User account</StyledH3>
+          <SubText>This section is not shown to external users.</SubText>
+        </StyledSection>
+      )}
     </>
   );
 }


### PR DESCRIPTION
### Summary:
- **What:** `Add section to account page to indicate whether an account is in the 'internal_user' split group.`
- **Ticket:** none
- **Env:** `none`

### Demos:
![Screenshot 2022-11-29 at 9 05 01 AM](https://user-images.githubusercontent.com/109251328/204615894-a9222d64-596d-42bb-8f50-9ef1655b64f6.png)

### Notes:
We will use the CZGE_internal segment in split to test the new samples and trees tables.  Since we expect no change, it will be helpful to have a quick way to determine whether an account is in the segment.  This will not show for users who are not in the CZGE_internal segment.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)