### PR TITLE
feat: github action schedule to remove stale stacks

### DIFF
--- a/.github/workflows/clean_happy_rdev.yml
+++ b/.github/workflows/clean_happy_rdev.yml
@@ -1,0 +1,28 @@
+name: Clean up stale happy stacks every hour
+
+on:
+  schedule:
+    # Runs "every 55th minute" (see https://crontab.guru)
+    - cron: "55 * * * *"
+jobs:
+  build:
+    name: Clean happy stacks
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+          role-session-name: HappyCleanupGenepiRdevStacks
+      - name: Clean up stale happy stacks
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.0
+        with:
+          tfe_token: ${{secrets.TFE_TOKEN}}
+          # the default stale period to delete a stack is 2 weeks
+          # override like this:
+          #time: 3 weeks
+          #time: 2 days


### PR DESCRIPTION
### Summary:
- **What:** This PR adds a CI GIthub Action that runs on a schedule (every hour) and removes old rdev stacks. An old rdev stack, by default, is a stack that has not been updated in two weeks. This stale period is configurable. If you'd like to update the cronjob period, simply change the schedule at the top of this action. This should help clean up unused stacks over time.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)