### PR TITLE
fix the last_updated migration

### DIFF
--- a/src/backend/database_migrations/versions/20221201_174505_add_last_updated_lineages.py
+++ b/src/backend/database_migrations/versions/20221201_174505_add_last_updated_lineages.py
@@ -23,14 +23,14 @@ def upgrade():
 
     conn = op.get_bind()
     insert_last_updated_sql = sa.sql.text(
-    """
-    UPDATE aspen.sample_lineages
-    SET last_updated = t.pangolin_last_updated FROM (SELECT *
-    FROM aspen.uploaded_pathogen_genomes upg
-    INNER JOIN aspen.pathogen_genomes pg
-    ON pg.entity_id = upg.pathogen_genome_id
-    ) t
-    WHERE aspen.sample_lineages.sample_id = t.sample_id
+        """
+        UPDATE aspen.sample_lineages
+        SET last_updated = t.pangolin_last_updated FROM (SELECT *
+        FROM aspen.uploaded_pathogen_genomes upg
+        INNER JOIN aspen.pathogen_genomes pg
+        ON pg.entity_id = upg.pathogen_genome_id
+        ) t
+        WHERE aspen.sample_lineages.sample_id = t.sample_id
     """
     )
 

--- a/src/backend/database_migrations/versions/20221201_174505_add_last_updated_lineages.py
+++ b/src/backend/database_migrations/versions/20221201_174505_add_last_updated_lineages.py
@@ -22,10 +22,16 @@ def upgrade():
     )
 
     conn = op.get_bind()
+
+    # this is the same as jess' query from backfill sample lineages,
+    # only tacking on the last_updated portion to the query.
+    # this is still valid at this time because we are still
+    # populating the pathogen_genome fields from the pangolin save script.
+
     insert_accessions_sql = sa.sql.text(
         """
-        INSERT INTO aspen.sample_lineages (last_updated)
-        SELECT pg.pangolin_last_updated
+        INSERT INTO aspen.sample_lineages (sample_id, lineage_type, lineage, lineage_probability, lineage_software_version, raw_lineage_output, last_updated)
+        SELECT s.id, 'PANGOLIN', pg.pangolin_lineage, pg.pangolin_probability, pg.pangolin_version, pg.pangolin_output, pg.pangolin_last_updated
         FROM aspen.uploaded_pathogen_genomes upg
         INNER JOIN aspen.pathogen_genomes pg ON pg.entity_id = upg.pathogen_genome_id
         INNER JOIN aspen.samples s ON s.id = upg.sample_id
@@ -34,6 +40,7 @@ def upgrade():
         ON CONFLICT DO NOTHING
         """
     )
+
     conn.execute(insert_accessions_sql)
 
 

--- a/src/backend/database_migrations/versions/20221201_174505_add_last_updated_lineages.py
+++ b/src/backend/database_migrations/versions/20221201_174505_add_last_updated_lineages.py
@@ -23,11 +23,11 @@ def upgrade():
 
     conn = op.get_bind()
     insert_last_updated_sql = sa.sql.text(
-        """
-    UPDATE aspen.sample_lineages 
-    SET last_updated = t.pangolin_last_updated FROM (SELECT *  
+    """
+    UPDATE aspen.sample_lineages
+    SET last_updated = t.pangolin_last_updated FROM (SELECT *
     FROM aspen.uploaded_pathogen_genomes upg
-    INNER JOIN aspen.pathogen_genomes pg 
+    INNER JOIN aspen.pathogen_genomes pg
     ON pg.entity_id = upg.pathogen_genome_id
     ) t
     WHERE aspen.sample_lineages.sample_id = t.sample_id


### PR DESCRIPTION
### Summary:
- **What:** there was an issue with the last migration where[ null values were being inserted into the db on the last update](https://github.com/chanzuckerberg/czgenepi/actions/runs/3633234849/jobs/6130011309)
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)