### PR TITLE
[pango fix] strip whitespace from first line for safety check

### DIFF
--- a/src/backend/aspen/workflows/import_pango_lineages/load_pango_lineages.py
+++ b/src/backend/aspen/workflows/import_pango_lineages/load_pango_lineages.py
@@ -85,7 +85,7 @@ def get_lineages(lineage_notes_file: io.TextIOBase) -> list[str]:
     """
     # First line is header, no lineage data, but we use as a safety check.
     first_line = next(lineage_notes_file)
-    first_line = first_line.replace(" ", "") # remove any extra spaces that could interfere with safety check
+    first_line = first_line.replace(" ", "")  # remove any extra spaces that could interfere with safety check
     safety_check_first_line(first_line)
 
     # Now we parse remainder of lines from file and extract lineages

--- a/src/backend/aspen/workflows/import_pango_lineages/load_pango_lineages.py
+++ b/src/backend/aspen/workflows/import_pango_lineages/load_pango_lineages.py
@@ -85,7 +85,9 @@ def get_lineages(lineage_notes_file: io.TextIOBase) -> list[str]:
     """
     # First line is header, no lineage data, but we use as a safety check.
     first_line = next(lineage_notes_file)
-    first_line = first_line.replace(" ", "")  # remove any extra spaces that could interfere with safety check
+    first_line = first_line.replace(
+        " ", ""
+    )  # remove any extra spaces that could interfere with safety check
     safety_check_first_line(first_line)
 
     # Now we parse remainder of lines from file and extract lineages

--- a/src/backend/aspen/workflows/import_pango_lineages/load_pango_lineages.py
+++ b/src/backend/aspen/workflows/import_pango_lineages/load_pango_lineages.py
@@ -85,7 +85,9 @@ def get_lineages(lineage_notes_file: io.TextIOBase) -> list[str]:
     """
     # First line is header, no lineage data, but we use as a safety check.
     first_line = next(lineage_notes_file)
+    first_line = first_line.replace(" ", "") # remove any extra spaces that could interfere with safety check
     safety_check_first_line(first_line)
+
     # Now we parse remainder of lines from file and extract lineages
     return [
         lineage


### PR DESCRIPTION
### Summary:
pango jobs were failling because we were expecting the first line in the lineages file to be  "Lineage\tDescription\n" but it was  "Lineage\tDescription \n" instead. This PR removes whitespaces before doing the safety check

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)