### PR TITLE
[SC-228205] Create Nextstrain tree modal Sample box copy

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
@@ -25,7 +25,10 @@ const InputInstructions = (): JSX.Element => {
           <div key={1}>
             Add{" "}
             <SemiBold>
-              {InputInstructionsPathogenStrings[pathogen].publicRepositoryIds}
+              {
+                InputInstructionsPathogenStrings[pathogen]
+                  .publicRepositoryIdType
+              }
             </SemiBold>{" "}
             (e.g.{" "}
             {

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/index.tsx
@@ -1,8 +1,12 @@
+import { useSelector } from "react-redux";
 import { NewTabLink } from "src/common/components/library/NewTabLink";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
+import { InputInstructionsPathogenStrings } from "./strings";
 import { SemiBold, StyledWrapper } from "./style";
 
 const InputInstructions = (): JSX.Element => {
+  const pathogen = useSelector(selectCurrentPathogen);
   return (
     <StyledWrapper>
       <CollapsibleInstructions
@@ -19,9 +23,16 @@ const InputInstructions = (): JSX.Element => {
             </NewTabLink>
           </div>,
           <div key={1}>
-            Add <SemiBold>GISAID IDs</SemiBold> (e.g. USA/CA-CZB-0000/2021,
-            hCoV-19/USA/CA-CZB-0000/2021 or EPI_ISL_0000),{" "}
-            <SemiBold>CZ GEN EPI Public IDs</SemiBold>, or{" "}
+            Add{" "}
+            <SemiBold>
+              {InputInstructionsPathogenStrings[pathogen].publicRepositoryIds}
+            </SemiBold>{" "}
+            (e.g.{" "}
+            {
+              InputInstructionsPathogenStrings[pathogen]
+                .publicRepositoryIdExamples
+            }
+            ), <SemiBold>CZ GEN EPI Public IDs</SemiBold>, or{" "}
             <SemiBold>CZ GEN EPI Private IDs</SemiBold> below to include samples
             in your tree.
           </div>,

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/strings.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/strings.ts
@@ -1,0 +1,20 @@
+import { Pathogen } from "src/common/redux/types";
+import { PathogenConfigType } from "src/common/types/pathogenConfig";
+
+interface InputInstructionsStrings {
+  publicRepositoryIds: string;
+  publicRepositoryIdExamples: string;
+}
+
+export const InputInstructionsPathogenStrings: PathogenConfigType<InputInstructionsStrings> =
+  {
+    [Pathogen.COVID]: {
+      publicRepositoryIds: "GISAID IDs",
+      publicRepositoryIdExamples:
+        "USA/CA-CZB-0000/2021, hCoV-19/USA/CA-CZB-0000/2021 or EPI_ISL_0000",
+    },
+    [Pathogen.MONKEY_POX]: {
+      publicRepositoryIds: "GenBank accession numbers",
+      publicRepositoryIdExamples: "U12345 or AF123456",
+    },
+  };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/strings.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/components/InputInstructions/strings.ts
@@ -2,19 +2,19 @@ import { Pathogen } from "src/common/redux/types";
 import { PathogenConfigType } from "src/common/types/pathogenConfig";
 
 interface InputInstructionsStrings {
-  publicRepositoryIds: string;
+  publicRepositoryIdType: string;
   publicRepositoryIdExamples: string;
 }
 
 export const InputInstructionsPathogenStrings: PathogenConfigType<InputInstructionsStrings> =
   {
     [Pathogen.COVID]: {
-      publicRepositoryIds: "GISAID IDs",
+      publicRepositoryIdType: "GISAID IDs",
       publicRepositoryIdExamples:
         "USA/CA-CZB-0000/2021, hCoV-19/USA/CA-CZB-0000/2021 or EPI_ISL_0000",
     },
     [Pathogen.MONKEY_POX]: {
-      publicRepositoryIds: "GenBank accession numbers",
+      publicRepositoryIdType: "GenBank accession numbers",
       publicRepositoryIdExamples: "U12345 or AF123456",
     },
   };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/index.tsx
@@ -1,13 +1,16 @@
 import { Icon } from "czifui";
 import { compact, filter } from "lodash";
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import { INPUT_DELIMITERS } from "src/common/constants/inputDelimiters";
 import {
   SampleValidationResponseType,
   useValidateSampleIds,
 } from "src/common/queries/samples";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { pluralize } from "src/common/utils/strUtils";
 import { InputInstructions } from "./components/InputInstructions";
+import { SampleIdInputPathogenStrings } from "./strings";
 import {
   BaselineFlexContainer,
   FlexContainer,
@@ -29,6 +32,7 @@ const SampleIdInput = ({
   handleInputValidation,
   shouldReset,
 }: Props): JSX.Element => {
+  const pathogen = useSelector(selectCurrentPathogen);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
   const [hasEverSubmittedSampleIds, setHasEverSubmittedSampleIds] =
     useState<boolean>(false);
@@ -155,7 +159,7 @@ const SampleIdInput = ({
         variant="outlined"
         rows={!isInEditMode ? 4 : 3}
         value={isInEditMode ? inputValue : inputDisplayValue}
-        placeholder="e.g. USA/CA-CZB-0000/2021, USA/CA-CDPH-000000/2021"
+        placeholder={SampleIdInputPathogenStrings[pathogen].idPlaceholderText}
         data-test-id="force-include-sample-id"
       />
       {shouldShowAddButton && (

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/strings.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/components/SampleIdInput/strings.ts
@@ -1,0 +1,16 @@
+import { Pathogen } from "src/common/redux/types";
+import { PathogenConfigType } from "src/common/types/pathogenConfig";
+
+interface SampleIdInputStrings {
+  idPlaceholderText: string;
+}
+
+export const SampleIdInputPathogenStrings: PathogenConfigType<SampleIdInputStrings> =
+  {
+    [Pathogen.COVID]: {
+      idPlaceholderText: "e.g. USA/CA-CZB-0000/2021, USA/CA-CDPH-000000/2021",
+    },
+    [Pathogen.MONKEY_POX]: {
+      idPlaceholderText: "e.g. U12345, AF123456",
+    },
+  };


### PR DESCRIPTION
### Summary:
- **What:** `Create Nextstrain tree modal Sample box copy`
- **Ticket:** [SC-228205](https://app.shortcut.com/genepi/story/228205)
- **Env:** `none`

### Demos:
![Screenshot 2023-01-10 at 9 31 19 AM](https://user-images.githubusercontent.com/109251328/211622357-0cdaad32-a83c-4f76-ae11-cd97e6521330.png)
![Screenshot 2023-01-10 at 9 30 24 AM](https://user-images.githubusercontent.com/109251328/211622366-37aae854-296d-4a96-9c61-dfb91ac19ede.png)

### Notes:
If you want to test this locally, you'll need to switch the local pathogen split flag for `[PATHOGEN_FEATURE_FLAGS.nextstrain_enabled]: {` to ON in order to open the modal.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)