### PR TITLE
fix: bug that was using the wrong updated field

### DIFF
--- a/.github/workflows/clean_happy_rdev.yml
+++ b/.github/workflows/clean_happy_rdev.yml
@@ -16,7 +16,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
+          role-duration-seconds: 1800
           role-session-name: HappyCleanupGenepiRdevStacks
       - name: Clean up stale happy stacks
         uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.3

--- a/.github/workflows/clean_happy_rdev.yml
+++ b/.github/workflows/clean_happy_rdev.yml
@@ -19,7 +19,7 @@ jobs:
           role-duration-seconds: 900
           role-session-name: HappyCleanupGenepiRdevStacks
       - name: Clean up stale happy stacks
-        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.2
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.3
         with:
           tfe_token: ${{secrets.TFE_TOKEN}}
           # the default stale period to delete a stack is 2 weeks


### PR DESCRIPTION
This version bump fixes a bug that was parsing the wrong LastUpdated field to know which stacks were stale. I also increased the session duration so that long-running actions don't get a session expiration error before finishing the delete.

### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)