### PR TITLE
Request a larger instance for pangolin

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -227,7 +227,7 @@ module pangolin_sfn_config {
   source   = "../sfn_config"
   app_name = "pangolin-sfn"
   image    = local.pangolin_image
-  memory   = 16000
+  memory   = 120000
   wdl_path = "workflows/pangolin.wdl"
   custom_stack_name     = local.custom_stack_name
   deployment_stage      = local.deployment_stage


### PR DESCRIPTION
This is the size used in testing run [here](https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/v2/executions/details/arn:aws:states:us-west-2:829407189049:execution:genepi-geprod-swipe-default-wdl:pango-32core-rerun) which should get an instance with 32 threads (note somewhere between Terraform and WDL the requested memory lose 2000 across all jobs).
This is the size of instance we use for tree runs, so not a big ask.