### PR TITLE
Change Galago domain

### DIFF
--- a/src/backend/aspen/api/main.py
+++ b/src/backend/aspen/api/main.py
@@ -37,14 +37,12 @@ def get_allowed_origins() -> List[str]:
 
     Gets list of all allowed origins for cross origin requests. This is pretty
     simple right now: we only serve the FE of our app and Galago with content
-    from our BE, so that's all this needs to cover. For ease, the Galago URLs
-    are just hardcoded. If we ever need to start handling a lot more CORS
-    requests or the Galago URLs become more dynamic, we should reevaluate
-    current process.
+    from our BE, so that's all this needs to cover. For ease, the Galago URL is
+    just hardcoded. If we ever need to start handling a lot more CORS requests,
+    we should reevaluate the current process.
     """
     allowed_origins = [
-        "https://galago.czgenepi.org",
-        "https://galago-labs.czgenepi.org",
+        "https://galago.cziscience.com",
     ]
     frontend_url = os.getenv("FRONTEND_URL")
     if frontend_url:

--- a/src/frontend/src/common/routes.ts
+++ b/src/frontend/src/common/routes.ts
@@ -8,7 +8,7 @@ export enum ROUTES {
   CZI = "https://chanzuckerberg.com/",
   DATA = "/data",
   DATA_SAMPLES = "/data/samples",
-  GALAGO = "https://galago.czgenepi.org/",
+  GALAGO = "https://galago.cziscience.com/",
   GISAID = "https://www.gisaid.org/",
   GITHUB = "https://github.com/chanzuckerberg/czgenepi/",
   GROUP = "/group",


### PR DESCRIPTION
### Summary:
App code changes for Galago moving to new domain.

**IMPORTANT:** Do **NOT** just merge and deploy. This change must be deployed to Prod at the same time we update the GitHub Pages custom URL for Galago. I believe all the CZI infra stuff is in place for the making the GitHub Pages change, but GitHub Pages change AND the deployed app code must change for the Galago link out to work correctly. If only one of those is done but not the other, the link out will break until the other is completed.

### Context:
With the hand-off to Theiagen, we're moving Galago to a new domain. It currently lives at `galago.czgenepi.org`, but since we're basically sunsetting that domain, we need to move it.  It will now live as a sub-domain under CZI Science at `galago.cziscience.com`. Since Galago is entirely browser-based, we do not serve it via AWS like most of our other CZI apps. Instead, it lives as a GitHub Page with a custom domain. I've worked with CZI Central to set up the appropriate records so GitHub Pages can use the new domain. However, because GitHub Pages only supports a single custom domain at a time, we have to switch the custom domain setting at the same time we deploy this app code. Nothing breaks permanently if they don't deploy simultaneously, but the Galago link out will be broken until both aspects are complete.

Once this PR is merged and deployed to Staging, the Galago link out will be broken there. I'll then coordinate with Central to make sure we're ready to switch over, do a Prod deploy, and change the GitHub Pages custom domain setting at the same time.