### PR TITLE
Tree location default - use max depth

### DIFF
--- a/src/frontend/src/common/queries/locations.ts
+++ b/src/frontend/src/common/queries/locations.ts
@@ -12,7 +12,7 @@ export interface LocationsResponse {
   locations: GisaidLocation[];
 }
 
-const locationDepthPathogenConfig: PathogenConfigType<
+export const locationDepthPathogenConfig: PathogenConfigType<
   keyof GisaidLocation | null
 > = {
   [Pathogen.COVID]: null,

--- a/src/frontend/src/common/queries/locations.ts
+++ b/src/frontend/src/common/queries/locations.ts
@@ -19,7 +19,30 @@ export const locationDepthPathogenConfig: PathogenConfigType<
   [Pathogen.MONKEY_POX]: "division",
 };
 
-const fetchLocations = (): Promise<LocationsResponse> => {
+const fetchAllLocations = (): Promise<LocationsResponse> => {
+  return getBackendApiJson(API.LOCATIONS);
+};
+
+export const USE_LOCATIONS_INFO_QUERY_KEY = {
+  entities: [ENTITIES.LOCATION_INFO],
+  id: "locationInfo",
+};
+
+const ONE_HOUR = 1000 * 60 * 60; // for react-query; milliseconds
+
+export function useLocations(): UseQueryResult<LocationsResponse, unknown> {
+  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchAllLocations, {
+    retry: false,
+    // Because locations are very stable and mildly heavy (~2Meg), we mark
+    // stale and re-fetch after an hour rather than default insta-stale.
+    // Note, this does not prevent garbage cleanup due to `cacheTime` if user
+    // does not have data "actively" used. In that case, re-fetch would happen
+    // next time a component using this data mounts and uses this func.
+    staleTime: ONE_HOUR,
+  });
+}
+
+const fetchPathogenDepthLocations = (): Promise<LocationsResponse> => {
   const state = store.getState();
   const pathogen = selectCurrentPathogen(state);
 
@@ -31,23 +54,31 @@ const fetchLocations = (): Promise<LocationsResponse> => {
   return getBackendApiJson(route);
 };
 
-export const USE_LOCATIONS_INFO_QUERY_KEY = {
+export const USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY = {
   entities: [ENTITIES.LOCATION_INFO],
-  id: "locationInfo",
+  id: "pathogenDepthocationInfo",
 };
 
-const ONE_HOUR = 1000 * 60 * 60; // for react-query; milliseconds
-
-export function useLocations(): UseQueryResult<LocationsResponse, unknown> {
-  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchLocations, {
-    retry: false,
-    // Because locations are very stable and mildly heavy (~2Meg), we mark
-    // stale and re-fetch after an hour rather than default insta-stale.
-    // Note, this does not prevent garbage cleanup due to `cacheTime` if user
-    // does not have data "actively" used. In that case, re-fetch would happen
-    // next time a component using this data mounts and uses this func.
-    staleTime: ONE_HOUR,
-  });
+export function useNamedPathogenDepthLocations(): UseQueryResult<
+  NamedLocationsResponse,
+  unknown
+> {
+  return useQuery(
+    [USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY],
+    fetchPathogenDepthLocations,
+    {
+      retry: false,
+      // Using `select` allows it to share cache with other USE_LOCATIONS_INFO_QUERY_KEY,
+      // but give a different view on the same data after processed by `select` func.
+      select: foldInNamesToLocations,
+      // Because locations are very stable and mildly heavy (~2Meg), we mark
+      // stale and re-fetch after an hour rather than default insta-stale.
+      // Note, this does not prevent garbage cleanup due to `cacheTime` if user
+      // does not have data "actively" used. In that case, re-fetch would happen
+      // next time a component using this data mounts and uses this func.
+      staleTime: ONE_HOUR,
+    }
+  );
 }
 
 interface NamedLocationsResponse {
@@ -77,7 +108,7 @@ export function useNamedLocations(): UseQueryResult<
   NamedLocationsResponse,
   unknown
 > {
-  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchLocations, {
+  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchAllLocations, {
     retry: false,
     // Using `select` allows it to share cache with other USE_LOCATIONS_INFO_QUERY_KEY,
     // but give a different view on the same data after processed by `select` func.
@@ -105,7 +136,7 @@ export function useNamedLocationsById(): UseQueryResult<
   NamedLocationsByIdResponse,
   unknown
 > {
-  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchLocations, {
+  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchAllLocations, {
     retry: false,
     // Using `select` allows it to share cache with other USE_LOCATIONS_INFO_QUERY_KEY,
     // but give a different view on the same data after processed by `select` func.

--- a/src/frontend/src/common/queries/locations.ts
+++ b/src/frontend/src/common/queries/locations.ts
@@ -23,7 +23,12 @@ const fetchAllLocations = (): Promise<LocationsResponse> => {
   return getBackendApiJson(API.LOCATIONS);
 };
 
-export const USE_LOCATIONS_INFO_QUERY_KEY = {
+type QueryKeyType = {
+  entities: ENTITIES[];
+  id: string;
+};
+
+export const USE_LOCATIONS_INFO_QUERY_KEY: QueryKeyType = {
   entities: [ENTITIES.LOCATION_INFO],
   id: "locationInfo",
 };
@@ -54,24 +59,14 @@ const fetchPathogenDepthLocations = (): Promise<LocationsResponse> => {
   return getBackendApiJson(route);
 };
 
-export const USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY = {
+export const USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY: QueryKeyType = {
   entities: [ENTITIES.LOCATION_INFO],
-  id: "pathogenDepthocationInfo",
+  id: "pathogenDepthLocationInfo",
 };
 
-export function useNamedPathogenDepthLocations(): UseQueryResult<
-  NamedLocationsResponse,
-  unknown
-> {
-  const state = store.getState();
-  const pathogen = selectCurrentPathogen(state);
-  // Choosing the query key based on the pathogen ensures that pathogens
-  // that use all of the locations for their trees don' have to re-fetch
-  // everything
-  const queryKey =
-    locationDepthPathogenConfig[pathogen] === null
-      ? USE_LOCATIONS_INFO_QUERY_KEY
-      : USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY;
+export function useNamedPathogenDepthLocations(
+  queryKey: QueryKeyType
+): UseQueryResult<NamedLocationsResponse, unknown> {
   return useQuery([queryKey], fetchPathogenDepthLocations, {
     retry: false,
     // Using `select` allows it to share cache with other USE_LOCATIONS_INFO_QUERY_KEY,

--- a/src/frontend/src/common/utils/locationUtils.ts
+++ b/src/frontend/src/common/utils/locationUtils.ts
@@ -151,3 +151,70 @@ export const getIdFromCollectionLocation = (
     return collectionLocation.id;
   }
 };
+
+function findMaxDepthLocation(
+  searchLocation: GisaidLocation | NamedGisaidLocation,
+  maxDepth: keyof GisaidLocation,
+  locations: NamedGisaidLocation[],
+  locationFinderCache: LocationFinderCache | null = null
+): NamedGisaidLocation | undefined {
+  // Safety check -- Should not occur, but if app hasn't finished loading the
+  // Locations data and this gets called, would blow up because we assume there
+  // are some Locations below. Instead, fallback to `undefined` location.
+  if (locations.length === 0) {
+    return undefined;
+  }
+
+  // Only do cache interactions if one was provided
+  if (
+    locationFinderCache !== null &&
+    locationFinderCache[`${searchLocation.id}${maxDepth}`]
+  ) {
+    return locationFinderCache[`${searchLocation.id}${maxDepth}`];
+  }
+
+  const locationHierarchy: (keyof GisaidLocation)[] = [
+    "region",
+    "country",
+    "division",
+    "location",
+  ];
+  const finalIndex = locationHierarchy.findIndex(
+    (element) => element === maxDepth
+  );
+
+  const foundLocations = locationHierarchy.reduce((acc, tier, index) => {
+    // Until we get to the index of the maxDepth, search for the searchLocation value
+    // After that, search for null
+    const filterValue = index <= finalIndex ? searchLocation[tier] : null;
+    return acc.filter((value) => value[tier] === filterValue);
+  }, locations);
+
+  const foundLocation =
+    foundLocations.length > 0 ? foundLocations[0] : undefined;
+
+  // If using cache, add latest result in to make future searches faster
+  if (locationFinderCache !== null && foundLocation) {
+    locationFinderCache[`${searchLocation.id}${maxDepth}`] = foundLocation;
+  }
+  return foundLocation;
+}
+
+export type LocationMaxDepthFinder = (
+  searchLocation: GisaidLocation,
+  maxDepth: keyof GisaidLocation
+) => NamedGisaidLocation | undefined;
+
+export function createMaxDepthLocationFinder(
+  locations: NamedGisaidLocation[]
+): LocationMaxDepthFinder {
+  const locationFinderCache: LocationFinderCache = {};
+  return (searchLocation: GisaidLocation, maxDepth: keyof GisaidLocation) => {
+    return findMaxDepthLocation(
+      searchLocation,
+      maxDepth,
+      locations,
+      locationFinderCache
+    );
+  };
+}

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -1,6 +1,7 @@
 import RadioGroup from "@mui/material/RadioGroup";
 import { Icon, Link } from "czifui";
 import { uniq } from "lodash";
+import { path } from "lodash/fp";
 import { SyntheticEvent, useEffect, useMemo, useState } from "react";
 import {
   AnalyticsTreeCreationNextstrain,
@@ -15,6 +16,8 @@ import { useLineages } from "src/common/queries/lineages";
 import {
   locationDepthPathogenConfig,
   useNamedPathogenDepthLocations,
+  USE_LOCATIONS_INFO_QUERY_KEY,
+  USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY,
 } from "src/common/queries/locations";
 import { RawTreeCreationWithId, useCreateTree } from "src/common/queries/trees";
 import { addNotification } from "src/common/redux/actions";
@@ -103,7 +106,14 @@ export const CreateNSTreeModal = ({
 
   // Filter based on location
   const { data: groupInfo } = useGroupInfo();
-  const { data: namedLocationsData } = useNamedPathogenDepthLocations();
+  // Choosing the query key based on the pathogen ensures that pathogens
+  // that use all of the locations for their trees don' have to re-fetch
+  // everything
+  const { data: namedLocationsData } = useNamedPathogenDepthLocations(
+    locationDepthPathogenConfig[pathogen] === null
+      ? USE_LOCATIONS_INFO_QUERY_KEY
+      : USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY
+  );
   const namedLocations: NamedGisaidLocation[] = useMemo(() => {
     return namedLocationsData?.namedLocations ?? [];
   }, [namedLocationsData]);

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -25,7 +25,7 @@ import {
   StyledCloseIconWrapper,
 } from "src/common/styles/iconStyle";
 import { getLocationFromGroup } from "src/common/utils/groupUtils";
-import { createStringToLocationFinder } from "src/common/utils/locationUtils";
+import { createMaxDepthLocationFinder } from "src/common/utils/locationUtils";
 import { pluralize } from "src/common/utils/strUtils";
 import { NotificationComponents } from "src/components/NotificationManager/components/Notification";
 import { TreeNameInput } from "src/components/TreeNameInput";
@@ -112,12 +112,13 @@ export const CreateNSTreeModal = ({
   const [selectedLocation, setSelectedLocation] =
     useState<NamedGisaidLocation | null>(getLocationFromGroup(groupInfo));
 
-  const stringToLocationFinder = useMemo(() => {
-    return createStringToLocationFinder(namedLocations);
+  const locationMaxDepthFinder = useMemo(() => {
+    return createMaxDepthLocationFinder(namedLocations);
   }, [namedLocations]);
 
   const setLocationToGroupDefault = () => {
     const locationDepth = locationDepthPathogenConfig[pathogen];
+
     const defaultTreeLocation =
       locationDepth === null
         ? // If locationDepth is not specified, use the group's location
@@ -127,7 +128,7 @@ export const CreateNSTreeModal = ({
         ? // Search for the location id that matches the max depth of the group's location
           // For example, for mpox the max depth is "division", we want to find the id of
           // the location that has the same division as the group's location, but location is null
-          stringToLocationFinder(groupInfo?.location[locationDepth] as string)
+          locationMaxDepthFinder(groupInfo?.location, locationDepth)
         : // If location is not defined, we can't set the default selectedLocation yet
           null;
     if (defaultTreeLocation) {
@@ -138,7 +139,7 @@ export const CreateNSTreeModal = ({
   // call returns
   useEffect(setLocationToGroupDefault, [
     groupInfo,
-    stringToLocationFinder,
+    locationMaxDepthFinder,
     pathogen,
   ]);
 

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -1,7 +1,6 @@
 import RadioGroup from "@mui/material/RadioGroup";
 import { Icon, Link } from "czifui";
 import { uniq } from "lodash";
-import { path } from "lodash/fp";
 import { SyntheticEvent, useEffect, useMemo, useState } from "react";
 import {
   AnalyticsTreeCreationNextstrain,

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -106,9 +106,33 @@ export const CreateNSTreeModal = ({
 
   // Filter based on location
   const { data: groupInfo } = useGroupInfo();
-  // Choosing the query key based on the pathogen ensures that pathogens
-  // that use all of the locations for their trees don' have to re-fetch
-  // everything
+
+  /*  useNamedLocations vs useNamedPathogenDepthLocations
+
+  useNamedLocations fetches all location data, down to the location level
+  i.e. Los Angeles County
+
+  useNamedPathogenDepthLocations fetches location data, down to the level
+  specified in locationDepthPathogenConfig.
+  For mpox, the depth is set as "division", so locations would only be
+  as specific as the division-level.  i.e. California
+
+  We have two different queries because some pathogens (mpox) only create trees 
+  using division data rather than location-level data. Other parts of the app - 
+  notably sample upload - still use the location-level data for mpox.
+  
+  When the app loads, we will fetch location-level data using the query key 
+  USE_LOCATIONS_INFO_QUERY_KEY.  When the pathogen uses division-level
+  locations for trees, we have a second fetch with a new query key,
+  USE_PATHOGEN_DEPTH_LOCATIONS_INFO_QUERY_KEY.
+  
+  Choosing the query key based on the pathogen ensures that pathogens
+  that use all of the locations for their trees, i.e. SC2, don't have to re-fetch
+  everything when opening the NS Tree Modal. 
+  Setting this inside of useNamedPathogetDepthLocations does not properly update 
+  the query key when switching between pathogens, which is why it is here.
+  */
+
   const { data: namedLocationsData } = useNamedPathogenDepthLocations(
     locationDepthPathogenConfig[pathogen] === null
       ? USE_LOCATIONS_INFO_QUERY_KEY

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/CreateNSTreeModal/index.tsx
@@ -130,7 +130,7 @@ export const CreateNSTreeModal = ({
         // For example, for mpox the max depth is "division", we want to find the id of
         // the location that has the same division as the group's location, but location is null
         defaultTreeLocation = locationMaxDepthFinder(
-          groupInfo?.location,
+          groupInfo.location,
           locationDepth
         );
       }


### PR DESCRIPTION
### Summary:
- **What:** `For mpox we are only using division rather than location.  We need to apply this to the create nextstrain tree modal default location.`
- **Ticket:** none
- **Env:** `none`

### Demos:
mpox:
![Screenshot 2023-02-01 at 12 39 51 PM](https://user-images.githubusercontent.com/109251328/216159601-a509176d-31c8-4b8b-9bec-503162adfce2.png)
sc2:
![Screenshot 2023-02-01 at 12 46 10 PM](https://user-images.githubusercontent.com/109251328/216159606-0f41a5f1-0874-45a6-ad00-74509d934529.png)

Mpox upload flow vs tree flow:
![Screenshot 2023-02-02 at 3 10 07 PM](https://user-images.githubusercontent.com/109251328/216472166-bf36ff2d-dc25-419e-89ed-e917be549eb0.png)
![Screenshot 2023-02-02 at 3 10 45 PM](https://user-images.githubusercontent.com/109251328/216472169-e7518643-f9a2-4e38-9a55-5c8a962a8123.png)

SC2 tree flow still has location-level data
![Screenshot 2023-02-02 at 3 12 24 PM](https://user-images.githubusercontent.com/109251328/216472222-fb429cd5-3702-4198-aacd-50d9ca7e13a2.png)


### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)