### PR TITLE
add info tooltip to createnstreemodal header

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -261,6 +261,15 @@ export const CreateNSTreeModal = ({
     </div>
   );
 
+  const HEADER_TOOLTIP_TEXT = (
+    <div>
+      Visit our help center to{" "}
+      <NewTabLink href="https://help.czgenepi.org/hc/en-us/articles/6712563575956-Build-on-demand-trees">
+        learn more about building Nextstrain trees in CZ GEN EPI.
+      </NewTabLink>
+    </div>
+  );
+
   const allPossibleTreeSamples = checkedSampleIds.concat(validatedInputSamples);
   const allFailedOrMissingSamples = failedSampleIds.concat(missingInputSamples);
   const allValidSamplesForTreeCreation = allPossibleTreeSamples.filter(
@@ -310,7 +319,20 @@ export const CreateNSTreeModal = ({
               <Icon sdsIcon="xMark" sdsSize="l" sdsType="static" />
             </StyledCloseIconWrapper>
           </StyledCloseIconButton>
-          <Header>Create New Phylogenetic Tree</Header>
+          <Header>
+            Create New Phylogenetic Tree
+            <StyledTooltip
+              arrow
+              leaveDelay={1000}
+              title={HEADER_TOOLTIP_TEXT}
+              placement="top"
+              data-test-id="header-tooltip"
+            >
+              <StyledInfoIconWrapper>
+                <Icon sdsIcon="infoCircle" sdsSize="s" sdsType="interactive" />
+              </StyledInfoIconWrapper>
+            </StyledTooltip>
+          </Header>
           <Title data-test-id="title-with-sample-total">
             {allSamplesRequestedTableAndInput.length}{" "}
             {pluralize("Sample", allValidSamplesForTreeCreation.length)} Total

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/style.ts
@@ -14,6 +14,7 @@ import {
 
 export const Header = styled.div`
   ${fontHeaderXl}
+  display: flex;
 `;
 
 export const Content = styled.div`


### PR DESCRIPTION
### Summary
- **What:** Add tooltip to NS tree modal header linking to help center article
- **Why:** Aid users in creating trees
- **Ticket:** [[sc-227223]](https://app.shortcut.com/genepi/story/227223)
- **Env:** https://maya-info-frontend.dev.czgenepi.org/
- **Design:** https://www.figma.com/file/anSx7d4wui5D9c8TEeaGGo/Create-Tree---Help-link-refinement?node-id=34%3A76959

### Demos
![after](https://user-images.githubusercontent.com/7562933/210895184-40b1a507-61a4-476a-955c-7d29b444295b.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)