### PR TITLE
Make sure aligned sequence dumps have an associated workflow.

### DIFF
--- a/.happy/terraform/modules/sfn_config/genbank-mpx.wdl
+++ b/.happy/terraform/modules/sfn_config/genbank-mpx.wdl
@@ -128,12 +128,16 @@ task IngestGenBankMPX {
     # save filtered metadata file to s3
     ${aws} s3 cp metadata.tsv.xz "s3://${aspen_s3_db_bucket}/${metadata_key}"
 
+    end_time=$(date +%s)
+
     # create the objects
-    python3 /usr/src/app/aspen/workflows/ingest_raw_sequences/save.py  \
-            --genbank-s3-bucket "${aspen_s3_db_bucket}"        \
-            --genbank-sequences-s3-key "${alignment_key}"  \
-            --genbank-metadata-s3-key "${metadata_key}"   \
-            --pathogen-slug "MPX"                                       \
+    python3 /usr/src/app/aspen/workflows/ingest_aligned_sequences/save.py  \
+            --genbank-s3-bucket "${aspen_s3_db_bucket}"                    \
+            --genbank-sequences-s3-key "${alignment_key}"                  \
+            --genbank-metadata-s3-key "${metadata_key}"                    \
+            --pathogen-slug "MPX"                                          \
+            --start-time "${start_time}"                                   \
+            --end-time "${end_time}"                                       \
             --public-repository "GenBank" > entity_id 
 
     >>>

--- a/src/backend/pipeline_tests/test_data/genbank_mpx_pipeline_inputs.json
+++ b/src/backend/pipeline_tests/test_data/genbank_mpx_pipeline_inputs.json
@@ -2,6 +2,6 @@
 "docker_image_id": "${DOCKER_REPO}genepi-gisaid:latest",
 "aws_region": "us-west-2",
 "genepi_config_secret_name": "genepi-config",
-"genbank_metadata_url": "https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz",
-"genbank_alignment_url": "https://data.nextstrain.org/files/workflows/monkeypox/alignment.fasta.xz"
+"genbank_metadata_url": "https://github.com/chanzuckerberg/czge-test-data/raw/main/public_repo_data/mpx_metadata.tsv.gz",
+"genbank_alignment_url": "https://github.com/chanzuckerberg/czge-test-data/raw/main/public_repo_data/mpx_alignment.fasta.xz"
 }


### PR DESCRIPTION
### Summary:
- **What:** Make sure we have enough data in the DB to support MPX tree builds.

### Notes:
We were having trouble kicking off MPX tree builds in staging even though we'd already executed the ingestion workflow. This is because our "start a tree build" job looks for the *most recent* alignment data, which we can only infer by looking at the workflow run that produced the alignment data. Our script wasn't creating an alignment workflow object at all, so tree builds couldn't be started.

I made a few other minor changes here too:
1. Renamed the workflow script to reflect that it's for working with *aligned* data rather than *raw* data
2. Updated our ingestion test script so that it doesn't download all the MPX data from nextstrain on every run. This will make it easier to write tests (Coming Soon(TM)!) against a successful import.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)