### PR TITLE
Update frontend container base image to node:14.21.3-buster-slim

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.4-slim AS base
+FROM node:14.21.3-buster-slim AS base
 WORKDIR /usr/src/app
 RUN chown node:node /usr/src/app
 ENV NODE_ENV=development


### PR DESCRIPTION
### Summary:
- **What:** Debian 9 "stretch" repos have been archived, causing issues with our current frontend container's build. This PR updates the frontend base image to a Debian 10 "buster" node image. This new image also uses a minor-version update of node. 
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:
Frontend built fine.
<img width="1840" alt="Screenshot 2023-04-25 at 10 47 00" src="https://user-images.githubusercontent.com/24234461/234360499-740afb3d-246d-4a5b-b01f-ef4c31e83122.png">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)