### PR TITLE
dry group location

### DIFF
--- a/src/frontend/src/common/utils/groupUtils.ts
+++ b/src/frontend/src/common/utils/groupUtils.ts
@@ -1,0 +1,7 @@
+import { foldInLocationName } from "../queries/locations";
+
+export const getLocationFromGroup = (
+  group: GroupDetails
+): NamedGisaidLocation | null => {
+  return group?.location ? foldInLocationName(group?.location) : null;
+};

--- a/src/frontend/src/common/utils/groupUtils.ts
+++ b/src/frontend/src/common/utils/groupUtils.ts
@@ -1,7 +1,7 @@
 import { foldInLocationName } from "../queries/locations";
 
 export const getLocationFromGroup = (
-  group: GroupDetails
+  group?: GroupDetails
 ): NamedGisaidLocation | null => {
   return group?.location ? foldInLocationName(group?.location) : null;
 };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -12,10 +12,7 @@ import type { TreeType } from "src/common/constants/types";
 import { TreeTypes } from "src/common/constants/types";
 import { useGroupInfo } from "src/common/queries/groups";
 import { useLineages } from "src/common/queries/lineages";
-import {
-  foldInLocationName,
-  useNamedLocations,
-} from "src/common/queries/locations";
+import { useNamedLocations } from "src/common/queries/locations";
 import { RawTreeCreationWithId, useCreateTree } from "src/common/queries/trees";
 import { addNotification } from "src/common/redux/actions";
 import { useDispatch, useSelector } from "src/common/redux/hooks";
@@ -24,6 +21,7 @@ import {
   StyledCloseIconButton,
   StyledCloseIconWrapper,
 } from "src/common/styles/iconStyle";
+import { getLocationFromGroup } from "src/common/utils/groupUtils";
 import { pluralize } from "src/common/utils/strUtils";
 import { NotificationComponents } from "src/components/NotificationManager/components/Notification";
 import { TreeNameInput } from "src/components/TreeNameInput";
@@ -107,17 +105,13 @@ export const CreateNSTreeModal = ({
 
   // If we have the group's location, use this as the default for the filter
   const [selectedLocation, setSelectedLocation] =
-    useState<NamedGisaidLocation | null>(
-      groupInfo?.location ? foldInLocationName(groupInfo?.location) : null
-    );
+    useState<NamedGisaidLocation | null>(getLocationFromGroup(groupInfo));
 
   // If the group call isn't back when this is loaded, we need to update when the
   // call returns
   useEffect(() => {
-    setSelectedLocation(
-      groupInfo?.location ? foldInLocationName(groupInfo?.location) : null
-    );
-  }, [groupInfo?.location]);
+    setSelectedLocation(getLocationFromGroup(groupInfo));
+  }, [groupInfo]);
 
   // Filter based on date ranges
   const [startDate, setStartDate] = useState<FormattedDateType>();
@@ -146,9 +140,7 @@ export const CreateNSTreeModal = ({
     setStartDate(undefined);
     setEndDate(undefined);
     setSelectedLineages([]);
-    setSelectedLocation(
-      groupInfo?.location ? foldInLocationName(groupInfo?.location) : null
-    );
+    setSelectedLocation(getLocationFromGroup(groupInfo));
     setIsFilterEnabled(false);
   };
 


### PR DESCRIPTION
### Summary
- **What:** DRY on a small snippet of code extracting a valid location from group
- **Why:** imo, more than 2x same code should be extracted to a function, and doubly so since this is a getter. I'd like to see us move towards getters more in the future for easier refactors.

### Testing
1. Make a NS tree
1. Ensure the location filter defaults to your current group's location

### Demos (no visual changes)
![Screenshot 2023-01-31 at 4 23 30 PM](https://user-images.githubusercontent.com/7562933/215914738-fc8ed253-3711-4e74-b7b0-a56bfd85a4e9.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)