### PR TITLE
add mpx tooltips

### DIFF
--- a/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTableNameCell/components/PhyloTreeStatusTag/index.tsx
+++ b/src/frontend/src/views/Data/components/TreesView/components/TreesTable/components/TreeTableNameCell/components/PhyloTreeStatusTag/index.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "czifui";
 import { TREE_STATUS } from "src/common/constants/types";
 import { StyledChip } from "./style";
 
@@ -14,23 +15,35 @@ interface Props {
   treeStatus: TREE_STATUS;
 }
 
-interface MapType {
-  [key: string]: CHIP_STATUS;
-}
-
-const STATUS_MAP: MapType = {
-  COMPLETED: "success",
-  FAILED: "error",
-  STARTED: "beta",
+const STATUS_MAP: Record<TREE_STATUS, CHIP_STATUS> = {
+  [TREE_STATUS.Completed]: "success",
+  [TREE_STATUS.Failed]: "error",
+  [TREE_STATUS.Started]: "beta",
 };
 
-const PhyloTreeStatusTag = ({ treeStatus }: Props): JSX.Element => (
-  <StyledChip
-    isRounded
-    label={treeStatus}
-    size="small"
-    status={STATUS_MAP[treeStatus] as CHIP_STATUS}
-  />
-);
+const PhyloTreeStatusTag = ({ treeStatus }: Props): JSX.Element => {
+  const Chip = (
+    <StyledChip
+      isRounded
+      label={treeStatus}
+      size="small"
+      status={STATUS_MAP[treeStatus]}
+    />
+  );
+
+  if (treeStatus === TREE_STATUS.Failed) {
+    return (
+      <Tooltip
+        arrow
+        title="Trees may fail if no samples satisfy the specified location, date, or lineage."
+        sdsStyle="light"
+      >
+        <span>{Chip}</span>
+      </Tooltip>
+    );
+  }
+
+  return Chip;
+};
 
 export { PhyloTreeStatusTag };


### PR DESCRIPTION
### Summary
- **What:** Add tooltip to failed tags in trees table
- **Why:** To indicate why a tree may fail
- **Discussion:** https://chanzuckerbergteam.slack.com/archives/C04P3FTSKDH/p1676052222374239

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/218590662-d3a16177-bfa1-44e6-9c4c-026de7079d85.png)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/218590730-cbd5042f-2754-445c-86f7-067c2e63ecc1.png)

### Notes
The original text made the tooltip awkward, so I added commas instead of slashes.
![tmp](https://user-images.githubusercontent.com/7562933/218590975-8bc06b05-88cc-4a16-b22d-b7d69622e7ad.png)

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)