### PR TITLE
Update email templates

### DIFF
--- a/src/frontend/auth0_templates/README.md
+++ b/src/frontend/auth0_templates/README.md
@@ -1,0 +1,30 @@
+# Email Templates and Auth0
+
+You'll find various email templates in this folder for communications we make with new users.
+
+## Git commiting has no impact on what is deployed! This is just version history.
+
+It's **very important** to realize that what is present here in the git repo has no direct impact on what is actually deployed for the email templates. We make commits here to track email versions over time, be able to revert to older versions, etc. But there is no connection to any kind of CI/CD or automated deploy: if you commit changes to the email templates and merge them in **it will change nothing about the deployed email templates.**
+
+**To make changes, you must go into the Auth0 dashboard** and directly save the new version of the template there. In the Auth0 console, you can find it under `Branding` > `Email Templates`. Remember you'll need to save the changes for each tenant (environment, eg, Staging, Prod, etc) you want to update, be sure you don't accidentally update just the Staging template or something.
+
+In addition to the content of the email template, there are a few other things we only track in the Auth0 console. If you want to change the email's subject line or from address, you'll need to do that there, and we don't have version tracking for those aspects. These values aren't necessarily identical across tenants (environments): for instance, we've prefixed the subject line with `[STAGING]` for everything in Staging.
+
+### Templates we actively use
+
+Auth0 has a number of different email templates available. As of right now, we only use a couple of them. Here are the templates we are currently using:
+
+- **"User Invitation"**: This is what the user gets upon being invited to the platform. It corresponds to the files `invite_new_user_email_template_prod.html` / `_staging.html`.
+  - The difference between the `_prod` and `_staging` versions of the template is very small: there's a few URLs in the email, and the difference is just to target the correct set of URLs based on the environemnt.
+  - There's also the Auth0 template "Verification Email (using Link)". At some point, we set the content of that template and it's identical to what's in "User Invitation", but it also appears to be disabled? Just in case, I [Vince] am continuing to keep them in sync, but I'm pretty confident it could be dropped entirely without any issue.
+- **"Welcome Email"**: This is what the user gets once they've signed up. It corresponds to the file `welcome_email_template.html`.
+
+### Playbook for updating email templates
+
+You don't have to follow this exactly, this is just here to outline how you should expect to handle updating email templates. The important parts are (A) remember that committing to the repo and merging does not deploy; (B) You deploy by updating the appropriate tenant (environment) in Auth0; (C) When the dust has settled, you should have committed and merged your changes to the main branch so email versions can be tracked over time.
+
+1. Locally make tweaks to the template(s) you're updating. Open the template in your local web browser to verify the changes appear to be correct. (Note: if you're making major style changes, you should probably look into support across various email clients. I don't really know the space, but it seems like email clients don't support HTML and CSS features you might take for granted in a reasonably recent web browser.)
+2. Commit the changes to your local branch.
+3. Update the Auth0 tenant for Staging. Test out your email template and make sure it works as expected. (You probably should update any other non-Prod tenants at this point as well.)
+4. Push up your branch and merge it in.
+5. Update the Auth0 tenant for Prod when you're ready for users to start receiving the new version of the template.

--- a/src/frontend/auth0_templates/invite_new_user_email_template_prod.html
+++ b/src/frontend/auth0_templates/invite_new_user_email_template_prod.html
@@ -30,7 +30,7 @@
                 />
                 </a>
               </div>
-              <div style='background-image:url("https://czgenepi.org/phyloTreeBackground.png");background-color:black;height:90px;width:70%;background-position:right;background-size:cover;'>
+              <div style='background-image:url("https://czgenepi.org/phyloTreeBackground.png");background-color:#000000;height:90px;width:70%;background-position:right;background-size:cover;'>
               </div>
             </div>
           </td>
@@ -43,8 +43,8 @@
             style='-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: "ProximaNova", sans-serif;height: 100% !important;'
           >
             <div class="main">
-              <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:black;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
-              <div style='text-align:left;margin-top:20px;color:black;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, you will need to make one to get started. This invitation will expire after 14 days.</div>
+              <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:#000000;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
+              <div style='text-align:left;margin-top:20px;color:#000000;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, we will prompt you to create one. This invitation will expire after 14 days.</div>
               <button style='margin-top: 40px;background-color:#511CC1;border-radius:40px;border:none;padding: 10px 30px;font-size:13px;line-height:18px;font-weight:600;'>
                 <span style='color:white;text-decoration:none;'>
                   <a style='color:white;text-decoration:none;' href={{ url }}>Accept Invitation</a>

--- a/src/frontend/auth0_templates/invite_new_user_email_template_prod.html
+++ b/src/frontend/auth0_templates/invite_new_user_email_template_prod.html
@@ -44,7 +44,7 @@
           >
             <div class="main">
               <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:#000000;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
-              <div style='text-align:left;margin-top:20px;color:#000000;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, we will prompt you to create one. This invitation will expire after 14 days.</div>
+              <div style='text-align:left;margin-top:20px;color:#000000;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, you will need to make one to get started. This invitation will expire after 14 days.</div>
               <button style='margin-top: 40px;background-color:#511CC1;border-radius:40px;border:none;padding: 10px 30px;font-size:13px;line-height:18px;font-weight:600;'>
                 <span style='color:white;text-decoration:none;'>
                   <a style='color:white;text-decoration:none;' href={{ url }}>Accept Invitation</a>

--- a/src/frontend/auth0_templates/invite_new_user_email_template_prod.html
+++ b/src/frontend/auth0_templates/invite_new_user_email_template_prod.html
@@ -43,6 +43,11 @@
             style='-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: "ProximaNova", sans-serif;height: 100% !important;'
           >
             <div class="main">
+              <div style='text-align:left;margin-top:20px;margin-bottom:20px;color:#000000;font-weight:400;font-size:16px;'>
+                On November 15, 2024, Theiagen Global Health Initiative will manage CZ GEN EPI, and the platform will be called TheiaGenEpi. Click
+                <a href="https://help.czgenepi.org/hc/en-us/articles/20083077583764-FAQs-CZ-GEN-EPI-Transfer-to-Theiagen-Global-Health-Initiative-TGHI">here</a>
+                for more information.
+              </div>
               <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:#000000;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
               <div style='text-align:left;margin-top:20px;color:#000000;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, you will need to make one to get started. This invitation will expire after 14 days.</div>
               <button style='margin-top: 40px;background-color:#511CC1;border-radius:40px;border:none;padding: 10px 30px;font-size:13px;line-height:18px;font-weight:600;'>

--- a/src/frontend/auth0_templates/invite_new_user_email_template_staging.html
+++ b/src/frontend/auth0_templates/invite_new_user_email_template_staging.html
@@ -30,7 +30,7 @@
                 />
                 </a>
               </div>
-              <div style='background-image:url("https://staging.czgenepi.org/phyloTreeBackground.png");background-color:black;height:90px;width:70%;background-position:right;background-size:cover;'>
+              <div style='background-image:url("https://staging.czgenepi.org/phyloTreeBackground.png");background-color:#000000;height:90px;width:70%;background-position:right;background-size:cover;'>
               </div>
             </div>
           </td>
@@ -43,8 +43,8 @@
             style='-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: "ProximaNova", sans-serif;height: 100% !important;'
           >
             <div class="main">
-              <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:black;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
-              <div style='text-align:left;margin-top:20px;color:black;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, you will need to make one to get started. This invitation will expire after 14 days.</div>
+              <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:#000000;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
+              <div style='text-align:left;margin-top:20px;color:#000000;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, you will need to make one to get started. This invitation will expire after 14 days.</div>
               <button style='margin-top: 40px;background-color:#511CC1;border-radius:40px;border:none;padding: 10px 30px;font-size:13px;line-height:18px;font-weight:600;'>
                 <span style='color:white;text-decoration:none;'>
                   <a style='color:white;text-decoration:none;' href={{ url }}>Accept Invitation</a>

--- a/src/frontend/auth0_templates/invite_new_user_email_template_staging.html
+++ b/src/frontend/auth0_templates/invite_new_user_email_template_staging.html
@@ -19,7 +19,7 @@
         <tr>
           <td>
             <div style='height:90px;border-bottom:5px solid #511CC1;overflow:hidden;display:flex;'>
-              <div style='background-color:"#000000";'>
+              <div style='background-color:#000000;'>
                 <a href="https://staging.czgenepi.org/">
                 <img
                   src="https://staging.czgenepi.org/CZGenEpiLogoWhite.png"

--- a/src/frontend/auth0_templates/invite_new_user_email_template_staging.html
+++ b/src/frontend/auth0_templates/invite_new_user_email_template_staging.html
@@ -43,6 +43,11 @@
             style='-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: "ProximaNova", sans-serif;height: 100% !important;'
           >
             <div class="main">
+              <div style='text-align:left;margin-top:20px;margin-bottom:20px;color:#000000;font-weight:400;font-size:16px;'>
+                On November 15, 2024, Theiagen Global Health Initiative will manage CZ GEN EPI, and the platform will be called TheiaGenEpi. Click
+                <a href="https://help.czgenepi.org/hc/en-us/articles/20083077583764-FAQs-CZ-GEN-EPI-Transfer-to-Theiagen-Global-Health-Initiative-TGHI">here</a>
+                for more information.
+              </div>
               <div style='padding: 20px;font-size:25px;font-weight:700;font-size:22px;line-height:25.3px;font-family:helvetica;color:#000000;'> You've been invited to join {% if organization.display_name %}{{organization.display_name}}'s {% else %} a {% endif %} group on CZ GEN EPI</div>
               <div style='text-align:left;margin-top:20px;color:#000000;font-weight:400;font-size:16px;'>Click on the link below to accept this invite and get started. If you do not already have an account with CZ GEN EPI, you will need to make one to get started. This invitation will expire after 14 days.</div>
               <button style='margin-top: 40px;background-color:#511CC1;border-radius:40px;border:none;padding: 10px 30px;font-size:13px;line-height:18px;font-weight:600;'>

--- a/src/frontend/auth0_templates/welcome_email_template.html
+++ b/src/frontend/auth0_templates/welcome_email_template.html
@@ -1,5 +1,7 @@
 <html>
   <body>
+    <div>On November 15, 2024, Theiagen Global Health Initiative will manage CZ GEN EPI, and the platform will be called TheiaGenEpi. Click <a href="https://help.czgenepi.org/hc/en-us/articles/20083077583764-FAQs-CZ-GEN-EPI-Transfer-to-Theiagen-Global-Health-Initiative-TGHI">here</a> for more information.</div>
+    <hr />
     <div>Hi {% if user.given_name %}{{ user.given_name }}{% else %}there{% endif %},</div>
     <br />
     <div>Congratulations! You have been added to {% if organization.display_name %}the {{ organization.display_name }} Group on {% endif %}<a href="http://czgenepi.org">CZ GEN EPI!</a> 🥳</div>

--- a/src/frontend/auth0_templates/welcome_email_template.html
+++ b/src/frontend/auth0_templates/welcome_email_template.html
@@ -6,13 +6,13 @@
     <br />
     <div>Congratulations! You have been added to {% if organization.display_name %}the {{ organization.display_name }} Group on {% endif %}<a href="http://czgenepi.org">CZ GEN EPI!</a> 🥳</div>
     <br />
-    <div>My name is Mikala, and I’m the product application scientist for the Chan Zuckerberg Initiative’s GEN EPI platform. CZ GEN EPI is an open-source, free, no-code genomic epidemiology analysis platform for public health. Our goal is to enable public health departments to identify the most effective interventions and policies to stop the spread of infectious diseases using genomic epidemiology. The secure, cloud-based platform streamlines the analysis of pathogen genomic data and generates phylogenetic trees with a single click—no need to install software or write code.</div>
+    <div>My name is Karyna, and I’m the product application scientist for the Chan Zuckerberg Initiative’s GEN EPI platform. CZ GEN EPI is an open-source, free, no-code genomic epidemiology analysis platform for public health. Our goal is to enable public health departments to identify the most effective interventions and policies to stop the spread of infectious diseases using genomic epidemiology. The secure, cloud-based platform streamlines the analysis of pathogen genomic data and generates phylogenetic trees with a single click—no need to install software or write code.</div>
     <br />
-    <div>If needed, you can access our CZ GEN EPI user guides and other genomic epidemiology resources by visiting our <a href="https://help.czgenepi.org/hc/en-us">Help Center</a>. You may also schedule an optional 1:1 tutorial with me <a href="https://calendly.com/mcaton-1/cz-gen-epi-onboarding">here.</a>
+    <div>If needed, you can access our CZ GEN EPI user guides and other genomic epidemiology resources by visiting our <a href="https://help.czgenepi.org/hc/en-us">Help Center</a>.</div>
     <br />
     <div>If you have any questions, please email us at <a href="mailto:hello@czgenepi.org">hello@czgenepi.org</a>. Welcome to CZ GEN EPI!</div>
     <br />
     <div>Best,</div>
-    <div>Mikala, on behalf of the CZ GEN EPI team</div>
+    <div>Karyna, on behalf of the CZ GEN EPI team</div>
   </body>
 </html>


### PR DESCRIPTION
### Summary:
- **What:** Updates the various email templates to mention transition
- **Ticket:** https://czi-tech.atlassian.net/browse/CZID-9109

### Notes:
- **IMPORTANT**: Merging this PR will **NOT** actually deploy anything regarding our email templates. See the new `README.md` file I just added in this PR for full details, but basically template files here in the repo are just to provide version tracking. To actually deploy, you need to make appropriate changes in the Auth0 console.
  - I'll be handling the deploy to Auth0, just wanted to point it out.
- As part of getting ready to make the changes, I noticed some discrepancies between what was present here in the repo and what was actually our "real", deployed templates on Auth0 around using `#000000` or `black` in CSS style. I [talked about it on Slack](https://czi-sci.slack.com/archives/C01HYJYA50W/p1720053610186999), but to sum up: there's a chance that using `#000000` in the deployed templates was a hotfix to avoid style issues with certain email clients, so I'm reproducing that here in the git repo and going to deploy it in that manner going forward.
- The welcome email still referenced Mikala, I converted it to Karyna after discussing it with Christine. There was also a link to a 1:1 scheduling link that's been defunct for awhile, I removed that.