### PR TITLE
Update GHA Happy version to 0.41.0

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -50,10 +50,10 @@ jobs:
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           stack-name: ge${{ github.event.deployment.environment }}stack
-          happy_version: "0.23.0"
+          happy_version: "0.41.0"
           create-tag: "false"
           tag: ${{ github.event.deployment.payload.tag }}
-          env: ${{ github.event.deployment.environment }} 
+          env: ${{ github.event.deployment.environment }}
       - name: Run integration tests
         env:
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -89,4 +89,4 @@ jobs:
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           stack-name: ${{ steps.stack-name.outputs.stack-name }}
-          happy_version: "0.23.0"
+          happy_version: "0.41.0"

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -148,7 +148,7 @@ jobs:
   #     - name: Install happy
   #       uses: chanzuckerberg/github-actions/.github/actions/install-happy@405f86e7f30b41403677c5df2d8d3339afa3c6d7
   #       with:
-  #         happy_version: "0.19.0"
+  #         happy_version: "0.41.0"
   #         install_globally: "true"
   #     - name: Playwright tests
   #       run: |
@@ -186,7 +186,7 @@ jobs:
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@405f86e7f30b41403677c5df2d8d3339afa3c6d7
         with:
-          happy_version: "0.19.0"
+          happy_version: "0.41.0"
           install_globally: "true"
       - name: Test Python
         run: |
@@ -214,7 +214,7 @@ jobs:
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@405f86e7f30b41403677c5df2d8d3339afa3c6d7
         with:
-          happy_version: "0.19.0"
+          happy_version: "0.41.0"
           install_globally: "true"
       - name: Test Gisaid workflow
         run: |
@@ -299,7 +299,7 @@ jobs:
         with:
           source-tag: ${{ env.SOURCE_TAG }}
           dest-tag: ${{ env.DEST_TAG }}
-          happy_version: "0.24.0"
+          happy_version: "0.41.0"
       - name: Generate payload
         run: |
           echo "payload={\"tag\":\"sha-${GITHUB_SHA:0:8}\"}" >> $GITHUB_ENV

--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           environment: staging
           owner: chanzuckerberg
           repo: czgenepi
-          happy_version: "0.23.0"
+          happy_version: "0.41.0"
       - name: Generate payload
         run: |
           if [ -n "${{ github.event.inputs.image_tag }}" ]; then


### PR DESCRIPTION
### Summary:
- **What:** We were on a pretty stale version of Happy for our GHA, this updates that.
- **Ticket:** None
- **Env:** None. If there's an issue, I figure we'll catch it the next time someone pushes up an `rdev-` branch

### Notes:

Sounds like we could also omit the Happy version entirely from the GHA and it would auto-pick whatever is latest, but pinning is probably best.

### Checklist:
- [x] I merged latest `trunk`
~ [ ] I manually verified the change~
- [x] I added labels to my PR
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)
(I'll mention in the treehouse that I updated the version, so if the next `rdev-` branch pushed up goes wonky, investigate this aspect first.)