### PR TITLE
chore: bump version of happy clean

### DIFF
--- a/.github/workflows/clean_happy_rdev.yml
+++ b/.github/workflows/clean_happy_rdev.yml
@@ -19,7 +19,7 @@ jobs:
           role-duration-seconds: 1800
           role-session-name: HappyCleanupGenepiRdevStacks
       - name: Clean up stale happy stacks
-        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.3
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.4
         with:
           tfe_token: ${{secrets.TFE_TOKEN}}
           # the default stale period to delete a stack is 2 weeks


### PR DESCRIPTION
Grabs the correct latest happy version

### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)