### PR TITLE
Fix sample list no qc status test

### DIFF
--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -346,6 +346,9 @@ async def test_samples_list_no_qc_status(
                             "lineage_probability": sample_lineages[
                                 i
                             ].lineage_probability,
+                            "last_updated": sample_lineages[i].last_updated.strftime(
+                                "%Y-%m-%d"
+                            ),
                             "reference_dataset_name": sample_lineages[
                                 i
                             ].reference_dataset_name,


### PR DESCRIPTION
### Summary:
- **What:** Updates a test in `test_samples.py`, `test_samples_list_no_qc_status`, to expect a `last_updated` field as part of the `lineages` key, added in #1489 
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)