### PR TITLE
Reinstate weekly tree builds for groups w/o recent samples

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, MutableSequence
 
 import click
 import sqlalchemy as sa
-from sqlalchemy import func
 
 from aspen.api.settings import CLISettings
 from aspen.config.config import Config
@@ -21,7 +20,6 @@ from aspen.database.models import (
     Pathogen,
     PhyloRun,
     PublicRepository,
-    Sample,
     TreeType,
     User,
     Workflow,
@@ -33,9 +31,6 @@ from aspen.util.swipe import NextstrainScheduledJob
 SCHEDULED_TREE_TYPE = "OVERVIEW"
 
 TEMPLATE_ARGS = {"filter_start_date": "12 weeks ago", "filter_end_date": "now"}
-
-# This needs to match the value for "filter_start_date" in TEMPLATE_ARGS.
-FILTER_START_INTERVAL_DAYS = 12 * 7  # 12 weeks ago
 
 
 def create_phylo_run(
@@ -167,25 +162,10 @@ def launch_all(pathogen):
         )
         for group in all_groups:
             schedule_expression = group.tree_parameters.get("schedule_expression", None)
-            # Make sure the number of samples collected in the past 12 weeks is > 0
-            # Note that in Postgres, date - date = int where the int is
-            # the intervening number of days.
-            filter_interval_samples_count_query = (
-                sa.select(func.count())
-                .select_from(Sample)
-                .where(
-                    Sample.submitting_group_id == group.id,
-                    func.current_date() - Sample.collection_date
-                    < FILTER_START_INTERVAL_DAYS,
-                )
-            )
-            filter_interval_samples_count: int = (
-                db.execute(filter_interval_samples_count_query).scalars().one()
-            )
             if (
                 schedule_expression is None
                 or datetime.date.today().weekday() in schedule_expression
-            ) and filter_interval_samples_count > 0:
+            ):
                 workflow = create_phylo_run(
                     db, group, TEMPLATE_ARGS, tree_type, pathogen_obj, repository
                 )

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -76,6 +76,12 @@ aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .meta
 $aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" /ncov/results/
 $aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" /ncov/results/
 
+# Build break if include.txt is empty. If we don't have any selected samples,
+# then copy in nextstrain's defaults.
+if [ ! -s /ncov/data/include.txt ]; then
+    cp /ncov/defaults/include.txt /ncov/data/include.txt
+fi
+
 # run snakemake, if run fails export the logs from snakemake and ncov to s3
 (cd /ncov && snakemake --printshellcmds auspice/ncov_aspen.json --profile my_profiles/aspen/ --resources=mem_mb=312320) || { $aws s3 cp /ncov/.snakemake/log/ "${s3_prefix}/logs/snakemake/" --recursive ; $aws s3 cp /ncov/logs/ "${s3_prefix}/logs/ncov/" --recursive ; }
 

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_ondemand.sh
@@ -76,7 +76,7 @@ aligned_gisaid_metadata_s3_key=$(echo "${aligned_gisaid_location}" | jq -r .meta
 $aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_sequences_s3_key}" /ncov/results/
 $aws s3 cp --no-progress "s3://${aligned_gisaid_s3_bucket}/${aligned_gisaid_metadata_s3_key}" /ncov/results/
 
-# Build break if include.txt is empty. If we don't have any selected samples,
+# Tree builds break if include.txt is empty. If we don't have any selected samples,
 # then copy in nextstrain's defaults.
 if [ ! -s /ncov/data/include.txt ]; then
     cp /ncov/defaults/include.txt /ncov/data/include.txt


### PR DESCRIPTION
### Summary:
- **What:** Add nextstrain default include.txt if our include.txt is empty, and stop filtering for recent samples before doing automated builds
- **Ticket:** [sc228874](https://app.shortcut.com/genepi/story/228874)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)