### PR TITLE
Pin Nextclade cli download to 2.14

### DIFF
--- a/src/backend/Dockerfile.lineage_qc
+++ b/src/backend/Dockerfile.lineage_qc
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y make wget git jq gcc unzip
 
 # install nextclade, check it installed correctly
 RUN apt-get --yes install curl
-RUN cd /usr/local/bin && curl -fsSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu" -o "nextclade" && chmod +x nextclade
+RUN cd /usr/local/bin && curl -fsSL "https://github.com/nextstrain/nextclade/releases/download/2.14.0/nextalign-x86_64-unknown-linux-gnu" -o "nextclade" && chmod +x nextclade
 RUN nextclade --version
 
 # Poetry: install app


### PR DESCRIPTION
### Summary:
- **What:** Pins our nextclade cli version to 2.14.
- **Ticket:** [CZID-9286](https://czi-tech.atlassian.net/browse/CZID-9286?atlOrigin=eyJpIjoiODhjMjNkOTM1NDQwNDU3YmFhOWEzMDFhNjY4NGU1ODkiLCJwIjoiaiJ9)
- **Env:** [rdev link](https://nextclade-v2-pin-frontend.dev.czgenepi.org/data/samples/groupId/17/pathogen/MPX)

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)

[CZID-9286]: https://czi-tech.atlassian.net/browse/CZID-9286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ