### PR TITLE
[SC-228363] bring back lineage tooltip

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/index.tsx
@@ -69,7 +69,7 @@ export const LineageTooltip = ({ children, lineage }: Props): JSX.Element => {
       width="wide"
       data-test-id="lineage-tooltip"
     >
-      <>{children}</>
+      <div>{children}</div>
     </Tooltip>
   );
 };

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTypeTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTypeTooltip/index.tsx
@@ -46,6 +46,8 @@ export const TreeTypeTooltip = ({ children, value }: Props): JSX.Element => {
     </div>
   );
 
+  // TODO-TR (ehoops): The lineage tooltip wasn't showing when children was wrapped in a fragment rather than a div
+  // todo is to verify this tooltip shows and if it doesn't, wrap it in a div.
   return (
     <Tooltip arrow placement="bottom-start" title={TOOLTIP_TEXT}>
       {children}


### PR DESCRIPTION
### Summary:
- **What:** `Lineage tooltip didn't display, now it does`
- **Ticket:** [sc228363](https://app.shortcut.com/genepi/story/228363)
- **Env:** `none`

### Demos:
![Screenshot 2022-12-13 at 9 12 45 AM](https://user-images.githubusercontent.com/109251328/207400054-b544c19d-33f9-4f40-ac11-c740b30d0a9a.png)

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)