### PR TITLE
Convert nextclade tag to a parse-able date

### DIFF
--- a/src/backend/aspen/workflows/nextclade/tests/test_nextclade_save.py
+++ b/src/backend/aspen/workflows/nextclade/tests/test_nextclade_save.py
@@ -122,7 +122,7 @@ def test_nextclade_save_new_entries(mocker, session, postgres_database):
     # matched against value from test tag.json in test data directory
     assert qc_metrics.reference_dataset_name == "SARS-CoV-2"
     assert qc_metrics.reference_sequence_accession == "MN908947"
-    assert qc_metrics.reference_dataset_tag == "2024-07-17--12-57-03Z"
+    assert qc_metrics.reference_dataset_tag == "2024-07-17T12-57-03Z"
     # matched against tag.json and nextclade.aligned.fasta in test data dir
     assert aligned_pathogen_genome.reference_name == "MN908947"
     assert aligned_pathogen_genome.sequence == "A" * 1001
@@ -222,7 +222,7 @@ def test_nextclade_save_overwrite(mocker, session, postgres_database):
     # matched against value from test tag.json in test data directory
     assert qc_metrics.reference_dataset_name == "SARS-CoV-2"
     assert qc_metrics.reference_sequence_accession == "MN908947"
-    assert qc_metrics.reference_dataset_tag == "2024-07-17--12-57-03Z"
+    assert qc_metrics.reference_dataset_tag == "2024-07-17T12-57-03Z"
     # matched against tag.json and nextclade.aligned.fasta in test data dir
     assert aligned_pathogen_genome.reference_name == "MN908947"
     assert aligned_pathogen_genome.sequence == "A" * 1001

--- a/src/backend/aspen/workflows/nextclade/utils.py
+++ b/src/backend/aspen/workflows/nextclade/utils.py
@@ -26,5 +26,5 @@ def extract_dataset_info(nextclade_tag_fh: IO[str]) -> Dict[str, str]:
     return {
         "name": nextclade_tag["attributes"]["name"],
         "accession": nextclade_tag["attributes"]["reference accession"],
-        "tag": nextclade_tag["version"]["tag"],
+        "tag": nextclade_tag["version"]["tag"].replace("--", "T"),
     }


### PR DESCRIPTION
Convert nextclade's version tag back to a parse-able date.

### Summary:
- **What:** `<brief description>`
- **Ticket:** [sc<fill_in_issue_number>](https://app.shortcut.com/genepi/story/<fill_in_issue_number>)
- **Env:** `<rdev link>`

### Demos:

### Notes:

### Checklist:
- [ ] I merged latest `<base branch>`
- [ ] I manually verified the change
- [ ] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)