### PR TITLE
Banner notifying users about mpox update

### DIFF
--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
@@ -16,6 +16,11 @@ export const Announcements = (): JSX.Element => {
     USER_FEATURE_FLAGS.transfer_banner
   );
 
+  const shouldShowMpoxUpdateBanner = isUserFlagOn(
+    flag,
+    USER_FEATURE_FLAGS.mpox_update_banner
+  );
+
   return (
     <>
       {shouldShowTransferBanner && (
@@ -31,6 +36,20 @@ export const Announcements = (): JSX.Element => {
             HERE
           </StyledNewTabLink>
           <B>&nbsp;FOR MORE INFORMATION.</B>
+        </StyledBanner>
+      )}
+      {shouldShowMpoxUpdateBanner && (
+        <StyledBanner sdsType="primary">
+          <B>
+          MPOX TREE BUILDS ARE NOW UPDATED.&nbsp;
+          </B>
+          <StyledNewTabLink
+            href="https://help.czgenepi.org/hc/en-us/articles/30224919249684-Tree-Building-Updates-09-06-2024"
+            sdsStyle="dashed"
+          >
+            LEARN MORE
+          </StyledNewTabLink>
+          <B>.</B>
         </StyledBanner>
       )}
     </>

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
@@ -9,15 +9,16 @@ import { isUserFlagOn } from "src/components/Split";
 
 // Show Banner to let users know we are transferring the app
 export const Announcements = (): JSX.Element => {
-  const flag = useTreatments([USER_FEATURE_FLAGS.transfer_banner]);
+  const transferFlag = useTreatments([USER_FEATURE_FLAGS.transfer_banner]);
+  const mpoxUpdateFlag = useTreatments([USER_FEATURE_FLAGS.mpox_update_banner]);
 
   const shouldShowTransferBanner = isUserFlagOn(
-    flag,
+    transferFlag,
     USER_FEATURE_FLAGS.transfer_banner
   );
 
   const shouldShowMpoxUpdateBanner = isUserFlagOn(
-    flag,
+    mpoxUpdateFlag,
     USER_FEATURE_FLAGS.mpox_update_banner
   );
 
@@ -41,7 +42,7 @@ export const Announcements = (): JSX.Element => {
       {shouldShowMpoxUpdateBanner && (
         <StyledBanner sdsType="primary">
           <B>
-          MPOX TREE BUILDS ARE NOW UPDATED.&nbsp;
+            MPOX TREE BUILDS ARE NOW UPDATED.&nbsp;
           </B>
           <StyledNewTabLink
             href="https://help.czgenepi.org/hc/en-us/articles/30224919249684-Tree-Building-Updates-09-06-2024"

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
@@ -41,9 +41,7 @@ export const Announcements = (): JSX.Element => {
       )}
       {shouldShowMpoxUpdateBanner && (
         <StyledBanner sdsType="primary">
-          <B>
-            MPOX TREE BUILDS ARE NOW UPDATED.&nbsp;
-          </B>
+          <B>MPOX TREE BUILDS ARE NOW UPDATED.&nbsp;</B>
           <StyledNewTabLink
             href="https://help.czgenepi.org/hc/en-us/articles/30224919249684-Tree-Building-Updates-09-06-2024"
             sdsStyle="dashed"

--- a/src/frontend/src/components/Split/types.ts
+++ b/src/frontend/src/components/Split/types.ts
@@ -21,6 +21,7 @@ export enum USER_FEATURE_FLAGS {
   multi_pathogen = "multi_pathogen",
   sunset_banner = "sunset_banner",
   transfer_banner = "transfer_banner",
+  mpox_update_banner = "mpox_update_banner",
 }
 
 /**


### PR DESCRIPTION
### Summary:
- **What:** Banner notifying users about mpox update

### Demos:

![image](https://github.com/user-attachments/assets/18fa1d88-b67c-437d-aab3-42c9f62d9e09)


### Notes:
- Adds a new in-app banner that notifies users we've updated the mpox tree build process.
- Banner is **in-app only**, we do not display it on the homepage (that is, you don't see it if you aren't logged in).
- Banner is behind the feature flag `mpox_update_banner`.
  - Feature flag is on in Staging and Prod right now, so banner will be displayed as soon as this code is deployed to those envs.
  - I figure we can turn off the feature flag / remove the banner in a few weeks, probably start of October or so?