### PR TITLE
add back last_updated to samples test

### DIFF
--- a/src/backend/aspen/api/views/tests/test_samples.py
+++ b/src/backend/aspen/api/views/tests/test_samples.py
@@ -346,6 +346,9 @@ async def test_samples_list_no_qc_status(
                             "lineage_probability": sample_lineages[
                                 i
                             ].lineage_probability,
+                            "last_updated": sample_lineages[i].last_updated.strftime(
+                                "%Y-%m-%d"
+                            ),
                             "reference_dataset_name": sample_lineages[
                                 i
                             ].reference_dataset_name,


### PR DESCRIPTION
### Summary:
- **What:** add back the last_updated field to the expected samples response 
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)