### PR TITLE
Update rebuild_tests.sh

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/rebuild_tests.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/rebuild_tests.sh
@@ -22,6 +22,6 @@ python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'Nor
 python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'North America/Mexico//' --pathogen MPX --tree-type overview && cp nextstrain_build.yaml build_config_tests/overview_country.yaml
 
 # Non-contextualized
-python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'North America/Mexico/Michoacan/Morelia' --pathogen MPX --tree-type non_contextualized && cp nextstrain_build.yaml build_config_tests/noncontextualized_country.yaml
-python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'North America/Mexico/Michoacan/' --pathogen MPX --tree-type non_contextualized && cp nextstrain_build.yaml build_config_tests/noncontextualized_country.yaml
+python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'North America/Mexico/Michoacan/Morelia' --pathogen MPX --tree-type non_contextualized && cp nextstrain_build.yaml build_config_tests/noncontextualized_location.yaml
+python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'North America/Mexico/Michoacan/' --pathogen MPX --tree-type non_contextualized && cp nextstrain_build.yaml build_config_tests/noncontextualized_division.yaml
 python export_test.py --sequences 10 --gisaid 0 --group-name CZI --location 'North America/Mexico//' --pathogen MPX --tree-type non_contextualized && cp nextstrain_build.yaml build_config_tests/noncontextualized_country.yaml


### PR DESCRIPTION
The division and location level noncontextualized yaml [here](https://github.com/chanzuckerberg/czgenepi/blob/3841dcceed1d7ec0e45ebc25e046ef864bd03dca/src/backend/aspen/workflows/nextstrain_run/build_config_tests/noncontextualized_location.yaml#L25-L30) looks a bit odd: line 26 doesn't exist in other yamls, and line 29 is missing location/division. The yaml builder looks good to me so I think it may be the filename in test code has a mismatch so these yamls didn't get updated/refreshed with the newest yaml builder: 
<img width="564" alt="image" src="https://user-images.githubusercontent.com/20667188/213246152-6bd97e4d-ccc3-49eb-acd0-64d3b30713a2.png">

