### PR TITLE
Fix download url for nextclade binary

### DIFF
--- a/src/backend/Dockerfile.lineage_qc
+++ b/src/backend/Dockerfile.lineage_qc
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y make wget git jq gcc unzip
 
 # install nextclade, check it installed correctly
 RUN apt-get --yes install curl
-RUN cd /usr/local/bin && curl -fsSL "https://github.com/nextstrain/nextclade/releases/download/2.14.0/nextalign-x86_64-unknown-linux-gnu" -o "nextclade" && chmod +x nextclade
+RUN cd /usr/local/bin && curl -fsSL "https://github.com/nextstrain/nextclade/releases/download/2.14.0/nextclade-x86_64-unknown-linux-gnu" -o "nextclade" && chmod +x nextclade
 RUN nextclade --version
 
 # Poetry: install app


### PR DESCRIPTION
### Summary:
- **What:** Fixes the url for the nextclade 2.14.0 binary download
- **Ticket:** CZID-9651
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)