### PR TITLE
Use group prefix for phylo tree s3 key

### DIFF
--- a/src/backend/aspen/util/swipe.py
+++ b/src/backend/aspen/util/swipe.py
@@ -80,7 +80,7 @@ class NextstrainJob(SwipeJob):
         output_suffix = f"/{group.name}/{str(now)}"
         execution_name = f"{group.prefix}-{self.job_type}-nextstrain-{str(now)}"
         extra_params = {
-            "s3_filestem": f"{group.location}/{run.tree_type}",
+            "s3_filestem": f"{group.prefix}/{run.tree_type}",
             "pathogen_slug": run.pathogen.slug,
             "workflow_id": run.id,
         }


### PR DESCRIPTION
### Summary:
- **What:** Uses the unique, required group prefix instead of the nullable, optional group location column for s3 keys for phylo trees.
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)