### PR TITLE
clear checked samples after download modal close [EZPZ]

### DIFF
--- a/src/frontend/src/common/components/library/data_subview/index.tsx
+++ b/src/frontend/src/common/components/library/data_subview/index.tsx
@@ -136,6 +136,7 @@ const DataSubview: FunctionComponent<Props> = ({
 
   const handleDownloadClose = () => {
     setDownloadModalOpen(false);
+    setCheckedSampleIds([]);
   };
 
   useEffect(() => {

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
@@ -76,7 +76,10 @@ const SampleTableModalManager = ({
         checkedSamples={checkedSamples}
         failedSampleIds={failedSampleIds}
         open={isDownloadModalOpen}
-        onClose={() => setIsDownloadModalOpen(false)}
+        onClose={() => {
+          setIsDownloadModalOpen(false);
+          clearCheckedSamples();
+        }}
       />
       <CreateNSTreeModal
         checkedSampleIds={checkedSampleIds}


### PR DESCRIPTION
### Summary:
- **What:** I noticed a bug while checking staging that samples do not clear after the modal is closed [this issue existed before the nextclade download was introduced]
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)