### PR TITLE
Add gisaid banner for covid only.

### DIFF
--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
@@ -1,32 +1,33 @@
-import { ROUTES } from "src/common/routes";
-import { Banner } from "czifui";
-import { NewTabLink } from "src/common/components/library/NewTabLink";
+import { useSelector } from "react-redux";
+import { selectCurrentPathogen } from "src/common/redux/selectors";
 import { B } from "src/common/styles/basicStyle";
+import { SplitPathogenWrapper } from "src/components/Split/SplitPathogenWrapper";
+import { PATHOGEN_FEATURE_FLAGS } from "src/components/Split/types";
+import { StyledBanner } from "./style";
 
-const PRIVACY_BANNER_EXPIRATION = "2023-02-01T00:00:00";
+// Note: this was previously for privacy policy announcements
+// It was pretty convenient to reuse - maybe we want to keep
+// it around for one-off banners.
 
+// Show Banner on Covid pages to let the user know that we
+// are currently unable to ingest GISAID data
 export const Announcements = (): JSX.Element => {
-  // Remove on or after Feb 1, 2023
-  const shouldRenderPrivacyBanner = () => {
-    const today = new Date();
-    const expirationDate = new Date(PRIVACY_BANNER_EXPIRATION);
-    return today.getTime() < expirationDate.getTime();
-  };
+  const pathogen = useSelector(selectCurrentPathogen);
 
-  const renderPrivacyBanner = () => (
+  return (
     <>
-      <Banner sdsType="primary">
-        <B>
-          We are updating our Privacy Policy to comply with CCPA, effective
-          January 3, 2023.
-        </B>{" "}
-        &nbsp;
-        <NewTabLink href={ROUTES.PRIVACY} sdsStyle="dashed">
-          View the updates.
-        </NewTabLink>
-      </Banner>
+      <SplitPathogenWrapper
+        pathogen={pathogen}
+        feature={PATHOGEN_FEATURE_FLAGS.show_gisaid_ingestion_banner}
+      >
+        <StyledBanner sdsType="primary">
+          <B>
+            As of 2/26/23, we have been experiencing difficulty fetching fresh
+            contextual data from GISAID for SARS-CoV-2 trees. We&apos;re working
+            on a solution and will update you when we have more information
+          </B>
+        </StyledBanner>
+      </SplitPathogenWrapper>
     </>
   );
-
-  return <>{shouldRenderPrivacyBanner() && renderPrivacyBanner()}</>;
 };

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/style.ts
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { Banner } from "czifui";
+
+export const StyledBanner = styled(Banner)`
+  /* media query - if less than 1490px wide, show on two lines */
+  @media (max-width: 1490px) {
+    height: 60px;
+  }
+
+  @media (max-width: 790px) {
+    height: 90px;
+  }
+`;

--- a/src/frontend/src/components/Split/pathogenSplitConfig.ts
+++ b/src/frontend/src/components/Split/pathogenSplitConfig.ts
@@ -33,6 +33,10 @@ const pathogenTrafficFlagConfig: PathogenTrafficFlagConfig = {
     [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
     [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.OFF,
   },
+  [PATHOGEN_FEATURE_FLAGS.show_gisaid_ingestion_banner]: {
+    [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
+    [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.OFF,
+  },
   [PATHOGEN_FEATURE_FLAGS.usher_linkout]: {
     [Pathogen.COVID]: SPLIT_SIMPLE_FLAG.ON,
     [Pathogen.MONKEY_POX]: SPLIT_SIMPLE_FLAG.ON,

--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -30,5 +30,6 @@ export enum PATHOGEN_FEATURE_FLAGS {
   lineage_filter_enabled = "PATHOGEN_lineage_filter_enabled",
   nextstrain_enabled = "PATHOGEN_nextstrain_enabled",
   public_repository = "PATHOGEN_public_repository",
+  show_gisaid_ingestion_banner = "PATHOGEN_show_gisaid_ingestion_banner",
   usher_linkout = "PATHOGEN_usher_linkout",
 }


### PR DESCRIPTION
### Summary:
- **What:** Add banner to let users know we aren't able to ingest gisaid data
- **Ticket:** none
- **Env:** none

### Demos:
wide screen
![Screenshot 2023-03-01 at 1 59 57 PM](https://user-images.githubusercontent.com/109251328/222275239-5e89b85c-8281-4268-9efe-531da0a772fd.png)

middle-width
![Screenshot 2023-03-01 at 1 59 44 PM](https://user-images.githubusercontent.com/109251328/222275244-e4f33bd0-d334-424d-960f-59baef155bcc.png)

small screen
![Screenshot 2023-03-01 at 1 59 35 PM](https://user-images.githubusercontent.com/109251328/222275245-8499b045-ac6b-483c-b4d8-9f1c82419b86.png)

### Notes:
I reused the privacy policy updates banner.  It's pretty nice to have one of these around for quick implementation.

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)