### PR TITLE
Maya/api camelize

### DIFF
--- a/src/frontend/src/common/api/index.tsx
+++ b/src/frontend/src/common/api/index.tsx
@@ -1,7 +1,7 @@
 import ENV from "src/common/constants/ENV";
-import { jsonToType } from "src/common/utils";
 import { store } from "../redux";
 import { selectCurrentGroup, selectCurrentPathogen } from "../redux/selectors";
+import { camelize } from "../utils/dataTransforms";
 
 export enum API {
   USERDATA = "/v2/users/me",
@@ -70,7 +70,7 @@ export const DEFAULT_DELETE_OPTIONS: RequestInit = {
 /**
  * Generic functions to interface with the backend API
  *
- * First chunk of things -- `API_KEY_TO_TYPE`, `convert`, and `apiResponse` --
+ * First chunk of things -- `apiResponse` --
  * are intended for "heavier" GETs to the backend that require some level
  * of data conversion for the response we get. For example, the samples
  * endpoint returns a bunch of stuff in snake_case, but we want camelCase,
@@ -87,39 +87,6 @@ export const DEFAULT_DELETE_OPTIONS: RequestInit = {
  * response, either would make sense, use your best judgment.
  **/
 
-const API_KEY_TO_TYPE: Record<string, string> = {
-  group: "Group",
-  phylo_trees: "Tree",
-  samples: "Sample",
-  user: "User",
-};
-
-function convert<U extends APIResponse, T extends U[keyof U]>(
-  entry: Record<string, JSONPrimitive>,
-  keyMap: Map<string, string | number> | null,
-  key: keyof U,
-  keySubMap?: Map<string, Map<string, string>>
-): T {
-  const converted = jsonToType<T>(entry, keyMap);
-  // key should always be a string anyways. no funky business please.
-  converted.type = API_KEY_TO_TYPE[String(key)];
-  // ^^^ FIXME (Vince) Does this get used anywhere? What was original purpose?
-
-  // If we end up with deeper nested objects, this could be recursive instead.
-  if (keySubMap) {
-    const convertedKeys = Object.keys(converted);
-    convertedKeys.forEach((convertedKey) => {
-      if (keySubMap.has(convertedKey)) {
-        converted[convertedKey] = jsonToType<T>(
-          converted[convertedKey],
-          keySubMap.get(convertedKey) || null
-        );
-      }
-    });
-  }
-  return converted;
-}
-
 /**
  * Make a GET request to backend API, parse results based on provided mapping.
  *
@@ -134,34 +101,15 @@ function convert<U extends APIResponse, T extends U[keyof U]>(
  */
 
 export async function apiResponse<T extends APIResponse>(
-  keys: (keyof T)[],
-  mappings: (Map<string, string | number> | null)[],
-  endpoint: string,
-  subMappings?: Map<string, Map<string, string>>[]
+  endpoint: string
 ): Promise<T> {
   const response = await fetch(ENV.API_URL + endpoint, DEFAULT_FETCH_OPTIONS);
-  const result = await response.json();
+  const apiData = await response.json();
   if (!response.ok) {
-    throw result;
+    throw apiData;
   }
 
-  const convertedData = keys.map((key, index) => {
-    type keyType = T[typeof key];
-    const typeData = result[key];
-    const keyMap = mappings[index];
-    const keySubMap = subMappings && subMappings[index];
-    let resultData: keyType | keyType[];
-    if (typeData instanceof Array) {
-      resultData = typeData.map((entry: Record<string, JSONPrimitive>) =>
-        convert<T, keyType>(entry, keyMap, key, keySubMap)
-      );
-    } else {
-      resultData = convert<T, keyType>(typeData, keyMap, key, keySubMap);
-    }
-    return [key, resultData];
-  });
-
-  return Object.fromEntries(convertedData);
+  return camelize(apiData);
 }
 
 /**
@@ -218,89 +166,12 @@ export interface SampleResponse extends APIResponse {
   samples: Sample[];
 }
 
-const GENBANK_SUBMAP = new Map<string, keyof Genbank>([
-  ["genbank_accession", "genbankAccession"],
-]);
-
-const GISAID_SUBMAP = new Map<string, keyof GISAID>([
-  ["gisaid_id", "gisaidId"],
-]);
-
-const LINEAGE_SUBMAP = new Map<string, keyof Lineage>([
-  ["lineage_type", "lineageType"],
-  ["lineage_software_version", "lineageSoftwareVersion"],
-  ["lineage_probability", "lineageProbability"],
-  ["last_updated", "lastUpdated"],
-  ["reference_dataset_name", "referenceDatasetName"],
-  ["reference_sequence_accession", "referenceSequenceAccession"],
-  ["reference_dataset_tag", "referenceDatasetTag"],
-  ["scorpio_call", "scorpioCall"],
-  ["scorpio_support", "scorpioSupport"],
-  ["qc_status", "qcStatus"],
-]);
-
-const QC_SUBMAP = new Map<string, keyof QCMetrics>([
-  ["qc_score", "qcScore"],
-  ["qc_software_version", "qcSoftwareVersion"],
-  ["qc_status", "qcStatus"],
-  ["qc_caller", "qcCaller"],
-  ["reference_dataset_name", "referenceDatasetName"],
-  ["reference_sequence_accession", "referenceSequenceAccession"],
-  ["reference_dataset_tag", "referenceDatasetTag"],
-]);
-
-const SAMPLE_SUBMAP = new Map<string, Map<string, string>>([
-  ["genbank", GENBANK_SUBMAP],
-  ["gisaid", GISAID_SUBMAP],
-  ["lineage", LINEAGE_SUBMAP],
-  ["qcMetrics", QC_SUBMAP],
-]);
-
-const SAMPLE_MAP = new Map<string, keyof Sample>([
-  ["collection_date", "collectionDate"],
-  ["collection_location", "collectionLocation"],
-  ["private_identifier", "privateId"],
-  ["public_identifier", "publicId"],
-  ["upload_date", "uploadDate"],
-  ["uploaded_by", "uploadedBy"],
-  ["sequencing_date", "sequencingDate"],
-  ["submitting_group", "submittingGroup"],
-  ["qc_metrics", "qcMetrics"],
-]);
-
 export const fetchSamples = (): Promise<SampleResponse> =>
-  apiResponse<SampleResponse>(
-    ["samples"],
-    [SAMPLE_MAP],
-    generateOrgSpecificUrl(ORG_API.SAMPLES),
-    [SAMPLE_SUBMAP]
-  );
+  apiResponse<SampleResponse>(generateOrgSpecificUrl(ORG_API.SAMPLES));
 
 export interface PhyloRunResponse extends APIResponse {
   phylo_trees: PhyloRun[];
 }
-const PHYLO_RUN_MAP = new Map<string, keyof PhyloRun>([
-  ["phylo_tree", "phyloTree"],
-  ["start_datetime", "startedDate"],
-  ["template_args", "templateArgs"],
-  ["workflow_id", "workflowId"],
-  ["workflow_status", "status"],
-]);
-
-const TEMPLATE_ARGS_MAP = new Map<string, keyof TemplateArgs>([
-  ["filter_pango_lineages", "filterPangoLineages"],
-  ["filter_start_date", "filterStartDate"],
-  ["filter_end_date", "filterEndDate"],
-  ["location_id", "locationId"],
-]);
-
-const PHYLO_RUN_SUBMAP = new Map<string, Map<string, string>>();
-PHYLO_RUN_SUBMAP.set("templateArgs", TEMPLATE_ARGS_MAP);
 
 export const fetchPhyloRuns = (): Promise<PhyloRunResponse> =>
-  apiResponse<PhyloRunResponse>(
-    ["phylo_runs"],
-    [PHYLO_RUN_MAP],
-    generateOrgSpecificUrl(ORG_API.PHYLO_RUNS),
-    [PHYLO_RUN_SUBMAP]
-  );
+  apiResponse<PhyloRunResponse>(generateOrgSpecificUrl(ORG_API.PHYLO_RUNS));

--- a/src/frontend/src/common/appRouting.ts
+++ b/src/frontend/src/common/appRouting.ts
@@ -1,6 +1,6 @@
 import { forEach } from "lodash";
 import { NextRouter, useRouter } from "next/router";
-import { fetchUserInfo, mapUserData } from "./queries/auth";
+import { fetchUserInfo } from "./queries/auth";
 import { store } from "./redux";
 import { setGroup, setPathogen } from "./redux/actions";
 import { selectCurrentGroup, selectCurrentPathogen } from "./redux/selectors";
@@ -11,6 +11,7 @@ import {
   isValidPathogen,
 } from "./redux/utils/pathogenUtils";
 import { workspacePaths } from "./routes";
+import { camelize } from "./utils/dataTransforms";
 import { canUserViewGroup } from "./utils/userInfo";
 
 // TODO (mlila): if we end up with more than two workspace values (groupId, pathogen)
@@ -101,7 +102,7 @@ const setWorkspaceGroupId = async (
   potentialUrlGroupId = ""
 ): Promise<string> => {
   const rawUserInfo = await fetchUserInfo();
-  const userInfo = mapUserData(rawUserInfo);
+  const userInfo = camelize(rawUserInfo);
   const { dispatch, getState } = store;
   const state = getState();
 

--- a/src/frontend/src/common/queries/auth.ts
+++ b/src/frontend/src/common/queries/auth.ts
@@ -15,6 +15,7 @@ import { API, DEFAULT_PUT_OPTIONS, getBackendApiJson } from "../api";
 import { selectCurrentGroup } from "../redux/selectors";
 import { ensureValidGroup } from "../redux/utils/groupUtils";
 import { ROUTES } from "../routes";
+import { camelize } from "../utils/dataTransforms";
 import { ENTITIES } from "./entities";
 import { GROUP_QUERY_ID_PREFIX } from "./groups";
 
@@ -35,19 +36,6 @@ export interface RawUserRequest {
   analytics_id: string;
   gisaid_submitter_id: string;
 }
-
-export const mapUserData = (obj: RawUserRequest): User => {
-  return {
-    acknowledgedPolicyVersion: obj.acknowledged_policy_version,
-    agreedToTos: obj.agreed_to_tos,
-    analyticsId: obj.analytics_id,
-    gisaidSubmitterId: obj.gisaid_submitter_id,
-    groups: obj.groups,
-    id: obj.id,
-    name: obj.name,
-    splitId: obj.split_id,
-  };
-};
 
 export const fetchUserInfo = (): Promise<RawUserRequest> => {
   return getBackendApiJson(API.USERDATA);
@@ -81,7 +69,7 @@ export function useUpdateUserInfo(): UseMutationResult<
 // Performs the needed `select` for `useUserInfo`, but also inserts a call
 // to analytics as a way to easily catch any changes to user info over time.
 function mapUserDataAndHandleAnalytics(obj: RawUserRequest): User {
-  const user = mapUserData(obj);
+  const user = camelize(obj);
   // Downstream will handle figuring out group info (and if it's ready yet).
   analyticsSendUserInfo(user);
   return user;
@@ -113,7 +101,7 @@ export function useUserInfo(): UseQueryResult<User, unknown> {
  */
 export const getCurrentUserInfo = (): User | undefined => {
   const rawUser = queryClient.getQueryData<RawUserRequest>([USE_USER_INFO]);
-  return rawUser && mapUserData(rawUser);
+  return rawUser && camelize(rawUser);
 };
 
 /**

--- a/src/frontend/src/common/queries/groups.ts
+++ b/src/frontend/src/common/queries/groups.ts
@@ -13,6 +13,7 @@ import {
   generateGroupSpecificUrl,
 } from "../api";
 import { API_URL } from "../constants/ENV";
+import { camelize } from "../utils/dataTransforms";
 import { ENTITIES } from "./entities";
 import { USE_PHYLO_RUN_INFO } from "./phyloRuns";
 import { USE_SAMPLE_INFO } from "./samples";
@@ -51,28 +52,6 @@ export const mapGroupData = (obj: RawGroupRequest): GroupDetails => {
     location: obj.default_tree_location,
     name: obj.name,
     prefix: obj.prefix,
-  };
-};
-
-const mapGroupInvitations = (obj: RawInvitationResponse): Invitation => {
-  return {
-    createdAt: obj.created_at,
-    expiresAt: obj.expires_at,
-    id: obj.id,
-    invitee: obj.invitee,
-    inviter: obj.inviter,
-  };
-};
-
-export const mapGroupMemberData = (obj: RawGroupMemberRequest): GroupMember => {
-  return {
-    acknowledgedPolicyVersion: obj.acknowledged_policy_version,
-    agreedToTos: obj.agreed_to_tos,
-    createdAt: obj.created_at,
-    email: obj.email,
-    id: obj.id,
-    name: obj.name,
-    role: obj.role,
   };
 };
 
@@ -124,7 +103,7 @@ export function useGroupMembersInfo(): UseQueryResult<GroupMember[], unknown> {
     retry: false,
     select: (data) => {
       const { members } = data;
-      return members.map((m) => mapGroupMemberData(m));
+      return members.map(camelize);
     },
   });
 }
@@ -156,7 +135,7 @@ export function useGroupInvitations(): UseQueryResult<Invitation[], unknown> {
     retry: false,
     select: (data) => {
       const { invitations } = data;
-      return invitations.map((i) => mapGroupInvitations(i));
+      return invitations.map(camelize);
     },
   });
 }

--- a/src/frontend/src/common/queries/phyloRuns.ts
+++ b/src/frontend/src/common/queries/phyloRuns.ts
@@ -20,18 +20,23 @@ import {
   getDownloadLinks,
   IdMap,
   reduceObjectArrayToLookupDict,
+  replaceKeyName,
 } from "../utils/dataTransforms";
 import { ENTITIES } from "./entities";
 import { MutationCallbacks } from "./types";
 
 const mapPhyloRuns = (data: PhyloRunResponse) => {
-  const phyloRuns = data.phylo_runs;
+  const phyloRuns = data.phyloRuns;
 
-  const transformedRuns = phyloRuns.map((p: PhyloRun) => ({
-    ...p,
-    ...getDownloadLinks(p),
-    treeType: getCapitalCaseTreeType(p),
-  }));
+  const transformedRuns = phyloRuns.map((p: PhyloRun) => {
+    replaceKeyName(p, "workflowStatus", "status");
+
+    return {
+      ...p,
+      ...getDownloadLinks(p),
+      treeType: getCapitalCaseTreeType(p),
+    };
+  });
 
   return reduceObjectArrayToLookupDict<PhyloRun>(transformedRuns, "id");
 };

--- a/src/frontend/src/common/queries/phyloRuns.ts
+++ b/src/frontend/src/common/queries/phyloRuns.ts
@@ -30,6 +30,7 @@ const mapPhyloRuns = (data: PhyloRunResponse) => {
 
   const transformedRuns = phyloRuns.map((p: PhyloRun) => {
     replaceKeyName(p, "workflowStatus", "status");
+    replaceKeyName(p, "startDatetime", "startedDate");
 
     return {
       ...p,

--- a/src/frontend/src/common/queries/phyloRuns.ts
+++ b/src/frontend/src/common/queries/phyloRuns.ts
@@ -26,7 +26,7 @@ import { ENTITIES } from "./entities";
 import { MutationCallbacks } from "./types";
 
 const mapPhyloRuns = (data: PhyloRunResponse) => {
-  const phyloRuns = data.phyloRuns;
+  const { phyloRuns } = data;
 
   const transformedRuns = phyloRuns.map((p: PhyloRun) => {
     replaceKeyName(p, "workflowStatus", "status");

--- a/src/frontend/src/common/queries/samples.ts
+++ b/src/frontend/src/common/queries/samples.ts
@@ -20,7 +20,11 @@ import {
 import { API_URL } from "../constants/ENV";
 import { store } from "../redux";
 import { selectCurrentPathogen } from "../redux/selectors";
-import { IdMap, reduceObjectArrayToLookupDict, replaceKeyName } from "../utils/dataTransforms";
+import {
+  IdMap,
+  reduceObjectArrayToLookupDict,
+  replaceKeyName,
+} from "../utils/dataTransforms";
 import { ENTITIES } from "./entities";
 import { MutationCallbacks } from "./types";
 

--- a/src/frontend/src/common/redux/utils/groupUtils.ts
+++ b/src/frontend/src/common/redux/utils/groupUtils.ts
@@ -1,10 +1,11 @@
+import { camelize } from "src/common/utils/dataTransforms";
 import {
   getLocalStorage,
   isWindowDefined,
 } from "src/common/utils/localStorage";
 import { canUserViewGroup } from "src/common/utils/userInfo";
 import { store } from "..";
-import { fetchUserInfo, mapUserData } from "../../queries/auth";
+import { fetchUserInfo } from "../../queries/auth";
 import { setGroup } from "../actions";
 import { selectCurrentGroup } from "../selectors";
 import { ReduxPersistenceTokens } from "../types";
@@ -15,7 +16,7 @@ export const ensureValidGroup = async (): Promise<void> => {
   const { dispatch, getState } = store;
   const state = getState();
   const rawUserInfo = await fetchUserInfo();
-  const userInfo = mapUserData(rawUserInfo);
+  const userInfo = camelize(rawUserInfo);
   const { groups } = userInfo;
 
   // wait until app initialized & user info loaded

--- a/src/frontend/src/common/utils/dataTransforms.ts
+++ b/src/frontend/src/common/utils/dataTransforms.ts
@@ -70,7 +70,7 @@ type PhyloTreeManipulationType = PhyloRun & { tree_type?: TreeType };
 export const getCapitalCaseTreeType = (
   phyloRun: PhyloTreeManipulationType
 ): string | undefined => {
-  const { tree_type: treeType } = phyloRun;
+  const { treeType } = phyloRun;
 
   if (typeof treeType !== "string" || treeType.toLowerCase() == "unknown") {
     return undefined;

--- a/src/frontend/src/common/utils/dataTransforms.ts
+++ b/src/frontend/src/common/utils/dataTransforms.ts
@@ -1,3 +1,4 @@
+import { camelCase, isArray, isObject, transform } from "lodash";
 import { generateOrgSpecificUrl, ORG_API } from "src/common/api";
 import ENV from "src/common/constants/ENV";
 import { TreeType } from "../constants/types";
@@ -82,4 +83,38 @@ export const getCapitalCaseTreeType = (
   }
 
   return nameParts.join("-");
+};
+
+/**
+ * Accepts any object with arbitrary levels of nesting (the nested bits can be objs or arrays),
+ * and returns essentially the same object with all the keys camelCased instead of snake_cased.
+ * Useful for parsing backend responses.
+ */
+export const camelize = (obj: any): any => {
+  return transform(obj, (acc, value, key, target) => {
+    const camelKey = isArray(target) ? key : camelCase(key);
+    acc[camelKey] = isObject(value) ? camelize(value) : value;
+  });
+};
+
+/**
+ * Will change the key associated with a value for the given object and keys.
+ * Example:
+ *   >>> replaceKeyName({ a: "apple" }, "a", "b");
+ *   <<< { b: "apple"}
+ */
+export const replaceKeyName = (
+  obj: any,
+  oldKey: string,
+  newKey: string
+): any => {
+  if (oldKey === newKey) return;
+
+  Object.defineProperty(
+    obj,
+    newKey,
+    Object.getOwnPropertyDescriptor(obj, oldKey) ?? {}
+  );
+
+  delete obj[oldKey];
 };

--- a/src/frontend/src/common/utils/dataTransforms.ts
+++ b/src/frontend/src/common/utils/dataTransforms.ts
@@ -91,7 +91,7 @@ export const getCapitalCaseTreeType = (
  * Useful for parsing backend responses.
  */
 export const camelize = (obj: any): any => {
-  return transform(obj, (acc, value, key, target) => {
+  return transform(obj, (acc, value, key: string, target) => {
     const camelKey = isArray(target) ? key : camelCase(key);
     acc[camelKey] = isObject(value) ? camelize(value) : value;
   });

--- a/src/frontend/src/common/utils/samples.ts
+++ b/src/frontend/src/common/utils/samples.ts
@@ -1,2 +1,6 @@
 export const getLineageFromSampleLineages = (lineages: Lineage[]): Lineage =>
   lineages?.[0];
+
+export const getLineageFromSample = (sample: Sample): string | undefined => {
+  return sample?.lineages?.[0]?.lineage;
+};

--- a/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/mapTsvData.ts
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SampleTableModalManager/components/DownloadModal/components/DownloadButton/mapTsvData.ts
@@ -38,7 +38,7 @@ export const mapTsvData = (checkedSamples: Sample[]): string[][] => {
     value: any;
   }): string[] => {
     return subHeaders.map((subHeader) => {
-      const subHeaderValue = value[subHeader.key];
+      const subHeaderValue = value?.[subHeader.key];
       return subHeaderValue ? String(subHeaderValue) : defaultEmptyValue;
     });
   };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/columnDefinitions/lineage.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/columnDefinitions/lineage.tsx
@@ -1,6 +1,9 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { memo } from "src/common/utils/memo";
-import { getLineageFromSampleLineages } from "src/common/utils/samples";
+import {
+  getLineageFromSample,
+  getLineageFromSampleLineages,
+} from "src/common/utils/samples";
 import { generateWidthStyles } from "src/common/utils/tableUtils";
 import { SortableHeader } from "src/views/Data/components/SortableHeader";
 import { LineageTooltip } from "../components/LineageTooltip";
@@ -46,4 +49,9 @@ export const lineageColumn: ColumnDef<Sample, any> = {
     );
   }),
   enableSorting: true,
+  sortingFn: (a, b) => {
+    const aLineage = getLineageFromSample(a.original) ?? "";
+    const bLineage = getLineageFromSample(b.original) ?? "";
+    return aLineage > bLineage ? -1 : 1;
+  },
 };

--- a/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/columnDefinitions/qualityControl.tsx
+++ b/src/frontend/src/views/Data/components/SamplesView/components/SamplesTable/columnDefinitions/qualityControl.tsx
@@ -3,6 +3,7 @@ import { CellComponent } from "czifui";
 import { memo } from "src/common/utils/memo";
 import { generateWidthStyles } from "src/common/utils/tableUtils";
 import { SortableHeader } from "src/views/Data/components/SortableHeader";
+import { getQCStatusFromSample } from "src/views/Upload/components/Samples/utils";
 import { QualityScoreTag } from "../components/QualityScoreTag";
 
 export const qualityControlColumn: ColumnDef<Sample, any> = {
@@ -34,8 +35,8 @@ export const qualityControlColumn: ColumnDef<Sample, any> = {
     );
   }),
   sortingFn: (a, b) => {
-    const statusA = a.original.qcMetrics[0].qcStatus;
-    const statusB = b.original.qcMetrics[0].qcStatus;
+    const statusA = getQCStatusFromSample(a.original) ?? "";
+    const statusB = getQCStatusFromSample(b.original) ?? "";
     return statusA > statusB ? -1 : 1;
   },
 };

--- a/src/frontend/src/views/Data/tableHeaders/commonSampleHeaders.tsx
+++ b/src/frontend/src/views/Data/tableHeaders/commonSampleHeaders.tsx
@@ -23,39 +23,39 @@ export const LINEAGE_HEADER: MetadataExportHeader<Sample> = {
       text: "Lineage",
     },
     {
-      key: "scorpio_call",
+      key: "scorpioCall",
       text: "Scorpio Call",
     },
     {
-      key: "scorpio_support",
+      key: "scorpioSupport",
       text: "Scorpio Support",
     },
     {
-      key: "last_updated",
+      key: "lastUpdated",
       text: "Last Updated",
     },
     {
-      key: "lineage_software_version",
+      key: "lineageSoftwareVersion",
       text: "Version",
     },
     {
-      key: "reference_dataset_name",
+      key: "referenceDatasetName",
       text: "Reference Dataset Name",
     },
     {
-      key: "lineage_type",
+      key: "lineageType",
       text: "Lineage Caller",
     },
     {
-      key: "reference_dataset_tag",
+      key: "referenceDatasetTag",
       text: "Reference Dataset Tag",
     },
     {
-      key: "reference_sequence_accession",
+      key: "referenceSequenceAccession",
       text: "Reference Sequence Accession",
     },
     {
-      key: "lineage_probability",
+      key: "lineageProbability",
       text: "Lineage Probability",
     },
   ],
@@ -66,19 +66,19 @@ export const QC_METRICS_HEADER: MetadataExportHeader<Sample> = {
   key: "qcMetrics",
   subHeaders: [
     {
-      key: "qc_caller",
+      key: "qcCaller",
       text: "QC Caller",
     },
     {
-      key: "qc_score",
+      key: "qcScore",
       text: "QC Score",
     },
     {
-      key: "qc_software_version",
+      key: "qcSoftwareVersion",
       text: "QC Software Version",
     },
     {
-      key: "qc_status",
+      key: "qcStatus",
       text: "QC Status",
     },
   ],
@@ -126,7 +126,7 @@ export const GISAID_HEADER: MetadataExportHeader<Sample> = {
       text: "GISAID Status",
     },
     {
-      key: "gisaid_id",
+      key: "gisaidId",
       text: "GISAID ID",
     },
   ],
@@ -142,7 +142,7 @@ export const GENBANK_HEADER: MetadataExportHeader<Sample> = {
       text: "GenBank Status",
     },
     {
-      key: "genbank_accession",
+      key: "genbankAccession",
       text: "GenBank Accession",
     },
   ],


### PR DESCRIPTION
### Summary
- **What:**
  - Remove maps/submaps for object keys to convert api responses from snake_case to camelCase.
  - I also fixed a couple of bugs I found in this branch
- **Why:** We can do this programmatically -- 99% of the time we just want a straight camelCase conversion.
- **Env:** https://maya-maps-frontend.dev.czgenepi.org/
- **Discussion:** https://czi-sci.slack.com/archives/C01HYJYA50W/p1675457987504069

### Testing
1. I tested pretty much everything in the app, including upload, download, link outs, static pages, table functionality like filter and sort, etc

### Demos
No visual changes.

### Checklist
- [x] I merged latest `maya-remove-old-tables`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)