### PR TITLE
Make it possible for version strings to match.

### DIFF
--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -15,7 +15,7 @@ RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize
 RUN chmod 775 *
 ## Checkout latest release
 RUN git clone https://github.com/yatisht/usher.git
-RUN cd usher && git checkout v0.6.0 && ./install/installUbuntu.sh
+RUN cd usher && git checkout v0.6.2 && ./install/installUbuntu.sh
 
 FROM python:3.10-slim-bullseye AS base
 ENV FLASK_APP=aspen.main

--- a/src/backend/aspen/workflows/pangolin/find_samples.py
+++ b/src/backend/aspen/workflows/pangolin/find_samples.py
@@ -20,15 +20,18 @@ def check_latest_pangolin_version() -> str:
     installed_version = (
         subprocess.check_output(["pangolin", "-pv"]).decode("utf-8").strip()
     )
-    installed_version = re.sub(".*?([0-9\\.]+)$", "\\1", installed_version)
+    # Only capture the bock of digits and . characters at the end of the version string
+    installed_version = re.sub(r".*?([0-9\.]+)$", r"\1", installed_version)
     return installed_version
 
 
 def should_sample_be_updated(sample: Sample, most_recent_pango_version: str) -> bool:
     if not sample.lineages:
         return True
+    # Grab the set of digits and . characters at the end of the version string
+    # to compare with the pango version.
     sample_lineage_version = re.sub(
-        ".*?([0-9\\.]+)$", "\\1", sample.lineages[0].lineage_software_version
+        r".*?([0-9\.]+)$", r"\1", sample.lineages[0].lineage_software_version
     )
     return sample_lineage_version != most_recent_pango_version
 

--- a/src/backend/aspen/workflows/pangolin/find_samples.py
+++ b/src/backend/aspen/workflows/pangolin/find_samples.py
@@ -20,7 +20,7 @@ def check_latest_pangolin_version() -> str:
     installed_version = (
         subprocess.check_output(["pangolin", "-pv"]).decode("utf-8").strip()
     )
-    installed_version = re.sub(".*?([0-9\.]+)$", "\\1", installed_version)
+    installed_version = re.sub(".*?([0-9\\.]+)$", "\\1", installed_version)
     return installed_version
 
 
@@ -28,7 +28,7 @@ def should_sample_be_updated(sample: Sample, most_recent_pango_version: str) -> 
     if not sample.lineages:
         return True
     sample_lineage_version = re.sub(
-        ".*?([0-9\.]+)$", "\\1", sample.lineages[0].lineage_software_version
+        ".*?([0-9\\.]+)$", "\\1", sample.lineages[0].lineage_software_version
     )
     return sample_lineage_version != most_recent_pango_version
 

--- a/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
+++ b/src/backend/aspen/workflows/pangolin/tests/test_pangolin_workflow.py
@@ -1,6 +1,7 @@
 import random
 from pathlib import Path, PosixPath
 from typing import Collection
+from unittest.mock import patch
 
 from click.testing import CliRunner, Result
 from sqlalchemy.orm import undefer
@@ -74,8 +75,10 @@ def mock_remote_db_uri(mocker, test_postgres_db_uri):
     )
 
 
-def test_pangolin_find_samples(mocker, session, postgres_database):
+@patch("aspen.workflows.pangolin.find_samples.check_latest_pangolin_version")
+def test_pangolin_find_samples(pango_version_mock, mocker, session, postgres_database):
 
+    pango_version_mock.return_value = "1.1.234"
     samples, _, pathogen = create_test_data(session)
     mock_remote_db_uri(mocker, postgres_database.as_uri())
 
@@ -103,7 +106,9 @@ def _run_sample_export(ids_filename):
     return output_filename
 
 
-def test_pangolin_export(mocker, session, postgres_database):
+@patch("aspen.workflows.pangolin.find_samples.check_latest_pangolin_version")
+def test_pangolin_export(pango_version_mock, mocker, session, postgres_database):
+    pango_version_mock.return_value = "1.1.234"
 
     samples, pathogen_genomes, pathogen = create_test_data(session)
     mock_remote_db_uri(mocker, postgres_database.as_uri())


### PR DESCRIPTION
### Summary:
- **What:** Reduce the number of samples we update on each pangolin run.
- **Ticket:** [sc229721](https://app.shortcut.com/genepi/story/229721)

### Notes:
This fix isn't perfect, but it should be a step towards making the scheduled pango job behave as expected. Previously, the `find_samples.py` script was looking for all samples whose version (as outputted by pangolin in the CSV file and written to our db) didn't match the current version of pangolin (as fetched from the pangoLEARN release version). The latest PangoLEARN version looks something like `2022-07-09` while versions outputted by pangolin look something like `PUSHER-v1.18.1.1` or `SCORPIO_v0.1.10`.

This PR:
1. Updates the code that gets the current pango version to use the output of `pangolin -pv` (which is currently `pangolin-data 1.18.1.1`) instead of pangolearn releases
2. We then compare the last sequence of digits and `.` characters at the end of the strings output by `pangolin -pv` and pangolin's CSV output to determine which sequences are out of date.

I tested this script in local dev and prod, and we went from updating many 000's of sample lineage calls to dozens on every run.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)