### PR TITLE
Make sure to apply pathogen filters to genome exports.

### DIFF
--- a/src/backend/aspen/test_infra/models/sequences.py
+++ b/src/backend/aspen/test_infra/models/sequences.py
@@ -29,17 +29,18 @@ def uploaded_pathogen_genome_factory(
 
 
 def uploaded_pathogen_genome_multifactory(
-    group, pathogen, uploaded_by_user, location, num_genomes
+    group, pathogen, uploaded_by_user, location, num_genomes, index_offset=0
 ):
     pathogen_genomes = []
     for i in range(num_genomes):
+        suffix = index_offset + i
         sample: Sample = sample_factory(
             group,
             uploaded_by_user,
             location,
             pathogen=pathogen,
-            private_identifier=f"private_identifier_{i}",
-            public_identifier=f"public_identifier_{i}",
+            private_identifier=f"private_identifier_{suffix}",
+            public_identifier=f"public_identifier_{suffix}",
         )
         pathogen_genome: UploadedPathogenGenome = uploaded_pathogen_genome_factory(
             sample,
@@ -65,17 +66,18 @@ def aligned_pathogen_genome_factory(
 
 
 def aligned_pathogen_genome_multifactory(
-    group, pathogen, uploaded_by_user, location, num_genomes
+    group, pathogen, uploaded_by_user, location, num_genomes, index_offset=0
 ):
     pathogen_genomes = []
     for i in range(num_genomes):
+        suffix = i + index_offset
         sample: Sample = sample_factory(
             group,
             uploaded_by_user,
             location,
             pathogen=pathogen,
-            private_identifier=f"private_identifier_{i}",
-            public_identifier=f"public_identifier_{i}",
+            private_identifier=f"private_identifier_{suffix}",
+            public_identifier=f"public_identifier_{suffix}",
         )
         pathogen_genome: AlignedPathogenGenome = aligned_pathogen_genome_factory(
             sample,

--- a/src/backend/aspen/workflows/nextstrain_run/export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/export.py
@@ -210,9 +210,11 @@ def export_run_config(
         # Fetch all of a group's samples.
         county_samples: List[PathogenGenome] = []
         if sequence_type == "aligned":
-            county_samples = get_aligned_county_samples(session, group)
+            county_samples = get_aligned_county_samples(
+                session, group, phylo_run.pathogen
+            )
         else:
-            county_samples = get_county_samples(session, group)
+            county_samples = get_county_samples(session, group, phylo_run.pathogen)
 
         # get the aligned upstream run info.
         aligned_repo_data: AlignedRepositoryData = [
@@ -260,11 +262,12 @@ def export_run_config(
         }
 
 
-def get_county_samples(session, group: Group):
+def get_county_samples(session, group: Group, pathogen: Pathogen):
     # Get all samples for the group
     all_samples: Iterable[Sample] = (
         session.query(Sample)
         .filter(Sample.submitting_group_id == group.id)
+        .filter(Sample.pathogen_id == pathogen.id)
         .options(
             joinedload(Sample.uploaded_pathogen_genome, innerjoin=True).undefer(
                 PathogenGenome.sequence
@@ -275,11 +278,12 @@ def get_county_samples(session, group: Group):
     return pathogen_genomes
 
 
-def get_aligned_county_samples(session, group: Group):
+def get_aligned_county_samples(session, group: Group, pathogen: Pathogen):
     # Get all samples for the group
     all_samples: Iterable[Sample] = (
         session.query(Sample)
         .filter(Sample.submitting_group_id == group.id)
+        .filter(Sample.pathogen_id == pathogen.id)
         .options(
             joinedload(Sample.aligned_pathogen_genome, innerjoin=True).undefer(
                 PathogenGenome.sequence

--- a/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
+++ b/src/backend/aspen/workflows/nextstrain_run/tests/test_export.py
@@ -68,22 +68,32 @@ def create_test_data(
             f"{group.location} Test City",
         )
     repository = random_default_repo_factory(split_client)
-    pathogen: Optional[Pathogen] = (
+    sc2: Optional[Pathogen] = (
         session.query(Pathogen).filter(Pathogen.slug == "SC2").one_or_none()
     )
-    if not pathogen:
-        pathogen = pathogen_factory("SC2", "SARS-CoV-2")
+    if not sc2:
+        sc2 = pathogen_factory("SC2", "SARS-CoV-2")
+    mpx: Optional[Pathogen] = (
+        session.query(Pathogen).filter(Pathogen.slug == "MPX").one_or_none()
+    )
+    if not mpx:
+        mpx = pathogen_factory("MPX", "Mpox")
     session.add(group)
 
     gisaid_samples: List[str] = [
         f"fake_gisaid_id{i}" for i in range(num_gisaid_samples)
     ]
 
-    pathogen_genomes = uploaded_pathogen_genome_multifactory(
-        group, pathogen, uploaded_by_user, location, num_county_samples
+    sc2_genomes = uploaded_pathogen_genome_multifactory(
+        group, sc2, uploaded_by_user, location, num_county_samples
+    )
+    mpx_genomes = uploaded_pathogen_genome_multifactory(
+        group, mpx, uploaded_by_user, location, num_county_samples, num_county_samples
     )
 
-    selected_samples = pathogen_genomes[:num_selected_samples]
+    pathogen = sc2
+    selected_samples = sc2_genomes[:num_selected_samples]
+
     gisaid_dump = aligned_repo_data_factory(
         pathogen=pathogen,
         repository=repository,
@@ -92,7 +102,7 @@ def create_test_data(
     ).outputs[0]
 
     inputs = selected_samples + [gisaid_dump]
-    session.add_all(inputs)
+    session.add_all(sc2_genomes + mpx_genomes + [gisaid_dump])
     if template_args is None:
         template_args = {}
 


### PR DESCRIPTION
### Summary:
- **What:** Fix the data that we export for tree builds.

### Notes:
When we build trees, we export all of a group's samples to a fasta file for the nexstrain pipeline to ingest. This export script was missing filters for specific pathogens, so it was writing all of a county's sequences for all pathogens to this file. These sequences were likely ignored by the SC2 pipeline, but broke the MPX pipeline which is stricter about input requirements.

I updated the tests to add sequences for multiple pathogens as part of the setup method, ensured that nearly all of the test cases failed, and then added the patch to export.py and all tests succeeded. I also manually kicked off a rebuild of a previously failed mpox tree in prod with this patch and it succeeded.

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)