### PR TITLE
Fixes for mpx trees

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -475,8 +475,8 @@ def populate_aligned_row(sample, sequence):
         upload_date = sample.uploaded_pathogen_genome.upload_date.strftime("%Y-%m-%d")
 
     row: MutableMapping[str, Any] = {
-        "strain": sample.public_identifier,
-        "accession": getattr(genbank_accession, "accession", None) or "",
+        "accession": sample.public_identifier,
+        "strain": getattr(genbank_accession, "accession", None) or "",
         "date": sample.collection_date.strftime("%Y-%m-%d"),
         "region": sample.collection_location.region,
         "country": sample.collection_location.country,

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -67,8 +67,8 @@ unxz /mpox/data/*.xz
 # If we've written out any samples, add them to the upstream metadata/fasta files
 if [ -e /mpox/data/sequences_czge.fasta ]; then
     # Skip the TSV header when appending
-    tail +2 /mpox/data/metadata_czge.tsv > /mpox/data/metadata.tsv
-    cat /mpox/data/sequences_czge.fasta > /mpox/data/sequences.fasta
+    tail +2 /mpox/data/metadata_czge.tsv >> /mpox/data/metadata.tsv
+    cat /mpox/data/sequences_czge.fasta >> /mpox/data/sequences.fasta
 fi;
 
 # Persist the build config we generated.


### PR DESCRIPTION
### Notes:
- Fixes a typo so that we *append* czge samples to upstream samples instead of *overwriting* the upstream samples
- Use public ID as the accession name, since that's the main key that the mpox tree build uses instead of "strain"

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)