### PR TITLE
Make sure we break stale mpox docker build cache.

### DIFF
--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -53,7 +53,7 @@ RUN mkdir /mpox && \
     git init && \
     git remote add origin https://github.com/chanzuckerberg/monkeypox.git && \
     git fetch origin subsampling && \
-    git reset --hard FETCH_HEAD
+    git reset --hard fd74f4b5f219035c9cbb7909b6f84f8a06fda76d
 
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)