### PR TITLE
Remove serial international samples for targeted trees

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/MPX_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/MPX_template.yaml
@@ -132,11 +132,6 @@ subsampling:
         type: "proximity"
         focus: "focal"
 
-    international_serial_sampling:
-      group_by: "region year" # lots of samples have no "month" so in order to include them, we'll only go by "year"
-      seq_per_group: 2
-      query: --query "(country != '{country}')"
-
   ########################
 
   NON_CONTEXTUALIZED:


### PR DESCRIPTION
The evolutionary rates for different mpox clades vary greatly. We currently don't tree builds that focus on a clade, so targeted trees are the closest alternatives. This PR removes the randomly selected international samples from targeted trees so we don't add samples from random clades to the tree. 