### PR TITLE
Fix the Augur CLI

### DIFF
--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -85,5 +85,7 @@ LABEL branch=${HAPPY_BRANCH}
 LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}
 ENV COMMIT_BRANCH=${HAPPY_BRANCH}
+# TODO - temporary workaround
+RUN pip install jsonschema==3.*
 
 WORKDIR /nextstrain

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -65,4 +65,7 @@ COPY . .
 # Install the aspen package
 RUN poetry install
 
+# TODO - temporary workaround
+RUN pip install jsonschema==3.*
+
 WORKDIR /nextstrain

--- a/src/backend/aspen/workflows/import_pango_lineages/.gitignore
+++ b/src/backend/aspen/workflows/import_pango_lineages/.gitignore
@@ -1,0 +1,1 @@
+*_lineage_notes.txt

--- a/src/backend/aspen/workflows/test-nextstrain.sh
+++ b/src/backend/aspen/workflows/test-nextstrain.sh
@@ -5,3 +5,4 @@ python3 /usr/src/app/aspen/workflows/nextstrain_run/error.py --test --phylo-run-
 touch test.txt
 touch /tmp/test.json
 python3 /usr/src/app/aspen/workflows/nextstrain_run/save.py --test --aspen-workflow-rev test --aspen-creation-rev test --ncov-rev test --aspen-docker-image-version test --end-time 1234 --phylo-run-id 1234 --bucket test --key test --resolved-template-args /tmp/test.json --tree-path test.txt
+augur filter --help


### PR DESCRIPTION
### Summary:
- **What:** This is a quickfix (hack, frankly) to update one of Augur's dependencies to a version it's happy with. We can/should investigate this further and come up with a cleaner fix, but should get trees working again in the meantime.
- **why:** We recently updated poetry, and it requires `jsonschema` version 4+, and `augur` requires `jsonschema` 3.x. It was error'ing with the following message:

![Screenshot 2023-01-18 at 4 02 16 PM](https://user-images.githubusercontent.com/475208/213324309-57d8e2d9-7cae-4ab9-8f2f-0c4cb7322715.png)

I've added a test to our CI job that ensures augur doesn't fail due to import problems.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)