### PR TITLE
SC-228652 Hide trees tab for mpox.

### DIFF
--- a/src/frontend/src/views/Data/components/DataNavigation/index.tsx
+++ b/src/frontend/src/views/Data/components/DataNavigation/index.tsx
@@ -1,8 +1,11 @@
 import { Tab } from "czifui";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import { useNewPhyloRunInfo as usePhyloRunInfo } from "src/common/queries/phyloRuns";
 import { useNewSampleInfo as useSampleInfo } from "src/common/queries/samples";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { ROUTES } from "src/common/routes";
 import { DataCategory } from "src/common/types/data";
 import { FilterPanelToggle } from "./FilterPanelToggle";
@@ -28,6 +31,7 @@ const DataNavigation = ({
   shouldShowSampleFilterToggle,
   toggleFilterPanel,
 }: Props): JSX.Element => {
+  const pathogen = useSelector(selectCurrentPathogen);
   const [currentTab, setCurrentTab] = useState<ROUTES>(ROUTES.DATA_SAMPLES);
   const [tabData, setTabData] = useState<Partial<DataCategory>[]>([]);
 
@@ -79,15 +83,26 @@ const DataNavigation = ({
         />
       )}
       <StyledTabs value={currentTab} sdsSize="large" onChange={handleTabClick}>
-        {tabData.map((tab) => (
-          <Tab
-            key={tab.to}
-            value={tab.to}
-            label={tab.text}
-            count={tab.count}
-            data-test-id={`menu-item-${tab.to}`}
-          />
-        ))}
+        {tabData.map((tab) => {
+          // NOTE!! Here we are temporarily hiding the tree tab for monkeypox until
+          // we complete the functionality next quarter. For features that will be
+          // hidden long-term, a config would be more appropriate than this if statement.
+          if (
+            pathogen === Pathogen.MONKEY_POX &&
+            tab.to === ROUTES.PHYLO_TREES
+          ) {
+            return;
+          }
+          return (
+            <Tab
+              key={tab.to}
+              value={tab.to}
+              label={tab.text}
+              count={tab.count}
+              data-test-id={`menu-item-${tab.to}`}
+            />
+          );
+        })}
       </StyledTabs>
     </Navigation>
   );

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -9,6 +9,7 @@ import { useProtectedRoute } from "src/common/queries/auth";
 import { usePhyloRunInfo } from "src/common/queries/phyloRuns";
 import { useSampleInfo } from "src/common/queries/samples";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { Pathogen } from "src/common/redux/types";
 import { DataCategory, Transform } from "src/common/types/data";
 import {
   IdMap,
@@ -160,9 +161,18 @@ const Data: FunctionComponent = () => {
   };
 
   // create JSX elements from categories
-  dataCategories.forEach((category) => {
+  const menuItemsOrNull = dataCategories.map((category) => {
+    // NOTE!! Here we are temporarily hiding the tree tab for monkeypox until
+    // we complete the functionality next quarter. For features that will be
+    // hidden long-term, a config would be more appropriate than this if statement.
+    if (
+      pathogen === Pathogen.MONKEY_POX &&
+      category.to === ROUTES.PHYLO_TREES
+    ) {
+      return null;
+    }
     const item = category.text.replace(" ", "-").toLowerCase();
-    dataJSX.menuItems.push(
+    return (
       <StyledMenuItem key={category.text}>
         <NextLink href={category.to} key={category.text} passHref>
           <a href="passHref">
@@ -182,6 +192,11 @@ const Data: FunctionComponent = () => {
       </StyledMenuItem>
     );
   });
+
+  // TODO: (ehoops) - once trees are re-enabled for mpx, we can remove this.
+  dataJSX.menuItems = menuItemsOrNull.filter(
+    (item) => item !== null
+  ) as Array<JSX.Element>; // Casting here because typescript thinks this can still be null.
 
   const subTitle = currentPath.startsWith(ROUTES.DATA_SAMPLES)
     ? "Samples"


### PR DESCRIPTION
### Summary:
- **What:** `Hide trees tab for mpox.`
- **Ticket:** [sc228652](https://app.shortcut.com/genepi/story/228652)
- **Env:** `<rdev link>`

### Demos:
![Screenshot 2022-12-16 at 10 56 16 AM](https://user-images.githubusercontent.com/109251328/208169556-333faece-2b35-4819-b07d-b98a5aa51720.png)
![Screenshot 2022-12-16 at 10 55 05 AM](https://user-images.githubusercontent.com/109251328/208169560-491cac95-d538-4623-9eba-7604076a55c1.png)

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)