### PR TITLE
Pin to an older version of augur libraries

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -1,4 +1,4 @@
-FROM nextstrain/base
+FROM nextstrain/base:build-20221207T221900Z
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer = "CZ Gen Epi"

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -1,7 +1,7 @@
 ## Dockerfile for aspen batch jobs
 ##
 ##
-FROM nextstrain/base
+FROM nextstrain/base:build-20221207T221900Z
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer = "CZ Gen Epi"


### PR DESCRIPTION
### Summary:
- **What:** Our nextstrain and gisaid builds are failing because of an incompatibility in the latest version of the `nextstrain/base` docker image that also upgrades the augur libraries. This pins to an older version
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Notes:
Our builds were failing due to this error:
```
Traceback (most recent call last):
  File "/ncov/scripts/sanitize_metadata.py", line 2, in <module>
    from augur.io import open_file, read_metadata
ImportError: cannot import name 'open_file' from 'augur.io' (/nextstrain/augur/augur/io/__init__.py)
```

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)