### PR TITLE
fix: mark the deployment status jobs as 'continue on error' due to faulty creds error

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -48,6 +48,9 @@ jobs:
           state: in_progress
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: "<filler>"
+          AWS_SECRET_ACCESS_KEY: "<filler>"
+          AWS_SESSION_TOKEN: "<filler>"
       - name: Update deployment
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@deploy-happy-stack-v1.7.0
         with:

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -74,6 +74,7 @@ jobs:
           state: success
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}
@@ -86,3 +87,4 @@ jobs:
           state: failure
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -76,6 +76,9 @@ jobs:
           state: success
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: "<filler>"
+          AWS_SECRET_ACCESS_KEY: "<filler>"
+          AWS_SESSION_TOKEN: "<filler>"
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Install happy dependencies
         run: |
           pip install -r .happy/requirements.txt
+      - uses: avakar/set-deployment-status@v1
+        with:
+          state: in_progress
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Update deployment
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@deploy-happy-stack-v1.7.0
         with:
@@ -62,6 +69,12 @@ jobs:
           echo "TODO - run functional tests against staging!"
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:
+      - name: Set deployment status to success if no errors
+        uses: avakar/set-deployment-status@v1
+        with:
+          state: success
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -43,14 +43,6 @@ jobs:
       - name: Install happy dependencies
         run: |
           pip install -r .happy/requirements.txt
-      - uses: avakar/set-deployment-status@v1
-        with:
-          state: in_progress
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: "<filler>"
-          AWS_SECRET_ACCESS_KEY: "<filler>"
-          AWS_SESSION_TOKEN: "<filler>"
       - name: Update deployment
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@deploy-happy-stack-v1.7.0
         with:
@@ -70,15 +62,6 @@ jobs:
           echo "TODO - run functional tests against staging!"
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:
-      - name: Set deployment status to success if no errors
-        uses: avakar/set-deployment-status@v1
-        with:
-          state: success
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: "<filler>"
-          AWS_SECRET_ACCESS_KEY: "<filler>"
-          AWS_SESSION_TOKEN: "<filler>"
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -79,3 +79,10 @@ jobs:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
         if: github.event.deployment.environment == 'prod' || failure()
+      - name: Set deployment status to failure if errors
+        uses: avakar/set-deployment-status@v1
+        if: failure()
+        with:
+          state: failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -48,8 +48,7 @@ jobs:
           state: in_progress
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        continue-on-error: true
       - name: Update deployment
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@deploy-happy-stack-v1.7.0
         with:
@@ -80,10 +79,3 @@ jobs:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
         if: github.event.deployment.environment == 'prod' || failure()
-      - name: Set deployment status to failure if errors
-        uses: avakar/set-deployment-status@v1
-        if: failure()
-        with:
-          state: failure
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Additional Notes relating to the backend are documented [here](docs/backend/).
 ## Additional Frontend Notes
 
 Additional Notes relating to the frontend are documented [here](docs/frontend/).
+
+
+## Statuses
+[![staging]](https://github.com/chanzuckerberg/czgenepi/actions?query=workflow%3A%22Deploy+Happy%22++)

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Additional Notes relating to the frontend are documented [here](docs/frontend/).
 
 
 ## Statuses
-[![staging]](https://github.com/chanzuckerberg/czgenepi/actions?query=workflow%3A%22Deploy+Happy%22++)
+[![staging](https://github.com/chanzuckerberg/czgenepi/actions/workflows/deploy-happy-stack.yml/badge.svg)](https://github.com/chanzuckerberg/czgenepi/actions?query=workflow%3A%22Deploy+Happy%22++)

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Additional Notes relating to the frontend are documented [here](docs/frontend/).
 
 
 ## Statuses
-[![staging](https://github.com/chanzuckerberg/czgenepi/actions/workflows/deploy-happy-stack.yml/badge.svg)](https://github.com/chanzuckerberg/czgenepi/actions?query=workflow%3A%22Deploy+Happy%22++)
+[![Happy Deployment](https://github.com/chanzuckerberg/czgenepi/actions/workflows/deploy-happy-stack.yml/badge.svg)](https://github.com/chanzuckerberg/czgenepi/actions?query=workflow%3A%22Deploy+Happy%22++)


### PR DESCRIPTION
### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

the `avakar/set-deployment-status@v1` workflow requires AWS credentials we don't have in static form. We still need the labeling functionality, but we're okay with ignoring any failures from it.


### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)