### PR TITLE
Maya/229189 close modal bug

### DIFF
--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/index.tsx
@@ -44,16 +44,20 @@ const SampleTableModalManager = ({
   // determine whether selected samples can be edited
   useEffect(() => {
     const numberOfCheckedSamples = checkedSampleIds.length;
-    if (numberOfCheckedSamples > 0 && numberOfCheckedSamples <= 100) {
-      setCanEditSamples(true);
-    } else {
-      setCanEditSamples(false);
-    }
+    const canEditSamples =
+      numberOfCheckedSamples > 0 && numberOfCheckedSamples <= 100;
+
+    setCanEditSamples(canEditSamples);
   }, [checkedSampleIds]);
 
   useEffect(() => {
     if (shouldStartUsherFlow) setShouldStartUsherFlow(false);
   }, [shouldStartUsherFlow]);
+
+  const handleDownloadModalClose = () => {
+    setIsDownloadModalOpen(false);
+    clearCheckedSamples();
+  };
 
   const handleDeleteSampleModalClose = () => {
     setIsDeleteSampleModalOpen(false);
@@ -70,10 +74,7 @@ const SampleTableModalManager = ({
       <DownloadModal
         checkedSamples={checkedSamples}
         open={isDownloadModalOpen}
-        onClose={() => {
-          setIsDownloadModalOpen(false);
-          clearCheckedSamples();
-        }}
+        onClose={handleDownloadModalClose}
       />
       <CreateNSTreeModal
         checkedSampleIds={checkedSampleIds}

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -31,6 +31,7 @@ const SamplesTable = ({
       isLoading={isLoading}
       initialSortKey="uploadDate"
       tableData={data}
+      uniqueIdentifier="id"
       checkedRows={checkedSamples}
       onSetCheckedRows={setCheckedSamples}
       enableMultiRowSelection

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/index.tsx
@@ -9,12 +9,14 @@ import { SAMPLE_TABLE_COLUMNS } from "./pathogenColumnConfig";
 interface Props {
   data: IdMap<Sample> | undefined;
   isLoading: boolean;
+  checkedSamples: Sample[];
   setCheckedSamples(samples: Sample[]): void;
 }
 
 const SamplesTable = ({
   data,
   isLoading,
+  checkedSamples,
   setCheckedSamples,
 }: Props): JSX.Element => {
   const pathogen = useSelector(selectCurrentPathogen);
@@ -29,6 +31,7 @@ const SamplesTable = ({
       isLoading={isLoading}
       initialSortKey="uploadDate"
       tableData={data}
+      checkedRows={checkedSamples}
       onSetCheckedRows={setCheckedSamples}
       enableMultiRowSelection
     />

--- a/src/frontend/src/views/Data/components/SamplesView/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/index.tsx
@@ -90,6 +90,7 @@ const SamplesView = (): JSX.Element => {
           <SamplesTable
             isLoading={isLoading}
             data={displayedRows}
+            checkedSamples={checkedSamples}
             setCheckedSamples={setCheckedSamples}
           />
         </MaxWidth>

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
@@ -138,6 +138,7 @@ const TreesTable = ({ data, isLoading }: Props): JSX.Element => {
       isLoading={isLoading}
       initialSortKey="startedDate"
       defaultColumn={defaultColumn}
+      uniqueIdentifier="workflowId"
     />
   );
 };


### PR DESCRIPTION
### Summary
- **What:** Resolve a bug where closing a modal (such as download modal) would clear checked sample state
- **Why:** Design parity with old table
- **Ticket:** [[sc-229189]](https://app.shortcut.com/genepi/story/229189)
- **Env:** https://maya-checked-bug-frontend.dev.czgenepi.org/

### Testing
1. Check some rows
1. Open the download modal
2. Close the download modal without downloading anything
3. Rows should no longer be checked

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/216430019-58b1b753-6e36-43fd-964e-ea87632de1d8.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/216430049-2a24b1d4-5ab3-4d4d-9ec1-0b2a6ef9e41a.gif)

### Checklist
- [x] I merged latest `maya/remove-old-tables`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)