### PR TITLE
SC-228635 Collection location bug

### DIFF
--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -160,7 +160,7 @@ const PrivateId = ({
 
 const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
   collectionLocation: ({ value }): JSX.Element => {
-    const location = value.location ?? value.division;
+    const location = value.location ?? value.division ?? value.country;
     return (
       <RowContent>
         <Cell data-test-id="row-collectionLocation">{location}</Cell>

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -232,7 +232,7 @@ const columns: ColumnDef<Sample, any>[] = [
       </SortableHeader>
     ),
     cell: ({ getValue }) => {
-      const { lineage } = getValue();
+      const lineage = getValue()?.lineage;
       const CellContent = (
         <StyledCellBasic
           shouldTextWrap
@@ -269,7 +269,9 @@ const columns: ColumnDef<Sample, any>[] = [
     cell: ({ getValue }) => (
       <StyledCellBasic
         shouldTextWrap
-        primaryText={getValue().location}
+        primaryText={
+          getValue().location || getValue().division || getValue().country
+        }
         primaryTextWrapLineCount={2}
         shouldShowTooltipOnHover={false}
       />


### PR DESCRIPTION
### Summary:
- **What:** `Show collection country if division and location are not available.`
- **Ticket:** [sc228635](https://app.shortcut.com/genepi/story/228635)
- **Env:** `none`

### Demos:
![Screenshot 2022-12-16 at 9 38 57 AM](https://user-images.githubusercontent.com/109251328/208156986-684eba06-4c93-425b-824e-480723932d35.png)
![Screenshot 2022-12-16 at 9 36 08 AM](https://user-images.githubusercontent.com/109251328/208156993-3b917a7e-1c85-4ae1-88c2-1a2d700e1397.png)


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)