### PR TITLE
fix: make sure mpox trees exclude invalid samples

### DIFF
--- a/src/backend/Dockerfile.nextstrain
+++ b/src/backend/Dockerfile.nextstrain
@@ -58,6 +58,7 @@ RUN mkdir /mpox && \
     git remote add origin https://github.com/chanzuckerberg/monkeypox.git && \
     git fetch origin subsampling && \
     git reset --hard fd74f4b5f219035c9cbb7909b6f84f8a06fda76d
+RUN chown nextstrain:nextstrain /mpox/config/exclude_accessions_mpxv.txt
 
 RUN mkdir -p /ncov/auspice
 RUN mkdir -p /ncov/logs

--- a/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
+++ b/src/backend/aspen/workflows/nextstrain_run/run_nextstrain_mpx.sh
@@ -31,6 +31,10 @@ echo "* set \$aspen_s3_db_bucket"
 aspen_s3_db_bucket="$(jq -r .S3_db_bucket <<< "$genepi_config")"
 set -x
 
+# Download the latest mpox exclusions list. This happens at RUN time, not BUILD time so that
+# we are always building trees with the latest upstream filters.
+wget https://raw.githubusercontent.com/nextstrain/mpox/master/phylogenetic/defaults/exclude_accessions.txt -O /mpox/config/exclude_accessions_mpxv.txt
+
 mkdir -p /mpox/data
 key_prefix="phylo_run/${S3_FILESTEM}/${WORKFLOW_ID}"
 s3_prefix="s3://${aspen_s3_db_bucket}/${key_prefix}"


### PR DESCRIPTION
### Summary:
- **What:** Download the latest excluded samples every time we build an mpox tree
- **Ticket:** 

### Demos:

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)