### PR TITLE
Update tree and gisaid download cron jobs to be weekly

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -193,7 +193,7 @@ module gisaid_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = local.swipe_sfn_arn
-  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 1 ? * MON-FRI *)"] : []
+  schedule_expressions  = contains(["geprod", "gestaging"], local.deployment_stage) ? ["cron(0 1 ? * TUE,THU,SUN *)"] : []
   event_role_arn        = local.event_role_arn
   extra_args            =  {
     genepi_config_secret_name = local.app_secret_name
@@ -325,7 +325,7 @@ module nextstrain_autorun_sfn_config {
   swipe_comms_bucket    = local.swipe_comms_bucket
   swipe_wdl_bucket      = local.swipe_wdl_bucket
   sfn_arn               = local.swipe_sfn_arn
-  schedule_expressions  = local.deployment_stage == "geprod" ? ["cron(0 3 ? * MON-FRI *)"] : []
+  schedule_expressions  = local.deployment_stage == "geprod" ? ["cron(0 3 ? * THU *)"] : []
   event_role_arn        = local.event_role_arn
   extra_args            =  {
     genepi_config_secret_name = local.app_secret_name


### PR DESCRIPTION
- Change tree runs to be once a week.

- GISAID only updates their data download twice a week now. So we can decrease this frequency too. 

* No rush. We can merge this next week if we want to test the other changes first. 