### PR TITLE
Stop using python 3.9

### DIFF
--- a/.happy/terraform/modules/sfn_config/pangolin.wdl
+++ b/.happy/terraform/modules/sfn_config/pangolin.wdl
@@ -43,7 +43,7 @@ task pangolin_workflow {
 
     cd /usr/src/app/aspen/workflows/pangolin
     ./update_pangolin.sh
-    /usr/local/bin/python3.9 find_samples.py --output-file "${SAMPLE_IDS_FILE}"
+    /usr/local/bin/python3 find_samples.py --output-file "${SAMPLE_IDS_FILE}"
     ./run_pangolin.sh
     >>>
 


### PR DESCRIPTION
### Summary:
- **What:** Fix pangolin workflow

### Notes:
We used to have multiple versions of python in some docker containers since we had a system-managed python and a miniconda-managed python. We've stopped using conda entirely so we only have a single version of python3, and that version is now 3.10. Just use the system managed `python3` alias to select the right python version automatically.

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)