### PR TITLE
remove pangolin fields from uploaded_pathogen_genome migration

### DIFF
--- a/src/backend/database_migrations/versions/20230112_223438_remove_pangolin_fields_upg.py
+++ b/src/backend/database_migrations/versions/20230112_223438_remove_pangolin_fields_upg.py
@@ -1,0 +1,26 @@
+"""
+
+Create Date: 2023-01-12 22:34:45.781948
+
+"""
+import enumtables  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20230112_223438"
+down_revision = "20230110_175025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("pathogen_genomes", "pangolin_probability", schema="aspen")
+    op.drop_column("pathogen_genomes", "pangolin_lineage", schema="aspen")
+    op.drop_column("pathogen_genomes", "pangolin_last_updated", schema="aspen")
+    op.drop_column("pathogen_genomes", "pangolin_version", schema="aspen")
+
+
+def downgrade():
+    raise NotImplementedError("Downgrade not supported.")


### PR DESCRIPTION
### Summary:
- **What:** migration to remove the pangolin fields from uploaded_pathogen_genome
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)