### PR TITLE
adding tooltips to qc_status tags

### DIFF
--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -3,10 +3,6 @@
 import { useTreatments } from "@splitsoftware/splitio-react";
 import { ChipProps, Icon } from "czifui";
 import {
-  TooltipDescriptionText,
-  TooltipHeaderText,
-} from "src/common/components/library/data_subview/style";
-import {
   defaultSampleCellRenderer,
   defaultTreeCellRenderer,
 } from "src/common/components/library/data_table";

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -110,7 +110,7 @@ const PrivateId = ({
         or bioinformatics errors. Learn more.
         <NewTabLink
           href={
-            "https://help.czgenepi.org/hc/en-us/articles/11569567939604-Download-QC-Metrics-and-Mutation-Data"
+            "https://docs.nextstrain.org/projects/nextclade/en/stable/user/algorithm/07-quality-control.html"
           }
         >
           Learn more

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -3,6 +3,10 @@
 import { useTreatments } from "@splitsoftware/splitio-react";
 import { ChipProps, Icon } from "czifui";
 import {
+  TooltipDescriptionText,
+  TooltipHeaderText,
+} from "src/common/components/library/data_subview/style";
+import {
   defaultSampleCellRenderer,
   defaultTreeCellRenderer,
 } from "src/common/components/library/data_table";
@@ -11,12 +15,14 @@ import {
   RowContent,
   TreeRowContent,
 } from "src/common/components/library/data_table/style";
+import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { createTableCellRenderer } from "src/common/utils";
 import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
 import { isUserFlagOn } from "src/components/Split";
 import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { CZ_BIOHUB_GROUP } from "src/views/Data/constants";
 import { LineageTooltip } from "./components/SamplesView/components/SamplesTable/components/LineageTooltip";
+import { StatusChip } from "./components/StatusChip";
 import { TreeActionMenu } from "./components/TreesView/components/TreesTable/components/TreeActionMenu";
 import TreeTableNameCell from "./components/TreesView/components/TreesTable/components/TreeTableNameCell";
 import { TreeTypeTooltip } from "./components/TreesView/components/TreesTable/components/TreeTypeTooltip";
@@ -25,7 +31,6 @@ import {
   GISAIDCell,
   PrivateIdValueWrapper,
   SampleIconWrapper,
-  StyledChip,
   StyledUploaderName,
   Subtext,
   UnderlinedCell,
@@ -92,9 +97,44 @@ const PrivateId = ({
     ? LABEL_STATUS.errorGenomeRecovery
     : LABEL_STATUS.successGenomeRecovery;
 
+  const PROCESSING_STATUS_TOOLTIP_TEXT = (
+    <div>
+      <div>
+        This sample doesn’t currently have a quality score because it is still
+        processing. Score will update when complete.
+      </div>
+    </div>
+  );
+
+  const GENERIC_STATUS_TOOLTIP_TEXT = (
+    <div>
+      <div>
+        <b>Quality Score: </b> Overall QC score from Nextclade which considers
+        genome completion and screens for potential contamination and sequencing
+        or bioinformatics errors. Learn more.
+        <NewTabLink
+          href={
+            "https://help.czgenepi.org/hc/en-us/articles/11569567939604-Download-QC-Metrics-and-Mutation-Data"
+          }
+        >
+          Learn more
+        </NewTabLink>
+      </div>
+    </div>
+  );
+
+  const FAILED_STATUS_TOOLTIP_TEXT = (
+    <div>
+      <div>
+        QC may fail when the sequence processing failed due to quality, or if
+        the uploaded sequence does not represent the correct pathogen
+      </div>
+    </div>
+  );
+
   const labelQCStatus = () => {
     const qcStatus = qcMetrics[0]?.qc_status;
-    switch (qcStatus) {
+    switch (qcStatus.toLowerCase()) {
       case "good":
         return LABEL_STATUS.success;
       case "bad":
@@ -107,6 +147,24 @@ const PrivateId = ({
         return LABEL_STATUS.processing;
     }
   };
+
+  const qcStatusLabel = labelQCStatus();
+
+  const LABEL_TO_TOOLTIP_TEXT: Record<string, JSX.Element> = {
+    processing: PROCESSING_STATUS_TOOLTIP_TEXT,
+    bad: GENERIC_STATUS_TOOLTIP_TEXT,
+    good: GENERIC_STATUS_TOOLTIP_TEXT,
+    mediocre: GENERIC_STATUS_TOOLTIP_TEXT,
+    failed: FAILED_STATUS_TOOLTIP_TEXT,
+  };
+
+  const label = usesNextcladeDownload
+    ? qcStatusLabel.label
+    : labelCZBFailedGenomeRecovery.label;
+
+  const status = usesNextcladeDownload
+    ? qcStatusLabel?.status
+    : labelCZBFailedGenomeRecovery.status;
 
   const displayName =
     submittingGroup?.name === CZ_BIOHUB_GROUP ? "CZ Biohub" : uploadedBy?.name;
@@ -134,19 +192,10 @@ const PrivateId = ({
         <PrivateIdValueWrapper>
           <CenteredFlexContainer>
             <span data-test-id="row-private-id">{value}</span>
-            <StyledChip
-              data-test-id="row-sample-status"
-              size="small"
-              label={
-                usesNextcladeDownload
-                  ? labelQCStatus()?.label
-                  : labelCZBFailedGenomeRecovery.label
-              }
-              status={
-                usesNextcladeDownload
-                  ? labelQCStatus()?.status
-                  : labelCZBFailedGenomeRecovery.status
-              }
+            <StatusChip
+              label={label}
+              status={status}
+              tooltipText={LABEL_TO_TOOLTIP_TEXT[label]}
             />
           </CenteredFlexContainer>
           <StyledUploaderName data-test-id="row-user-name">

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadMenuSelection/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadMenuSelection/index.tsx
@@ -56,7 +56,6 @@ const DownloadMenuSelection = ({
   return (
     <Tooltip
       arrow
-      inverted
       title={tooltipTitle}
       disableHoverListener={!isDisabled}
       placement="top"

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 import DialogActions from "src/common/components/library/Dialog/components/DialogActions";
 import DialogContent from "src/common/components/library/Dialog/components/DialogContent";
 import DialogTitle from "src/common/components/library/Dialog/components/DialogTitle";
+import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { Pathogen } from "src/common/redux/types";
 import {
@@ -121,11 +122,8 @@ const DownloadModal = ({
   );
   const NO_NEXTCLADE_DATA_TOOLTIP_TEXT = (
     <div>
-      <TooltipHeaderText>No QC data available for download.</TooltipHeaderText>
-      <TooltipDescriptionText>
-        Select at least 1 sample with a QC Status of good, mediocre, or bad to
-        proceed.
-      </TooltipDescriptionText>
+      <b>No QC data available for download.</b> Select at least 1 sample with a
+      QC Status of good, mediocre, or bad to proceed.
     </div>
   );
 
@@ -186,7 +184,14 @@ const DownloadModal = ({
                   fileTypes=".csv"
                 >
                   Download a list of nucelotide and protein mutations and QC
-                  metrics for the selected samples. Learn More.
+                  metrics for the selected samples.{" "}
+                  <NewTabLink
+                    href={
+                      "https://help.czgenepi.org/hc/en-us/articles/11569567939604-Download-QC-Metrics-and-Mutation-Data"
+                    }
+                  >
+                    Learn more
+                  </NewTabLink>
                 </DownloadMenuSelection>
               )}
               {isGisaidTemplateEnabled && (

--- a/src/frontend/src/views/Data/components/StatusChip/index.tsx
+++ b/src/frontend/src/views/Data/components/StatusChip/index.tsx
@@ -1,0 +1,34 @@
+import { ChipProps, Tooltip } from "czifui";
+import { useState } from "react";
+import { StyledChip } from "../../style";
+
+interface Props {
+  label: string;
+  status: ChipProps["status"];
+  tooltipText: JSX.Element;
+}
+
+const StatusChip = ({ label, status, tooltipText }: Props): JSX.Element => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+  return (
+    <Tooltip
+      arrow
+      title={tooltipText}
+      placement="top"
+      PopperProps={{
+        anchorEl,
+      }}
+    >
+      <span onMouseOver={(e) => setAnchorEl(e.currentTarget)}>
+        <StyledChip
+          data-test-id="row-sample-status"
+          size="small"
+          label={label}
+          status={status}
+        />
+      </span>
+    </Tooltip>
+  );
+};
+
+export { StatusChip };


### PR DESCRIPTION
### Summary:
- **What:** add in tooltips for qc_status tags, also add in learn more links, address some design issues
- **Ticket:** [sc228641](https://app.shortcut.com/genepi/story/228641)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)