### PR TITLE
type mappings for lineage, qc metrics, gisaid, genbank types

### DIFF
--- a/src/frontend/e2e/tests/filter-samples.spec.ts
+++ b/src/frontend/e2e/tests/filter-samples.spec.ts
@@ -338,8 +338,8 @@ function prepareTestData() {
     defaults.lineages = [
       {
         lineage: "BA.1.15",
-        lineage_type: "PANGOLIN",
-        lineage_software_version: "1.0.0",
+        lineageType: "PANGOLIN",
+        lineageSoftwareVersion: "1.0.0",
       },
     ];
     mockResponseData.push(getSampleResponseData(defaults));
@@ -408,15 +408,15 @@ function getDefaults(): Partial<SampleResponseDefaults> {
     lineages: [
       {
         lineage: "QA.1.15",
-        lineage_type: "PANGOLIN",
-        lineage_software_version: "1.0.0",
+        lineageType: "PANGOLIN",
+        lineageSoftwareVersion: "1.0.0",
       },
     ],
     qc_metrics: [
       {
-        qc_software_version: "1.0.0",
-        qc_status: "good",
-        qc_caller: "PANGOLIN",
+        qcSoftwareVersion: "1.0.0",
+        qcStatus: "good",
+        qcCaller: "PANGOLIN",
       },
     ],
     private: false,

--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -217,6 +217,45 @@ export async function putBackendApiJson<T>(
 export interface SampleResponse extends APIResponse {
   samples: Sample[];
 }
+
+const GENBANK_SUBMAP = new Map<string, keyof Genbank>([
+  ["genbank_accession", "genbankAccession"],
+]);
+
+const GISAID_SUBMAP = new Map<string, keyof GISAID>([
+  ["gisaid_id", "gisaidId"],
+]);
+
+const LINEAGE_SUBMAP = new Map<string, keyof Lineage>([
+  ["lineage_type", "lineageType"],
+  ["lineage_software_version", "lineageSoftwareVersion"],
+  ["lineage_probability", "lineageProbability"],
+  ["last_updated", "lastUpdated"],
+  ["reference_dataset_name", "referenceDatasetName"],
+  ["reference_sequence_accession", "referenceSequenceAccession"],
+  ["reference_dataset_tag", "referenceDatasetTag"],
+  ["scorpio_call", "scorpioCall"],
+  ["scorpio_support", "scorpioSupport"],
+  ["qc_status", "qcStatus"],
+]);
+
+const QC_SUBMAP = new Map<string, keyof QCMetrics>([
+  ["qc_score", "qcScore"],
+  ["qc_software_version", "qcSoftwareVersion"],
+  ["qc_status", "qcStatus"],
+  ["qc_caller", "qcCaller"],
+  ["reference_dataset_name", "referenceDatasetName"],
+  ["reference_sequence_accession", "referenceSequenceAccession"],
+  ["reference_dataset_tag", "referenceDatasetTag"],
+]);
+
+const SAMPLE_SUBMAP = new Map<string, Map<string, string>>([
+  ["genbank", GENBANK_SUBMAP],
+  ["gisaid", GISAID_SUBMAP],
+  ["lineage", LINEAGE_SUBMAP],
+  ["qcMetrics", QC_SUBMAP],
+]);
+
 const SAMPLE_MAP = new Map<string, keyof Sample>([
   ["collection_date", "collectionDate"],
   ["collection_location", "collectionLocation"],
@@ -233,7 +272,8 @@ export const fetchSamples = (): Promise<SampleResponse> =>
   apiResponse<SampleResponse>(
     ["samples"],
     [SAMPLE_MAP],
-    generateOrgSpecificUrl(ORG_API.SAMPLES)
+    generateOrgSpecificUrl(ORG_API.SAMPLES),
+    [SAMPLE_SUBMAP]
   );
 
 export interface PhyloRunResponse extends APIResponse {

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -288,8 +288,8 @@ export const DataTable: FunctionComponent<Props> = ({
         String(item.publicId),
         Boolean(
           item.qcMetrics.length > 0 &&
-            (item.qcMetrics[0].qc_status === "Bad" ||
-              item.qcMetrics[0].qc_status === "Failed")
+            (item.qcMetrics[0].qcStatus === "Bad" ||
+              item.qcMetrics[0].qcStatus === "Failed")
         )
       );
     };

--- a/src/frontend/src/common/types/bioinformatics.d.ts
+++ b/src/frontend/src/common/types/bioinformatics.d.ts
@@ -5,31 +5,36 @@ interface BioinformaticsType {
 
 interface GISAID {
   status: "submitted" | "not_eligible" | "accepted" | "rejected" | "no_info";
-  gisaid_id?: string;
+  gisaidId?: string;
+}
+
+interface Genbank {
+  status: string;
+  genbankAccession: string;
 }
 
 interface Lineage {
   lineage: string;
-  lineage_type: string;
-  lineage_software_version: string;
-  lineage_probability?: string;
-  last_updated?: string;
-  reference_dataset_name?: string;
-  reference_sequence_accession?: string;
-  reference_dataset_tag?: string;
-  scorpio_call?: string;
-  scorpio_support?: string;
-  qc_status?: string;
+  lineageType: string;
+  lineageSoftwareVersion: string;
+  lineageProbability?: string;
+  lastUpdated?: string;
+  referenceDatasetName?: string;
+  referenceSequenceAccession?: string;
+  referenceDatasetTag?: string;
+  scorpioCall?: string;
+  scorpioSupport?: string;
+  qcStatus?: string;
 }
 
 interface QCMetrics {
-  qc_score?: string;
-  qc_software_version: string;
-  qc_status: string;
-  qc_caller: string;
-  reference_dataset_name?: string;
-  reference_sequence_accession?: string;
-  reference_dataset_tag?: string;
+  qcScore?: string;
+  qcSoftwareVersion: string;
+  qcStatus: string;
+  qcCaller: string;
+  referenceDatasetName?: string;
+  referenceSequenceAccession?: string;
+  referenceDatasetTag?: string;
 }
 
 enum TREE_STATUS {

--- a/src/frontend/src/common/utils/typeUtils.tsx
+++ b/src/frontend/src/common/utils/typeUtils.tsx
@@ -14,31 +14,30 @@ function formatQCMetricsValue(
   // invalid with failed until we have designs to address the invalid case)
   if (JSON.stringify(inputValue) === "[]") {
     return [{ qcStatus: "Processing" }];
-  } else {
-    // this is guaranteed to be QCMetric since we did the earlier check
-    const qcMetric = inputValue as unknown as QCMetrics[];
-    qcMetric.map((e) => {
-      const qcStatusValue = e.qcStatus;
-      // TODO: remove this when we have designs ready to deal with invalid case, for now put a bandaid over the problem by marking samples as Failed
-      if (qcStatusValue === "invalid") {
-        e["qcStatus"] = "Failed";
-      } else {
-        // Capitalize first letter of qcStatus
-        e["qcStatus"] =
-          qcStatusValue.charAt(0).toUpperCase() + qcStatusValue.slice(1);
-      }
-    });
-    return qcMetric;
   }
+
+  // this is guaranteed to be QCMetric since we did the earlier check
+  const qcMetric = inputValue as unknown as QCMetrics[];
+  qcMetric.map((e) => {
+    const { qcStatus } = e;
+    // TODO: remove this when we have designs ready to deal with invalid case, for now put a bandaid over the problem by marking samples as Failed
+    if (qcStatus === "invalid") {
+      e["qcStatus"] = "Failed";
+    } else {
+      // Capitalize first letter of qcStatus
+      e["qcStatus"] = qcStatus.charAt(0).toUpperCase() + qcStatus.slice(1);
+    }
+  });
+  return qcMetric;
 }
 
 function getInputValue(
   inputObject: Record<string, JSONPrimitive>,
   key: string
 ): JSONPrimitive | { qcStatus: string }[] | QCMetrics[] {
-  // stub qcStatus to be 'processing if no qc_metrics data is available (this means sample was recently uploaded)'
+  // stub qcStatus to be 'processing if no qcMetrics data is available (this means sample was recently uploaded)'
   const inputValue = inputObject[key];
-  if (key === "qc_metrics") {
+  if (key === "qcMetrics") {
     return formatQCMetricsValue(inputValue);
   } else {
     return inputValue;

--- a/src/frontend/src/common/utils/typeUtils.tsx
+++ b/src/frontend/src/common/utils/typeUtils.tsx
@@ -8,23 +8,23 @@ export function get<T, K extends keyof T>(o: T, propertyName: K): T[K] {
 
 function formatQCMetricsValue(
   inputValue: JSONPrimitive
-): { qc_status: string }[] | QCMetrics[] {
+): { qcStatus: string }[] | QCMetrics[] {
   // we have a lot of early processing to do for QCMetrics (we need to add a stub of processing
   // if there are no available qcMetrics, capitalize the statuses for the QCFilter and replace
   // invalid with failed until we have designs to address the invalid case)
   if (JSON.stringify(inputValue) === "[]") {
-    return [{ qc_status: "Processing" }];
+    return [{ qcStatus: "Processing" }];
   } else {
     // this is guaranteed to be QCMetric since we did the earlier check
     const qcMetric = inputValue as unknown as QCMetrics[];
     qcMetric.map((e) => {
-      const qcStatusValue = e.qc_status;
+      const qcStatusValue = e.qcStatus;
       // TODO: remove this when we have designs ready to deal with invalid case, for now put a bandaid over the problem by marking samples as Failed
       if (qcStatusValue === "invalid") {
-        e["qc_status"] = "Failed";
+        e["qcStatus"] = "Failed";
       } else {
-        // Capitalize first letter of qc_status
-        e["qc_status"] =
+        // Capitalize first letter of qcStatus
+        e["qcStatus"] =
           qcStatusValue.charAt(0).toUpperCase() + qcStatusValue.slice(1);
       }
     });
@@ -35,8 +35,8 @@ function formatQCMetricsValue(
 function getInputValue(
   inputObject: Record<string, JSONPrimitive>,
   key: string
-): JSONPrimitive | { qc_status: string }[] | QCMetrics[] {
-  // stub qc_status to be 'processing if no qc_metrics data is available (this means sample was recently uploaded)'
+): JSONPrimitive | { qcStatus: string }[] | QCMetrics[] {
+  // stub qcStatus to be 'processing if no qc_metrics data is available (this means sample was recently uploaded)'
   const inputValue = inputObject[key];
   if (key === "qc_metrics") {
     return formatQCMetricsValue(inputValue);
@@ -55,7 +55,7 @@ export function jsonToType<T>(
   inputObject: Record<string, JSONPrimitive>,
   keyMap: Map<string, string | number> | null
 ): T {
-  const entries: Array<Array<JSONPrimitive | { qc_status: string }[]>> = [];
+  const entries: Array<Array<JSONPrimitive | { qcStatus: string }[]>> = [];
   Object.keys(inputObject).forEach((key) => {
     const inputValue = getInputValue(inputObject, key);
     if (keyMap === null) {

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -56,7 +56,7 @@ const DATA_FILTER_INIT = {
     params: {
       multiSelected: [],
     },
-    transform: (d: Sample) => d.qcMetrics[0]?.qc_status,
+    transform: (d: Sample) => d.qcMetrics[0]?.qcStatus,
     type: TypeFilterType.Multiple,
   },
   collectionDate: {

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -85,12 +85,12 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     );
   },
   gisaid: ({ value }) => {
-    const { gisaid_id, status } = value as Sample["gisaid"];
+    const { gisaidId, status } = value as Sample["gisaid"];
     return (
       <RowContent>
         <GISAIDCell data-test-id="row-gisaid-id">
           {status}
-          {gisaid_id && <Subtext>{gisaid_id}</Subtext>}
+          {gisaidId && <Subtext>{gisaidId}</Subtext>}
         </GISAIDCell>
       </RowContent>
     );

--- a/src/frontend/src/views/Data/cellRenderers.tsx
+++ b/src/frontend/src/views/Data/cellRenderers.tsx
@@ -101,7 +101,7 @@ const SAMPLE_CUSTOM_RENDERERS: Record<string | number, CellRenderer> = {
     // If we start adding multiple lineages per sample we'll need to revisit this logic.
     const firstLineageValue = value[0];
     const hasLineage = Boolean(
-      firstLineageValue && firstLineageValue.lineage_software_version
+      firstLineageValue && firstLineageValue.lineageSoftwareVersion
     );
     const Component = hasLineage ? UnderlinedRowContent : RowContent;
 

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -51,7 +51,7 @@ const DownloadModal = ({
   useEffect(() => {
     const noQCIds = checkedSamples
       // for now samples should only have one qcMetrics entry
-      .filter((s) => s.qcMetrics[0].qc_status === "Processing")
+      .filter((s) => s.qcMetrics[0].qcStatus === "Processing")
       .map((s) => s.publicId);
     setNoQCDataSampleIds(noQCIds);
   }, [checkedSamples]);

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/CovidLineageTooltip/index.tsx
@@ -4,30 +4,30 @@ import { Label, Text, Wrapper } from "./style";
 
 const KEY_TO_LABELS = {
   lineage: "Lineage",
-  qc_status: "QC Status",
-  scorpio_call: "Scorpio Call",
-  scorpio_support: "Scorpio Support",
-  lineage_software_version: "Version",
-  lineage_type: "Lineage Type",
-  lineage_probability: "Lineage Probability",
-  last_updated: "Last Updated",
-  reference_dataset_name: "Reference Dataset Name",
-  reference_sequence_accession: "Reference Sequence Accession",
-  reference_dataset_tag: "Reference Dataset Tag",
+  qcStatus: "QC Status",
+  scorpioCall: "Scorpio Call",
+  scorpioSupport: "Scorpio Support",
+  lineageSoftwareVersion: "Version",
+  lineageType: "Lineage Type",
+  lineageProbability: "Lineage Probability",
+  lastUpdated: "Last Updated",
+  referenceDatasetName: "Reference Dataset Name",
+  referenceSequenceAccession: "Reference Sequence Accession",
+  referenceDatasetTag: "Reference Dataset Tag",
 };
 
 const DISPLAY_ORDER: Array<keyof Lineage> = [
   "lineage",
-  "qc_status",
-  "lineage_software_version",
-  "lineage_type",
-  "lineage_probability",
-  "last_updated",
-  "scorpio_call",
-  "scorpio_support",
-  "reference_dataset_name",
-  "reference_sequence_accession",
-  "reference_dataset_tag",
+  "qcStatus",
+  "lineageSoftwareVersion",
+  "lineageType",
+  "lineageProbability",
+  "lastUpdated",
+  "scorpioCall",
+  "scorpioSupport",
+  "referenceDatasetName",
+  "referenceSequenceAccession",
+  "referenceDatasetTag",
 ];
 
 export const CovidLineageTooltip = ({
@@ -41,10 +41,10 @@ export const CovidLineageTooltip = ({
         // skip certain keys for now that are extra and not included in current design
         if (
           ![
-            "reference_dataset_name",
-            "reference_sequence_accession",
-            "reference_dataset_tag",
-            "lineage_type",
+            "referenceDatasetName",
+            "referenceSequenceAccession",
+            "referenceDatasetTag",
+            "lineageType",
           ].includes(key)
         ) {
           return (

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/GeneralViralLineageTooltip/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/LineageTooltip/components/GeneralViralLineageTooltip/index.tsx
@@ -4,30 +4,30 @@ import { Label, Text, Wrapper } from "./style";
 
 const KEY_TO_LABELS = {
   lineage: "Lineage",
-  qc_status: "QC Status",
-  scorpio_call: "Scorpio Call",
-  scorpio_support: "Scorpio Support",
-  lineage_software_version: "Version",
-  lineage_type: "Lineage Type",
-  lineage_probability: "Lineage Probability",
-  last_updated: "Last Updated",
-  reference_dataset_name: "Nextclade Dataset",
-  reference_sequence_accession: "Reference Sequence Accession",
-  reference_dataset_tag: "Reference Dataset Tag",
+  qcStatus: "QC Status",
+  scorpioCall: "Scorpio Call",
+  scorpioSupport: "Scorpio Support",
+  lineageSoftwareVersion: "Version",
+  lineageType: "Lineage Type",
+  lineageProbability: "Lineage Probability",
+  lastUpdated: "Last Updated",
+  referenceDatasetName: "Reference Dataset Name",
+  referenceSequenceAccession: "Reference Sequence Accession",
+  referenceDatasetTag: "Reference Dataset Tag",
 };
 
 const DISPLAY_ORDER: Array<keyof Lineage> = [
   "lineage",
-  "qc_status",
-  "reference_dataset_name",
-  "lineage_software_version",
-  "lineage_type",
-  "lineage_probability",
-  "last_updated",
-  "scorpio_call",
-  "scorpio_support",
-  "reference_sequence_accession",
-  "reference_dataset_tag",
+  "qcStatus",
+  "referenceDatasetName",
+  "lineageSoftwareVersion",
+  "lineageType",
+  "lineageProbability",
+  "lastUpdated",
+  "scorpioCall",
+  "scorpioSupport",
+  "referenceSequenceAccession",
+  "referenceDatasetTag",
 ];
 
 export const GeneralViralLineageTooltip = ({
@@ -41,13 +41,13 @@ export const GeneralViralLineageTooltip = ({
         // skip certain keys for now that are extra and not included in current design
         if (
           ![
-            "lineage_probability",
-            "lineage_type",
-            "qc_status",
-            "reference_sequence_accession",
-            "reference_dataset_tag",
-            "scorpio_call",
-            "scorpio_support",
+            "lineageProbability",
+            "lineageType",
+            "qcStatus",
+            "referenceSequenceAccession",
+            "referenceDatasetTag",
+            "scorpioCall",
+            "scorpioSupport",
           ].includes(key)
         ) {
           return (

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/QualityScoreTag/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/components/QualityScoreTag/index.tsx
@@ -35,7 +35,7 @@ const STATUS_LABELS: StatusLabelMap = {
 const getLabelForQCMetric = (qcMetric: QCMetrics): StatusLabel => {
   if (!qcMetric) return STATUS_LABELS.processing;
 
-  const qcStatus = qcMetric.qc_status;
+  const { qcStatus } = qcMetric;
 
   switch (qcStatus?.toLowerCase()) {
     case "good":

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -181,8 +181,8 @@ const columns: ColumnDef<Sample, any>[] = [
       );
     }),
     sortingFn: (a, b) => {
-      const statusA = a.original.qcMetrics[0].qc_status;
-      const statusB = b.original.qcMetrics[0].qc_status;
+      const statusA = a.original.qcMetrics[0].qcStatus;
+      const statusB = b.original.qcMetrics[0].qcStatus;
       return statusA > statusB ? -1 : 1;
     },
   },

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -336,12 +336,12 @@ const columns: ColumnDef<Sample, any>[] = [
       </SortableHeader>
     ),
     cell: memo(({ getValue, cell }) => {
-      const { gisaid_id, status } = getValue();
+      const { gisaidId, status } = getValue();
       return (
         <StyledCellBasic
           key={cell.id}
           primaryText={status}
-          secondaryText={gisaid_id}
+          secondaryText={gisaidId}
           shouldShowTooltipOnHover={false}
         />
       );

--- a/src/frontend/src/views/Data/components/SamplesView/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/index.tsx
@@ -55,7 +55,7 @@ const SamplesView = (): JSX.Element => {
   // update list of qcStatuses to use in the filter panel on the left side of the screen
   const qcStatuses = useMemo(
     () =>
-      uniq(compact(map(samples, (d) => d.qcMetrics[0]?.qc_status)))
+      uniq(compact(map(samples, (d) => d.qcMetrics[0]?.qcStatus)))
         .sort()
         .map((name) => ({ name })),
     [samples]

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -219,7 +219,7 @@ const Data: FunctionComponent = () => {
       return { name: l as string };
     });
   const qcStatuses = uniq(
-    compact(map(sampleMap, (d) => d.qcMetrics[0]?.qc_status))
+    compact(map(sampleMap, (d) => d.qcMetrics[0]?.qcStatus))
   )
     .sort()
     .map((l) => {

--- a/src/frontend/src/views/Data/table-headers/commonSampleHeaders.tsx
+++ b/src/frontend/src/views/Data/table-headers/commonSampleHeaders.tsx
@@ -40,39 +40,39 @@ export const LINEAGE_HEADER: Header = {
       text: "Lineage",
     },
     {
-      key: "scorpio_call",
+      key: "scorpioCall",
       text: "Scorpio Call",
     },
     {
-      key: "scorpio_support",
+      key: "scorpioSupport",
       text: "Scorpio Support",
     },
     {
-      key: "last_updated",
+      key: "lastUpdated",
       text: "Last Updated",
     },
     {
-      key: "lineage_software_version",
+      key: "lineageSoftwareVersion",
       text: "Version",
     },
     {
-      key: "reference_dataset_name",
+      key: "referenceDatasetName",
       text: "Reference Dataset Name",
     },
     {
-      key: "lineage_type",
+      key: "lineageType",
       text: "Lineage Caller",
     },
     {
-      key: "reference_dataset_tag",
+      key: "referenceDatasetTag",
       text: "Reference Dataset Tag",
     },
     {
-      key: "reference_sequence_accession",
+      key: "referenceSequenceAccession",
       text: "Reference Sequence Accession",
     },
     {
-      key: "lineage_probability",
+      key: "lineageProbability",
       text: "Lineage Probability",
     },
   ],
@@ -179,7 +179,7 @@ export const GISAID_HEADER = {
       text: "GISAID Status",
     },
     {
-      key: "gisaid_id",
+      key: "gisaidId",
       text: "GISAID ID",
     },
   ],
@@ -201,7 +201,7 @@ export const GENBANK_HEADER = {
       text: "GenBank Status",
     },
     {
-      key: "genbank_accession",
+      key: "genbankAccession",
       text: "GenBank Accession",
     },
   ],

--- a/src/frontend/src/views/Data/table-headers/commonSampleHeaders.tsx
+++ b/src/frontend/src/views/Data/table-headers/commonSampleHeaders.tsx
@@ -93,19 +93,19 @@ export const QC_METRICS_HEADER: Header = {
   sortKey: ["lineage", "lineage"],
   subHeaders: [
     {
-      key: "qc_caller",
+      key: "qcCaller",
       text: "QC Caller",
     },
     {
-      key: "qc_score",
+      key: "qcScore",
       text: "QC Score",
     },
     {
-      key: "qc_software_version",
+      key: "qcSoftwareVersion",
       text: "QC Software Version",
     },
     {
-      key: "qc_status",
+      key: "qcStatus",
       text: "QC Status",
     },
   ],

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -264,8 +264,8 @@ export function getBadOrFailedQCSampleIds(samples: Sample[]) {
       // for now there should only ever be one qcMetrics entry per sample
       .filter(
         (s) =>
-          s.qcMetrics[0].qc_status === "Bad" ||
-          s.qcMetrics[0].qc_status === "Failed"
+          s.qcMetrics[0].qcStatus === "Bad" ||
+          s.qcMetrics[0].qcStatus === "Failed"
       )
       .map((s) => s.publicId)
   );


### PR DESCRIPTION
### Summary
- **What:** Convert nested subtypes received from the back end from snake_case to camelCase
- **Why:** Prevents errors, as well as adherence to stylistic JS conventions -- JS typically does not use underscores for dicts or var names, unless they are constants.

### Demos
No visual changes.

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [x] I ~added~ updated relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)