### PR TITLE
Update mpox genbank file paths

### DIFF
--- a/.happy/terraform/modules/sfn_config/genbank-mpx.wdl
+++ b/.happy/terraform/modules/sfn_config/genbank-mpx.wdl
@@ -6,8 +6,8 @@ workflow LoadGenBankMPX {
         String aws_region = "us-west-2"
         String genepi_config_secret_name
         String remote_dev_prefix = ""
-        String genbank_metadata_url = "https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz"
-        String genbank_alignment_url = "https://data.nextstrain.org/files/workflows/monkeypox/alignment.fasta.xz"
+        String genbank_metadata_url = "https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz"
+        String genbank_alignment_url = "https://data.nextstrain.org/files/workflows/mpox/alignment.fasta.xz"
     }
 
     call IngestGenBankMPX {


### PR DESCRIPTION
Nextstrain updated their file paths. The old version still works but we're updating it in case they stop using the old one. Links are tested.
<img width="577" alt="image" src="https://github.com/user-attachments/assets/3ddebe8b-8661-4306-b576-ea43e97a61bb">
