### PR TITLE
Re-enable trees tab for mpox.

### DIFF
--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -161,16 +161,7 @@ const Data: FunctionComponent = () => {
   };
 
   // create JSX elements from categories
-  const menuItemsOrNull = dataCategories.map((category) => {
-    // NOTE!! Here we are temporarily hiding the tree tab for monkeypox until
-    // we complete the functionality next quarter. For features that will be
-    // hidden long-term, a config would be more appropriate than this if statement.
-    if (
-      pathogen === Pathogen.MONKEY_POX &&
-      category.to === ROUTES.PHYLO_TREES
-    ) {
-      return null;
-    }
+  dataJSX.menuItems = dataCategories.map((category) => {
     const item = category.text.replace(" ", "-").toLowerCase();
     return (
       <StyledMenuItem key={category.text}>
@@ -192,11 +183,6 @@ const Data: FunctionComponent = () => {
       </StyledMenuItem>
     );
   });
-
-  // TODO: (ehoops) - once trees are re-enabled for mpx, we can remove this.
-  dataJSX.menuItems = menuItemsOrNull.filter(
-    (item) => item !== null
-  ) as Array<JSX.Element>; // Casting here because typescript thinks this can still be null.
 
   const subTitle = currentPath.startsWith(ROUTES.DATA_SAMPLES)
     ? "Samples"

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -9,7 +9,6 @@ import { useProtectedRoute } from "src/common/queries/auth";
 import { usePhyloRunInfo } from "src/common/queries/phyloRuns";
 import { useSampleInfo } from "src/common/queries/samples";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
-import { Pathogen } from "src/common/redux/types";
 import { DataCategory, Transform } from "src/common/types/data";
 import {
   IdMap,


### PR DESCRIPTION
### Summary:
- **What:** `Re-enable trees tab for mpox.`
- **Ticket:** none
- **Env:** `none`

### Demos:
![Screenshot 2023-02-01 at 2 55 32 PM](https://user-images.githubusercontent.com/109251328/216184788-474b3817-fbb6-469d-8de1-a68ff03ac93d.png)

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)