### PR TITLE
Retrieve default contextual repository from Split for scheduled runs

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -239,7 +239,7 @@ def get_template_args_for_focal_group(
     return None
 
 
-def get_pathogen_db_objects(db, split_client, pathogen_string):
+def get_pathogen_db_objects(db, split_client, pathogen):
     pathogen_obj = (
         db.execute(sa.select(Pathogen).filter(Pathogen.slug == pathogen))
         .scalars()

--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, MutableSequence
 import click
 import dateparser
 import sqlalchemy as sa
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, Session
 
 from aspen.api.settings import CLISettings
 from aspen.config.config import Config
@@ -239,7 +239,7 @@ def get_template_args_for_focal_group(
     return None
 
 
-def get_pathogen_db_objects(db, split_client, pathogen):
+def get_pathogen_db_objects(db: Session, split_client: SplitClient, pathogen: str):
     pathogen_obj = (
         db.execute(sa.select(Pathogen).filter(Pathogen.slug == pathogen))
         .scalars()

--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -137,7 +137,13 @@ def launch_one(
         groups_query = sa.select(Group).where(where_clause)  # type: ignore
         group_obj: Group = db.execute(groups_query).scalars().one()
         workflow = create_phylo_run(
-            db, group_obj, template_args_obj, tree_type_obj, pathogen_obj, repository, contextual_repository
+            db,
+            group_obj,
+            template_args_obj,
+            tree_type_obj,
+            pathogen_obj,
+            repository,
+            contextual_repository,
         )
 
         job = NextstrainScheduledJob(settings)
@@ -324,7 +330,13 @@ def launch_all(pathogen):
                     )
                     continue
                 workflow = create_phylo_run(
-                    db, group, template_args, tree_type, pathogen_obj, repository, contextual_repository
+                    db,
+                    group,
+                    template_args,
+                    tree_type,
+                    pathogen_obj,
+                    repository,
+                    contextual_repository,
                 )
 
                 job = NextstrainScheduledJob(settings)

--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -307,8 +307,8 @@ def launch_all(pathogen: str, dry_run: bool):
                     group,
                     pathogen_obj,
                     repository,
-                    dateparser.parse(DEFAULT_TEMPLATE_ARGS["filter_start_date"]).date(),
-                    dateparser.parse(DEFAULT_TEMPLATE_ARGS["filter_end_date"]).date(),
+                    dateparser.parse(DEFAULT_TEMPLATE_ARGS["filter_start_date"]).date(),  # type: ignore
+                    dateparser.parse(DEFAULT_TEMPLATE_ARGS["filter_end_date"]).date(),  # type: ignore
                 )
                 if not template_args:
                     print(

--- a/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/create_phyloruns.py
@@ -250,16 +250,6 @@ def get_pathogen_db_objects(db: Session, split_client: SplitClient, pathogen: st
     default_repository = split_client.get_pathogen_treatment(
         "PATHOGEN_public_repository", pathogen_obj
     )
-    import logging
-
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
-    logger.debug(f"pathogen: {pathogen_obj.slug}")
-    logger.debug(f"split_repo_value for pathogen: {default_repository}")
-    all_repos = db.execute(sa.select(PublicRepository)).scalars().all()
-    for repo in all_repos:
-        logger.debug(f"Repo {repo.id}: {repo.name}")
-
     repository = (
         db.execute(
             sa.select(PublicRepository).filter(

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_create_phyloruns.py
@@ -1,0 +1,155 @@
+from typing import List, Optional
+
+from sqlalchemy.sql.expression import and_
+
+from aspen.database.models import (
+    Group,
+    Location,
+    Pathogen,
+    TreeType,
+    User,
+    WorkflowStatusType,
+)
+from aspen.test_infra.models.location import location_factory
+from aspen.test_infra.models.pathogen import pathogen_factory
+from aspen.test_infra.models.repository import random_default_repo_factory
+from aspen.test_infra.models.sequences import uploaded_pathogen_genome_multifactory
+from aspen.test_infra.models.usergroup import group_factory, user_factory
+from aspen.test_infra.models.workflow import aligned_repo_data_factory
+from aspen.workflows.nextstrain_run.create_phyloruns import launch_all, launch_one
+
+
+def create_test_data(
+    session,
+    split_client,
+    num_county_samples,  # Total # of samples to associate with a group
+    num_selected_samples,  # How many of those samples are workflow inputs
+    num_gisaid_samples,  # How many gisaid samples to add to a workflow
+    group_name=None,  # Override group name
+    group_location=None,  # Override group location
+    group_division=None,  # Override group division
+    template_args=None,  # Send template args
+    tree_type: TreeType = TreeType.OVERVIEW,
+):
+    if group_name is None:
+        group_name = f"testgroup-{tree_type.value}"
+    group: Group = group_factory(
+        name=group_name, division=group_division, location=group_location
+    )
+    uploaded_by_user: User = user_factory(
+        group,
+        email=f"{group_name}{tree_type.value}@dh.org",
+        auth0_user_id=group_name,
+    )
+    location: Optional[Location] = (
+        session.query(Location)
+        .filter(
+            and_(
+                Location.region == "North America",
+                Location.country == "USA",
+                Location.division == f"{group.division} Test Division",
+                Location.location == f"{group.location} Test City",
+            )
+        )
+        .one_or_none()
+    )
+    if not location:
+        location = location_factory(
+            "North America",
+            "USA",
+            f"{group.division} Test Division",
+            f"{group.location} Test City",
+        )
+    repository = random_default_repo_factory(split_client)
+    pathogen: Optional[Pathogen] = (
+        session.query(Pathogen).filter(Pathogen.slug == "SC2").one_or_none()
+    )
+    if not pathogen:
+        pathogen = pathogen_factory("SC2", "SARS-CoV-2")
+    session.add(group)
+
+    gisaid_samples: List[str] = [
+        f"fake_gisaid_id{i}" for i in range(num_gisaid_samples)
+    ]
+
+    pathogen_genomes = uploaded_pathogen_genome_multifactory(
+        group, pathogen, uploaded_by_user, location, num_county_samples
+    )
+
+    selected_samples = pathogen_genomes[:num_selected_samples]
+    gisaid_dump = aligned_repo_data_factory(
+        pathogen=pathogen,
+        repository=repository,
+        sequences_s3_key=f"{group_name}{tree_type.value}",
+        metadata_s3_key=f"{group_name}{tree_type.value}",
+    ).outputs[0]
+
+    inputs = selected_samples + [gisaid_dump]
+    session.add_all(inputs)
+    if template_args is None:
+        template_args = {}
+
+    session.commit()
+    return group
+
+
+def mock_remote_db_uri(mocker, test_postgres_db_uri):
+    mocker.patch(
+        "aspen.config.config.Config.DATABASE_URI",
+        new_callable=mocker.PropertyMock,
+        return_value=test_postgres_db_uri,
+    )
+
+
+# Make sure we're properly creating phylo runs
+def test_launch_one(mocker, session, split_client, postgres_database):
+    mock_remote_db_uri(mocker, postgres_database.as_uri())
+
+    # use option defaults
+    template_args = "{}"
+    tree_type = "OVERVIEW"
+    pathogen = "SC2"
+    # return the created phylo run for inspection, skip SFN launch
+    dry_run = True
+
+    test_group = create_test_data(session, split_client, 10, 10, 10)
+    phylo_run = launch_one(test_group.name, template_args, tree_type, pathogen, dry_run)
+    assert phylo_run.group.id == test_group.id
+    assert phylo_run.workflow_status == WorkflowStatusType.STARTED
+    assert phylo_run.pathogen == pathogen
+    assert phylo_run.tree_type == tree_type
+    assert phylo_run.template_args == template_args
+    assert type(phylo_run.contextual_repository_id) is int
+
+
+# Make sure we're properly creating phylo runs
+def test_launch_all(mocker, session, split_client, postgres_database):
+    mock_remote_db_uri(mocker, postgres_database.as_uri())
+
+    # use option defaults
+    pathogen = "SC2"
+    # return the created phylo run for inspection, skip SFN launch
+    dry_run = True
+
+    group_ids = set()
+
+    for name in ["alpha", "beta", "gamma"]:
+        test_group = create_test_data(
+            session, split_client, 10, 10, 10, group_name=f"{name}-group"
+        )
+        group_ids.add(test_group.id)
+
+    phylo_runs = launch_all(pathogen, dry_run)
+    assert len(phylo_runs) == 3
+
+    group_ids_launched = set()
+    for phylo_run in phylo_runs:
+        assert phylo_run.group_id in group_ids
+        group_ids_launched.add(phylo_run.group_id)
+        assert phylo_run.workflow_status == WorkflowStatusType.STARTED
+        assert phylo_run.pathogen == pathogen
+        assert phylo_run.tree_type == tree_type
+        assert phylo_run.template_args == template_args
+        assert type(phylo_run.contextual_repository_id) is int
+
+    assert group_ids == group_ids_launched

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_create_phyloruns.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Optional
 
 from click.testing import CliRunner
@@ -110,8 +111,6 @@ def test_launch_one(mocker, session, split_client, postgres_database):
     try:
         assert result.exit_code == 0
     except Exception:
-        import traceback
-
         traceback.print_tb(result.exc_info[2])
         print(result.exc_info[1])
         print(result.exc_info[0])
@@ -130,8 +129,6 @@ def test_launch_all(mocker, session, split_client, postgres_database):
     try:
         assert result.exit_code == 0
     except Exception:
-        import traceback
-
         traceback.print_tb(result.exc_info[2])
         print(result.exc_info[1])
         print(result.exc_info[0])

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_create_phyloruns.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_create_phyloruns.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from sqlalchemy.sql.expression import and_
 
@@ -67,10 +67,6 @@ def create_test_data(
     if not pathogen:
         pathogen = pathogen_factory("SC2", "SARS-CoV-2")
     session.add(group)
-
-    gisaid_samples: List[str] = [
-        f"fake_gisaid_id{i}" for i in range(num_gisaid_samples)
-    ]
 
     pathogen_genomes = uploaded_pathogen_genome_multifactory(
         group, pathogen, uploaded_by_user, location, num_county_samples
@@ -148,8 +144,8 @@ def test_launch_all(mocker, session, split_client, postgres_database):
         group_ids_launched.add(phylo_run.group_id)
         assert phylo_run.workflow_status == WorkflowStatusType.STARTED
         assert phylo_run.pathogen == pathogen
-        assert phylo_run.tree_type == tree_type
-        assert phylo_run.template_args == template_args
+        assert phylo_run.tree_type == TreeType.OVERVIEW
+        assert type(phylo_run.template_args) is str
         assert type(phylo_run.contextual_repository_id) is int
 
     assert group_ids == group_ids_launched


### PR DESCRIPTION
### Summary:
- **What:** For scheduled nextstrain builds, retrieves the default contextual repository from split and adds it to the phylo run object on creation. Fixes a bug where previously this was not added, causing those jobs to fail.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)