### PR TITLE
Bugfix: sample deletion

### DIFF
--- a/.github/workflows/scheduled-prod-deploy.yml
+++ b/.github/workflows/scheduled-prod-deploy.yml
@@ -1,9 +1,11 @@
 name: Scheduled Deploy
 
 on:
-  schedule:
-    # Weekly Tuesday & Thursdays @ 16:00 UTC (8am PST [winter] / 9am PDT [summer])
-     - cron: '0 16 * * 2'
+  # Vince, Mar 31 2023: Since updates are less frequent at the moment, turning
+  # off scheduled deploys for now in favor of manual Prod pushes only.
+  # schedule:
+  #   # Weekly Tuesday & Thursdays @ 16:00 UTC (8am PST [winter] / 9am PDT [summer])
+  #    - cron: '0 16 * * 2,4'
   workflow_dispatch:
     inputs:
       image_tag:

--- a/src/backend/aspen/database/models/sample.py
+++ b/src/backend/aspen/database/models/sample.py
@@ -198,7 +198,9 @@ class Sample(idbase, DictMixin):  # type: ignore
     # need to include those to maintain expected usage. "delete-orphan" is less
     # common, but handles cases when child is removed from a parent collection.
     aligned_pathogen_genome = relationship(  # type: ignore
-        "AlignedPathogenGenome", back_populates="sample", cascade="delete, delete-orphan, merge, save-update"
+        "AlignedPathogenGenome",
+        back_populates="sample",
+        cascade="delete, delete-orphan, merge, save-update",
     )
     lineages = relationship("SampleLineage", back_populates="sample")  # type: ignore
     aligned_peptides = relationship("AlignedPeptides", back_populates="sample")  # type: ignore

--- a/src/backend/aspen/database/models/sequences.py
+++ b/src/backend/aspen/database/models/sequences.py
@@ -121,13 +121,10 @@ class AlignedPathogenGenome(PathogenGenome):
     )
 
     sample_id = Column(Integer, ForeignKey(Sample.id), unique=True, nullable=False)
-    # The default value of cascade is "save-update, merge", so if we want to enable "delete", we
-    # need to include the other options as well to maintain backwards compatibility.
     sample = relationship(  # type: ignore
         Sample,
         back_populates="aligned_pathogen_genome",
         uselist=False,
-        cascade="delete, merge, save-update",
     )
     aligned_date = Column(DateTime, nullable=False, server_default=func.now())
     reference_name = Column(String, nullable=False)


### PR DESCRIPTION
### Summary:
- **What:** Bugfix for sample deletions failing on any sample older than a ~few seconds 
- **Ticket:** No ticket, based off [this bug report](https://czi-sci.slack.com/archives/C01JJH9RXRA/p1680044276770949) in Slack
- **Env:** None

### Demos:
Screenshots from before and after code change. Running a SQLAlchemy Python repl console locally.

**Before**

<img width="961" alt="image" src="https://user-images.githubusercontent.com/89553795/229183209-1f1f6d72-cb3e-4477-b720-fee29d110a1b.png">

The sample here has a child `aligned_pathogen_genome`. When we attempt to delete the sample, there is no cascade to the child APG, so that would mean it's foreign key back to the sample would violate the not-null constraint, which means the delete fails when we attempt to commit the session.

---

**After**

<img width="834" alt="image" src="https://user-images.githubusercontent.com/89553795/229184217-f3dd578e-6585-47ef-b88e-db8d9c4dab71.png">

Two things happening here. You can't see the results in these screenshots -- I was verifying results separately by hitting the DB directly outside of the repl session -- but there are two things happening here.

First, when we delete `alpha_apg`, while it has an associated sample, after deleting the APG, the sample is left alone. Previously we had a delete cascade from APG to the parent sample; talking with Jess, this appears to not be what we want since a sample can (theoretically, although not actually right now) have multiple APGs.

Second, `beta_sample` was chosen because it has an associated APG. When we delete the sample, it gets deleted without an error, and its child APG is also deleted.



### Explanation of bug and fix:
If a user uploaded a sample and then immediately deleted it (within a few seconds), the delete would go through fine. However, if a sample was uploaded and we waited awhile before trying to delete, it became impossible to delete. This was because samples do not immediately get an APG when they are uploaded. The APG is attached to it after the lineage-qc workflow finishes, since we get the APG out of that workflow. This matters because (A) we did not have a delete cascade from Sample -> APG and (B) APG has a foreign key reference `sample_id` that must not be null. So if we tried to delete a Sample before the APG was created, everything was hunky-dory. But if deleted after the APG was attached, the sample deletion would set the associated `AlignedPathogenGenome.sample_id` to NULL because the parent was deleted, but that would then trigger the NOT NULL constraint to explode. The fix was simply to put a delete cascade on Sample -> APG so any associated APG would be deleted along with the sample, which is what we want.

### Other notes:
- We had a delete cascade from APG -> Sample before. If you delete the APG, it would delete its parent Sample. Talking about this with Jess, that seemed like something we did not want: a Sample can have multiple APGs potentially, and a Sample can stand without having an APG, so cascading that delete seems bad, so I removed that cascade.
  - We do have cascade deletes from UploadedPathogenGenome -> Sample though. While that's still (mostly) a child -> parent delete, the way things are set up right now really assumes a 1-to-1 relationship and that all samples must have a UPG, so that cascade has been kept (although we don't currently use that cascade since we never target and delete the UPG specifically anywhere).
- Using a `cascade` keyword of `all` is apparently considered dangerous practice if you're doing asyncio. See the [warning on this page of docs](https://docs.sqlalchemy.org/en/20/orm/cascades.html). Pertinent part is "The `all` cascade option implies the `refresh-expire` cascade setting which may not be desirable when using [asyncio]". If you then dig into it some more, there's other warnings about how `refresh-expire` can get you into trouble when using asyncio. So I converted those cascades we had `all` in to explicitly naming the cascade types we want.
  - I waffled on this hard. As far as I know, we haven't had any issues around using `all`. This is probably being unnecessarily careful. On the other hand, `all` is just an alias that doesn't actually convert to that many cascade types, so the only ones we dropped were `refresh-expire` (because of warnings in docs) and `expunge` (because I'm very confident we're not using that aspect at all). In the end, it seemed slightly better to do the explicit approach considering the warning.
- We had this note for awhile: "it's unclear why we need explicit cascade rules on some of these relationships and not others" -- I figured it out! I updated the note, but basically it came down to this: all of the child relationships have foreign keys pointing back to Sample. But only _some_ of those children have NOT NULL constraints on the FK. Those that have the constraint need the cascade, while those that have no such constraint do not need the cascade. This comes down to the fact that SQLAlchemy defaults to non-deletion of children while setting the FK reference of the child to NULL. As an aside, this means that for any samples we deleted in the past, those children rows without the cascade are still floating around, orphaned.
  - I waffled on this one too! I considered adding delete cascades to those that had no cascade, but figured I'd just leave it alone since I wasn't sure if we actually always did want to delete the children when the parent sample got deleted for those.
-  The UploadedPathogenGenome relationship is built with a `backref`. That's a legacy relationship construct and SQlAlchemy now says you should avoid using it and build with `back_populates` instead (like the other relationships you'll see here). With `back_populates`, you create a `relationship` on both models, but with `backref` you only do it on a single model and the relationship gets auto-magically put on the other model. We ought to switch over to `back_populates` throughout, but we have a lot of `backrefs` in the code base for other relationships outside of Sample associated stuff. So I figured it was best to just leave that aspect alone.
- Lastly, a random, but interesting thing I learned. The SQLAlchemy `cascade` with a relationship works, but if you ever need to drop tons and tons of stuff via cascade -- say delete parent A, that has many children Bs, with grandchildren Cs, etc, etc -- you probably want to have the DB take care of it directly. The SQLAlchemy `cascade` is emitting SQL to handle the cascades from the Python side, but you can do this entirely in the DB as well. The flag to be aware of is `passive_deletes`. You can read more in the [docs here](https://docs.sqlalchemy.org/en/20/orm/cascades.html#using-foreign-key-on-delete-cascade-with-orm-relationships), and I also liked the shorter and simpler write-up in this [blog here](https://esmithy.net/2020/06/20/sqlalchemy-cascade-delete/) (start at the section titled "Database Cascades" (my favorite part from the post is this quote: "This is a situation where some real confusion can set in, and what I and some of my colleagues have done in the past is flail around a while until we end up turning ORM-level cascades back on, declare victory and move on."))

### Disabling scheduled Prod releases
Finally, but totally unrelated, this PR is turning off scheduled Prod releases. We aren't releasing changes fast enough or watching the app closely enough to keep scheduled Prod releases. So we're going to disable it for now and just switch over to manually kicking off Prod releases when we want them.

### Checklist:
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I added relevant unit tests