### PR TITLE
[SC-225247] move upload button

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -14,6 +14,7 @@ import {
   StyledChip,
   StyledDiv,
   StyledFlexChildDiv,
+  StyledUploadButton,
   TooltipDescriptionText,
   TooltipHeaderText,
 } from "./style";
@@ -25,6 +26,8 @@ import { UsherTreeFlow } from "src/views/Data/components/SamplesView/components/
 import { DeleteSamplesConfirmationModal } from "src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DeleteSamplesConfirmationModal";
 import { EditSamplesConfirmationModal } from "src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal";
 import { IconButton } from "src/views/Data/components/SamplesView/components/SampleTableModalManager/components/IconButton";
+import { Link } from "czifui";
+import { ROUTES } from "src/common/routes";
 
 interface Props {
   data?: BioinformaticsMap;
@@ -223,6 +226,17 @@ const DataSubview: FunctionComponent<Props> = ({
             onEditSelected={() => setEditSampleConfirmationOpen(true)}
             data-test-id="sample-page-more-action-btn"
           />
+          <Link href={ROUTES.UPLOAD_STEP1} passHref>
+            <StyledUploadButton
+              component="a"
+              href="passHref"
+              sdsType="primary"
+              sdsStyle="rounded"
+              data-test-id="upload-btn"
+            >
+              Upload
+            </StyledUploadButton>
+          </Link>
         </DownloadWrapper>
       );
     }

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -226,17 +226,15 @@ const DataSubview: FunctionComponent<Props> = ({
             onEditSelected={() => setEditSampleConfirmationOpen(true)}
             data-test-id="sample-page-more-action-btn"
           />
-          <Link href={ROUTES.UPLOAD_STEP1} passHref>
-            <StyledUploadButton
-              component="a"
-              href="passHref"
-              sdsType="primary"
-              sdsStyle="rounded"
-              data-test-id="upload-btn"
-            >
-              Upload
-            </StyledUploadButton>
-          </Link>
+          <StyledUploadButton
+            component="a"
+            href={ROUTES.UPLOAD_STEP1}
+            sdsType="primary"
+            sdsStyle="rounded"
+            data-test-id="upload-btn"
+          >
+            Upload
+          </StyledUploadButton>
         </DownloadWrapper>
       );
     }

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -26,7 +26,6 @@ import { UsherTreeFlow } from "src/views/Data/components/SamplesView/components/
 import { DeleteSamplesConfirmationModal } from "src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DeleteSamplesConfirmationModal";
 import { EditSamplesConfirmationModal } from "src/views/Data/components/SamplesView/components/SampleTableModalManager/components/EditSamplesConfirmationModal";
 import { IconButton } from "src/views/Data/components/SamplesView/components/SampleTableModalManager/components/IconButton";
-import { Link } from "czifui";
 import { ROUTES } from "src/common/routes";
 
 interface Props {

--- a/src/frontend/src/common/components/library/data_subview/style.ts
+++ b/src/frontend/src/common/components/library/data_subview/style.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import {
+  Button,
   Chip,
   CommonThemeProps,
   fontHeaderXs,
@@ -93,4 +94,13 @@ export const SamplesTable = styled.div`
 export const StyledBar = styled.div`
   display: flex;
   justify-content: space-between;
+`;
+
+export const StyledUploadButton = styled(Button)`
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-left: ${spaces?.l}px;
+    `;
+  }}
 `;

--- a/src/frontend/src/components/NavBar/components/AppNavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/index.tsx
@@ -1,27 +1,13 @@
 import { useTreatments } from "@splitsoftware/splitio-react";
-import { Icon } from "czifui";
 import Link from "next/link";
-import { MouseEventHandler, useState } from "react";
 import { useUserInfo } from "src/common/queries/auth";
 import { ROUTES } from "src/common/routes";
 import { HiddenLabel } from "src/common/styles/accessibility";
-import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
 import { isUserFlagOn } from "src/components/Split";
 import { USER_FEATURE_FLAGS } from "src/components/Split/types";
-import { InviteModal } from "src/views/GroupMembersPage/components/MembersTab/components/InviteModal";
 import RightNav from "../RightNav";
-import { GroupDetailsDropdown } from "./components/GroupDetailsDropdown";
 import { PathogenTabs } from "./components/PathogenTabs";
-import {
-  DropdownClickTarget,
-  LeftNav,
-  Logo,
-  LogoAnchor,
-  NavBar,
-  NavOrg,
-  Separator,
-  StyledNavIconWrapper,
-} from "./style";
+import { LeftNav, Logo, LogoAnchor, NavBar, Separator } from "./style";
 
 /*
  * This nav bar is shown when a user is both authenticated and
@@ -29,10 +15,6 @@ import {
  * aka behind auth logic
  */
 const AppNavBar = (): JSX.Element => {
-  const [anchorEl, setAnchorEl] = useState<Element | null>(null);
-  const [isGroupDetailsDropdownOpen, setIsGroupDetailsDropdownOpen] =
-    useState<boolean>(false);
-  const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
   const { data: userInfo } = useUserInfo();
 
   const flag = useTreatments([USER_FEATURE_FLAGS.multi_pathogen]);
@@ -41,16 +23,7 @@ const AppNavBar = (): JSX.Element => {
     USER_FEATURE_FLAGS.multi_pathogen
   );
 
-  const group = getCurrentGroupFromUserInfo(userInfo);
   const route = userInfo ? ROUTES.DATA : ROUTES.HOMEPAGE;
-
-  const toggleDropdown: MouseEventHandler = (e) => {
-    const newAnchor = isGroupDetailsDropdownOpen ? null : e.currentTarget;
-    setAnchorEl(newAnchor);
-    setIsGroupDetailsDropdownOpen(!isGroupDetailsDropdownOpen);
-  };
-
-  const name = group?.name;
 
   return (
     <NavBar data-test-id="navbar">
@@ -65,27 +38,6 @@ const AppNavBar = (): JSX.Element => {
           <>
             <Separator />
             <PathogenTabs />
-          </>
-        )}
-        {name && (
-          <>
-            <Separator />
-            <InviteModal
-              onClose={() => setIsInviteModalOpen(false)}
-              open={isInviteModalOpen}
-              groupName={name}
-            />
-            <DropdownClickTarget onClick={toggleDropdown}>
-              <NavOrg>{name}</NavOrg>
-              <StyledNavIconWrapper>
-                <Icon sdsIcon="chevronDown" sdsSize="xs" sdsType="static" />
-              </StyledNavIconWrapper>
-              <GroupDetailsDropdown
-                anchorEl={anchorEl}
-                onClickInvite={() => setIsInviteModalOpen(true)}
-                open={isGroupDetailsDropdownOpen}
-              />
-            </DropdownClickTarget>
           </>
         )}
       </LeftNav>

--- a/src/frontend/src/components/NavBar/components/AppNavBar/style.ts
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/style.ts
@@ -1,13 +1,6 @@
 import styled from "@emotion/styled";
-import {
-  CommonThemeProps,
-  fontHeaderL,
-  getColors,
-  getPalette,
-  getSpaces,
-} from "czifui";
+import { CommonThemeProps, getColors, getSpaces } from "czifui";
 import LogoImage from "src/common/images/logo_complete_white.svg";
-import { iconFillWhite } from "src/common/styles/iconStyle";
 
 export const Logo = styled(LogoImage)`
   height: 25px;
@@ -60,45 +53,6 @@ export const LeftNav = styled.div`
 export const NavBar = styled.div`
   background-color: black;
   height: 50px;
-  display: flex;
-  align-items: center;
-`;
-
-export const NavOrg = styled.div`
-  ${fontHeaderL}
-
-  height: 100%;
-  color: white;
-  align-items: center;
-  display: flex;
-
-  a {
-    color: white;
-  }
-`;
-
-export const DropdownClickTarget = styled.button`
-  display: flex;
-  align-items: center;
-  border: none;
-  ${(props: CommonThemeProps) => {
-    const palette = getPalette(props);
-
-    return `
-      background-color: ${palette?.common?.black};
-    `;
-  }}
-`;
-
-export const StyledNavIconWrapper = styled.div`
-  ${iconFillWhite}
-  ${(props: CommonThemeProps) => {
-    const spaces = getSpaces(props);
-
-    return `
-      margin: 0 ${spaces?.l}px;
-    `;
-  }}
   display: flex;
   align-items: center;
 `;

--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
@@ -3,7 +3,12 @@ import { useState } from "react";
 import { API } from "src/common/api";
 import ENV from "src/common/constants/ENV";
 import { ROUTES } from "src/common/routes";
-import { StyledNavButton, StyledNavIconWrapper } from "./style";
+import {
+  StyledNavButton,
+  StyledNavIconWrapper,
+  UserMenuButton,
+  UserMenuIcon,
+} from "./style";
 
 interface UserMenuProps {
   user: string | undefined;
@@ -30,17 +35,9 @@ const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
 
   return (
     <>
-      <StyledNavButton
-        data-test-id="nav-user-menu"
-        onClick={handleClick}
-        endIcon={
-          <StyledNavIconWrapper>
-            <Icon sdsIcon="chevronDown" sdsSize="xs" sdsType="static" />
-          </StyledNavIconWrapper>
-        }
-      >
-        {user}
-      </StyledNavButton>
+      <UserMenuButton data-test-id="nav-user-menu" onClick={handleClick}>
+        <Icon sdsIcon="person" sdsSize="l" sdsType="static" />
+      </UserMenuButton>
       <Menu
         anchorEl={anchorEl}
         keepMounted

--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/index.tsx
@@ -3,18 +3,9 @@ import { useState } from "react";
 import { API } from "src/common/api";
 import ENV from "src/common/constants/ENV";
 import { ROUTES } from "src/common/routes";
-import {
-  StyledNavButton,
-  StyledNavIconWrapper,
-  UserMenuButton,
-  UserMenuIcon,
-} from "./style";
+import { UserMenuButton } from "./style";
 
-interface UserMenuProps {
-  user: string | undefined;
-}
-
-const UserMenu = ({ user }: UserMenuProps): JSX.Element => {
+const UserMenu = (): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {

--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/style.ts
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/style.ts
@@ -1,6 +1,13 @@
 import styled from "@emotion/styled";
-import { Button, CommonThemeProps, getPalette } from "czifui";
-import { iconFillWhite } from "src/common/styles/iconStyle";
+import {
+  Button,
+  CommonThemeProps,
+  getColors,
+  getCorners,
+  getPalette,
+  getSpaces,
+} from "czifui";
+import { iconFillBlack, iconFillWhite } from "src/common/styles/iconStyle";
 
 export const StyledNavButton = styled(Button)`
   ${(props: CommonThemeProps) => {
@@ -13,4 +20,36 @@ export const StyledNavButton = styled(Button)`
 
 export const StyledNavIconWrapper = styled.div`
   ${iconFillWhite}
+`;
+
+export const UserMenuButton = styled(Button)`
+  height: 34px;
+  width: 34px;
+  min-width: unset;
+  border-radius: 50%;
+  ${iconFillWhite}
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+    const colors = getColors(props);
+    const corners = getCorners(props);
+    const palette = getPalette(props);
+
+    return `
+      border-radius: ${corners?.l};
+      padding: ${spaces?.xs};
+      background-color: ${colors?.gray[600]};
+
+      &:hover, &:focus {
+        background-color: ${colors?.gray[500]};
+      }
+
+      &:active {
+        svg {
+          fill: black;
+        }
+        background-color: ${palette?.common?.white};
+      }
+
+    `;
+  }}
 `;

--- a/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/style.ts
+++ b/src/frontend/src/components/NavBar/components/RightNav/components/UserMenu/style.ts
@@ -7,7 +7,7 @@ import {
   getPalette,
   getSpaces,
 } from "czifui";
-import { iconFillBlack, iconFillWhite } from "src/common/styles/iconStyle";
+import { iconFillWhite } from "src/common/styles/iconStyle";
 
 export const StyledNavButton = styled(Button)`
   ${(props: CommonThemeProps) => {

--- a/src/frontend/src/components/NavBar/components/RightNav/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/index.tsx
@@ -1,38 +1,76 @@
-import { Tooltip } from "czifui";
+import { Icon, Tooltip } from "czifui";
+import { MouseEventHandler, useState } from "react";
 import FeedbackIcon from "src/common/icons/feedback.svg";
 import { useUserInfo } from "src/common/queries/auth";
 import { HiddenLabel } from "src/common/styles/accessibility";
+import { getCurrentGroupFromUserInfo } from "src/common/utils/userInfo";
+import { InviteModal } from "src/views/GroupMembersPage/components/MembersTab/components/InviteModal";
+import { GroupDetailsDropdown } from "../AppNavBar/components/GroupDetailsDropdown";
 import UserMenu from "./components/UserMenu";
-import { StyledDiv, StyledIconWrapper, StyledLink } from "./style";
+import {
+  DropdownClickTarget,
+  NavOrg,
+  StyledDiv,
+  StyledIconWrapper,
+  StyledLink,
+  StyledNavIconWrapper,
+} from "./style";
 
 export default function RightNav(): JSX.Element {
   const { data: userInfo } = useUserInfo();
+  const group = getCurrentGroupFromUserInfo(userInfo);
 
-  function LoggedInNav(): JSX.Element {
-    return (
-      <StyledDiv>
-        <HiddenLabel id="feedback-label">Submit issues or feedback</HiddenLabel>
-        <Tooltip
-          arrow
-          title="Submit Issues or Feedback"
-          sdsStyle="dark"
-          placement="bottom"
+  const name = group?.name;
+  const [anchorEl, setAnchorEl] = useState<Element | null>(null);
+  const [isGroupDetailsDropdownOpen, setIsGroupDetailsDropdownOpen] =
+    useState<boolean>(false);
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
+  const toggleDropdown: MouseEventHandler = (e) => {
+    const newAnchor = isGroupDetailsDropdownOpen ? null : e.currentTarget;
+    setAnchorEl(newAnchor);
+    setIsGroupDetailsDropdownOpen(!isGroupDetailsDropdownOpen);
+  };
+  return (
+    <StyledDiv>
+      {name && (
+        <>
+          <InviteModal
+            onClose={() => setIsInviteModalOpen(false)}
+            open={isInviteModalOpen}
+            groupName={name}
+          />
+          <DropdownClickTarget onClick={toggleDropdown}>
+            <NavOrg>{name}</NavOrg>
+            <StyledNavIconWrapper>
+              <Icon sdsIcon="chevronDown" sdsSize="xs" sdsType="static" />
+            </StyledNavIconWrapper>
+            <GroupDetailsDropdown
+              anchorEl={anchorEl}
+              onClickInvite={() => setIsInviteModalOpen(true)}
+              open={isGroupDetailsDropdownOpen}
+            />
+          </DropdownClickTarget>
+        </>
+      )}
+      <HiddenLabel id="feedback-label">Submit issues or feedback</HiddenLabel>
+      <Tooltip
+        arrow
+        title="Submit Issues or Feedback"
+        sdsStyle="dark"
+        placement="bottom"
+      >
+        <StyledLink
+          aria-labelledby="feedback-label"
+          href="https://airtable.com/shr2SrkMN8DK1mLEK"
+          target="_blank"
+          rel="noreferrer"
         >
-          <StyledLink
-            aria-labelledby="feedback-label"
-            href="https://airtable.com/shr2SrkMN8DK1mLEK"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <StyledIconWrapper>
-              <FeedbackIcon aria-hidden="true" />
-            </StyledIconWrapper>
-          </StyledLink>
-        </Tooltip>
-        <UserMenu user={userInfo?.name} />
-      </StyledDiv>
-    );
-  }
-
-  return <LoggedInNav />;
+          <StyledIconWrapper>
+            <FeedbackIcon aria-hidden="true" />
+          </StyledIconWrapper>
+        </StyledLink>
+      </Tooltip>
+      <UserMenu user={userInfo?.name} />
+    </StyledDiv>
+  );
 }

--- a/src/frontend/src/components/NavBar/components/RightNav/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/index.tsx
@@ -70,7 +70,7 @@ export default function RightNav(): JSX.Element {
           </StyledIconWrapper>
         </StyledLink>
       </Tooltip>
-      <UserMenu user={userInfo?.name} />
+      <UserMenu />
     </StyledDiv>
   );
 }

--- a/src/frontend/src/components/NavBar/components/RightNav/index.tsx
+++ b/src/frontend/src/components/NavBar/components/RightNav/index.tsx
@@ -1,16 +1,9 @@
 import { Tooltip } from "czifui";
-import Link from "next/link";
 import FeedbackIcon from "src/common/icons/feedback.svg";
 import { useUserInfo } from "src/common/queries/auth";
 import { HiddenLabel } from "src/common/styles/accessibility";
-import { ROUTES } from "../../../../common/routes";
 import UserMenu from "./components/UserMenu";
-import {
-  StyledDiv,
-  StyledIconWrapper,
-  StyledLink,
-  UploadButton,
-} from "./style";
+import { StyledDiv, StyledIconWrapper, StyledLink } from "./style";
 
 export default function RightNav(): JSX.Element {
   const { data: userInfo } = useUserInfo();
@@ -18,17 +11,6 @@ export default function RightNav(): JSX.Element {
   function LoggedInNav(): JSX.Element {
     return (
       <StyledDiv>
-        <Link href={ROUTES.UPLOAD_STEP1} passHref>
-          <UploadButton
-            component="a"
-            href="passHref"
-            sdsType="secondary"
-            sdsStyle="rounded"
-            data-test-id="upload-btn"
-          >
-            Upload
-          </UploadButton>
-        </Link>
         <HiddenLabel id="feedback-label">Submit issues or feedback</HiddenLabel>
         <Tooltip
           arrow

--- a/src/frontend/src/components/NavBar/components/RightNav/style.ts
+++ b/src/frontend/src/components/NavBar/components/RightNav/style.ts
@@ -3,10 +3,12 @@ import {
   Button,
   CommonThemeProps,
   fontBodyXs,
+  fontHeaderL,
   getColors,
   getPalette,
   getSpaces,
 } from "czifui";
+import { iconFillWhite } from "src/common/styles/iconStyle";
 
 const whiteBorder = "border: 1px solid white;";
 export const UploadButton = styled(Button)`
@@ -56,7 +58,7 @@ export const StyledLink = styled.a`
 
     return `
       padding: ${spaces?.xxxs}px;
-      margin-right: ${spaces?.xs}px;
+      margin-right: ${spaces?.xl}px;
     `;
   }}
 `;
@@ -77,4 +79,43 @@ export const StyledIconWrapper = styled.div`
       }
     `;
   }}
+`;
+
+export const DropdownClickTarget = styled.button`
+  display: flex;
+  align-items: center;
+  border: none;
+  ${(props: CommonThemeProps) => {
+    const palette = getPalette(props);
+
+    return `
+      background-color: ${palette?.common?.black};
+    `;
+  }}
+`;
+
+export const NavOrg = styled.div`
+  ${fontHeaderL}
+
+  height: 100%;
+  color: white;
+  align-items: center;
+  display: flex;
+
+  a {
+    color: white;
+  }
+`;
+
+export const StyledNavIconWrapper = styled.div`
+  ${iconFillWhite}
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+
+    return `
+      margin: 0 ${spaces?.l}px;
+    `;
+  }}
+  display: flex;
+  align-items: center;
 `;

--- a/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
+++ b/src/frontend/src/components/NavBar/components/StaticPageNavBar/index.tsx
@@ -80,7 +80,7 @@ export default function StaticPageNavBar(): JSX.Element {
       </MobileNavLink>
     );
 
-    RightNav = <UserMenu user={userInfo.name} />;
+    RightNav = <UserMenu />;
   } else {
     MobileRightNav = (
       <>

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/index.tsx
@@ -1,3 +1,5 @@
+import { Link } from "czifui";
+import { ROUTES } from "src/common/routes";
 import { IconButton } from "../IconButton";
 import { MoreActionsMenu } from "./components/MoreActionMenu";
 import { TreeSelectionMenu } from "./components/TreeSelectionMenu";
@@ -5,6 +7,7 @@ import {
   Divider,
   StyledChip,
   StyledSelectedCount,
+  StyledUploadButton,
   StyledWrapper,
   TooltipDescriptionText,
   TooltipHeaderText,
@@ -77,6 +80,17 @@ const SampleTableActions = ({
         onEditSelected={openEditSampleModal}
         data-test-id="sample-page-more-action-btn"
       />
+      <Link href={ROUTES.UPLOAD_STEP1} passHref>
+        <StyledUploadButton
+          component="a"
+          href="passHref"
+          sdsType="primary"
+          sdsStyle="rounded"
+          data-test-id="upload-btn"
+        >
+          Upload
+        </StyledUploadButton>
+      </Link>
     </StyledWrapper>
   );
 };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/style.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import {
+  Button,
   Chip,
   CommonThemeProps,
   fontHeaderXs,
@@ -64,6 +65,15 @@ export const TooltipDescriptionText = styled.div`
     const colors = getColors(props);
     return `
       color: ${colors?.gray[400]};
+    `;
+  }}
+`;
+
+export const StyledUploadButton = styled(Button)`
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+    return `
+      margin-left: ${spaces?.l}px;
     `;
   }}
 `;


### PR DESCRIPTION
### Summary:
- **What:** `Move upload button from App Nav to top of samples table`
- **Ticket:** [sc225247](https://app.shortcut.com/genepi/story/225247)
- **Env:** `none`

### Demos:
![Screenshot 2022-11-30 at 2 34 04 PM](https://user-images.githubusercontent.com/109251328/204924034-62ead4b9-bf77-4ee5-85b3-719bb8e19e28.png)

### Notes:
The pathogen tabs remain behind the multi_pathogen split flag.  However, moving the upload button and moving the group menu is not behind a flag.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)