### PR TITLE
Merge czge & gisaid mpox samples for tree builds

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -466,10 +466,6 @@ def populate_uploaded_row(sample, sequence):
 
 
 def populate_aligned_row(sample, sequence):
-    genbank_accession: Optional[Accession] = None
-    for accession in sample.accessions:
-        if accession.accession_type == AccessionType.GENBANK:
-            genbank_accession = accession
     upload_date = None
     if sample.uploaded_pathogen_genome is not None:
         upload_date = sample.uploaded_pathogen_genome.upload_date.strftime("%Y-%m-%d")

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -476,7 +476,7 @@ def populate_aligned_row(sample, sequence):
 
     row: MutableMapping[str, Any] = {
         "accession": sample.public_identifier,
-        "strain": getattr(genbank_accession, "accession", None) or "",
+        "strain": sample.public_identifier,
         "date": sample.collection_date.strftime("%Y-%m-%d"),
         "region": sample.collection_location.region,
         "country": sample.collection_location.country,

--- a/src/backend/aspen/workflows/nextstrain_run/merge_mpx.py
+++ b/src/backend/aspen/workflows/nextstrain_run/merge_mpx.py
@@ -1,0 +1,74 @@
+import csv
+import io
+
+import click
+from Bio import SeqIO
+
+
+@click.command("merge")
+@click.option("--unique-column", type=str, required=True)
+@click.option(
+    "required_metadata_fh", "--required-metadata", type=click.File("r"), required=True
+)
+@click.option(
+    "required_sequences_fh", "--required-sequences", type=click.File("r"), required=True
+)
+@click.option(
+    "upstream_metadata_fh", "--upstream-metadata", type=click.File("r"), required=True
+)
+@click.option(
+    "upstream_sequences_fh", "--upstream-sequences", type=click.File("r"), required=True
+)
+@click.option(
+    "destination_metadata_fh",
+    "--destination-metadata",
+    type=click.File("w"),
+    required=True,
+)
+@click.option(
+    "destination_sequences_fh",
+    "--destination-sequences",
+    type=click.File("w"),
+    required=True,
+)
+def cli(
+    unique_column: str,
+    required_metadata_fh: io.TextIOBase,
+    required_sequences_fh: io.TextIOBase,
+    upstream_metadata_fh: io.TextIOBase,
+    upstream_sequences_fh: io.TextIOBase,
+    destination_metadata_fh: io.TextIOWrapper,
+    destination_sequences_fh: io.TextIOWrapper,
+):
+    required_ids = set([])
+    required_sequences = SeqIO.parse(required_sequences_fh, "fasta")
+    for record in required_sequences:
+        SeqIO.write(record, destination_sequences_fh, "fasta-2line")
+        required_ids.add(record.id)
+
+    upstream_sequences = SeqIO.parse(upstream_sequences_fh, "fasta")
+    unique_records_iterator = (
+        item for item in upstream_sequences if item.id not in required_ids
+    )
+    SeqIO.write(unique_records_iterator, destination_sequences_fh, "fasta-2line")
+
+    required_metadata: csv.DictReader = csv.DictReader(
+        required_metadata_fh, delimiter="\t"
+    )
+    upstream_metadata: csv.DictReader = csv.DictReader(
+        upstream_metadata_fh, delimiter="\t"
+    )
+    destination_metadata: csv.DictWriter = csv.DictWriter(
+        destination_metadata_fh, fieldnames=upstream_metadata.fieldnames
+    )
+    destination_metadata.writeheader()
+    for row in required_metadata:
+        destination_metadata.writerow(row)
+    for row in upstream_metadata:
+        if row[unique_column] in required_ids:
+            continue
+        destination_metadata.writerow(row)
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/backend/aspen/workflows/nextstrain_run/merge_mpx.py
+++ b/src/backend/aspen/workflows/nextstrain_run/merge_mpx.py
@@ -63,9 +63,7 @@ def cli(
     upstream_metadata: csv.DictReader = csv.DictReader(
         upstream_metadata_fh, delimiter="\t"
     )
-    destination_metadata: csv.DictWriter = csv.DictWriter(
-        destination_metadata_fh, fieldnames=upstream_metadata.fieldnames, delimiter="\t"
-    )
+    destination_metadata: csv.DictWriter = csv.DictWriter(destination_metadata_fh, fieldnames=upstream_metadata.fieldnames, delimiter="\t")  # type: ignore
     destination_metadata.writeheader()
     for row in required_metadata:
         required_ids.add(row[required_match_column])

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -69,7 +69,7 @@ if [ -e /mpox/data/sequences_czge.fasta ]; then
     # Skip the TSV header when appending
     tail +2 /mpox/data/metadata_czge.tsv >> /mpox/data/metadata.tsv
     cat /mpox/data/sequences_czge.fasta >> /mpox/data/sequences.fasta
-    python3 merge_mpx.py --required-metadata metadata_czge.tsv --required-sequences sequences.fasta --upstream-metadata /mpox/data/metadata.tsv --upstream-sequences /mpox/data/sequences.fasta --destination-metadata merged.tsv --destination-sequences merged.fasta --unique-column accession
+    python3 merge_mpx.py --required-metadata metadata_czge.tsv --required-sequences sequences.fasta --upstream-metadata /mpox/data/metadata.tsv --upstream-sequences /mpox/data/sequences.fasta --destination-metadata merged.tsv --destination-sequences merged.fasta --required-match-column strain --upstream-match-column accession
     mv merged.tsv /mpox/data/metadata.tsv
     mv merged.fasta /mpox/data/sequences.fasta
 fi;

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -59,19 +59,21 @@ aligned_upstream_sequences_s3_key=$(echo "${aligned_upstream_location}" | jq -r 
 aligned_upstream_metadata_s3_key=$(echo "${aligned_upstream_location}" | jq -r .metadata_key)
 
 # fetch the upstream dataset
-$aws s3 cp --no-progress "s3://${aligned_upstream_s3_bucket}/${aligned_upstream_sequences_s3_key}" /mpox/data/sequences.fasta.xz
-$aws s3 cp --no-progress "s3://${aligned_upstream_s3_bucket}/${aligned_upstream_metadata_s3_key}" /mpox/data/metadata.tsv.xz
-
-unxz /mpox/data/*.xz
+if [ ! -e /mpox/data/upstream_sequences.fasta ]; then
+    $aws s3 cp --no-progress "s3://${aligned_upstream_s3_bucket}/${aligned_upstream_sequences_s3_key}" /mpox/data/upstream_sequences.fasta.xz
+    unxz /mpox/data/*.xz
+fi
+if [ ! -e /mpox/data/upstream_metadata.tsv ]; then
+    $aws s3 cp --no-progress "s3://${aligned_upstream_s3_bucket}/${aligned_upstream_metadata_s3_key}" /mpox/data/upstream_metadata.tsv.xz
+    unxz /mpox/data/*.xz
+fi
 
 # If we've written out any samples, add them to the upstream metadata/fasta files
 if [ -e /mpox/data/sequences_czge.fasta ]; then
-    # Skip the TSV header when appending
-    tail +2 /mpox/data/metadata_czge.tsv >> /mpox/data/metadata.tsv
-    cat /mpox/data/sequences_czge.fasta >> /mpox/data/sequences.fasta
-    python3 merge_mpx.py --required-metadata metadata_czge.tsv --required-sequences sequences.fasta --upstream-metadata /mpox/data/metadata.tsv --upstream-sequences /mpox/data/sequences.fasta --destination-metadata merged.tsv --destination-sequences merged.fasta --required-match-column strain --upstream-match-column accession
-    mv merged.tsv /mpox/data/metadata.tsv
-    mv merged.fasta /mpox/data/sequences.fasta
+    python3 merge_mpx.py --required-metadata /mpox/data/metadata_czge.tsv --required-sequences /mpox/data/sequences_czge.fasta --upstream-metadata /mpox/data/upstream_metadata.tsv --upstream-sequences /mpox/data/upstream_sequences.fasta --destination-metadata /mpox/data/metadata.tsv --destination-sequences /mpox/data/sequences.fasta --required-match-column strain --upstream-match-column accession
+else
+    cp /mpox/data/upstream_metadata.tsv /mpox/data/metadata.tsv
+    cp /mpox/data/upstream_sequences.fasta /mpox/data/sequences.fasta
 fi;
 
 # Persist the build config we generated.

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -69,6 +69,9 @@ if [ -e /mpox/data/sequences_czge.fasta ]; then
     # Skip the TSV header when appending
     tail +2 /mpox/data/metadata_czge.tsv >> /mpox/data/metadata.tsv
     cat /mpox/data/sequences_czge.fasta >> /mpox/data/sequences.fasta
+    python3 merge_mpx.py --required-metadata metadata_czge.tsv --required-sequences sequences.fasta --upstream-metadata /mpox/data/metadata.tsv --upstream-sequences /mpox/data/sequences.fasta --destination-metadata merged.tsv --destination-sequences merged.fasta --unique-column accession
+    mv merged.tsv /mpox/data/metadata.tsv
+    mv merged.fasta /mpox/data/sequences.fasta
 fi;
 
 # Persist the build config we generated.

--- a/src/backend/aspen/workflows/nextstrain_run/save.py
+++ b/src/backend/aspen/workflows/nextstrain_run/save.py
@@ -5,6 +5,7 @@ from typing import IO, MutableSequence, Set
 
 import click
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.exc import NoResultFound
 
 from aspen.config.config import Config
 from aspen.database.connection import (
@@ -103,17 +104,25 @@ def cli(
             ):
                 included_samples.append(uploaded_pathogen_genome.sample)
 
-        # create an output
-        phylo_tree = PhyloTree(
-            s3_bucket=bucket,
-            s3_key=key,
-            constituent_samples=included_samples,
-            name=phylo_run.name,
-            group=phylo_run.group,
-            tree_type=phylo_run.tree_type,
-            pathogen=phylo_run.pathogen,
-            resolved_template_args=resolved_template_args,
-        )
+        try:
+            # Overwrite our existing tree output
+            phylo_tree: PhyloTree = (
+                session.query(PhyloTree)
+                .filter(PhyloTree.producing_workflow_id == phylo_run_id)
+                .one()
+            )
+        except NoResultFound:
+            # Create a new tree
+            phylo_tree = PhyloTree()
+
+        phylo_tree.s3_bucket = bucket
+        phylo_tree.s3_key = key
+        phylo_tree.constituent_samples = included_samples
+        phylo_tree.name = phylo_run.name
+        phylo_tree.group = phylo_run.group
+        phylo_tree.tree_type = phylo_run.tree_type
+        phylo_tree.pathogen = phylo_run.pathogen
+        phylo_tree.resolved_template_args = resolved_template_args
 
         # update the run object with the metadata about the run.
         phylo_run.end_datetime = end_time_datetime

--- a/src/backend/aspen/workflows/nextstrain_run/save.py
+++ b/src/backend/aspen/workflows/nextstrain_run/save.py
@@ -104,6 +104,16 @@ def cli(
             ):
                 included_samples.append(uploaded_pathogen_genome.sample)
 
+        phylo_tree_kwargs = {
+            "s3_bucket": bucket,
+            "s3_key": key,
+            "constituent_samples": included_samples,
+            "name": phylo_run.name,
+            "group": phylo_run.group,
+            "tree_type": phylo_run.tree_type,
+            "pathogen": phylo_run.pathogen,
+            "resolved_template_args": resolved_template_args,
+        }
         try:
             # Overwrite our existing tree output
             phylo_tree: PhyloTree = (
@@ -111,18 +121,11 @@ def cli(
                 .filter(PhyloTree.producing_workflow_id == phylo_run_id)
                 .one()
             )
+            for k, v in phylo_tree_kwargs.items():
+                setattr(phylo_tree, k, v)
         except NoResultFound:
             # Create a new tree
-            phylo_tree = PhyloTree()
-
-        phylo_tree.s3_bucket = bucket
-        phylo_tree.s3_key = key
-        phylo_tree.constituent_samples = included_samples
-        phylo_tree.name = phylo_run.name
-        phylo_tree.group = phylo_run.group
-        phylo_tree.tree_type = phylo_run.tree_type
-        phylo_tree.pathogen = phylo_run.pathogen
-        phylo_tree.resolved_template_args = resolved_template_args
+            phylo_tree = PhyloTree(**phylo_tree_kwargs)
 
         # update the run object with the metadata about the run.
         phylo_run.end_datetime = end_time_datetime


### PR DESCRIPTION
### Summary:
What this PR does:
- Puts czge sample public identifiers in the `strain` column of metadata.tsv
- Replaces `/` with `_` in sample public identifiers when populating the `accession` column of metadata.tsv
- Removes any samples from the genbank metadata/sequences files that have `accession` names that match the `strain` names in the czge metadata
- Combines processed czge & gisaid files into final metadata/sequences files ready for tree build

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)