### PR TITLE
pin pulp to 2.7.0 in Dockerfile.pangolin

### DIFF
--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -41,6 +41,10 @@ RUN apt-get update && apt-get install -y  \
 # Install Pangolin and PangoLEARN + deps (for ncov)
 # The cov-lineages projects aren't available on PyPI, so install via git URLs.
 RUN pip3 install snakemake==7.30.1
+# required to fix broken snakemake dependency, see this link: https://github.com/snakemake/snakemake/issues/2607,
+# snakemake moved away from pulp in 8.1.2 but we would need to upgrade python in order to use that version
+# for now pinning pulp to 2.7.0 works
+RUN pip3 install pulp==2.7.0
 RUN pip3 install git+https://github.com/cov-lineages/pangolin.git@v4.3.1
 RUN pip3 install git+https://github.com/cov-lineages/pangolin-data.git@v1.23.1
 RUN pip3 install git+https://github.com/cov-lineages/scorpio.git@v0.3.19


### PR DESCRIPTION
### Summary:
- **What:** pangolin was failing due to snakemake dependency not being properly pinned, leading to an interface change in pulp that snakemake couldn't resolve. See issue link [here](https://github.com/snakemake/snakemake/issues/2607)
- **Ticket:** https://czi-tech.atlassian.net/jira/software/c/projects/CZID/boards/139?assignee=605e7b9a2c761b00692c17e1&selectedIssue=CZID-9642
- **Env:** `<rdev link>`

### Demos:
1. launch ec2
2. pull CZGE repo
3. `cd src/backend; docker build . -f Dockerfile.pangolin --tag pangolin:latest`
4. `docker run -v /mnt/czgenepi:/mnt/czgenepi --rm -it pangolin:latest bash`
5. pull `https://github.com/cov-lineages/pangolin/blob/master/tests/test-data/sequence1.fasta` file locally
6. `pangolin --threads 16 sequence1.fasta --outfile lineage_report.csv`
7. check that pulp dependency issue is resolved.


### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)