### PR TITLE
Remove extra Learn More from QC tooltip.

### DIFF
--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -107,7 +107,7 @@ const PrivateId = ({
       <div>
         <b>Quality Score: </b> Overall QC score from Nextclade which considers
         genome completion and screens for potential contamination and sequencing
-        or bioinformatics errors. Learn more.
+        or bioinformatics errors.
         <NewTabLink
           href={
             "https://docs.nextstrain.org/projects/nextclade/en/stable/user/algorithm/07-quality-control.html"

--- a/src/frontend/src/views/Data/table-headers/commonSampleHeaders.tsx
+++ b/src/frontend/src/views/Data/table-headers/commonSampleHeaders.tsx
@@ -117,7 +117,7 @@ export const QC_METRICS_HEADER: Header = {
       linkText: "Learn more.",
     },
     regularText:
-      "Overall QC score from Nextclade which considers genome completion and screens for potential contamination and sequencing or bioinformatics errors. Learn more.",
+      "Overall QC score from Nextclade which considers genome completion and screens for potential contamination and sequencing or bioinformatics errors.",
   },
 };
 


### PR DESCRIPTION
### Summary:
- **What:** `Remove extra Learn More from QC tooltip.`
- **Ticket:** none
- **Env:** `none`

### Demos:
![Screenshot 2023-01-03 at 4 02 17 PM](https://user-images.githubusercontent.com/109251328/210461233-d511618d-aae0-4599-970d-59694f30012e.png)

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)