### PR TITLE
Fix usher linkout for mpx

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/UsherTreeFlow/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/UsherTreeFlow/index.tsx
@@ -16,9 +16,10 @@ interface Props {
   shouldStartUsherFlow: boolean;
 }
 
-const USHER_DBS: PathogenConfigType<string> = {
-  [Pathogen.COVID]: "wuhCor1",
-  [Pathogen.MONKEY_POX]: "hub_3471181_GCF_014621545.1",
+const USHER_PATHOGEN_PARAMS: PathogenConfigType<string> = {
+  [Pathogen.COVID]: "db=wuhCor1",
+  [Pathogen.MONKEY_POX]:
+    "db=hub_3471181_GCF_014621545.1&hgHubConnect.hub.3471181=1",
 };
 
 const generateUsherLink = (
@@ -29,13 +30,12 @@ const generateUsherLink = (
 ) => {
   const encodedFileLink = encodeURIComponent(remoteFile);
 
-  const DB_PARAM = `db=${USHER_DBS[pathogen]}`;
   const FILE_PARAM = `remoteFile=${encodedFileLink}`;
   const TREE_TYPE_PARAM = `phyloPlaceTree=${treeType}`;
   const SAMPLE_COUNT_PARAM = `subtreeSize=${sampleCount}`;
 
   const queryParams = [
-    DB_PARAM,
+    USHER_PATHOGEN_PARAMS[pathogen],
     FILE_PARAM,
     TREE_TYPE_PARAM,
     SAMPLE_COUNT_PARAM,


### PR DESCRIPTION
### Summary:
- **What:** Linkouts to UShER for Mpox trees weren't working because there's an **undocumented** parameter that was missing from our URL's

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)