### PR TITLE
[SC-229469] Remove 500+ sample error message.

### DIFF
--- a/src/frontend/src/components/WebformTable/common/types.ts
+++ b/src/frontend/src/components/WebformTable/common/types.ts
@@ -34,7 +34,6 @@ export enum ERROR_CODE {
   DEFAULT, // BAD FILE NAME
   INVALID_NAME,
   MISSING_FIELD, // Missing required column entirely: no header field found
-  OVER_MAX_SAMPLES,
   DUPLICATE_PRIVATE_IDS, // Duplicate Private IDs were found in tsv upload
   DUPLICATE_PUBLIC_IDS, // Duplicate Public IDs were found in tsv upload
 }

--- a/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
+++ b/src/frontend/src/views/Upload/components/Metadata/components/ImportFile/components/Alerts/Error.tsx
@@ -19,7 +19,6 @@ const ERROR_CODE_TO_MESSAGE: Record<
 > = {
   [ERROR_CODE.INVALID_NAME]: InvalidNameMessage,
   [ERROR_CODE.MISSING_FIELD]: MissingFieldMessage,
-  [ERROR_CODE.OVER_MAX_SAMPLES]: "placeholder",
   [ERROR_CODE.DEFAULT]: DefaultMessage,
 };
 
@@ -41,7 +40,6 @@ export default function Error({
     [ERROR_CODE.MISSING_FIELD]: (
       <B>Import Failed, file missing required field.</B>
     ),
-    [ERROR_CODE.OVER_MAX_SAMPLES]: "placeholder",
     [ERROR_CODE.DEFAULT]: (
       <B>Something went wrong, please try again or contact us!</B>
     ),

--- a/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
+++ b/src/frontend/src/views/Upload/components/Samples/components/AlertTable/index.tsx
@@ -20,8 +20,6 @@ const ERROR_CODE_MESSAGES: Record<BASE_ERROR_CODE, string> = {
   [ERROR_CODE.INVALID_NAME]:
     "Sample Name (from FASTA) did not meet our requirements, please update and retry. Sample names must be no longer than 120 characters and can only contain letters from the English alphabet (A-Z, upper and lower case), numbers (0-9), periods (.), hyphens (-), underscores (_), spaces ( ), and forward slashes (/).",
   [ERROR_CODE.MISSING_FIELD]: "placeholder",
-  [ERROR_CODE.OVER_MAX_SAMPLES]:
-    "This file contains more than 500 samples, which exceeds the maximum for each upload process. Please limit the samples to 500 or less",
 };
 
 interface Props {

--- a/src/frontend/src/views/Upload/components/Samples/utils.ts
+++ b/src/frontend/src/views/Upload/components/Samples/utils.ts
@@ -37,12 +37,6 @@ export async function handleFiles(
         ];
       })
     );
-    if (Object.keys(result).length > 500) {
-      finalErrors = {
-        ...finalErrors,
-        [ERROR_CODE.OVER_MAX_SAMPLES]: [file.name],
-      };
-    }
     finalResult = { ...finalResult, ...samplesWithFilename };
     finalErrors = deepmerge(finalErrors, errors);
   }


### PR DESCRIPTION
### Summary:
- **What:** `Even though we removed the 500+ sample limit, we were still showing an error message on the upload page. 
 This removes the error message.`
- **Ticket:** [sc-229469](https://app.shortcut.com/genepi/story/229469)
- **Env:** `none`

### Demos:
![Screenshot 2023-02-23 at 4 02 47 PM](https://user-images.githubusercontent.com/109251328/221059308-bdf92fc2-2073-4f17-87ad-313ec254bdd1.png)


### Notes: The 500+ sample upload already worked.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)