### PR TITLE
Maya/229189 trees perf

### DIFF
--- a/src/frontend/src/common/queries/locations.ts
+++ b/src/frontend/src/common/queries/locations.ts
@@ -86,31 +86,3 @@ export function useNamedLocations(): UseQueryResult<
     staleTime: ONE_HOUR,
   });
 }
-
-interface NamedLocationsByIdResponse {
-  namedLocationsById: IdMap<NamedGisaidLocation>;
-}
-
-const getNamedLocationsById = (
-  data: LocationsResponse
-): NamedLocationsByIdResponse => {
-  const { locations } = data;
-  const namedLocations = locations.map(foldInLocationName);
-  return {
-    namedLocationsById: reduceObjectArrayToLookupDict(namedLocations, "id"),
-  };
-};
-
-export function useNamedLocationsById(): UseQueryResult<
-  NamedLocationsByIdResponse,
-  unknown
-> {
-  return useQuery([USE_LOCATIONS_INFO_QUERY_KEY], fetchLocations, {
-    retry: false,
-    // Using `select` allows it to share cache with other USE_LOCATIONS_INFO_QUERY_KEY,
-    // but give a different view on the same data after processed by `select` func.
-    select: getNamedLocationsById,
-    // It's stable, avoid unnecessary re-fetches. More info in `useLocations`
-    staleTime: ONE_HOUR,
-  });
-}

--- a/src/frontend/src/common/queries/locations.ts
+++ b/src/frontend/src/common/queries/locations.ts
@@ -5,7 +5,6 @@ import { store } from "../redux";
 import { selectCurrentPathogen } from "../redux/selectors";
 import { Pathogen } from "../redux/types";
 import { PathogenConfigType } from "../types/pathogenConfig";
-import { IdMap, reduceObjectArrayToLookupDict } from "../utils/dataTransforms";
 import { ENTITIES } from "./entities";
 
 export interface LocationsResponse {

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -18,8 +18,6 @@ import {
   SampleResponse,
 } from "../api";
 import { API_URL } from "../constants/ENV";
-import { store } from "../redux";
-import { selectCurrentPathogen } from "../redux/selectors";
 import { IdMap, reduceObjectArrayToLookupDict } from "../utils/dataTransforms";
 import { ENTITIES } from "./entities";
 import { MutationCallbacks } from "./types";

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -281,15 +281,7 @@ export const USE_SAMPLE_INFO = {
   id: "sampleInfo",
 };
 
-export function useSampleInfo(): UseQueryResult<SampleResponse, unknown> {
-  const state = store.getState();
-  const pathogen = selectCurrentPathogen(state);
-  return useQuery([USE_SAMPLE_INFO, pathogen], () => fetchSamples(), {
-    retry: false,
-  });
-}
-
-export function useNewSampleInfo(): UseQueryResult<IdMap<Sample>, unknown> {
+export function useSampleInfo(): UseQueryResult<IdMap<Sample>, unknown> {
   return useQuery([USE_SAMPLE_INFO], () => fetchSamples(), {
     retry: false,
     select: mapSampleData,

--- a/src/frontend/src/common/utils/locationUtils.ts
+++ b/src/frontend/src/common/utils/locationUtils.ts
@@ -1,4 +1,6 @@
 import { distance } from "fastest-levenshtein";
+import { foldInLocationName } from "../queries/locations";
+import { reduceObjectArrayToLookupDict } from "./dataTransforms";
 
 // Produce unique string to name a GISAID location from its various attributes
 export function stringifyGisaidLocation(location?: GisaidLocation): string {
@@ -150,4 +152,19 @@ export const getIdFromCollectionLocation = (
   if (collectionLocation && typeof collectionLocation !== "string") {
     return collectionLocation.id;
   }
+};
+
+export interface NamedLocationsByIdResponse {
+  namedLocationsById: IdMap<NamedGisaidLocation>;
+}
+
+export const getNamedLocationsById = (
+  locations: NamedGisaidLocation[]
+): NamedLocationsByIdResponse => {
+  if (!locations) return {};
+
+  const namedLocations = locations.map(foldInLocationName);
+  return {
+    namedLocationsById: reduceObjectArrayToLookupDict(namedLocations, "id"),
+  };
 };

--- a/src/frontend/src/common/utils/locationUtils.ts
+++ b/src/frontend/src/common/utils/locationUtils.ts
@@ -155,7 +155,7 @@ export const getIdFromCollectionLocation = (
 };
 
 export const getNamedLocationsById = (
-  locations: NamedGisaidLocation[]
+  locations: GisaidLocation[]
 ): IdMap<NamedGisaidLocation> => {
   if (!locations) return {};
 

--- a/src/frontend/src/common/utils/locationUtils.ts
+++ b/src/frontend/src/common/utils/locationUtils.ts
@@ -1,6 +1,6 @@
 import { distance } from "fastest-levenshtein";
 import { foldInLocationName } from "../queries/locations";
-import { reduceObjectArrayToLookupDict } from "./dataTransforms";
+import { IdMap, reduceObjectArrayToLookupDict } from "./dataTransforms";
 
 // Produce unique string to name a GISAID location from its various attributes
 export function stringifyGisaidLocation(location?: GisaidLocation): string {
@@ -154,17 +154,11 @@ export const getIdFromCollectionLocation = (
   }
 };
 
-export interface NamedLocationsByIdResponse {
-  namedLocationsById: IdMap<NamedGisaidLocation>;
-}
-
 export const getNamedLocationsById = (
   locations: NamedGisaidLocation[]
-): NamedLocationsByIdResponse => {
+): IdMap<NamedGisaidLocation> => {
   if (!locations) return {};
 
   const namedLocations = locations.map(foldInLocationName);
-  return {
-    namedLocationsById: reduceObjectArrayToLookupDict(namedLocations, "id"),
-  };
+  return reduceObjectArrayToLookupDict(namedLocations, "id");
 };

--- a/src/frontend/src/components/Table/index.tsx
+++ b/src/frontend/src/components/Table/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@tanstack/react-table";
 import { Table as SDSTable, TableHeader, TableRow } from "czifui";
 import { isEqual, map } from "lodash";
-import { memo, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useVirtual, VirtualItem } from "react-virtual";
 import { IdMap } from "src/common/utils/dataTransforms";
 import { StyledWrapper } from "./style";
@@ -190,4 +190,4 @@ const Table = <T extends any>({
   );
 };
 
-export default memo(Table);
+export default Table;

--- a/src/frontend/src/components/Table/index.tsx
+++ b/src/frontend/src/components/Table/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@tanstack/react-table";
 import { Table as SDSTable, TableHeader, TableRow } from "czifui";
 import { isEqual, map } from "lodash";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { useVirtual, VirtualItem } from "react-virtual";
 import { IdMap } from "src/common/utils/dataTransforms";
 import { StyledWrapper } from "./style";
@@ -171,7 +171,10 @@ const Table = <T extends any>({
             {virtualRows.map((vRow: VirtualItem) => {
               const row = rows[vRow.index];
               return (
-                <TableRow key={row.id} shouldShowTooltipOnHover={false}>
+                <TableRow
+                  key={`row-${row.id}`}
+                  shouldShowTooltipOnHover={false}
+                >
                   {row
                     .getVisibleCells()
                     .map((cell) =>
@@ -187,4 +190,4 @@ const Table = <T extends any>({
   );
 };
 
-export default Table;
+export default memo(Table);

--- a/src/frontend/src/components/Table/style.ts
+++ b/src/frontend/src/components/Table/style.ts
@@ -1,19 +1,15 @@
 import styled from "@emotion/styled";
 import { CommonThemeProps, getColors } from "czifui";
 
-// needed to keep search bar sticky
 export const StyledWrapper = styled.div`
+  /* needed to keep search bar sticky */
   flex: 1 1 auto;
   overflow-y: auto;
-
-  & > div {
-    overflow: auto;
-  }
 
   ${(props: CommonThemeProps) => {
     const colors = getColors(props);
     return `
-      tr:hover {
+      tbody tr:hover {
         background-color: ${colors?.primary[100]};
       }
     `;

--- a/src/frontend/src/views/Data/components/DataNavigation/index.tsx
+++ b/src/frontend/src/views/Data/components/DataNavigation/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { usePhyloRunInfo } from "src/common/queries/phyloRuns";
-import { useNewSampleInfo as useSampleInfo } from "src/common/queries/samples";
+import { useSampleInfo } from "src/common/queries/samples";
 import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { Pathogen } from "src/common/redux/types";
 import { ROUTES } from "src/common/routes";

--- a/src/frontend/src/views/Data/components/SamplesView/index.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/index.tsx
@@ -1,7 +1,7 @@
 import { compact, map, uniq } from "lodash";
 import { useMemo, useState } from "react";
 import { HeadAppTitle } from "src/common/components";
-import { useNewSampleInfo as useSampleInfo } from "src/common/queries/samples";
+import { useSampleInfo } from "src/common/queries/samples";
 import { IdMap } from "src/common/utils/dataTransforms";
 import { FilterPanel } from "src/components/FilterPanel";
 import { SearchBar } from "src/components/Table/components/SearchBar";

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/actionMenu.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/actionMenu.tsx
@@ -1,0 +1,24 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { CellComponent, CellHeader } from "czifui";
+import { memo } from "src/common/utils/memo";
+import { generateWidthStyles } from "src/common/utils/tableUtils";
+import { TreeActionMenu } from "../components/TreeActionMenu";
+
+export const actionMenu: ColumnDef<PhyloRun, any> = {
+  id: "action",
+  size: 160,
+  header: ({ column, header }) => (
+    <CellHeader
+      key={header.id}
+      style={generateWidthStyles(column)}
+      hideSortIcon
+    >
+      {" "}
+    </CellHeader>
+  ),
+  cell: memo(({ row, cell }) => (
+    <CellComponent key={cell.id}>
+      <TreeActionMenu phyloRun={row.original} />
+    </CellComponent>
+  )),
+};

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/startedDate.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/startedDate.tsx
@@ -1,0 +1,34 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { memo } from "src/common/utils/memo";
+import { generateWidthStyles } from "src/common/utils/tableUtils";
+import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
+// TODO-TR: import
+import { StyledCellBasic } from "src/views/Data/components/SamplesView/components/SamplesTable/style";
+import { SortableHeader } from "src/views/Data/components/SortableHeader";
+
+export const startedDate: ColumnDef<PhyloRun, any> = {
+  id: "startedDate",
+  accessorKey: "startedDate",
+  size: 160,
+  header: ({ header, column }) => (
+    <SortableHeader
+      header={header}
+      style={generateWidthStyles(column)}
+      tooltipStrings={{
+        boldText: "Creation Date",
+        regularText: "Date on which the tree was generated.",
+      }}
+    >
+      Creation Date
+    </SortableHeader>
+  ),
+  cell: memo(({ getValue, cell }) => (
+    <StyledCellBasic
+      key={cell.id}
+      verticalAlign="center"
+      shouldShowTooltipOnHover={false}
+      primaryText={datetimeWithTzToLocalDate(getValue())}
+    />
+  )),
+  enableSorting: true,
+};

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/startedDate.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/startedDate.tsx
@@ -2,9 +2,8 @@ import { ColumnDef } from "@tanstack/react-table";
 import { memo } from "src/common/utils/memo";
 import { generateWidthStyles } from "src/common/utils/tableUtils";
 import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
-// TODO-TR: import
-import { StyledCellBasic } from "src/views/Data/components/SamplesView/components/SamplesTable/style";
 import { SortableHeader } from "src/views/Data/components/SortableHeader";
+import { StyledCellBasic } from "../style";
 
 export const startedDate: ColumnDef<PhyloRun, any> = {
   id: "startedDate",

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeName.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeName.tsx
@@ -1,12 +1,13 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { CellComponent } from "czifui";
+import { IdMap } from "src/common/utils/dataTransforms";
 import { memo } from "src/common/utils/memo";
 import { generateWidthStyles } from "src/common/utils/tableUtils";
 import TreeTableNameCell from "../components/TreeTableNameCell";
 import { StyledSortableHeader } from "../style";
 
 export const treeName = (
-  locations: NamedGisaidLocation[]
+  locations: IdMap<NamedGisaidLocation>
 ): ColumnDef<PhyloRun, any> => ({
   id: "name",
   accessorKey: "name",

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeName.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeName.tsx
@@ -1,0 +1,34 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { CellComponent } from "czifui";
+import { memo } from "src/common/utils/memo";
+import { generateWidthStyles } from "src/common/utils/tableUtils";
+import TreeTableNameCell from "../components/TreeTableNameCell";
+import { StyledSortableHeader } from "../style";
+
+export const treeName = (
+  locations: NamedGisaidLocation[]
+): ColumnDef<PhyloRun, any> => ({
+  id: "name",
+  accessorKey: "name",
+  minSize: 350,
+  header: ({ header, column }) => (
+    <StyledSortableHeader
+      header={header}
+      style={generateWidthStyles(column)}
+      tooltipStrings={{
+        boldText: "Tree Name",
+        regularText:
+          "User-provided tree name. Auto-generated tree builds are named ”Y Contextual“, where Y is your Group Name.",
+      }}
+    >
+      Tree Name
+    </StyledSortableHeader>
+  ),
+  cell: memo(({ row, cell }) => (
+    <CellComponent key={cell.id}>
+      <TreeTableNameCell phyloRun={row.original} locations={locations} />
+    </CellComponent>
+  )),
+  enableSorting: true,
+  sortingFn: "alphanumeric",
+});

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeName.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeName.tsx
@@ -6,6 +6,10 @@ import { generateWidthStyles } from "src/common/utils/tableUtils";
 import TreeTableNameCell from "../components/TreeTableNameCell";
 import { StyledSortableHeader } from "../style";
 
+/**
+ * Typically, column defs are regular objects. However, fetching location data is very expensive, so
+ * this column def is a function that accepts the (hopefully memoized) map of locations
+ */
 export const treeName = (
   locations: IdMap<NamedGisaidLocation>
 ): ColumnDef<PhyloRun, any> => ({

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeType.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeType.tsx
@@ -1,9 +1,9 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { memo } from "src/common/utils/memo";
 import { generateWidthStyles } from "src/common/utils/tableUtils";
-import { StyledCellBasic } from "src/views/Data/components/SamplesView/components/SamplesTable/style";
 import { SortableHeader } from "src/views/Data/components/SortableHeader";
 import { TreeTypeTooltip } from "../components/TreeTypeTooltip";
+import { StyledCellBasic } from "../style";
 
 export const treeType: ColumnDef<PhyloRun, any> = {
   id: "treeType",

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeType.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/columnDefinitions/treeType.tsx
@@ -1,0 +1,43 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { memo } from "src/common/utils/memo";
+import { generateWidthStyles } from "src/common/utils/tableUtils";
+import { StyledCellBasic } from "src/views/Data/components/SamplesView/components/SamplesTable/style";
+import { SortableHeader } from "src/views/Data/components/SortableHeader";
+import { TreeTypeTooltip } from "../components/TreeTypeTooltip";
+
+export const treeType: ColumnDef<PhyloRun, any> = {
+  id: "treeType",
+  accessorKey: "treeType",
+  size: 160,
+  header: ({ header, column }) => (
+    <SortableHeader
+      header={header}
+      style={generateWidthStyles(column)}
+      tooltipStrings={{
+        boldText: "Tree Type",
+        link: {
+          href: "https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4/edit?usp=sharing",
+          linkText: "Read our guide to learn more.",
+        },
+        regularText:
+          "CZ Gen Epi-defined profiles for tree building based on primary use case and build settings.",
+      }}
+    >
+      Tree Type
+    </SortableHeader>
+  ),
+  cell: memo(({ getValue, cell }) => {
+    const type = getValue();
+    return (
+      <TreeTypeTooltip value={type}>
+        <StyledCellBasic
+          key={cell.id}
+          verticalAlign="center"
+          shouldShowTooltipOnHover={false}
+          primaryText={getValue()}
+        />
+      </TreeTypeTooltip>
+    );
+  }),
+  enableSorting: true,
+};

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTableNameCell/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTableNameCell/index.tsx
@@ -7,10 +7,8 @@ import {
 import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { TREE_STATUS } from "src/common/constants/types";
 import { useGroupInfo } from "src/common/queries/groups";
-import {
-  foldInLocationName,
-  useNamedLocationsById,
-} from "src/common/queries/locations";
+import { foldInLocationName } from "src/common/queries/locations";
+import { NamedLocationsByIdResponse } from "src/common/utils/locationUtils";
 import { NO_CONTENT_FALLBACK } from "src/views/Upload/components/common/constants";
 import NextstrainConfirmationModal from "../NextstrainConfirmationModal";
 import { PhyloTreeStatusTag } from "./components/PhyloTreeStatusTag";
@@ -28,6 +26,7 @@ import {
 
 interface Props {
   phyloRun: PhyloRun;
+  locations: NamedLocationsByIdResponse;
 }
 
 const getDateRangeString = (phyloRun: PhyloRun): string => {
@@ -43,13 +42,12 @@ const getDateRangeString = (phyloRun: PhyloRun): string => {
   return `${startDate} to ${endDate}`;
 };
 
-const TreeTableNameCell = ({ phyloRun }: Props): JSX.Element => {
+const TreeTableNameCell = ({ phyloRun, locations }: Props): JSX.Element => {
   const [open, setOpen] = useState(false);
   const { name, phyloTree, status, templateArgs, user } = phyloRun;
   const treeId = phyloTree?.id;
   const userName = user?.name;
   const isDisabled = status !== TREE_STATUS.Completed || !treeId;
-  const { data: namedLocationsById } = useNamedLocationsById();
 
   const { data: groupInfo } = useGroupInfo();
 
@@ -67,8 +65,8 @@ const TreeTableNameCell = ({ phyloRun }: Props): JSX.Element => {
     // namedLocationsData takes a while to load. We do not want to show
     // the group location here because it is incorrect. Instead, we show
     // nothing until the data is ready.
-    if (!namedLocationsById) return "";
-    return namedLocationsById.namedLocationsById[templateLocationId].name;
+    if (!locations) return "";
+    return locations.locations[templateLocationId].name;
   };
 
   const handleClickOpen = () => {

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTableNameCell/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTableNameCell/index.tsx
@@ -8,7 +8,7 @@ import { analyticsTrackEvent } from "src/common/analytics/methods";
 import { TREE_STATUS } from "src/common/constants/types";
 import { useGroupInfo } from "src/common/queries/groups";
 import { foldInLocationName } from "src/common/queries/locations";
-import { NamedLocationsByIdResponse } from "src/common/utils/locationUtils";
+import { IdMap } from "src/common/utils/dataTransforms";
 import { NO_CONTENT_FALLBACK } from "src/views/Upload/components/common/constants";
 import NextstrainConfirmationModal from "../NextstrainConfirmationModal";
 import { PhyloTreeStatusTag } from "./components/PhyloTreeStatusTag";
@@ -26,7 +26,7 @@ import {
 
 interface Props {
   phyloRun: PhyloRun;
-  locations: NamedLocationsByIdResponse;
+  locations: IdMap<NamedGisaidLocation>;
 }
 
 const getDateRangeString = (phyloRun: PhyloRun): string => {
@@ -66,7 +66,7 @@ const TreeTableNameCell = ({ phyloRun, locations }: Props): JSX.Element => {
     // the group location here because it is incorrect. Instead, we show
     // nothing until the data is ready.
     if (!locations) return "";
-    return locations.locations[templateLocationId].name;
+    return locations[templateLocationId].name;
   };
 
   const handleClickOpen = () => {

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
@@ -28,7 +28,18 @@ const defaultColumn: Partial<ColumnDef<PhyloRun, any>> = {
 };
 
 const TreesTable = ({ data, isLoading }: Props): JSX.Element => {
-  console.log("TreesTable");
+  const { data: locationData = {} } = useLocations();
+  const { locations } = locationData;
+
+  const namedLocationsById = useMemo(
+    () => getNamedLocationsById(locations),
+    [locations]
+  );
+
+  const columns: ColumnDef<PhyloRun, any>[] = useMemo(() => {
+    return [treeName(namedLocationsById), startedDate, treeType, actionMenu];
+  }, [namedLocationsById]);
+
   return (
     <Table<PhyloRun>
       columns={columns}

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
@@ -1,130 +1,21 @@
-import { CellComponent, CellHeader } from "czifui";
 import { ColumnDef } from "@tanstack/react-table";
 import { IdMap } from "src/common/utils/dataTransforms";
-import { datetimeWithTzToLocalDate } from "src/common/utils/timeUtils";
-import { TreeActionMenu } from "./components/TreeActionMenu";
-import { TreeTypeTooltip } from "./components/TreeTypeTooltip";
-import { SortableHeader } from "src/views/Data/components/SortableHeader";
 import { StyledCellBasic } from "../../../SamplesView/components/SamplesTable/style";
-import TreeTableNameCell from "./components/TreeTableNameCell";
-import { StyledSortableHeader } from "./style";
-import { generateWidthStyles } from "src/common/utils/tableUtils";
 import { NO_CONTENT_FALLBACK } from "src/components/Table/constants";
 import { memo } from "src/common/utils/memo";
 import Table from "src/components/Table";
+import { useLocations } from "src/common/queries/locations";
+import { useMemo } from "react";
+import { getNamedLocationsById } from "src/common/utils/locationUtils";
+import { treeName } from "./columnDefinitions/treeName";
+import { startedDate } from "./columnDefinitions/startedDate";
+import { treeType } from "./columnDefinitions/treeType";
+import { actionMenu } from "./columnDefinitions/actionMenu";
 
 interface Props {
   data: IdMap<PhyloRun> | undefined;
   isLoading: boolean;
 }
-
-const columns: ColumnDef<PhyloRun, any>[] = [
-  {
-    id: "name",
-    accessorKey: "name",
-    minSize: 350,
-    header: ({ header, column }) => (
-      <StyledSortableHeader
-        header={header}
-        style={generateWidthStyles(column)}
-        tooltipStrings={{
-          boldText: "Tree Name",
-          regularText:
-            "User-provided tree name. Auto-generated tree builds are named ”Y Contextual“, where Y is your Group Name.",
-        }}
-      >
-        Tree Name
-      </StyledSortableHeader>
-    ),
-    cell: memo(({ row, cell }) => (
-      <CellComponent key={cell.id}>
-        <TreeTableNameCell phyloRun={row.original} />
-      </CellComponent>
-    )),
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-  },
-  {
-    id: "startedDate",
-    accessorKey: "startedDate",
-    size: 160,
-    header: ({ header, column }) => (
-      <SortableHeader
-        header={header}
-        style={generateWidthStyles(column)}
-        tooltipStrings={{
-          boldText: "Creation Date",
-          regularText: "Date on which the tree was generated.",
-        }}
-      >
-        Creation Date
-      </SortableHeader>
-    ),
-    cell: memo(({ getValue, cell }) => (
-      <StyledCellBasic
-        key={cell.id}
-        verticalAlign="center"
-        shouldShowTooltipOnHover={false}
-        primaryText={datetimeWithTzToLocalDate(getValue())}
-      />
-    )),
-    enableSorting: true,
-  },
-  {
-    id: "treeType",
-    accessorKey: "treeType",
-    size: 160,
-    header: ({ header, column }) => (
-      <SortableHeader
-        header={header}
-        style={generateWidthStyles(column)}
-        tooltipStrings={{
-          boldText: "Tree Type",
-          link: {
-            href: "https://docs.google.com/document/d/1_iQgwl3hn_pjlZLX-n0alUbbhgSPZvpW_0620Hk_kB4/edit?usp=sharing",
-            linkText: "Read our guide to learn more.",
-          },
-          regularText:
-            "CZ Gen Epi-defined profiles for tree building based on primary use case and build settings.",
-        }}
-      >
-        Tree Type
-      </SortableHeader>
-    ),
-    cell: memo(({ getValue, cell }) => {
-      const type = getValue();
-      return (
-        <TreeTypeTooltip value={type}>
-          <StyledCellBasic
-            key={cell.id}
-            verticalAlign="center"
-            shouldShowTooltipOnHover={false}
-            primaryText={getValue()}
-          />
-        </TreeTypeTooltip>
-      );
-    }),
-    enableSorting: true,
-  },
-  {
-    id: "action",
-    size: 160,
-    header: ({ column, header }) => (
-      <CellHeader
-        key={header.id}
-        style={generateWidthStyles(column)}
-        hideSortIcon
-      >
-        {" "}
-      </CellHeader>
-    ),
-    cell: memo(({ row, cell }) => (
-      <CellComponent key={cell.id}>
-        <TreeActionMenu phyloRun={row.original} />
-      </CellComponent>
-    )),
-  },
-];
 
 const defaultColumn: Partial<ColumnDef<PhyloRun, any>> = {
   cell: memo(({ getValue }) => (

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
@@ -36,8 +36,8 @@ const columns: ColumnDef<PhyloRun, any>[] = [
         Tree Name
       </StyledSortableHeader>
     ),
-    cell: memo(({ row }) => (
-      <CellComponent>
+    cell: memo(({ row, cell }) => (
+      <CellComponent key={cell.id}>
         <TreeTableNameCell phyloRun={row.original} />
       </CellComponent>
     )),
@@ -60,8 +60,9 @@ const columns: ColumnDef<PhyloRun, any>[] = [
         Creation Date
       </SortableHeader>
     ),
-    cell: memo(({ getValue }) => (
+    cell: memo(({ getValue, cell }) => (
       <StyledCellBasic
+        key={cell.id}
         verticalAlign="center"
         shouldShowTooltipOnHover={false}
         primaryText={datetimeWithTzToLocalDate(getValue())}
@@ -90,11 +91,12 @@ const columns: ColumnDef<PhyloRun, any>[] = [
         Tree Type
       </SortableHeader>
     ),
-    cell: memo(({ getValue }) => {
+    cell: memo(({ getValue, cell }) => {
       const type = getValue();
       return (
         <TreeTypeTooltip value={type}>
           <StyledCellBasic
+            key={cell.id}
             verticalAlign="center"
             shouldShowTooltipOnHover={false}
             primaryText={getValue()}
@@ -107,13 +109,17 @@ const columns: ColumnDef<PhyloRun, any>[] = [
   {
     id: "action",
     size: 160,
-    header: ({ column }) => (
-      <CellHeader style={generateWidthStyles(column)} hideSortIcon>
+    header: ({ column, header }) => (
+      <CellHeader
+        key={header.id}
+        style={generateWidthStyles(column)}
+        hideSortIcon
+      >
         {" "}
       </CellHeader>
     ),
-    cell: memo(({ row }) => (
-      <CellComponent>
+    cell: memo(({ row, cell }) => (
+      <CellComponent key={cell.id}>
         <TreeActionMenu phyloRun={row.original} />
       </CellComponent>
     )),
@@ -121,16 +127,17 @@ const columns: ColumnDef<PhyloRun, any>[] = [
 ];
 
 const defaultColumn: Partial<ColumnDef<PhyloRun, any>> = {
-  cell: ({ getValue }) => (
+  cell: memo(({ getValue }) => (
     <StyledCellBasic
       verticalAlign="center"
       shouldShowTooltipOnHover={false}
       primaryText={(getValue() || NO_CONTENT_FALLBACK) as string}
     />
-  ),
+  )),
 };
 
 const TreesTable = ({ data, isLoading }: Props): JSX.Element => {
+  console.log("TreesTable");
   return (
     <Table<PhyloRun>
       columns={columns}

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
@@ -1,6 +1,5 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { IdMap } from "src/common/utils/dataTransforms";
-import { StyledCellBasic } from "../../../SamplesView/components/SamplesTable/style";
 import { NO_CONTENT_FALLBACK } from "src/components/Table/constants";
 import { memo } from "src/common/utils/memo";
 import Table from "src/components/Table";
@@ -11,6 +10,7 @@ import { treeName } from "./columnDefinitions/treeName";
 import { startedDate } from "./columnDefinitions/startedDate";
 import { treeType } from "./columnDefinitions/treeType";
 import { actionMenu } from "./columnDefinitions/actionMenu";
+import { StyledCellBasic } from "./style";
 
 interface Props {
   data: IdMap<PhyloRun> | undefined;

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/index.tsx
@@ -28,7 +28,7 @@ const defaultColumn: Partial<ColumnDef<PhyloRun, any>> = {
 };
 
 const TreesTable = ({ data, isLoading }: Props): JSX.Element => {
-  const { data: locationData = {} } = useLocations();
+  const { data: locationData = { locations: [] } } = useLocations();
   const { locations } = locationData;
 
   const namedLocationsById = useMemo(

--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/style.ts
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/style.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { CellBasic, getFontWeights } from "czifui";
 import { SortableHeader } from "src/views/Data/components/SortableHeader";
 
 export const StyledSortableHeader = styled(SortableHeader)`
@@ -13,4 +14,16 @@ export const StyledWrapper = styled.div`
   & > div {
     overflow: auto;
   }
+`;
+
+export const StyledCellBasic = styled(CellBasic)`
+  ${(props) => {
+    const fontWeights = getFontWeights(props);
+    return `
+      span {
+        font-weight: ${fontWeights?.semibold};
+        word-break: break-word;
+      }
+    `;
+  }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Improvements for the trees table
  - add ids and memoize components to improve perf on trees table
  - move trees table column defs to their own files
  - make a huge perf improvement for tree name cell location code -- see inline comment
  - minor style & import updates
  - remove old/unused samples hook
- **Why:** Last bits of work for table refactor 🙌 🚀 
- **Ticket:** [[sc-229189]](https://app.shortcut.com/genepi/story/229189)
- **Env:** https://maya-tree-table-perf-frontend.dev.czgenepi.org/

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/216470427-e1f8d30b-d222-4976-bfc3-987cf0edd990.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/216470429-80dcf299-8660-4e1a-924a-dc08c1062e57.gif)

### Checklist
- [x] I merged latest `maya/remove-old-tables`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)