### PR TITLE
Performance improvements and style updates for samples table

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -2378,6 +2378,11 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
+    "@reach/observe-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
+    },
     "@sinclair/typebox": {
       "version": "0.24.44",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.44.tgz",
@@ -10475,6 +10480,14 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtual": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
+      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
+      "requires": {
+        "@reach/observe-rect": "^1.1.0"
       }
     },
     "react-virtualized-auto-sizer": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -69,6 +69,7 @@
     "react-csv": "^2.1.7",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.2",
+    "react-virtual": "^2.10.4",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",
     "redux": "^4.2.0",

--- a/src/frontend/src/common/styles/appStyle.ts
+++ b/src/frontend/src/common/styles/appStyle.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 export const StyledApp = styled.div`
-  height: 100vh;
+  height: 99vh;
   flex-flow: column wrap;
   justify-content: center;
 `;

--- a/src/frontend/src/common/utils/memo.ts
+++ b/src/frontend/src/common/utils/memo.ts
@@ -1,0 +1,19 @@
+import React, { PropsWithChildren, SFC } from "react";
+
+export const memo = <P extends Record<string, unknown>>(
+  Component: SFC<P>,
+  propsAreEqual?: (
+    prevProps: Readonly<PropsWithChildren<P>>,
+    nextProps: Readonly<PropsWithChildren<P>>
+  ) => boolean
+) => {
+  const memoized = React.memo(Component, propsAreEqual);
+
+  Object.defineProperty(memoized, "displayName", {
+    set(name) {
+      Component.displayName = name;
+    },
+  });
+
+  return memoized;
+};

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/DefaultCell/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/DefaultCell/index.tsx
@@ -1,4 +1,5 @@
 import { Cell, Getter } from "@tanstack/react-table";
+import { memo } from "src/common/utils/memo";
 import { NO_CONTENT_FALLBACK } from "src/components/Table/constants";
 import { StyledCellBasic } from "../../style";
 
@@ -11,15 +12,14 @@ interface DefaultCellProps {
   getValue: Getter<any>;
 }
 
-export const DefaultCell = ({
-  cell,
-  getValue,
-}: DefaultCellProps): JSX.Element => (
-  <StyledCellBasic
-    key={cell.id}
-    shouldTextWrap
-    primaryText={getValue() || NO_CONTENT_FALLBACK}
-    primaryTextWrapLineCount={2}
-    shouldShowTooltipOnHover={false}
-  />
+export const DefaultCell = memo(
+  ({ cell, getValue }: DefaultCellProps): JSX.Element => (
+    <StyledCellBasic
+      key={cell.id}
+      shouldTextWrap
+      primaryText={getValue() || NO_CONTENT_FALLBACK}
+      primaryTextWrapLineCount={2}
+      shouldShowTooltipOnHover={false}
+    />
+  )
 );

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/DefaultCell/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/DefaultCell/index.tsx
@@ -1,5 +1,5 @@
 import { Cell, Getter } from "@tanstack/react-table";
-import { memo } from "src/common/utils/memo";
+import { memo } from "react";
 import { NO_CONTENT_FALLBACK } from "src/components/Table/constants";
 import { StyledCellBasic } from "../../style";
 
@@ -12,14 +12,14 @@ interface DefaultCellProps {
   getValue: Getter<any>;
 }
 
-export const DefaultCell = memo(
-  ({ cell, getValue }: DefaultCellProps): JSX.Element => (
-    <StyledCellBasic
-      key={cell.id}
-      shouldTextWrap
-      primaryText={getValue() || NO_CONTENT_FALLBACK}
-      primaryTextWrapLineCount={2}
-      shouldShowTooltipOnHover={false}
-    />
-  )
+const DefaultCell = ({ cell, getValue }: DefaultCellProps): JSX.Element => (
+  <StyledCellBasic
+    key={cell.id}
+    shouldTextWrap
+    primaryText={getValue() || NO_CONTENT_FALLBACK}
+    primaryTextWrapLineCount={2}
+    shouldShowTooltipOnHover={false}
+  />
 );
+
+export default memo(DefaultCell);

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
@@ -64,7 +64,7 @@ export const CovidLineageTooltip = ({
       width="wide"
       data-test-id="lineage-tooltip"
     >
-      {children}
+      <>{children}</>
     </Tooltip>
   );
 };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
@@ -64,7 +64,7 @@ export const CovidLineageTooltip = ({
       width="wide"
       data-test-id="lineage-tooltip"
     >
-      <div>{children}</div>
+      {children}
     </Tooltip>
   );
 };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
@@ -64,7 +64,7 @@ export const CovidLineageTooltip = ({
       width="wide"
       data-test-id="lineage-tooltip"
     >
-      <>{children}</>
+      <div>{children}</div>
     </Tooltip>
   );
 };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/VirtualBumper/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/VirtualBumper/index.tsx
@@ -8,7 +8,7 @@ interface Props {
  * This component adds a bumper onto the top and bottom of the virtualized list.
  * Without a bumper, your list may jump around as you scroll.
  */
-const VirtualBumper = ({ padding }: Props): JSX.Element => {
+const VirtualBumper = ({ padding = 0 }: Props): JSX.Element | null => {
   if (padding <= 0) return null;
 
   return (

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/VirtualBumper/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/VirtualBumper/index.tsx
@@ -1,20 +1,44 @@
 import { TableRow } from "czifui";
+import { ReactNode } from "react";
+import { VirtualItem } from "react-virtual";
 
 interface Props {
-  padding?: number;
+  children?: ReactNode;
+  totalSize?: number;
+  virtualRows?: VirtualItem[];
 }
 
 /**
  * This component adds a bumper onto the top and bottom of the virtualized list.
  * Without a bumper, your list may jump around as you scroll.
  */
-const VirtualBumper = ({ padding = 0 }: Props): JSX.Element | null => {
-  if (padding <= 0) return null;
+const VirtualBumper = ({
+  children,
+  virtualRows,
+  totalSize,
+}: Props): JSX.Element | null => {
+  if (!virtualRows || !totalSize || !children) return null;
+
+  const paddingTop = virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0)
+      : 0;
 
   return (
-    <TableRow>
-      <td style={{ height: `${padding}px` }} />
-    </TableRow>
+    <>
+      {paddingTop > 0 && (
+        <TableRow>
+          <td style={{ height: `${paddingTop}px` }} />
+        </TableRow>
+      )}
+      {children}
+      {paddingBottom > 0 && (
+        <TableRow>
+          <td style={{ height: `${paddingBottom}px` }} />
+        </TableRow>
+      )}
+    </>
   );
 };
 

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/VirtualBumper/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/VirtualBumper/index.tsx
@@ -1,0 +1,21 @@
+import { TableRow } from "czifui";
+
+interface Props {
+  padding?: number;
+}
+
+/**
+ * This component adds a bumper onto the top and bottom of the virtualized list.
+ * Without a bumper, your list may jump around as you scroll.
+ */
+const VirtualBumper = ({ padding }: Props): JSX.Element => {
+  if (padding <= 0) return null;
+
+  return (
+    <TableRow>
+      <td style={{ height: `${padding}px` }} />
+    </TableRow>
+  );
+};
+
+export { VirtualBumper };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -16,7 +16,7 @@ import {
   TableHeader,
 } from "czifui";
 import { map } from "lodash";
-import { memo, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useVirtual } from "react-virtual";
 import { IdMap } from "src/common/utils/dataTransforms";
 import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
@@ -33,6 +33,7 @@ import { EmptyTable } from "src/views/Data/components/EmptyState";
 import { generateWidthStyles } from "src/common/utils";
 import { getLineageFromSampleLineages } from "src/common/utils/samples";
 import { QualityScoreTag } from "./components/QualityScoreTag";
+import { memo } from "src/common/utils/memo";
 
 interface Props {
   data: IdMap<Sample> | undefined;
@@ -103,7 +104,7 @@ const columns: ColumnDef<Sample, any>[] = [
         Private ID
       </SortableHeader>
     ),
-    cell: ({ getValue, row, cell }) => {
+    cell: memo(({ getValue, row, cell }) => {
       const { uploadedBy, private: isPrivate } = row?.original;
       const uploader = uploadedBy?.name;
 
@@ -127,7 +128,7 @@ const columns: ColumnDef<Sample, any>[] = [
           }}
         />
       );
-    },
+    }),
     enableSorting: true,
   },
   {
@@ -165,14 +166,14 @@ const columns: ColumnDef<Sample, any>[] = [
         Quality Score
       </SortableHeader>
     ),
-    cell: ({ getValue, cell }) => {
+    cell: memo(({ getValue, cell }) => {
       const qcMetric = getValue()?.[0];
       return (
         <CellComponent key={cell.id}>
           <QualityScoreTag qcMetric={qcMetric} />
         </CellComponent>
       );
-    },
+    }),
     sortingFn: (a, b) => {
       const statusA = a.original.qcMetrics[0].qc_status;
       const statusB = b.original.qcMetrics[0].qc_status;
@@ -194,7 +195,7 @@ const columns: ColumnDef<Sample, any>[] = [
         Upload Date
       </SortableHeader>
     ),
-    cell: ({ getValue, cell }) => (
+    cell: memo(({ getValue, cell }) => (
       <StyledCellBasic
         key={cell.id}
         shouldTextWrap
@@ -202,7 +203,7 @@ const columns: ColumnDef<Sample, any>[] = [
         primaryTextWrapLineCount={2}
         shouldShowTooltipOnHover={false}
       />
-    ),
+    )),
   },
   {
     id: "collectionDate",
@@ -243,7 +244,7 @@ const columns: ColumnDef<Sample, any>[] = [
         Lineage
       </SortableHeader>
     ),
-    cell: ({ getValue, cell }) => {
+    cell: memo(({ getValue, cell }) => {
       const lineages = getValue();
       const lineage = getLineageFromSampleLineages(lineages);
       const CellContent = (
@@ -261,7 +262,7 @@ const columns: ColumnDef<Sample, any>[] = [
       ) : (
         CellContent
       );
-    },
+    }),
     enableSorting: true,
   },
   {
@@ -280,7 +281,7 @@ const columns: ColumnDef<Sample, any>[] = [
         Collection Location
       </SortableHeader>
     ),
-    cell: ({ getValue, cell }) => (
+    cell: memo(({ getValue, cell }) => (
       <StyledCellBasic
         key={cell.id}
         shouldTextWrap
@@ -290,7 +291,7 @@ const columns: ColumnDef<Sample, any>[] = [
         primaryTextWrapLineCount={2}
         shouldShowTooltipOnHover={false}
       />
-    ),
+    )),
     enableSorting: true,
   },
   {
@@ -328,7 +329,7 @@ const columns: ColumnDef<Sample, any>[] = [
         GISAID
       </SortableHeader>
     ),
-    cell: ({ getValue, cell }) => {
+    cell: memo(({ getValue, cell }) => {
       const { gisaid_id, status } = getValue();
       return (
         <StyledCellBasic
@@ -338,7 +339,7 @@ const columns: ColumnDef<Sample, any>[] = [
           shouldShowTooltipOnHover={false}
         />
       );
-    },
+    }),
     enableSorting: true,
   },
 ];

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -28,12 +28,14 @@ import {
   StyledInputCheckbox,
   StyledPrivateId,
   StyledTableRow,
+  StyledWrapper,
 } from "./style";
 import { EmptyTable } from "src/views/Data/components/EmptyState";
 import { generateWidthStyles } from "src/common/utils";
 import { getLineageFromSampleLineages } from "src/common/utils/samples";
 import { QualityScoreTag } from "./components/QualityScoreTag";
 import { memo } from "src/common/utils/memo";
+import { VirtualBumper } from "./components/VirtualBumper";
 
 interface Props {
   data: IdMap<Sample> | undefined;
@@ -390,9 +392,18 @@ const SamplesTable = ({
   const rowVirtualizer = useVirtual({
     parentRef: tableContainerRef,
     size: rows.length,
-    overscan: 10,
+    // increasing the `overscan` number will enable smoother scrolling, but will also add more nodes
+    // to the DOM, and may impact performance of other things in view, such as filters and modals
+    overscan: 25,
   });
-  const { virtualItems: virtualRows } = rowVirtualizer;
+  const { virtualItems: virtualRows, totalSize } = rowVirtualizer;
+
+  const paddingTop = virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0)
+      : 0;
+  // end virtualization code
 
   useEffect(() => {
     // for each selected row in the table, map the react-table internal row to the data (Sample)
@@ -409,7 +420,7 @@ const SamplesTable = ({
   }
 
   return (
-    <div ref={tableContainerRef}>
+    <StyledWrapper ref={tableContainerRef}>
       <Table>
         <TableHeader>
           {table
@@ -419,6 +430,7 @@ const SamplesTable = ({
             )}
         </TableHeader>
         <tbody>
+          <VirtualBumper padding={paddingTop} />
           {virtualRows.map((vRow) => {
             const row = rows[vRow.index];
             return (
@@ -431,9 +443,10 @@ const SamplesTable = ({
               </StyledTableRow>
             );
           })}
+          <VirtualBumper padding={paddingBottom} />
         </tbody>
       </Table>
-    </div>
+    </StyledWrapper>
   );
 };
 

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -407,7 +407,7 @@ const SamplesTable = ({
       </TableHeader>
       <tbody>
         {table.getRowModel().rows.map((row) => (
-          <StyledTableRow key={row.id}>
+          <StyledTableRow key={row.id} shouldShowTooltipOnHover={false}>
             {row
               .getVisibleCells()
               .map((cell) =>

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -163,6 +163,10 @@ const columns: ColumnDef<Sample, any>[] = [
           boldText: "Quality Score",
           regularText:
             "Overall QC score from Nextclade which considers genome completion and screens for potential contamination and sequencing or bioinformatics errors.",
+          link: {
+            href: "https://docs.nextstrain.org/projects/nextclade/en/stable/user/algorithm/07-quality-control.html",
+            linkText: "Learn more",
+          },
         }}
       >
         Quality Score
@@ -237,7 +241,7 @@ const columns: ColumnDef<Sample, any>[] = [
           boldText: "Lineage",
           link: {
             href: "https://cov-lineages.org/pangolin.html",
-            linkText: "Learn more.",
+            linkText: "Learn more",
           },
           regularText:
             "A lineage is a named group of related sequences. A few lineages have been associated with changes in the epidemiological or biological characteristics of the virus. We continually update these lineages based on the evolving Pangolin designations. Lineages determined by Pangolin.",

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -401,12 +401,6 @@ const SamplesTable = ({
     overscan: 25,
   });
   const { virtualItems: virtualRows, totalSize } = rowVirtualizer;
-
-  const paddingTop = virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
-  const paddingBottom =
-    virtualRows.length > 0
-      ? totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0)
-      : 0;
   // end virtualization code
 
   useEffect(() => {
@@ -434,20 +428,20 @@ const SamplesTable = ({
             )}
         </TableHeader>
         <tbody>
-          <VirtualBumper padding={paddingTop} />
-          {virtualRows.map((vRow: VirtualItem) => {
-            const row = rows[vRow.index];
-            return (
-              <StyledTableRow key={row.id} shouldShowTooltipOnHover={false}>
-                {row
-                  .getVisibleCells()
-                  .map((cell) =>
-                    flexRender(cell.column.columnDef.cell, cell.getContext())
-                  )}
-              </StyledTableRow>
-            );
-          })}
-          <VirtualBumper padding={paddingBottom} />
+          <VirtualBumper totalSize={totalSize} virtualRows={virtualRows}>
+            {virtualRows.map((vRow: VirtualItem) => {
+              const row = rows[vRow.index];
+              return (
+                <StyledTableRow key={row.id} shouldShowTooltipOnHover={false}>
+                  {row
+                    .getVisibleCells()
+                    .map((cell) =>
+                      flexRender(cell.column.columnDef.cell, cell.getContext())
+                    )}
+                </StyledTableRow>
+              );
+            })}
+          </VirtualBumper>
         </tbody>
       </Table>
     </StyledWrapper>

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -16,12 +16,12 @@ import {
   TableHeader,
 } from "czifui";
 import { map } from "lodash";
-import { useEffect, useRef, useState } from "react";
-import { useVirtual } from "react-virtual";
+import React, { useEffect, useRef, useState } from "react";
+import { useVirtual, VirtualItem } from "react-virtual";
 import { IdMap } from "src/common/utils/dataTransforms";
 import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
 import { LineageTooltip } from "./components/LineageTooltip";
-import { DefaultCell } from "./components/DefaultCell";
+import DefaultCell from "./components/DefaultCell";
 import { SortableHeader } from "src/views/Data/components/SortableHeader";
 import {
   StyledCellBasic,
@@ -431,7 +431,7 @@ const SamplesTable = ({
         </TableHeader>
         <tbody>
           <VirtualBumper padding={paddingTop} />
-          {virtualRows.map((vRow) => {
+          {virtualRows.map((vRow: VirtualItem) => {
             const row = rows[vRow.index];
             return (
               <StyledTableRow key={row.id} shouldShowTooltipOnHover={false}>
@@ -450,4 +450,4 @@ const SamplesTable = ({
   );
 };
 
-export default memo(SamplesTable);
+export default React.memo(SamplesTable);

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
@@ -56,4 +56,8 @@ export const StyledInputCheckbox = styled(InputCheckbox)`
 export const StyledWrapper = styled.div`
   flex: 1 1 auto;
   overflow-y: auto;
+
+  & > div {
+    overflow: auto;
+  }
 `;

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
@@ -9,6 +9,8 @@ import {
 } from "czifui";
 
 export const StyledPrivateId = styled(CellBasic)`
+  padding-left: 0;
+
   ${(props) => {
     const fontWeights = getFontWeights(props);
     return `

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/style.ts
@@ -51,3 +51,9 @@ export const StyledInputCheckbox = styled(InputCheckbox)`
     `;
   }}
 `;
+
+// needed to keep search bar sticky
+export const StyledWrapper = styled.div`
+  flex: 1 1 auto;
+  overflow-y: auto;
+`;

--- a/src/frontend/src/views/Data/components/SortableHeader/index.tsx
+++ b/src/frontend/src/views/Data/components/SortableHeader/index.tsx
@@ -36,6 +36,7 @@ export const SortableHeader = ({
         sdsStyle: "light",
         title: <TooltipText tooltipStrings={tooltipStrings} />,
         enterDelay: 1000,
+        enterNextDelay: 300,
       }}
       {...props}
     >


### PR DESCRIPTION
### Summary
- **What:** Address performance issues with the new samples table
  - memoize every component that is used by the table (at the cell level)
  - memoize the qc statuses and lineages, as they don't need to be recalculated unless the input changes
  - virtualize the table
  - remove unneeded tooltips
- **Why:** It isn't usable in the current state, due to blocking fxn calls preventing interaction with the entire browser.
- **Ticket:** [[sc-228059]](https://app.shortcut.com/genepi/story/228059)
- **Env:** https://maya-sanity-check-frontend.dev.czgenepi.org/

### Testing
1. Ensure the env has at least 1,000 samples
1. Try to do any action on the page, like clicking a checkbox or filtering/sorting the table
2. Page should not have significant lag when attempting these actions

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/213532997-73d6507b-7bb5-4a9a-b606-491b30161ef7.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/213533027-bae9faf6-2c39-4d8d-93cc-0d4795caab51.gif)

### Notes
- Will need to apply similar improvements to the tree table, in a follow up PR.
- You may wish to review this PR one commit at a time.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)