### PR TITLE
add next nextclade to download modal / add warnings badQC data

### DIFF
--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -169,6 +169,9 @@ def create_sample_lineage(session, sample):
 
 
 def create_sample_qc_metrics(session, sample):
+    should_there_be_an_associated_qc = random.choice([True, False])
+    if not should_there_be_an_associated_qc:
+        return None
 
     sample_qc_metric = (
         session.query(SampleQCMetric).filter(SampleQCMetric.sample == sample).first()
@@ -189,7 +192,7 @@ def create_sample_qc_metrics(session, sample):
         ],
     }
 
-    there_be_an_associated_qc = random.choice([True, False])
+    should_there_be_an_associated_qc = random.choice([True, False])
     random_qc_status = random.choice(list(random_qc_status_scores.keys()))
     random_qc_score = random.choice(random_qc_status_scores[random_qc_status])
 
@@ -201,11 +204,9 @@ def create_sample_qc_metrics(session, sample):
         qc_status=random_qc_status,
         raw_qc_output={},
     )
-    if there_be_an_associated_qc: 
-        session.add(sample_qc_metrics)
-        return sample_qc_metrics
-    print("decided not to have an associated QC")    
-    return None
+
+    session.add(sample_qc_metrics)
+    return sample_qc_metrics
 
 
 def create_sample(

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -192,7 +192,6 @@ def create_sample_qc_metrics(session, sample):
         ],
     }
 
-    should_there_be_an_associated_qc = random.choice([True, False])
     random_qc_status = random.choice(list(random_qc_status_scores.keys()))
     random_qc_score = random.choice(random_qc_status_scores[random_qc_status])
 

--- a/src/backend/scripts/setup_localdata.py
+++ b/src/backend/scripts/setup_localdata.py
@@ -189,6 +189,7 @@ def create_sample_qc_metrics(session, sample):
         ],
     }
 
+    there_be_an_associated_qc = random.choice([True, False])
     random_qc_status = random.choice(list(random_qc_status_scores.keys()))
     random_qc_score = random.choice(random_qc_status_scores[random_qc_status])
 
@@ -200,9 +201,11 @@ def create_sample_qc_metrics(session, sample):
         qc_status=random_qc_status,
         raw_qc_output={},
     )
-
-    session.add(sample_qc_metrics)
-    return sample_qc_metrics
+    if there_be_an_associated_qc: 
+        session.add(sample_qc_metrics)
+        return sample_qc_metrics
+    print("decided not to have an associated QC")    
+    return None
 
 
 def create_sample(

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -229,6 +229,7 @@ const SAMPLE_MAP = new Map<string, keyof Sample>([
   ["sequencing_date", "sequencingDate"],
   ["submitting_group", "submittingGroup"],
   ["czb_failed_genome_recovery", "CZBFailedGenomeRecovery"],
+  ["qc_metrics", "qcMetrics"],
 ]);
 
 export const fetchSamples = (): Promise<SampleResponse> =>

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -21,6 +21,7 @@ export enum ORG_API {
   SAMPLES_VALIDATE_IDS = "samples/validate_ids/",
   SAMPLES_FASTA_DOWNLOAD = "sequences/",
   SAMPLES_TEMPLATE_DOWNLOAD = "samples/submission_template",
+  SAMPLES_NEXTCLADE_DOWNLOAD = "samples/nextclade/", // TODO: this is a stub for now, hook it up for real when it's ready
   GET_FASTA_URL = "sequences/getfastaurl",
   USHER_TREE_OPTIONS = "usher/tree_versions/",
 }

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -238,7 +238,6 @@ const DataSubview: FunctionComponent<Props> = ({
     const checkedSamples = compact(
       checkedSampleIds.map((id) => data?.[id]) as Sample[]
     );
-
     return (
       <>
         {tableData !== undefined && viewName === VIEWNAME.SAMPLES && (

--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -96,6 +96,7 @@ const DataSubview: FunctionComponent<Props> = ({
   const [checkedSampleIds, setCheckedSampleIds] = useState<string[]>([]);
   const [isDownloadModalOpen, setDownloadModalOpen] = useState(false);
   const [failedSampleIds, setFailedSampleIds] = useState<string[]>([]);
+  const [badQCSampleIds, setBadQCSampleIds] = useState<string[]>([]);
   const [isNSCreateTreeModalOpen, setIsNSCreateTreeModalOpen] =
     useState<boolean>(false);
   const [shouldStartUsherFlow, setShouldStartUsherFlow] =
@@ -251,12 +252,14 @@ const DataSubview: FunctionComponent<Props> = ({
               onClose={handleDownloadClose}
             />
             <CreateNSTreeModal
+              badQCSampleIds={badQCSampleIds}
               checkedSampleIds={checkedSampleIds}
               failedSampleIds={failedSampleIds}
               open={isNSCreateTreeModalOpen}
               onClose={handleCreateTreeClose}
             />
             <UsherTreeFlow
+              badQCSampleIds={badQCSampleIds}
               checkedSampleIds={checkedSampleIds}
               failedSampleIds={failedSampleIds}
               shouldStartUsherFlow={shouldStartUsherFlow}
@@ -300,6 +303,8 @@ const DataSubview: FunctionComponent<Props> = ({
               setCheckedSampleIds={setCheckedSampleIds}
               failedSampleIds={failedSampleIds}
               setFailedSampleIds={setFailedSampleIds}
+              badQCSampleIds={badQCSampleIds}
+              setBadQCSampleIds={setBadQCSampleIds}
               viewName={viewName}
               data={
                 dataFilterFunc && tableData

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -313,7 +313,7 @@ export const DataTable: FunctionComponent<Props> = ({
       handleRowCheckboxClick(
         String(item.publicId),
         Boolean(item.CZBFailedGenomeRecovery),
-        Boolean(item.qc_metrics && item.qc_metrics[0].qc_status === "bad")
+        Boolean(item.qc_metrics.length > 0 && item.qc_metrics[0].qc_status === "bad")
       );
     };
     return (

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -143,8 +143,8 @@ function extractPublicIdsFromDataWFailedGenomeRecovery(data: TableItem[]) {
 function extractPublicIdsWBadQCData(data: Sample[]) {
   return data
     .filter(
-      // for now there should only ever be one qc_metrics entry per sample
-      (s) => s.qc_metrics.length > 0 && s.qc_metrics[0].qc_status === "bad"
+      // for now there should only ever be one qcMetrics entry per sample
+      (s) => s.qcMetrics.length > 0 && s.qcMetrics[0].qc_status === "bad"
     )
     .map((s) => s.publicId);
 }
@@ -315,7 +315,7 @@ export const DataTable: FunctionComponent<Props> = ({
         String(item.publicId),
         Boolean(item.CZBFailedGenomeRecovery),
         Boolean(
-          item.qc_metrics.length > 0 && item.qc_metrics[0].qc_status === "bad"
+          item.qcMetrics.length > 0 && item.qcMetrics[0].qc_status === "bad"
         )
       );
     };

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -140,14 +140,12 @@ function extractPublicIdsFromDataWFailedGenomeRecovery(data: TableItem[]) {
   return failedSampleIds;
 }
 
-function extractPublicIdsWBadQCData(data: TableItem[]) {
-  const badQCDataSampleIds: string[] = [];
-  for (const key in data) {
-    if (data[key as any].qc_metrics?.qc_status === "bad") {
-      badQCDataSampleIds.push(String(data[key as any].publicId));
-    }
-  }
-  return badQCDataSampleIds;
+function extractPublicIdsWBadQCData(data: Sample[]) {
+  return data
+    .filter(
+      (s) => s.qc_metrics.length > 0 && s.qc_metrics[0].qc_status === "bad"
+    )
+    .map((s) => s.publicId);
 }
 
 interface TableState {
@@ -234,7 +232,7 @@ export const DataTable: FunctionComponent<Props> = ({
       // set isHeaderChecked to true, add all samples in current view
       setCheckedSampleIds(checkedSampleIds.concat(newPublicIds));
       setFailedSampleIds(failedSampleIds.concat(newFailedIds));
-      setBadQCSampleIds(badQCSampleIds.concat(newBadQCDataIds))
+      setBadQCSampleIds(badQCSampleIds.concat(newBadQCDataIds));
       setIsHeaderChecked(true);
     }
   }
@@ -242,7 +240,7 @@ export const DataTable: FunctionComponent<Props> = ({
   function handleRowCheckboxClick(
     sampleId: string,
     failedGenomeRecovery: boolean,
-    badQCData: boolean,
+    badQCData: boolean
   ) {
     if (checkedSampleIds.includes(sampleId)) {
       setCheckedSampleIds(checkedSampleIds.filter((id) => id !== sampleId));
@@ -313,7 +311,7 @@ export const DataTable: FunctionComponent<Props> = ({
       handleRowCheckboxClick(
         String(item.publicId),
         Boolean(item.CZBFailedGenomeRecovery),
-        Boolean(item.qc_metrics && item.qc_metrics[0].qc_status === "bad"),
+        Boolean(item.qc_metrics && item.qc_metrics[0].qc_status === "bad")
       );
     };
     return (

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -143,6 +143,7 @@ function extractPublicIdsFromDataWFailedGenomeRecovery(data: TableItem[]) {
 function extractPublicIdsWBadQCData(data: Sample[]) {
   return data
     .filter(
+      // for now there should only ever be one qc_metrics entry per sample
       (s) => s.qc_metrics.length > 0 && s.qc_metrics[0].qc_status === "bad"
     )
     .map((s) => s.publicId);
@@ -212,8 +213,8 @@ export const DataTable: FunctionComponent<Props> = ({
       false
     );
     const newFailedIds = extractPublicIdsFromDataWFailedGenomeRecovery(data);
-    // TODO TableItem[] appears identicle to Sample[] we should go through and refactor this once we have time to do so
-    // since TableItem and Sample are identicle i think it's safe to do this cast here
+    // TODO TableItem[] appears identical to Sample[] we should go through and refactor this once we have time to do so
+    // since TableItem and Sample are identical i think it's safe to do this cast here
     const newBadQCDataIds = extractPublicIdsWBadQCData(data as Sample[]);
 
     if (isHeaderIndeterminant || isHeaderChecked) {
@@ -337,7 +338,7 @@ export const DataTable: FunctionComponent<Props> = ({
       const item = tableData[props.index];
       return (
         <TableRow style={props.style} data-test-id="table-row">
-          {/* cast item as sample since they are identicle, related to earlier TODO around replacing all instances of TableItem with Sample */}
+          {/* cast item as sample since they are identical, related to earlier TODO around replacing all instances of TableItem with Sample */}
           {isSampleTable && rowCheckbox(item as Sample)}
           {item ? (
             sampleRow(item)

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -313,7 +313,9 @@ export const DataTable: FunctionComponent<Props> = ({
       handleRowCheckboxClick(
         String(item.publicId),
         Boolean(item.CZBFailedGenomeRecovery),
-        Boolean(item.qc_metrics.length > 0 && item.qc_metrics[0].qc_status === "bad")
+        Boolean(
+          item.qc_metrics.length > 0 && item.qc_metrics[0].qc_status === "bad"
+        )
       );
     };
     return (

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -212,7 +212,9 @@ export const DataTable: FunctionComponent<Props> = ({
       false
     );
     const newFailedIds = extractPublicIdsFromDataWFailedGenomeRecovery(data);
-    const newBadQCDataIds = extractPublicIdsWBadQCData(data);
+    // TODO TableItem[] appears identicle to Sample[] we should go through and refactor this once we have time to do so
+    // since TableItem and Sample are identicle i think it's safe to do this cast here
+    const newBadQCDataIds = extractPublicIdsWBadQCData(data as Sample[]);
 
     if (isHeaderIndeterminant || isHeaderChecked) {
       // remove samples in current data selection when selecting checkbox when indeterminate
@@ -303,7 +305,7 @@ export const DataTable: FunctionComponent<Props> = ({
     });
   };
 
-  const rowCheckbox = (item: TableItem): React.ReactNode => {
+  const rowCheckbox = (item: Sample): React.ReactNode => {
     const checked: boolean = checkedSampleIds.includes(
       item?.publicId as string
     );
@@ -333,7 +335,8 @@ export const DataTable: FunctionComponent<Props> = ({
       const item = tableData[props.index];
       return (
         <TableRow style={props.style} data-test-id="table-row">
-          {isSampleTable && rowCheckbox(item)}
+          {/* cast item as sample since they are identicle, related to earlier TODO around replacing all instances of TableItem with Sample */}
+          {isSampleTable && rowCheckbox(item as Sample)}
           {item ? (
             sampleRow(item)
           ) : (

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -34,7 +34,8 @@ export enum PUBLIC_REPOSITORY_NAME {
 
 type FileDownloadEndpointType =
   | ORG_API.SAMPLES_FASTA_DOWNLOAD
-  | ORG_API.SAMPLES_TEMPLATE_DOWNLOAD;
+  | ORG_API.SAMPLES_TEMPLATE_DOWNLOAD
+  | ORG_API.SAMPLES_NEXTCLADE_DOWNLOAD;
 interface SampleFileDownloadType {
   endpoint: FileDownloadEndpointType;
   page?: number;

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -58,7 +58,7 @@ interface Sample extends BioinformaticsType {
   gisaid: GISAID;
   CZBFailedGenomeRecovery: boolean;
   lineages: [Lineage];
-  qc_metrics: [QCMetrics];
+  qcMetrics: [QCMetrics];
   private?: boolean;
 }
 

--- a/src/frontend/src/common/types/table.d.ts
+++ b/src/frontend/src/common/types/table.d.ts
@@ -18,8 +18,8 @@ interface Header {
 }
 
 type TableItem = Record<
-  string | number ,
-  JSONPrimitive | Record<string, JSONPrimitive>  
+  string | number,
+  JSONPrimitive | Record<string, JSONPrimitive>
 >;
 
 interface CustomTableRenderProps {

--- a/src/frontend/src/common/types/table.d.ts
+++ b/src/frontend/src/common/types/table.d.ts
@@ -18,8 +18,8 @@ interface Header {
 }
 
 type TableItem = Record<
-  string | number,
-  JSONPrimitive | Record<string, JSONPrimitive>
+  string | number ,
+  JSONPrimitive | Record<string, JSONPrimitive>  
 >;
 
 interface CustomTableRenderProps {

--- a/src/frontend/src/common/utils/strUtils.ts
+++ b/src/frontend/src/common/utils/strUtils.ts
@@ -3,6 +3,7 @@ const WORDS_TO_PLURALIZE: Record<string, string> = {
   was: "were",
   is: "are",
   it: "they",
+  does: "do",
 };
 
 export const pluralize = (str: string, count: number): string => {

--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -23,6 +23,7 @@ export enum USER_FEATURE_FLAGS {
   table_refactor = "table_refactor",
   tree_location_filter = "tree_location_filter",
   static_metadata_table = "static_metadata_table",
+  nextclade_download = "nextclade_download",
 }
 
 /**

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/CreateNSTreeModal.test.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/CreateNSTreeModal.test.tsx
@@ -12,6 +12,7 @@ test("shows NS and GISAID attribution", async () => {
         <CreateNSTreeModal
           checkedSampleIds={[]}
           failedSampleIds={[]}
+          badQCSampleIds={[]}
           open
           onClose={noop}
         />

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/BadQCSampleAlert/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/BadQCSampleAlert/index.tsx
@@ -1,0 +1,24 @@
+import { pluralize } from "src/common/utils/strUtils";
+import { SemiBold, StyledCallout } from "./style";
+
+interface Props {
+  numBadQCSamples: number;
+}
+
+const BadQCSampleAlert = ({ numBadQCSamples }: Props): JSX.Element | null => {
+  if (numBadQCSamples <= 0) return null;
+
+  return (
+    <StyledCallout intent="warning">
+      <SemiBold>
+        {" "}
+        {numBadQCSamples} Selected {pluralize("Sample", numBadQCSamples)} have a
+        QC status of {"bad"},{" "}
+      </SemiBold>
+      which means that their placement in the phylogenetic tree will be less
+      reliable.
+    </StyledCallout>
+  );
+};
+
+export { BadQCSampleAlert };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/BadQCSampleAlert/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/BadQCSampleAlert/style.ts
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+import { Callout, CommonThemeProps, getFontWeights } from "czifui";
+
+export const SemiBold = styled.span`
+  ${(props: CommonThemeProps) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      font-weight: ${fontWeights?.semibold};
+    `;
+  }}
+`;
+
+export const StyledCallout = styled(Callout)`
+  width: 100%;
+`;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -33,6 +33,7 @@ import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { TreeNameInput } from "src/components/TreeNameInput";
 import { Header } from "../DownloadModal/style";
 import { FailedSampleAlert } from "../FailedSampleAlert";
+import { BadQCSampleAlert } from "./components/BadQCSampleAlert";
 import { CreateTreeButton } from "./components/CreateTreeButton";
 import { MissingSampleAlert } from "./components/MissingSampleAlert";
 import {
@@ -72,6 +73,7 @@ export type ResetFiltersType = {
 interface Props {
   checkedSampleIds: string[];
   failedSampleIds: string[];
+  badQCSampleIds: string[];
   open: boolean;
   onClose: () => void;
 }
@@ -79,6 +81,7 @@ interface Props {
 export const CreateNSTreeModal = ({
   checkedSampleIds,
   failedSampleIds,
+  badQCSampleIds,
   open,
   onClose,
 }: Props): JSX.Element => {
@@ -441,6 +444,7 @@ export const CreateNSTreeModal = ({
           />
           <MissingSampleAlert missingSamples={missingInputSamples} />
           <FailedSampleAlert numFailedSamples={failedSampleIds?.length} />
+          <BadQCSampleAlert numBadQCSamples={badQCSampleIds?.length} />
         </StyledDialogContent>
         <StyledFooter>
           <CreateTreeButton

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
@@ -116,6 +116,7 @@ const DownloadButton = ({
     analyticsTrackEvent<AnalyticsSamplesDownloadFile>(
       EVENT_TYPES.SAMPLES_DOWNLOAD_FILE,
       {
+        // TODO: add nextclade download to analytics once defined
         includes_consensus_genome: isFastaSelected,
         includes_genbank_template: isGenbankSelected,
         includes_gisaid_template: isGisaidSelected,

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
@@ -28,6 +28,7 @@ import { StyledButton } from "./style";
 
 interface Props {
   checkedSamples: Sample[];
+  sampleIdsWQCData: string[];
   isFastaSelected: boolean;
   isGenbankSelected: boolean;
   isGisaidSelected: boolean;
@@ -39,6 +40,7 @@ interface Props {
 
 const DownloadButton = ({
   checkedSamples,
+  sampleIdsWQCData,
   isFastaSelected,
   isGenbankSelected,
   isGisaidSelected,
@@ -156,7 +158,7 @@ const DownloadButton = ({
     if (isNextcladeDataSelected) {
       downloadMutation.mutate({
         endpoint: ORG_API.SAMPLES_NEXTCLADE_DOWNLOAD,
-        sampleIds: completedSampleIds,
+        sampleIds: sampleIdsWQCData,
       });
     }
 

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/index.tsx
@@ -32,6 +32,7 @@ interface Props {
   isGenbankSelected: boolean;
   isGisaidSelected: boolean;
   isMetadataSelected: boolean;
+  isNextcladeDataSelected: boolean;
   completedSampleIds: string[];
   handleCloseModal(): void;
 }
@@ -42,6 +43,7 @@ const DownloadButton = ({
   isGenbankSelected,
   isGisaidSelected,
   isMetadataSelected,
+  isNextcladeDataSelected,
   completedSampleIds,
   handleCloseModal,
 }: Props): JSX.Element | null => {
@@ -136,7 +138,8 @@ const DownloadButton = ({
     isFastaSelected ||
     isMetadataSelected ||
     isGisaidSelected ||
-    isGenbankSelected
+    isGenbankSelected ||
+    isNextcladeDataSelected
   );
 
   const onClick = () => {
@@ -145,6 +148,13 @@ const DownloadButton = ({
     if (isFastaSelected) {
       downloadMutation.mutate({
         endpoint: ORG_API.SAMPLES_FASTA_DOWNLOAD,
+        sampleIds: completedSampleIds,
+      });
+    }
+
+    if (isNextcladeDataSelected) {
+      downloadMutation.mutate({
+        endpoint: ORG_API.SAMPLES_NEXTCLADE_DOWNLOAD,
         sampleIds: completedSampleIds,
       });
     }

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -43,6 +43,8 @@ const DownloadModal = ({
   const [isMetadataSelected, setMetadataSelected] = useState<boolean>(false);
   const [isGisaidSelected, setGisaidSelected] = useState<boolean>(false);
   const [isGenbankSelected, setGenbankSelected] = useState<boolean>(false);
+  const [isNextcladeDataSelected, setNextcladeDataSelected] = useState(false);
+
   const pathogen = useSelector(selectCurrentPathogen);
   const isGisaidTemplateEnabled = pathogen === Pathogen.COVID;
 
@@ -69,11 +71,16 @@ const DownloadModal = ({
     setGenbankSelected(!isGenbankSelected);
   };
 
+  const handleNextcladeDataClick = function () {
+    setNextcladeDataSelected(!isNextcladeDataSelected);
+  }
+
   const handleCloseModal = () => {
     setFastaSelected(false);
     setMetadataSelected(false);
     setGenbankSelected(false);
     setGisaidSelected(false);
+    setNextcladeDataSelected(false);
     onClose();
   };
 
@@ -121,7 +128,6 @@ const DownloadModal = ({
                 Download multiple consensus genomes in a single concatenated
                 file.
               </DownloadMenuSelection>
-
               <DownloadMenuSelection
                 id="download-metadata-checkbox"
                 isChecked={isMetadataSelected}
@@ -132,6 +138,16 @@ const DownloadModal = ({
                 Sample metadata including Private and Public IDs, Collection
                 Date, Sequencing Date, Lineage, GISAID Status, and ISL Accession
                 #.
+              </DownloadMenuSelection>
+              <DownloadMenuSelection
+                id="download-nextclade-checkbox"
+                isChecked={isNextcladeDataSelected}
+                onChange={handleNextcladeDataClick}
+                downloadTitle="Sample Mutations and QC Metrics"
+                fileTypes=".csv"
+              >
+                Download a list of nucelotide and protein mutations and QC metrics 
+                for the selected samples. Learn More.
               </DownloadMenuSelection>
               {isGisaidTemplateEnabled && (
                 <DownloadMenuSelection
@@ -169,6 +185,7 @@ const DownloadModal = ({
                   Learn More.
                 </Link>
               </DownloadMenuSelection>
+
             </Container>
             {failedSampleIds.length > 0 &&
               !isFastaDisabled && ( //ignore alert if fasta is already disabled
@@ -198,6 +215,7 @@ const DownloadModal = ({
               isGenbankSelected={isGenbankSelected}
               isGisaidSelected={isGisaidSelected}
               isMetadataSelected={isMetadataSelected}
+              isNextcladeDataSelected={isNextcladeDataSelected}
               completedSampleIds={completedSampleIds}
               handleCloseModal={handleCloseModal}
             />

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -1,3 +1,4 @@
+import { useTreatments } from "@splitsoftware/splitio-react";
 import { Alert, Icon, Link } from "czifui";
 import { useState } from "react";
 import { useSelector } from "react-redux";
@@ -12,6 +13,8 @@ import {
 } from "src/common/styles/iconStyle";
 import { pluralize } from "src/common/utils/strUtils";
 import Dialog from "src/components/Dialog";
+import { isUserFlagOn } from "src/components/Split";
+import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { DownloadButton } from "./components/DownloadButton";
 import { DownloadMenuSelection } from "./components/DownloadMenuSelection";
 import {
@@ -47,6 +50,12 @@ const DownloadModal = ({
 
   const pathogen = useSelector(selectCurrentPathogen);
   const isGisaidTemplateEnabled = pathogen === Pathogen.COVID;
+
+  const nextcladeDownloadFlag = useTreatments([USER_FEATURE_FLAGS.nextclade_download]);
+  const usesNextcladeDownload = isUserFlagOn(
+    nextcladeDownloadFlag,
+    USER_FEATURE_FLAGS.nextclade_download
+  );
 
   const completedSampleIds = checkedSamples
     .filter((sample) => !failedSampleIds.includes(sample.publicId))
@@ -139,6 +148,7 @@ const DownloadModal = ({
                 Date, Sequencing Date, Lineage, GISAID Status, and ISL Accession
                 #.
               </DownloadMenuSelection>
+              { usesNextcladeDownload && (
               <DownloadMenuSelection
                 id="download-nextclade-checkbox"
                 isChecked={isNextcladeDataSelected}
@@ -149,6 +159,7 @@ const DownloadModal = ({
                 Download a list of nucelotide and protein mutations and QC metrics 
                 for the selected samples. Learn More.
               </DownloadMenuSelection>
+              )}
               {isGisaidTemplateEnabled && (
                 <DownloadMenuSelection
                   id="download-gisaid-checkbox"

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -11,7 +11,7 @@ import {
   StyledCloseIconButton,
   StyledCloseIconWrapper,
 } from "src/common/styles/iconStyle";
-import { pluralize, pluralizeVerb } from "src/common/utils/strUtils";
+import { pluralize } from "src/common/utils/strUtils";
 import Dialog from "src/components/Dialog";
 import { isUserFlagOn } from "src/components/Split";
 import { USER_FEATURE_FLAGS } from "src/components/Split/types";
@@ -49,8 +49,6 @@ const DownloadModal = ({
   const [isNextcladeDataSelected, setNextcladeDataSelected] = useState(false);
   const [noQCDataSampleIds, setNoQCDataSampleIds] = useState<number>(0);
 
-  console.log("checkedSamples: ", checkedSamples);
-  console.log("noQCDataSampleIds: ", noQCDataSampleIds);
   const pathogen = useSelector(selectCurrentPathogen);
   const isGisaidTemplateEnabled = pathogen === Pathogen.COVID;
 
@@ -64,7 +62,7 @@ const DownloadModal = ({
 
   useEffect(() => {
     const noQCIds = checkedSamples
-      .filter((s) => s.qc_metrics.length === 0)
+      .filter((s) => JSON.stringify(s.qc_metrics) === "[]")
       .map((s) => s.publicId);
     setNoQCDataSampleIds(noQCIds.length);
   }, [checkedSamples]);

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/UsherTreeFlow/components/UsherPlacementModal/index.tsx
@@ -40,10 +40,12 @@ import {
   Title,
   TreeNameInfoWrapper,
 } from "./style";
+import { BadQCSampleAlert } from "../../../CreateNSTreeModal/components/BadQCSampleAlert";
 
 interface Props {
   checkedSampleIds: string[];
   failedSampleIds: string[];
+  badQCSampleIds: string[];
   open: boolean;
   onClose: () => void;
   onLinkCreateSuccess(
@@ -74,6 +76,7 @@ const getDefaultNumSamplesPerSubtree = (numSelected: number): number => {
 export const UsherPlacementModal = ({
   failedSampleIds,
   checkedSampleIds,
+  badQCSampleIds,
   onClose,
   onLinkCreateSuccess,
   open,
@@ -334,6 +337,7 @@ export const UsherPlacementModal = ({
                 )}
               </StyledTextField>
               <FailedSampleAlert numFailedSamples={failedSampleIds?.length} />
+              <BadQCSampleAlert numBadQCSamples={badQCSampleIds?.length} />
             </div>
             <StyledButton
               sdsType="primary"

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/UsherTreeFlow/index.tsx
@@ -13,6 +13,7 @@ import { UsherPlacementModal } from "./components/UsherPlacementModal";
 interface Props {
   checkedSampleIds: string[];
   failedSampleIds: string[];
+  badQCSampleIds: string[];
   shouldStartUsherFlow: boolean;
 }
 
@@ -47,6 +48,7 @@ const generateUsherLink = (
 const UsherTreeFlow = ({
   checkedSampleIds,
   failedSampleIds,
+  badQCSampleIds,
   shouldStartUsherFlow,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -111,6 +113,7 @@ const UsherTreeFlow = ({
       <UsherPlacementModal
         checkedSampleIds={checkedSampleIds}
         failedSampleIds={failedSampleIds}
+        badQCSampleIds={badQCSampleIds}
         open={isPlacementOpen}
         onClose={() => setIsPlacementOpen(false)}
         onLinkCreateSuccess={onLinkCreateSuccess}

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
@@ -17,6 +17,7 @@ const SampleTableModalManager = ({
 }: Props): JSX.Element => {
   const [checkedSampleIds, setCheckedSampleIds] = useState<string[]>([]);
   const [failedSampleIds, setFailedSampleIds] = useState<string[]>([]);
+  const [badQCSampleIds, setBadQCSampleIds] = useState<string[]>([]);
   const [canEditSamples, setCanEditSamples] = useState<boolean>(false);
 
   const [isDeleteSampleModalOpen, setIsDeleteSampleModalOpen] =
@@ -36,9 +37,12 @@ const SampleTableModalManager = ({
     const failedIds = checkedSamples
       .filter((s) => s.CZBFailedGenomeRecovery)
       .map((s) => s.publicId);
-
+    const badQCIds = checkedSamples
+      .filter((s) => s.qc_metrics[0].qc_status === "bad")
+      .map((s) => s.publicId);
     setCheckedSampleIds(checkedIds);
     setFailedSampleIds(failedIds);
+    setBadQCSampleIds(badQCIds);
   }, [checkedSamples]);
 
   // determine whether selected samples can be edited
@@ -76,12 +80,14 @@ const SampleTableModalManager = ({
       <CreateNSTreeModal
         checkedSampleIds={checkedSampleIds}
         failedSampleIds={failedSampleIds}
+        badQCSampleIds={badQCSampleIds}
         open={isNSCreateTreeModalOpen}
         onClose={() => setIsNSCreateTreeModalOpen(false)}
       />
       <UsherTreeFlow
         checkedSampleIds={checkedSampleIds}
         failedSampleIds={failedSampleIds}
+        badQCSampleIds={badQCSampleIds}
         shouldStartUsherFlow={shouldStartUsherFlow}
       />
       <DeleteSamplesConfirmationModal

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
@@ -38,7 +38,8 @@ const SampleTableModalManager = ({
       .filter((s) => s.CZBFailedGenomeRecovery)
       .map((s) => s.publicId);
     const badQCIds = checkedSamples
-      .filter((s) => s.qc_metrics[0].qc_status === "bad")
+      // for now there should only ever be one qcMetrics entry per sample
+      .filter((s) => s.qcMetrics[0].qc_status === "bad")
       .map((s) => s.publicId);
     setCheckedSampleIds(checkedIds);
     setFailedSampleIds(failedIds);


### PR DESCRIPTION
### Summary:
- **What:** adds option to download nextclade csv file from the download modal
- **Ticket:** [sc197083](https://app.shortcut.com/genepi/story/197083)
- **Env:** `<rdev link>`

### Demos:
<img width="561" alt="Screenshot 2022-12-13 at 8 13 53 AM" src="https://user-images.githubusercontent.com/13052132/207388606-b142b525-daff-4b9f-9d96-69836e0c07fd.png">
<img width="597" alt="Screenshot 2022-12-13 at 8 13 38 AM" src="https://user-images.githubusercontent.com/13052132/207388611-c82dabe4-4720-498b-a3e0-90173b32c930.png">
<img width="597" alt="Screenshot 2022-12-13 at 8 13 22 AM" src="https://user-images.githubusercontent.com/13052132/207388617-771c9a73-a826-4712-a1e8-5881d7c1ab9a.png">
<img width="497" alt="Screenshot 2022-12-13 at 8 30 28 AM" src="https://user-images.githubusercontent.com/13052132/207389941-25794f5c-b311-4d7e-a3a5-e1120d79bf57.png">




### Notes:
still working on getting the rdev setup! 

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)