### PR TITLE
unpin Pangolin data

### DIFF
--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -41,10 +41,10 @@ RUN apt-get update && apt-get install -y  \
 # Install Pangolin and PangoLEARN + deps (for ncov)
 # The cov-lineages projects aren't available on PyPI, so install via git URLs.
 RUN pip3 install snakemake==6.8.0
-RUN pip3 install git+https://github.com/cov-lineages/pangolin.git@v4.1.3
-RUN pip3 install git+https://github.com/cov-lineages/pangolin-data.git@v1.16
-RUN pip3 install git+https://github.com/cov-lineages/scorpio.git@v0.3.17
-RUN pip3 install git+https://github.com/cov-lineages/constellations.git@v0.1.10
+RUN pip3 install git+https://github.com/cov-lineages/pangolin.git@v4.2
+RUN pip3 install git+https://github.com/cov-lineages/pangolin-data.git
+RUN pip3 install git+https://github.com/cov-lineages/scorpio.git
+RUN pip3 install git+https://github.com/cov-lineages/constellations.git
 RUN pip3 install pysam==0.19.1
 
 # libtbb doesn't install well on bullseye:


### PR DESCRIPTION
What do you think if we unpin the underlying data for Pango lineages? So we can have the newest lineage assignments as new lineages become available... which also means we need to reinstate auto deployment, but that is a separate conversation. 

I can only test the changes don't break things once they're on staging fyi. 