### PR TITLE
Support limiting location listing depth.

### DIFF
--- a/src/backend/aspen/api/schemas/locations.py
+++ b/src/backend/aspen/api/schemas/locations.py
@@ -6,7 +6,7 @@ from aspen.api.schemas.base import BaseRequest, BaseResponse
 class LocationResponse(BaseResponse):
     id: int
     region: str
-    country: str
+    country: Optional[str]
     division: Optional[str]
     location: Optional[str]
 

--- a/src/backend/aspen/api/views/locations.py
+++ b/src/backend/aspen/api/views/locations.py
@@ -51,8 +51,8 @@ async def list_locations(
     # Add null filters to our query
     for col in required_null_columns:
         all_locations_query = all_locations_query.where(
-            getattr(Location, col) == None
-        )  # noqa
+            getattr(Location, col) == None  # noqa: E711
+        )
     result = await db.execute(all_locations_query)
     response = []
     for row in result.scalars():

--- a/src/backend/aspen/api/views/locations.py
+++ b/src/backend/aspen/api/views/locations.py
@@ -1,8 +1,9 @@
 import functools
+from enum import Enum
 from typing import Dict, List, Optional
 
 import sqlalchemy as sa
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import asc
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import and_, BinaryExpression
@@ -22,6 +23,14 @@ router = APIRouter()
 
 
 LOCATION_KEYS = ("region", "country", "division", "location")
+LOCATION_DEPTH = ["region", "country", "division", "location"]
+
+
+class LocationDepthEnum(str, Enum):
+    LOCATION = "location"
+    DIVISION = "division"
+    COUNTRY = "country"
+    REGION = "region"
 
 
 @router.get("/", response_model=LocationListResponse)
@@ -30,10 +39,20 @@ async def list_locations(
     db: AsyncSession = Depends(get_db),
     settings: APISettings = Depends(get_settings),
     user: User = Depends(get_auth_user),
+    max_location_depth: LocationDepthEnum = Query(default=LocationDepthEnum.LOCATION),
 ) -> LocationListResponse:
 
     # load the locations.
     all_locations_query = sa.select(Location)  # type: ignore
+    # Find out which columns need to be forced to null based on our max location depth
+    required_null_columns = LOCATION_DEPTH[
+        LOCATION_DEPTH.index(max_location_depth) + 1 :
+    ]
+    # Add null filters to our query
+    for col in required_null_columns:
+        all_locations_query = all_locations_query.where(
+            getattr(Location, col) == None
+        )  # noqa
     result = await db.execute(all_locations_query)
     response = []
     for row in result.scalars():

--- a/src/backend/aspen/api/views/tests/test_locations.py
+++ b/src/backend/aspen/api/views/tests/test_locations.py
@@ -1,0 +1,112 @@
+from typing import Optional
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aspen.test_infra.models.location import location_factory
+from aspen.test_infra.models.usergroup import user_factory
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+# test LIST locations #
+
+
+async def test_list_locations(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    # Make multiple locations
+    locations: list[list[Optional[str]]] = [
+        ["North America", "USA", "California", None],
+        ["North America", "USA", "Missouri", "Kansas City"],
+        ["Oceania", "Australia", "Queensland", "Brisbane"],
+        ["Oceania", "Australia", "Queensland", "Cairns"],
+        ["Oceania", "Australia", "Queensland", None],
+        ["Oceania", "Australia", None, None],
+        ["South America", "Brazil", None, None],
+        ["South America", "Argentina", None, None],
+        ["South America", None, None, None],
+    ]
+    for location in locations:
+        location = location_factory(location[0], location[1], location[2], location[3])
+        async_session.add(location)
+
+    user = user_factory(None)
+
+    async_session.add(user)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+    response_obj = await http_client.get(
+        "/v2/locations/",
+        headers=auth_headers,
+    )
+
+    res = response_obj.json()
+    assert len(res["locations"]) == 9
+    for item in res["locations"]:
+        assert [
+            item["region"],
+            item["country"],
+            item["division"],
+            item["location"],
+        ] in locations
+
+
+async def test_list_locations_with_depth(
+    async_session: AsyncSession,
+    http_client: AsyncClient,
+):
+    # Make multiple locations
+    locations: list[list[Optional[str]]] = [
+        ["North America", "USA", "Missouri", "Kansas City"],
+        ["Oceania", "Australia", "Queensland", "Brisbane"],
+        ["Oceania", "Australia", "Queensland", "Cairns"],
+    ]
+    divisions: list[list[Optional[str]]] = [
+        ["North America", "USA", "California", None],
+        ["Oceania", "Australia", "Queensland", None],
+    ]
+    countries: list[list[Optional[str]]] = [
+        ["Oceania", "Australia", None, None],
+        ["South America", "Brazil", None, None],
+        ["South America", "Argentina", None, None],
+    ]
+    regions: list[list[Optional[str]]] = [
+        ["Oceania", None, None, None],
+        ["South America", None, None, None],
+    ]
+    for location in locations + divisions + countries + regions:
+        location = location_factory(location[0], location[1], location[2], location[3])
+        async_session.add(location)
+
+    user = user_factory(None)
+
+    async_session.add(user)
+    await async_session.commit()
+
+    auth_headers = {"user_id": user.auth0_user_id}
+
+    async def check_response(depth: str, valid_rows: list[list[Optional[str]]]):
+        response_obj = await http_client.get(
+            f"/v2/locations/?max_location_depth={depth}",
+            headers=auth_headers,
+        )
+
+        res = response_obj.json()
+        assert len(res["locations"]) == len(valid_rows)
+        for item in res["locations"]:
+            assert [
+                item["region"],
+                item["country"],
+                item["division"],
+                item["location"],
+            ] in valid_rows
+
+    await check_response("location", regions + countries + divisions + locations)
+    await check_response("division", regions + countries + divisions)
+    await check_response("country", regions + countries)
+    await check_response("region", regions)

--- a/src/backend/aspen/test_infra/models/location.py
+++ b/src/backend/aspen/test_infra/models/location.py
@@ -4,8 +4,8 @@ from aspen.database.models import Location
 
 
 def location_factory(
-    region: str,
-    country: str,
+    region: Optional[str],
+    country: Optional[str],
     division: Optional[str] = None,
     location: Optional[str] = None,
     latitude: Optional[float] = None,

--- a/src/backend/aspen/test_infra/models/usergroup.py
+++ b/src/backend/aspen/test_infra/models/usergroup.py
@@ -43,7 +43,7 @@ def group_factory(
 
 
 def user_factory(
-    group: Group,
+    group: Optional[Group] = None,
     name="test",
     auth0_user_id="test_auth0_id",
     email="test_user@dph.org",

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -38,6 +38,8 @@ s3_prefix="s3://${aspen_s3_db_bucket}/${key_prefix}"
 # We use a file to pass from `export.py` to `save.py` before writing them to DB
 RESOLVED_TEMPLATE_ARGS_SAVEFILE=/tmp/resolved_template_args.json
 
+mpox_git_rev=$(cd /ncov && git rev-parse HEAD)
+
 # dump the sequences, metadata, and builds.yaml for a run out to disk.
 # TODO -- we need to emit *aligned* mpox sequences!!!
 aligned_upstream_location=$(
@@ -90,7 +92,7 @@ end_time=$(date +%s)
 python3 /usr/src/app/aspen/workflows/nextstrain_run/save.py                 \
     --aspen-workflow-rev "${aspen_workflow_rev}"                            \
     --aspen-creation-rev "${aspen_creation_rev}"                            \
-    --ncov-rev "${ncov_git_rev}"                                            \
+    --ncov-rev "${mpox_git_rev}"                                            \
     --aspen-docker-image-version ""                                         \
     --end-time "${end_time}"                                                \
     --phylo-run-id "${WORKFLOW_ID}"                                         \

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -38,7 +38,7 @@ s3_prefix="s3://${aspen_s3_db_bucket}/${key_prefix}"
 # We use a file to pass from `export.py` to `save.py` before writing them to DB
 RESOLVED_TEMPLATE_ARGS_SAVEFILE=/tmp/resolved_template_args.json
 
-mpox_git_rev=$(cd /ncov && git rev-parse HEAD)
+mpox_git_rev=$(cd /mpox && git rev-parse HEAD)
 
 # dump the sequences, metadata, and builds.yaml for a run out to disk.
 # TODO -- we need to emit *aligned* mpox sequences!!!

--- a/src/cli/aspencli.py
+++ b/src/cli/aspencli.py
@@ -165,7 +165,8 @@ class ApiClient:
             )
             raise click.UsageError(err_msg)
         if not self.pathogen_slug:
-            err_msg = ("The endpoint this command uses requires a pathogen slug.\n"
+            err_msg = (
+                "The endpoint this command uses requires a pathogen slug.\n"
                 "You need to use the `--pathogen-slug` option with the slug \n"
                 "(or set a CZGE_PATHOGEN env var with the slug) for the desired pathogen."
             )
@@ -605,10 +606,17 @@ def locations():
 
 
 @locations.command(name="list")
+@click.option(
+    "--max-location-depth",
+    type=click.Choice(["region", "country", "division", "location"]),
+)
 @click.pass_context
-def list_locations(ctx):
+def list_locations(ctx, max_location_depth):
     api_client = ctx.obj["api_client"]
-    resp = api_client.get("/v2/locations/")
+    params = {}
+    if max_location_depth:
+        params["max_location_depth"] = max_location_depth
+    resp = api_client.get("/v2/locations/", params=params)
     print(resp.text)
 
 


### PR DESCRIPTION
### Summary:
- **What:** Support limiting the listing depth for locations to only division/country/region levels
- **Ticket:** [sc229000](https://app.shortcut.com/genepi/story/229000)
- **Env:** `<rdev link>`

### Demos:

### Notes:
This also includes a fix for our tree build workflow!

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)