### PR TITLE
[SC-225245] Hide/show tree creation menu items based on pathogen.

### DIFF
--- a/src/frontend/src/components/Split/pathogenSplitConfig.ts
+++ b/src/frontend/src/components/Split/pathogenSplitConfig.ts
@@ -25,13 +25,17 @@ const pathogenTrafficFlagConfig: PathogenTrafficFlagConfig = {
     [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
     [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.OFF,
   },
+  [PATHOGEN_FEATURE_FLAGS.nextstrain_enabled]: {
+    [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
+    [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.OFF,
+  },
   [PATHOGEN_FEATURE_FLAGS.public_repository]: {
     [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
     [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.OFF,
   },
   [PATHOGEN_FEATURE_FLAGS.usher_linkout]: {
     [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
-    [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.OFF,
+    [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.ON,
   },
 };
 

--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -32,6 +32,7 @@ export enum USER_FEATURE_FLAGS {
 export enum PATHOGEN_FEATURE_FLAGS {
   galago_linkout = "PATHOGEN_galago_linkout",
   lineage_filter_enabled = "PATHOGEN_lineage_filter_enabled",
+  nextstrain_enabled = "PATHOGEN_nextstrain_enabled",
   public_repository = "PATHOGEN_public_repository",
   usher_linkout = "PATHOGEN_usher_linkout",
 }

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/components/TreeSelectionMenu/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/SampleTableActions/components/TreeSelectionMenu/index.tsx
@@ -2,6 +2,10 @@ import { Menu, MenuItem, Tooltip } from "czifui";
 import { MouseEventHandler, useState } from "react";
 import { TooltipDescriptionText, TooltipHeaderText } from "../../style";
 import { IconButton } from "../../../IconButton";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { SplitPathogenWrapper } from "src/components/Split/SplitPathogenWrapper";
+import { PATHOGEN_FEATURE_FLAGS } from "src/components/Split/types";
 
 interface Props {
   openNSTreeModal: () => void;
@@ -16,6 +20,8 @@ const TreeSelectionMenu = ({
   isMenuDisabled,
   isUsherDisabled,
 }: Props): JSX.Element => {
+  const pathogen = useSelector(selectCurrentPathogen);
+
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
@@ -74,21 +80,34 @@ const TreeSelectionMenu = ({
         onClose={handleClose}
         data-test-id="run-nextstrain-phylo-analysis-icon"
       >
-        <MenuItem onClick={handleClickNS} data-test-id="nextstrain-phylo-tree">
-          Nextstrain Phylogenetic Tree
-        </MenuItem>
-        <Tooltip
-          arrow
-          disableHoverListener={!isUsherDisabled}
-          placement="bottom"
-          title={USHER_DISABLED_TEXT}
+        <SplitPathogenWrapper
+          pathogen={pathogen}
+          feature={PATHOGEN_FEATURE_FLAGS.nextstrain_enabled}
         >
-          <div>
-            <MenuItem onClick={handleClickUsher} disabled={isUsherDisabled}>
-              UShER Phylogenetic Placement
-            </MenuItem>
-          </div>
-        </Tooltip>
+          <MenuItem
+            onClick={handleClickNS}
+            data-test-id="nextstrain-phylo-tree"
+          >
+            Nextstrain Phylogenetic Tree
+          </MenuItem>
+        </SplitPathogenWrapper>
+        <SplitPathogenWrapper
+          pathogen={pathogen}
+          feature={PATHOGEN_FEATURE_FLAGS.usher_linkout}
+        >
+          <Tooltip
+            arrow
+            disableHoverListener={!isUsherDisabled}
+            placement="bottom"
+            title={USHER_DISABLED_TEXT}
+          >
+            <div>
+              <MenuItem onClick={handleClickUsher} disabled={isUsherDisabled}>
+                UShER Phylogenetic Placement
+              </MenuItem>
+            </div>
+          </Tooltip>
+        </SplitPathogenWrapper>
       </Menu>
     </>
   );


### PR DESCRIPTION
### Summary:
- **What:** `Hide/show tree creation options based on current pathogen`
- **Ticket:** [sc225245](https://app.shortcut.com/genepi/story/225245)
- **Env:** `none`

### Demos:
![Screenshot 2022-12-02 at 8 03 30 AM](https://user-images.githubusercontent.com/109251328/205335193-2f583518-057a-4296-aacd-18494ffabaf9.png)
![Screenshot 2022-12-02 at 8 03 41 AM](https://user-images.githubusercontent.com/109251328/205335200-47ae4eac-a149-4381-803e-6cbfe008c8de.png)
![Screenshot 2022-12-02 at 8 03 56 AM](https://user-images.githubusercontent.com/109251328/205335202-527aaff9-de0d-4cac-9d34-5483e3471265.png)

### Notes:
Updating the Usher link was done by Lucia in [this PR](https://github.com/chanzuckerberg/czgenepi/pull/1484).

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)