### PR TITLE
fix 500 sample limit bug; remove static md table ff

### DIFF
--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -20,7 +20,6 @@ export enum USER_FEATURE_FLAGS {
   internal_user = "internal_user",
   multi_pathogen = "multi_pathogen",
   table_refactor = "table_refactor",
-  static_metadata_table = "static_metadata_table",
 }
 
 /**

--- a/src/frontend/src/views/Upload/components/Metadata/index.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/index.tsx
@@ -1,4 +1,3 @@
-import { useTreatments } from "@splitsoftware/splitio-react";
 import { Button, Link } from "czifui";
 import NextLink from "next/link";
 import { useCallback, useMemo, useState } from "react";
@@ -8,8 +7,6 @@ import { NewTabLink } from "src/common/components/library/NewTabLink";
 import { EMPTY_OBJECT, noop } from "src/common/constants/empty";
 import { ROUTES } from "src/common/routes";
 import { createStringToLocationFinder } from "src/common/utils/locationUtils";
-import { isUserFlagOn } from "src/components/Split";
-import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { WebformTable } from "src/components/WebformTable";
 import {
   Metadata as MetadataType,
@@ -49,22 +46,12 @@ export default function Metadata({
   const [autocorrectWarnings, setAutocorrectWarnings] =
     useState<SampleIdToWarningMessages>(EMPTY_OBJECT);
 
-  // Used for displaying a static metadata table
-  const flag = useTreatments([USER_FEATURE_FLAGS.static_metadata_table]);
-  const isStaticMetadataTableFlagOn = isUserFlagOn(
-    flag,
-    USER_FEATURE_FLAGS.static_metadata_table
-  );
-
   let numberOfDetectedSamples = 0;
   if (samples != null) {
     numberOfDetectedSamples = Object.keys(samples).length;
   }
 
-  let useStaticMetadataTable = false;
-  if (numberOfDetectedSamples >= 100 && isStaticMetadataTableFlagOn) {
-    useStaticMetadataTable = true;
-  }
+  const shouldUseStaticMetadataTable = numberOfDetectedSamples >= 100;
 
   // Used by file upload parser to convert location strings to Locations
   const stringToLocationFinder = useMemo(() => {
@@ -120,6 +107,7 @@ export default function Metadata({
       warningMessages.get(WARNING_CODE.AUTO_CORRECT) || EMPTY_OBJECT
     );
   }
+
   return (
     <>
       <HeadAppTitle subTitle="Metadata and Sharing" />
@@ -134,7 +122,7 @@ export default function Metadata({
         <Progress step="2" />
       </Header>
       <Content>
-        {useStaticMetadataTable && (
+        {shouldUseStaticMetadataTable && (
           <StyledCallout intent="info" autoDismiss={false} onClose={noop}>
             <B>Notice something different about this page?</B> When uploading
             100 or more samples, metadata must be imported from a TSV or CSV.
@@ -167,7 +155,7 @@ export default function Metadata({
           stringToLocationFinder={stringToLocationFinder}
         />
 
-        {useStaticMetadataTable && (
+        {shouldUseStaticMetadataTable && (
           <StaticTable
             metadata={metadata}
             setIsValid={setIsValid}
@@ -175,7 +163,7 @@ export default function Metadata({
           />
         )}
 
-        {!useStaticMetadataTable && (
+        {!shouldUseStaticMetadataTable && (
           <WebformTable
             setIsValid={setIsValid}
             metadata={metadata}

--- a/src/frontend/src/views/Upload/components/Samples/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/index.tsx
@@ -1,6 +1,5 @@
 import { Button, Icon } from "czifui";
 import Link from "next/link";
-import { useTreatments } from "@splitsoftware/splitio-react";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { HeadAppTitle } from "src/common/components";
@@ -8,8 +7,6 @@ import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { ROUTES } from "src/common/routes";
 import AlertAccordion from "src/components/AlertAccordion";
 import { CollapsibleInstructions } from "src/components/CollapsibleInstructions";
-import { isUserFlagOn } from "src/components/Split";
-import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import Progress from "../common/Progress";
 import {
   ButtonWrapper,
@@ -50,21 +47,13 @@ export default function Samples({ samples, setSamples }: Props): JSX.Element {
   const [isLoadingFile, setIsLoadingFile] = useState(false);
   const [tooManySamples, setTooManySamples] = useState(false);
 
-  const flag = useTreatments([USER_FEATURE_FLAGS.static_metadata_table]);
-  const isStaticMetadataTableFlagOn = isUserFlagOn(
-    flag,
-    USER_FEATURE_FLAGS.static_metadata_table
-  );
-
   useEffect(() => {
     if (samples) {
       const counts = getUploadCounts(samples);
       setSampleCount(counts.sampleCount);
       setFileCount(counts.fileCount);
-      let tooManySamples = Object.keys(samples).length > 500;
-      if (isStaticMetadataTableFlagOn) {
-        tooManySamples = false;
-      }
+      const tooManySamples = Object.keys(samples).length > 500;
+
       setTooManySamples(tooManySamples);
     }
   }, [samples]);


### PR DESCRIPTION
### Summary
- **What:** 
  - Fix a bug where the user could upload more than 500 samples at a time, despite seeing the error message that they couldn't
  - Remove the static metadata table feature flag
- **Why:** This feature is in production and the flag is no longer needed
- **Env:** https://maya-static-md-frontend.dev.czgenepi.org/

### Testing
1. Upload a sample .fasta file with more than 500 samples on the first step of the upload process
2. Ensure you cannot continue on to add metadata until fewer samples are added

### Demos
#### Before (see `Continue` button not disabled)
![Screenshot 2023-01-18 at 12 49 11 PM](https://user-images.githubusercontent.com/7562933/213291509-a784dae4-472b-420d-be25-f50ceb672fdc.png)

#### After (see `Continue` button properly disabled)
![Screenshot 2023-01-18 at 12 48 22 PM](https://user-images.githubusercontent.com/7562933/213291733-5eddb59d-ddd9-4334-9167-d742b65abe32.png)

### Notes
- I assume nothing else has to be done on this project so the feature flag was completely removed from the code base
- I assumed that we still want to use the original table in cases where the user uploads fewer than 100 samples, so I changed the conditional that switched between the two conditions, and left in the new and old tables. The old table will be used when the number of samples is small, and the new one will be used when the number of samples is large.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)