### PR TITLE
feat: update mpox banner to outage banner for theigen transfer

### DIFF
--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
@@ -41,14 +41,14 @@ export const Announcements = (): JSX.Element => {
       )}
       {shouldShowMpoxUpdateBanner && (
         <StyledBanner sdsType="primary">
-          <B>MPOX TREE BUILDS ARE NOW UPDATED.&nbsp;</B>
+          <B>PLANNED OUTAGE FROM NOVEMBER 15 AT 8 AM PST UNTIL NOVEMBER 18 AT 12 PM PST. THEIAGENEPI WILL REPLACE CZ GEN EPI. CLICK &nbsp;</B>
           <StyledNewTabLink
-            href="https://help.czgenepi.org/hc/en-us/articles/30224919249684-Tree-Building-Updates-09-06-2024"
+            href="https://help.czgenepi.org/hc/en-us/articles/20083077583764-FAQs-CZ-GEN-EPI-Transfer-to-Theiagen-Global-Health-Initiative-TGHI"
             sdsStyle="dashed"
           >
-            LEARN MORE
+            HERE
           </StyledNewTabLink>
-          <B>.</B>
+          <B>&nbsp;FOR MORE INFORMATION.</B>
         </StyledBanner>
       )}
     </>

--- a/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
+++ b/src/frontend/src/components/NavBar/components/AppNavBar/components/Announcements/index.tsx
@@ -41,7 +41,10 @@ export const Announcements = (): JSX.Element => {
       )}
       {shouldShowMpoxUpdateBanner && (
         <StyledBanner sdsType="primary">
-          <B>PLANNED OUTAGE FROM NOVEMBER 15 AT 8 AM PST UNTIL NOVEMBER 18 AT 12 PM PST. THEIAGENEPI WILL REPLACE CZ GEN EPI. CLICK &nbsp;</B>
+          <B>
+            PLANNED OUTAGE FROM NOVEMBER 15 AT 8 AM PST UNTIL NOVEMBER 18 AT 12
+            PM PST. THEIAGENEPI WILL REPLACE CZ GEN EPI. CLICK &nbsp;
+          </B>
           <StyledNewTabLink
             href="https://help.czgenepi.org/hc/en-us/articles/20083077583764-FAQs-CZ-GEN-EPI-Transfer-to-Theiagen-Global-Health-Initiative-TGHI"
             sdsStyle="dashed"


### PR DESCRIPTION
### Summary:
- **What:** Update banner for outage in anticipation of thiegen transfer
- **Ticket:** no ticket
- **Env:** `<rdev link>`

### Demos:

<img width="1383" alt="Screenshot 2024-11-04 at 11 32 42 AM" src="https://github.com/user-attachments/assets/9ed796f8-0366-46a4-9923-437a32b5edfb">

### Notes:

### Checklist:
- [x] I merged latest `<base branch>`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I tested in multiple browsers
- [x] I added relevant unit tests
- [x] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)