### PR TITLE
update SSL/TLS cert in backend containers for RDS connection

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -25,6 +25,10 @@ FROM python:3.10-slim-bullseye AS base
 ENV FLASK_APP=aspen.main
 EXPOSE 3000
 
+# Install DB certs.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 # Utility
 RUN apt-get update && apt-get install -y vim procps wget make jq nano
 

--- a/src/backend/Dockerfile.gisaid
+++ b/src/backend/Dockerfile.gisaid
@@ -49,6 +49,10 @@ RUN apt-get -qq update && apt-get -qq -y install \
 
 ENV FLASK_ENV=development
 
+# Install DB certs.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 # Install poetry
 RUN apt install -y libdigest-sha-perl
 ENV POETRY_VERSION=1.3.2

--- a/src/backend/Dockerfile.lineage_qc
+++ b/src/backend/Dockerfile.lineage_qc
@@ -13,6 +13,10 @@ WORKDIR /usr/src/app
 
 RUN apt-get update && apt-get install -y make wget git jq gcc unzip
 
+# Install DB certs.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 # install nextclade, check it installed correctly
 RUN apt-get --yes install curl
 RUN cd /usr/local/bin && curl -fsSL "https://github.com/nextstrain/nextclade/releases/download/2.14.0/nextclade-x86_64-unknown-linux-gnu" -o "nextclade" && chmod +x nextclade

--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -30,6 +30,10 @@ RUN apt-get -qq update && apt-get -qq -y install \
     build-essential \
     && locale-gen en_US.UTF-8
 
+# Install DB certs.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 # Install poetry
 RUN apt install -y libdigest-sha-perl
 ENV POETRY_VERSION=1.3.2

--- a/src/backend/Dockerfile.pangolin
+++ b/src/backend/Dockerfile.pangolin
@@ -38,6 +38,10 @@ RUN apt-get update && apt-get install -y  \
         libprotobuf23 \
         libtbb2
 
+# Install DB certs.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+RUN update-ca-certificates
+
 # Install Pangolin and PangoLEARN + deps (for ncov)
 # The cov-lineages projects aren't available on PyPI, so install via git URLs.
 RUN pip3 install snakemake==7.30.1


### PR DESCRIPTION
### Summary:
- **What:** our RDS Root CAs are expiring in august and need to be replaced, updating our application docker images to download and register the new certificates from AWS's RDS truststore 
- **Ticket:** [CZID-9720](https://czi-tech.atlassian.net/browse/CZID-9720)
- **Env:** `<rdev link>`

### Testing:
Built each docker image, exec'd into container, ran  `openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep RSA2048` to verify certificate installation (recommended from [here](https://czi.atlassian.net/wiki/spaces/SI/pages/3049259009/Infra+Eng+Upgrading+RDS+Root+CAs+rds-ca-2019))

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)

[CZID-9720]: https://czi-tech.atlassian.net/browse/CZID-9720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ