### PR TITLE
Temporarily disable Tuesday autodeploy.

### DIFF
--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -3,7 +3,7 @@ name: Scheduled Deploy
 on:
   schedule:
     # Weekly Tuesday & Thursdays @ 16:00 UTC (8am PST [winter] / 9am PDT [summer])
-     - cron: '0 16 * * 2,4'
+     - cron: '0 16 * * 4'
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)