### PR TITLE
Maya/check fix

### DIFF
--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -21,7 +21,7 @@ import {
   TableRow,
   TreeRowContent,
 } from "./style";
-import { getBadOrFailedQCSampleIds } from "src/views/Upload/components/Samples/utils";
+import { getBadOrFailedQCSampleIds, isSampleQCStatusBad } from "src/views/Upload/components/Samples/utils";
 
 interface Props {
   data?: TableItem[];
@@ -286,11 +286,7 @@ export const DataTable: FunctionComponent<Props> = ({
     const handleClick = function handleClick() {
       handleRowCheckboxClick(
         String(item.publicId),
-        Boolean(
-          item.qcMetrics.length > 0 &&
-            (item.qcMetrics[0].qcStatus === "Bad" ||
-              item.qcMetrics[0].qcStatus === "Failed")
-        )
+        Boolean(isSampleQCStatusBad(item))
       );
     };
     return (

--- a/src/frontend/src/common/components/library/data_table/index.tsx
+++ b/src/frontend/src/common/components/library/data_table/index.tsx
@@ -21,7 +21,10 @@ import {
   TableRow,
   TreeRowContent,
 } from "./style";
-import { getBadOrFailedQCSampleIds, isSampleQCStatusBad } from "src/views/Upload/components/Samples/utils";
+import {
+  getBadOrFailedQCSampleIds,
+  isSampleQCStatusBad,
+} from "src/views/Upload/components/Samples/utils";
 
 interface Props {
   data?: TableItem[];
@@ -284,10 +287,7 @@ export const DataTable: FunctionComponent<Props> = ({
       item?.publicId as string
     );
     const handleClick = function handleClick() {
-      handleRowCheckboxClick(
-        String(item.publicId),
-        Boolean(isSampleQCStatusBad(item))
-      );
+      handleRowCheckboxClick(String(item.publicId), isSampleQCStatusBad(item));
     };
     return (
       <RowCheckbox

--- a/src/frontend/src/components/FilterPanel/index.tsx
+++ b/src/frontend/src/components/FilterPanel/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "src/common/analytics/eventTypes";
 import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
+import { getQCStatusFromSample } from "src/views/Upload/components/Samples/utils";
 import { CollectionDateFilter } from "./components/CollectionDateFilter";
 import { LineageFilter } from "./components/LineageFilter";
 import { QCStatusFilter } from "./components/QCStatusFilter";
@@ -56,7 +57,7 @@ const DATA_FILTER_INIT = {
     params: {
       multiSelected: [],
     },
-    transform: (d: Sample) => d.qcMetrics[0]?.qcStatus,
+    transform: getQCStatusFromSample,
     type: TypeFilterType.Multiple,
   },
   collectionDate: {

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "src/common/styles/iconStyle";
 import { pluralize } from "src/common/utils/strUtils";
 import Dialog from "src/components/Dialog";
+import { getQCStatusFromSample } from "src/views/Upload/components/Samples/utils";
 import { DownloadButton } from "./components/DownloadButton";
 import { DownloadMenuSelection } from "./components/DownloadMenuSelection";
 import {
@@ -51,7 +52,7 @@ const DownloadModal = ({
   useEffect(() => {
     const noQCIds = checkedSamples
       // for now samples should only have one qcMetrics entry
-      .filter((s) => s.qcMetrics[0]?.qcStatus === "Processing")
+      .filter((s) => getQCStatusFromSample(s) === "Processing")
       .map((s) => s.publicId);
     setNoQCDataSampleIds(noQCIds);
   }, [checkedSamples]);

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -36,6 +36,7 @@ import { getLineageFromSampleLineages } from "src/common/utils/samples";
 import { QualityScoreTag } from "./components/QualityScoreTag";
 import { memo } from "src/common/utils/memo";
 import { VirtualBumper } from "./components/VirtualBumper";
+import { getQCStatusFromSample } from "src/views/Upload/components/Samples/utils";
 
 interface Props {
   data: IdMap<Sample> | undefined;
@@ -181,8 +182,8 @@ const columns: ColumnDef<Sample, any>[] = [
       );
     }),
     sortingFn: (a, b) => {
-      const statusA = a.original.qcMetrics[0].qcStatus;
-      const statusB = b.original.qcMetrics[0].qcStatus;
+      const statusA = getQCStatusFromSample(a.original);
+      const statusB = getQCStatusFromSample(b.original);
       return statusA > statusB ? -1 : 1;
     },
   },

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -182,8 +182,8 @@ const columns: ColumnDef<Sample, any>[] = [
       );
     }),
     sortingFn: (a, b) => {
-      const statusA = getQCStatusFromSample(a.original);
-      const statusB = getQCStatusFromSample(b.original);
+      const statusA = getQCStatusFromSample(a.original) ?? "";
+      const statusB = getQCStatusFromSample(b.original) ?? "";
       return statusA > statusB ? -1 : 1;
     },
   },

--- a/src/frontend/src/views/Data/components/SamplesView/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/index.tsx
@@ -5,6 +5,7 @@ import { useNewSampleInfo as useSampleInfo } from "src/common/queries/samples";
 import { IdMap } from "src/common/utils/dataTransforms";
 import { FilterPanel } from "src/components/FilterPanel";
 import { SearchBar } from "src/components/Table/components/SearchBar";
+import { getQCStatusFromSample } from "src/views/Upload/components/Samples/utils";
 import { DataNavigation } from "../DataNavigation";
 import SamplesTable from "./components/SamplesTable";
 import { SampleTableModalManager } from "./components/SampleTableModalManager";
@@ -55,7 +56,7 @@ const SamplesView = (): JSX.Element => {
   // update list of qcStatuses to use in the filter panel on the left side of the screen
   const qcStatuses = useMemo(
     () =>
-      uniq(compact(map(samples, (d) => d.qcMetrics[0]?.qcStatus)))
+      uniq(compact(map(samples, getQCStatusFromSample)))
         .sort()
         .map((name) => ({ name })),
     [samples]

--- a/src/frontend/src/views/Data/index.tsx
+++ b/src/frontend/src/views/Data/index.tsx
@@ -21,6 +21,7 @@ import { USER_FEATURE_FLAGS } from "src/components/Split/types";
 import { DataSubview } from "../../common/components";
 import { VIEWNAME } from "../../common/constants/types";
 import { ROUTES } from "../../common/routes";
+import { getQCStatusFromSample } from "../Upload/components/Samples/utils";
 import { SampleRenderer, TreeRenderer } from "./cellRenderers";
 import { FilterPanelToggle } from "./components/DataNavigation/FilterPanelToggle";
 import { SamplesView } from "./components/SamplesView";
@@ -218,9 +219,7 @@ const Data: FunctionComponent = () => {
     .map((l) => {
       return { name: l as string };
     });
-  const qcStatuses = uniq(
-    compact(map(sampleMap, (d) => d.qcMetrics[0]?.qcStatus))
-  )
+  const qcStatuses = uniq(compact(map(sampleMap, getQCStatusFromSample)))
     .sort()
     .map((l) => {
       return { name: l as string };

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -263,7 +263,7 @@ export const isSampleQCStatusBad = (sample?: Sample): boolean => {
   return status === "Bad" || status === "Failed";
 };
 
-export function getBadOrFailedQCSampleIds(samples: Sample[]): Sample[] {
+export function getBadOrFailedQCSampleIds(samples: Sample[]): string[] {
   return (
     samples
       // for now there should only ever be one qcMetrics entry per sample

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -258,15 +258,20 @@ export function hasSamples(samples: Samples | null): boolean {
   return Object.keys(samples).length > 0;
 }
 
-export function getBadOrFailedQCSampleIds(samples: Sample[]) {
+export const isSampleQCStatusBad = (sample?: Sample): boolean => {
+  const status = getQCStatusFromSample(sample);
+  return status === "Bad" || status === "Failed";
+};
+
+export function getBadOrFailedQCSampleIds(samples: Sample[]): Sample[] {
   return (
     samples
       // for now there should only ever be one qcMetrics entry per sample
-      .filter(
-        (s) =>
-          s.qcMetrics[0].qcStatus === "Bad" ||
-          s.qcMetrics[0].qcStatus === "Failed"
-      )
+      .filter(isSampleQCStatusBad)
       .map((s) => s.publicId)
   );
 }
+
+export const getQCStatusFromSample = (sample?: Sample): string | undefined => {
+  return sample?.qcMetrics?.[0]?.qcStatus;
+};


### PR DESCRIPTION
### Summary
- **What:** More robust solution to displaying samples without any qc metrics attached
- **Why:** Otherwise, when we try to interact with table rows that display samples that do not have qc metrics, the app crashes
- **Env:** https://maya-check-frontend.dev.czgenepi.org/
- **Discussion:** https://czi-sci.slack.com/archives/C03HB6F0B47/p1675280222595779

### Demos
#### Before: 
![Screenshot 2023-02-01 at 11 36 08 AM](https://user-images.githubusercontent.com/7562933/216212648-6d4ea558-8432-4b45-a4ae-94e4a9008b4b.png)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/216212745-0c65b55a-032f-4d5f-86f7-25f0cbea99b8.gif)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)