### PR TITLE
remove czb failed genome recovery from sa models

### DIFF
--- a/src/backend/aspen/database/models/sample.py
+++ b/src/backend/aspen/database/models/sample.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     func,
     Integer,
     JSON,
-    sql,
     String,
     text,
     UniqueConstraint,
@@ -176,17 +175,6 @@ class Sample(idbase, DictMixin):  # type: ignore
                 "PHA4GE": "specimen_processing",
             }
         },
-    )
-
-    czb_failed_genome_recovery = Column(
-        Boolean,
-        nullable=True,
-        default=False,
-        server_default=sql.expression.false(),
-        comment=(
-            "This is set to true iff this sample was sequenced by CZB and failed genome "
-            "recovery."
-        ),
     )
 
     accessions = relationship(


### PR DESCRIPTION
### Summary:
- **What:** once migration is applied, remove the czb_failed_genome_recovery field from the samples sql alchemy model
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)